### PR TITLE
replacing footnotes plugin entry. adding board and component-faq to m…

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,8 @@ nav:
   - Components:
     - Motor: 'components/motor.md'
     - Servo: 'components/servo.md'
+    - Board: 'components/board.md'
+    - Component FAQ: 'components/component-faq.md'
   - Services:
     - Vision: 'services/vision.md'
   - Appendix:
@@ -40,7 +42,8 @@ extra:
       link: https://github.com/viamrobotics/tutorials-and-docs/
       name: docs source on github
 markdown_extensions:
+    - footnotes
     - admonition
     - codehilite
-    - footnotes 
+  
 


### PR DESCRIPTION
replacing lost footnotes plugin entry. adding board and component-faq to menu.

There is no doc to review. This is to get the footnotes working again (the entry was lost on another commit) and replace the lost board and component-faq entries.