### PR TITLE
DAD-84 move security doc

### DIFF
--- a/docs/product-overviews/fleet-management.md
+++ b/docs/product-overviews/fleet-management.md
@@ -23,7 +23,7 @@ If the user uses remote control in the Viam App ([https://app.viam.com](https://
 
 [WebRTC Docs](https://pkg.go.dev/go.viam.com/utils@v0.0.3/rpc#hdr-Connection)
 
-[Authentication Docs](../../deeper-dive/security)
+[Authentication Docs](../../security)
 
 Local communication between parts can be done over gRPC or WebRTC.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,7 +1,7 @@
 ---
 title: "Security"
 linkTitle: "Security"
-weight: 10
+weight: 25
 type: "docs"
 description: "Explanation of how we manage shared secrets, authentication, and authorization throughout the Viam system."
 ---


### PR DESCRIPTION
Said different things in two different tickets as far as where to put it so I just did this. Seems weird to put it above product overviews so I put it below them but in plain sight in /docs/.