### PR TITLE
Update SDK-as-server.md

### DIFF
--- a/docs/product-overviews/SDK-as-server.md
+++ b/docs/product-overviews/SDK-as-server.md
@@ -38,11 +38,6 @@ You can view the complete tutorial on how to create a custom component in Python
 
 You can view more component implementation examples in <file>components.py</file>, found in the <a href="https://github.com/viamrobotics/viam-python-sdk/blob/main/examples/server/v1/components.py" target="_blank">Viam Python SDK repo</a>[^compsamp].
 
+[^API Reference]:Viam Python SDK Component Reference: <a href="https://python.viam.dev/autoapi/viam/components/index.html" target="_blank">ht<span></span>tps://python.viam.dev/autoapi/viam/components/index.html</a>
+
 [^compsamp]:<file>components.py</file>: <a href="https://github.com/viamrobotics/viam-python-sdk/blob/main/examples/server/v1/components.py" target="_blank">ht<span></span>tps://github.com/viamrobotics/viam-python-sdk/blob/main/examples/server/v1/components.py</a>
-
-
-
-[You can find the API reference here.](https://python.viam.dev/autoapi/viam/components/index.html)
-
-
-<span></span>


### PR DESCRIPTION
Fixed formatting on API reference footnote.

before:
<img width="614" alt="Screen Shot 2022-10-19 at 11 37 32 AM" src="https://user-images.githubusercontent.com/4650739/196753606-74d2f197-c142-49f7-995e-bd32a0052b5e.png">

After:
<img width="645" alt="Screen Shot 2022-10-19 at 11 43 55 AM" src="https://user-images.githubusercontent.com/4650739/196753635-301bfacd-5bb6-41eb-b636-c020902dc02e.png">

<img width="645" alt="Screen Shot 2022-10-19 at 11 46 18 AM" src="https://user-images.githubusercontent.com/4650739/196753673-7846871c-8c27-4fba-b5fc-b930439e191f.png">
