### PR TITLE
DAD-174: Added Python and Golang tabbed code blocks

### DIFF
--- a/docs/tutorials/how-to-build-a-mock-robot.md
+++ b/docs/tutorials/how-to-build-a-mock-robot.md
@@ -343,7 +343,7 @@ Now that you have your mock sub-part connected as a remote to your main mock rob
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-To control your motor sub-part, you will need to import the [MotorClient](https://python.viam.dev/autoapi/viam/components/motor/client/index.html). Paste this at the top of your file:
+To control your motor sub-part, you will need to import the [Motor Client](https://python.viam.dev/autoapi/viam/components/motor/client/index.html). Paste this at the top of your file:
 
 ```python
 from viam.components.motor import MotorClient
@@ -351,6 +351,8 @@ from viam.components.motor import MotorClient
 
 {{% /tab %}}
 {{% tab name="Golang" %}}
+
+To control your motor sub-part, you will need to import the [Motor Client](https://github.com/viamrobotics/rdk/blob/main/components/motor/client.go). Paste this at the top of your file:
 
 ```go
 import (


### PR DESCRIPTION
Updates:
* Added Go and Python support
* Changed verbiage to support multiple SDKs
* Changed images to an image HTML tag so I could control its size on the page
* Updated to relative links

Ticket: https://viam.atlassian.net/browse/DAD-174?atlOrigin=eyJpIjoiMTUyYjA4ZDRmNTYyNGJlMGFhYTU0YTUwZWU2Y2UwZjAiLCJwIjoiaiJ9

Page Preview: https://docs-test.viam.dev/884ac04a6f80b3f4b1cb239a8c7aaa5d635382d2/public/tutorials/how-to-build-a-mock-robot/