### PR TITLE
add anchor to RDK in glossary and add links to it from RDK mentions

### DIFF
--- a/docs/appendix/glossary.md
+++ b/docs/appendix/glossary.md
@@ -44,7 +44,7 @@ For example, UR5e is a model of the arm component type.
 Processes are often used to create a new local instance of viam-server to implement drivers for custom components.
 They provide a bespoke, OS-specific process managed by the viam-server to either run once or indefinitely; for example, to run one of Viam's camera servers.
 
-**RDK (Robot Development Kit)**: The official Viam-developed codebase that provides all functionality of an SDK and more. (golang)
+<a id="rdk_anchor" />**RDK (Robot Development Kit)**: The official Viam-developed codebase that provides all functionality of an SDK and more. (golang)
 
 * The RDK contains: 
     * Go SDK

--- a/docs/getting-started/high-level-overview.md
+++ b/docs/getting-started/high-level-overview.md
@@ -19,7 +19,7 @@ A robot with multiple parts will have one main part and any number of _sub-parts
 Each part runs a session of the viam-server, which handles receiving API requests and translating them into hardware actuation.
 The viam-server reads in a configuration file that defines the components, services, and other processes.
 
-Processes are scripts or programs run by the [Robot Development Kit (RDK)](/product-overviews/rdk) whose life cycle is managed by the Viam server.
+Processes are scripts or programs run by the [Robot Development Kit (RDK)](../../appendix/glossary#rdk_anchor) whose life cycle is managed by the Viam server.
 One example is running a [Software Development Kit (SDK)](/product-overviews/sdk-as-server) server like the Python SDK where the implementation of a component is easier to create than in the RDK.
 
 Each `viam-server` instance is defined by a configuration file that describes its components, the services it employs, and connections to other viam-server instances that it wants to communicate with, which we call _remotes_.
@@ -51,7 +51,7 @@ They use the same APIs as the web UI.
 _Figure 2.
 Example architecture showing how SDK-based applications communicate with your robot’s main instance of `viam-server` over gRPC._
 
-If your hardware isn't supported by Viam’s RDK, you can write your own implementation of a component model.
+If your hardware isn't supported by Viam’s [RDK](../../appendix/glossary#rdk_anchor), you can write your own implementation of a component model.
 If a library already exists, then you just need to write a few lines of code.
 To read more on how to do this, check out our documentation on [Using Our SDKs for a Server Component Implementation](/product-overviews/sdk-as-server).
 Your part will manage this process and expose the API as it does with all of your other components.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -15,7 +15,7 @@ This tutorial requires the following hardware:
 * An internet connected computer
 * A way to connect the microSD card to the computer (ex, microSD slot or microSD reader)
 
-Before installing the Viam RDK, you will need a Raspberry Pi running a 64-bit Linux distribution.
+Before installing the Viam [RDK](../../appendix/glossary#rdk_anchor), you will need a Raspberry Pi running a 64-bit Linux distribution.
 If you do not have Linux installed on your Raspberry Pi, skip ahead to [Installing Raspian on the Raspberry Pi](#installing-raspian-on-the-raspberry-pi).
 If you already have a Raspberry Pi with Linux installed on it, check if the Linux installation on your Raspberry Pi is 64-bit.
 First, `ssh` into your Pi and then run `lscpu`.

--- a/docs/getting-started/robot-config.md
+++ b/docs/getting-started/robot-config.md
@@ -20,14 +20,14 @@ Components have Types which indicate the API for that component (for example, ar
 They also have Models, which indicate which implementation should be used to actuate with them.
 For example, an arm component could be a UR5 or an xArm and the appropriate implementation is indicated by selecting the corresponding Model.
 These component implementations can come from a few different sources.
-The most common models of a component will have implementations in RDK, which can be selected from the Model dropdown of the configuration UI.
+The most common models of a component will have implementations in [RDK](../../appendix/glossary#rdk_anchor), which can be selected from the Model dropdown of the configuration UI.
 If the Model you are working with is not supported in RDK, you’ll have to write your own component driver in one of Viam’s SDKs.
 For example, a component you are using may have an existing Python library.
 In that case, you could use Viam’s Python SDK to wrap the existing component library in Viam’s API for that component Type using a few short lines of Python.
 If no library currently exists, you will have to write a full driver for that component’s API in the language of your choice using the Viam SDK for that language.
 
 ## Running a Robot on the RDK
-When the RDK starts, it uses the secret in its cloud configuration file to ask the Viam App ([https://app.viam.com](https://app.viam.com)) for its robot configuration (see Runtime architecture).
+When the [RDK](../../appendix/glossary#rdk_anchor) starts, it uses the secret in its cloud configuration file to ask the Viam App ([https://app.viam.com](https://app.viam.com)) for its robot configuration (see Runtime architecture).
 
 Next, the configuration is parsed and processed section by section specified in the JSON config fields, notably remotes, components, services, and processes.
 

--- a/docs/tutorials/how-to-make-an-LED-blink-with-a-raspberry-pi-using-viam.md
+++ b/docs/tutorials/how-to-make-an-LED-blink-with-a-raspberry-pi-using-viam.md
@@ -39,7 +39,7 @@ You will need the following tools to complete the project:
 
 ## Project setup
 
-Before you proceed with building your circuit, you are going to need to set up the operating system on your Raspberry Pi and install Viam Server on the Pi. We recommend that you follow along with the [Installing Viam RDK Server on Raspberry Pi](../../getting-started/installation) guide in the Viam documentation. Be sure to follow all the steps including [adding your Pi on the Viam App.](../../getting-started/installation/#adding-your-pi-on-the-viam-app)
+Before you proceed with building your circuit, you are going to need to set up the operating system on your Raspberry Pi and install Viam Server on the Pi. We recommend that you follow along with the [Installing Viam Server on Raspberry Pi](../../getting-started/installation) guide in the Viam documentation. Be sure to follow all the steps including [adding your Pi on the Viam App.](../../getting-started/installation/#adding-your-pi-on-the-viam-app)
 
 *Note: If you have any issues whatsoever setting up Viam on your Raspberry Pi, let us know on the [Viam Community Slack](http://viamrobotics.slack.com), and we will be happy to help you get up and running.*
 


### PR DESCRIPTION
I didn't add it to every mention of RDK; just the first few in the overview etc.