### PR TITLE
stop resetting domain name during publish task

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,4 +29,7 @@ jobs:
           pip install --no-cache-dir -r etc/requirements.txt
           
       - name: Generate docs
-        run: mkdocs gh-deploy
+        run: |
+          touch CNAME
+          echo 'docs.viam.com' > CNAME
+          mkdocs gh-deploy


### PR DESCRIPTION
i believe this will fix the bad behavior we saw yesterday wherein a new commit caused the github pages domain to reset:
https://stackoverflow.com/questions/66311145/github-pages-custom-domain-settings-gets-reset-during-new-commit
https://stackoverflow.com/questions/67183664/why-is-my-github-pages-custom-domain-constantly-reset