### PR TITLE
Dad 156 add a note that the webgamepad component must be called web gamepad

### DIFF
--- a/docs/components/input-controller.md
+++ b/docs/components/input-controller.md
@@ -104,7 +104,7 @@ This allows a gamepad to be connected remotely, via a browser and the html5 Game
 
 ### Config
 {{% alert="Note" color="note" %}}
-You **must** use "WebGamePad" as the `name` of the web gamepad controller. This restriction will be removed in the future.
+You **must** use "WebGamepad" as the `name` of the web gamepad controller. This restriction will be removed in the future.
 {{% /alert %}}
 
 


### PR DESCRIPTION
Added a caution concerning the literal naming of the WebGamePad controller.