### PR TITLE
DAD-198: Added Markdownlint.yaml file

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -12,21 +12,5 @@ MD024:
   # Only check sibling headings
   siblings_only: true
 
-# MD025/single-title/single-h1 - Multiple top-level headings in the same document
-MD025:
-  # Heading level
-  level: 1
-  # RegExp for matching title in front matter
-  front_matter_title: "^\\s*title\\s*[:=]"
-
 # MD033/no-inline-html - Inline HTML
-MD033:
-  # Allowed elements
-  allowed_elements: ["img", "ol", "a", "tr", "td", "code", "table", "thead", "tbody", "th", "blockquote"]
-
-# MD041/first-line-heading/first-line-h1 - First line in a file should be a top-level heading
-MD041:
-  # Heading level
-  level: 1
-  # RegExp for matching title in front matter
-  front_matter_title: "^\\s*title\\s*[:=]"
+MD033: false


### PR DESCRIPTION
Added the default Markdown Linter, but modified these options based on testing. A couple of them are Front Matter specific options. Let me know if you have any issues with this.

MD013/line-length - Line length
MD013: false

MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
MD024:
  Only check sibling headings
  siblings_only: true

MD033/no-inline-html - Inline HTML
MD033: false
