### PR TITLE
remove the word `types` from descriptions

### DIFF
--- a/docs/components/arm.md
+++ b/docs/components/arm.md
@@ -3,7 +3,7 @@ title: "Arm Component"
 linkTitle: "Arm"
 weight: 10
 type: "docs"
-description: "Explanation of arm types, configuration, and usage in Viam."
+description: "Explanation of arm configuration and usage in Viam."
 # SME: Peter L
 ---
 

--- a/docs/components/board.md
+++ b/docs/components/board.md
@@ -3,7 +3,7 @@ title: "Board Component"
 linkTitle: "Board"
 weight: 20
 type: "docs"
-description: "Explanation of board types, configuration, and usage in Viam."
+description: "Explanation of board configuration and usage in Viam."
 # SMEs: Gautham, Rand
 ---
 In the Viam framework, a **board** is the signal wire hub of a robot.

--- a/docs/components/camera.md
+++ b/docs/components/camera.md
@@ -3,7 +3,7 @@ title: "Camera Component"
 linkTitle: "Camera"
 weight: 40
 type: "docs"
-description: "Explanation of camera types, configuration, and usage in Viam."
+description: "Explanation of camera configuration and usage in Viam."
 # SMEs: Bijan, Maxim
 ---
 A Viam Camera is a source of 2D and/or 3D images (e.g. a webcam, lidar, time-of-flight sensor, etc). A single image is returned from the camera upon request, and images can be streamed continuously from the camera by using systems that do fast, repeated requests. 

--- a/docs/components/encoder.md
+++ b/docs/components/encoder.md
@@ -3,7 +3,7 @@ title: "Encoder Component"
 linkTitle: "Encoder"
 weight: 50
 type: "docs"
-description: "Explanation of encoder types, configuration, and usage in Viam."
+description: "Explanation of encoder configuration and usage in Viam."
 # SME: Rand
 ---
 An encoder is a device that is used to sense angular position, direction and/or speed of rotation.

--- a/docs/components/gantry.md
+++ b/docs/components/gantry.md
@@ -4,7 +4,7 @@ linkTitle: "Gantry"
 draft: false
 weight: 50
 type: "docs"
-description: "Explanation of gantry types, configuration, and usage in Viam."
+description: "Explanation of gantry configuration and usage in Viam."
 # SME: Rand
 ---
 

--- a/docs/components/gripper.md
+++ b/docs/components/gripper.md
@@ -4,7 +4,7 @@ linkTitle: "Gripper"
 weight: 60
 draft: true
 type: "docs"
-description: "Explanation of gripper types, configuration, and usage in Viam."
+description: "Explanation of gripper configuration and usage in Viam."
 ---
 This will look similar to the [motor doc](../motor/), but describing how to wire up and configure a gripper.
 

--- a/docs/components/motor.md
+++ b/docs/components/motor.md
@@ -3,7 +3,7 @@ title: "Motor Component"
 linkTitle: "Motor"
 weight: 70
 type: "docs"
-description: "Explanation of motor types, configuration, and usage in Viam."
+description: "Explanation of motor configuration and usage in Viam."
 # SME: Rand, Jessamy
 ---
 {{% alert title="Note" color="note" %}}

--- a/docs/components/movement-sensor.md
+++ b/docs/components/movement-sensor.md
@@ -3,7 +3,7 @@ title: "Movement Sensor Component"
 linkTitle: "Movement Sensor"
 weight: 70
 type: "docs"
-description: "Explanation of movement sensor types, configuration, and usage in Viam."
+description: "Explanation of movement sensor configuration and usage in Viam."
 # SME: Rand
 ---
 The movement sensor component is an abstraction of a sensor that gives data on where a robot is and how fast it is moving.

--- a/docs/components/pose-tracker.md
+++ b/docs/components/pose-tracker.md
@@ -4,7 +4,7 @@ linkTitle: "Pose Tracker"
 weight: 80
 type: "docs"
 draft: true
-description: "Explanation of pose tracker types, configuration, and usage in Viam."
+description: "Explanation of pose tracker configuration and usage in Viam."
 ---
 # Coming soon!
 This will look similar to the [motor doc](../motor/), but describing how to wire up and configure a pose tracker.

--- a/docs/components/sensor.md
+++ b/docs/components/sensor.md
@@ -4,7 +4,7 @@ linkTitle: "Sensor"
 weight: 70
 draft: false
 type: "docs"
-description: "Explanation of sensor types, configuration, and usage in Viam."
+description: "Explanation of sensor configuration and usage in Viam."
 # SME: #team-bucket
 ---
 This page explains how to set up a generic sensor component with Viam.


### PR DESCRIPTION
Was inaccurate as each of these docs documents a single component type. We could replace the word "types" with "models," but some component docs only describe a single model, so I think deleting it is better.