### PR TITLE
copied navbar-version-selector.html to docs site partials.

### DIFF
--- a/layouts/partials/navbar-version-selector.html
+++ b/layouts/partials/navbar-version-selector.html
@@ -1,0 +1,12 @@
+<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+	{{ .Site.Params.version_menu }}
+</a>
+<div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+	{{ $path := "" }}
+	{{ if .Site.Params.version_menu_pagelinks }}
+		{{ $path = .Page.RelPermalink }}
+	{{ end }}
+	{{ range .Site.Params.versions }}
+	<a class="dropdown-item" href="{{ .url }}{{ $path }}">{{ .version }}</a>
+	{{ end }}
+</div>


### PR DESCRIPTION
(replaced angle brackets with dashes so they'd stop rendering here)
-!--- Removed the {{.url}} so we could use this to link to sdk docs. Hugo was prepending the docsite url to the sdk url --- 
!-- - a class="dropdown-item" href="{{ .url }}{{ $path }}" ->{{ .version }} -</a - ---

This is the line being used:
-  a class="dropdown-item" href="{{ $path }}"  - {{ .version }}- /a  -

Note: This can’t be verified outside of prod. Hugo doesn’t build the sdk url the same way in local mode. To verify before merging: Run, “Hugo” to build the html locally inside public/. Open index.html. Verify that the SDK link on ~L.69 is correct. It should be: https:/python.viam.dev/