### PR TITLE
Modified headings CSS for mobile.

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -226,9 +226,6 @@ END MARKETING CSS
     }
 }
 
-
-
-
 /* color: sets the text color in the alert*/
 /* background: sets the background color in the alert*/
 /* border-color: sets the color of the LH border in the alert*/


### PR DESCRIPTION
Removed excess newlines
removed non-working css for old notes/cautions/warnings/ poc

Headings shrink at 576px.