### PR TITLE
[bug] Closing an open code tag on mock robot tutorial

### DIFF
--- a/docs/tutorials/build-a-mock-robot.md
+++ b/docs/tutorials/build-a-mock-robot.md
@@ -315,7 +315,7 @@ You can do this by going to **CONFIG** and then going to the **NETWORK** tab. He
 {
     "bind_address": "localhost:8081"
 }
-
+```
 
 Be sure to save before continuing.
 


### PR DESCRIPTION
Preview: https://docs-test.viam.dev/98b0b79fc690545ee7ccc352ad226f794fdf78ba/public/tutorials/build-a-mock-robot/

Before:
![Screenshot 2022-11-10 at 4 38 31 PM](https://user-images.githubusercontent.com/4650739/201221056-a7527436-1c19-4e42-8e69-ac2fd0ac6c6e.png)

After:
![Screenshot 2022-11-10 at 4 40 28 PM](https://user-images.githubusercontent.com/4650739/201221235-92e3db27-bfd2-4cf7-b29f-5c1158a4e461.png)