### PR TITLE
DAD-183 add extra param notes to motion

### DIFF
--- a/docs/services/motion.md
+++ b/docs/services/motion.md
@@ -170,7 +170,7 @@ Behaviour is by no means guaranteed to be stable.
 
 ### Linear Constraint
 
-The linear constraint (`{“motion_profile”: “linear”}`) forces the path taken by `component_name` to follow an exact linear path from the start to the goal
+The linear constraint (`{“motion_profile”: “linear”}`) forces the path taken by `component_name` to follow an exact linear path from the start to the goal.
 If the start and goal orientations are different, the orientation along the path will follow the quaternion Slerp (Spherical Linear Interpolation) of the orientation from start to goal.
 This has the following sub-options:
 


### PR DESCRIPTION
Added a bunch of missing newlines so the actual changes to look at are:

- Line 30: added "(experimental)"
- Line 166-169: added a note about experimental extra params (thanks Peter for suggested wording)
- Line 164: tweaked punctuation

This shouldn't necessarily be the same note that is in the SLAM docs because it's not the extra param itself that isn't stable, but rather the arguments passed to it and their functionality, as I understand it. If we really want it to match the SLAM docs maybe we could say "The motion profile constraints passed via the `extra` parameter are experimental features. Stability is not guaranteed. Breaking changes are likely to occur, and occur often." Dunno if it matters.