### PR TITLE
correct issues from Hazal

### DIFF
--- a/content/en/docs/components/motor.md
+++ b/content/en/docs/components/motor.md
@@ -89,10 +89,10 @@ Nested within `pins` (note that only two or three of these are required dependin
 
 Name | Type | Description |
 ---- | ---- | ----- |
-`a` | string | See [Pins](motor#pins). Pin number such as "36." Viam uses board pin numbers, not GPIO numbers.
-`b` | string | See [Pins](motor#pins). Pin number such as "36." Viam uses board pin numbers, not GPIO numbers.
-`dir` | string | See [Pins](motor#pins). Pin number such as "36." Viam uses board pin numbers, not GPIO numbers.
-`pwm` | string | See [Pins](motor#pins). Pin number such as "36." Viam uses board pin numbers, not GPIO numbers.
+`a` | string | See [Pins](#pins). Pin number such as "36." Viam uses board pin numbers, not GPIO numbers.
+`b` | string | See [Pins](#pins). Pin number such as "36." Viam uses board pin numbers, not GPIO numbers.
+`dir` | string | See [Pins](#pins). Pin number such as "36." Viam uses board pin numbers, not GPIO numbers.
+`pwm` | string | See [Pins](#pins). Pin number such as "36." Viam uses board pin numbers, not GPIO numbers.
 
 #### Optional Attributes
 Name | Type | Default Value | Description

--- a/content/en/docs/components/servo.md
+++ b/content/en/docs/components/servo.md
@@ -34,7 +34,7 @@ A 1.5ms signal will hold the servo in the middle or “neutral” position, 1ms 
 ## Wiring
 Here's an example of how a servo might be wired to a Raspberry Pi:  
 
-![servo-wiring](img/servo-wiring.png)
+![servo-wiring](../img/servo-wiring.png)
 
 ## Viam Configuration
 


### PR DESCRIPTION
For the SDK link on our encoder page, there doesn't seem to be an encoder component in the SDK. I left a question in slack for them, but figure we ought to get the fixes in.
 
fixed img on servo.
fixed pins links on motor.