### PR TITLE
Corrected typo

### DIFF
--- a/content/en/docs/deeper-dive/controls-package.md
+++ b/content/en/docs/deeper-dive/controls-package.md
@@ -125,7 +125,7 @@ The motor_name attribute is unused for now and one should pass a Controllable in
 }
 ```
 ### PID
-PID (or Proportional Integral Derivative ) is a wildly used method to control a process variable. 
+PID (or Proportional Integral Derivative ) is a widely used method to control a process variable. 
 The PID takes an error which is equal to SP - PV, and calculate a value that can be feed back into the endpoint.
 The mathematical form of a PID is:
 


### PR DESCRIPTION
Fahmina and Mike--unclear to me who to send this to
our lawyer noted a typo in what she described as the controls package page.   i'm not so familiar with our docs so i don't know which page she is talking about. but you can see her comment below.   might be worth doing a word search for wildly used and make sure we replace it as described.

thanks!
Jon

FYI there's a typo on the controls package page. "wildly used" should probably be "widely used".
