### PR TITLE
DAD-188: Added Go and Python examples to Board Component

### DIFF
--- a/docs/components/board.md
+++ b/docs/components/board.md
@@ -330,4 +330,4 @@ Name | Type | Default Value | Description
 
 ## Implementation
 
-See the [example code above](#getting-started-with-gpio-and-the-viam-sdk) to get started, and also check out our more complete [Python SDK Documentation](https://python.viam.dev/autoapi/viam/components/board/board/index.html)
+See the [example code above](#getting-started-with-gpio-and-the-viam-sdk) to get started, and also check out our more complete [Python SDK Documentation](https://python.viam.dev/autoapi/viam/components/board/board/index.html).


### PR DESCRIPTION
Added Python and Go code to the GPIO section of the board doc.

Ticket: https://viam.atlassian.net/browse/DAD-188

Preview: https://docs-test.viam.dev/eb273a553dd15842999d0e2671b6bbe3b37e0730/public/components/board/

![Screenshot 2022-11-10 at 4 08 36 PM](https://user-images.githubusercontent.com/4650739/201216318-1d7c74e5-0e89-44e1-b75e-bfeee43dfead.png)
