### PR TITLE
Created file as a replacement H2 Implementation section.

### DIFF
--- a/static/include/implementation.md
+++ b/static/include/implementation.md
@@ -1,0 +1,3 @@
+## Implementation
+* [Python SDK Documentation](https://python.viam.dev/autoapi/viam/components/arm/index.html)
+* [Go SDK Documentation](https://pkg.go.dev/go.viam.com/rdk/robot/client#section-readme)


### PR DESCRIPTION
To use, replace the whole implementation section (including heading) with the include shortcode referencing static/include/implementation.md. Now we'll only need to update one file to update sdk links at the page bottom.

![image](https://user-images.githubusercontent.com/110131669/199570118-7ab4c2e4-db30-4001-ab87-9a849fddbccf.png)
