### PR TITLE
Added notes on converting from gDocs to Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ## Dependencies
 
 * npm
-  * Install 16 (LTS) via <https://nodejs.org/en/download/>.
+  * Install 16 (LTS) via [https://nodejs.org/en/download/](https://nodejs.org/en/download/).
 
 * Hugo
   * macOS/Linux: `brew install hugo`
-  * Windows: <https://gohugo.io/getting-started/installing/>
+  * Windows: [https://gohugo.io/getting-started/installing/](https://nodejs.org/en/download/)
 
 ## Local Development
 
@@ -22,7 +22,7 @@
 
 ## Building
 
-This will build and serve public from a separate, non-hugo server, at <http://localhost:9000>.
+This will build and serve `/public` from a separate, non-Hugo server, at [http://localhost:9000](http://localhost:9000).
 
 `make build-prod && python3 -m http.server 9000 --directory public`
 
@@ -60,7 +60,7 @@ When you are ready to contribute changes to the docs:
 ### Converting from Google Docs to Markdown
 
 1. Export your Google Document as `.docx` file. Go to "File" -> "Download as" -> "Microsoft Word (.docx)".
-2. Use [pandoc](https://pandoc.org/) to convert to markdown and export media to a directory. Here's an example command:
+2. Use [Pandoc](https://pandoc.org/) to convert to markdown and export media to a directory. Here's an example command:
 
    ```bash
    pandoc --wrap=preserve --extract-media ./ NAME_OF_YOUR_DOCUMENT.docx -o NAME_OF_YOUR_DOCUMENT.md
@@ -82,7 +82,7 @@ Be sure that you have the [markdownlint VS Code extension](https://marketplace.v
 
 ### Front Matter
 
-```mardown
+```markdown
 ---
 title: "Build a line-following robot with only a rover and a webcam"
 linkTitle: "Line Follower"
@@ -99,9 +99,9 @@ description: "Instructions for building a line-following robot that uses a webca
 
 ### Linking
 
-When linking to an image or another page in markdown, it's best to use a relative link. For example, if you were writing in `getting-started/high-level-overview.md`, hugo sees this as a directory on the site of `docs.viam.com/getting-started/high-level-overview/`.
+When linking to an image or another page in markdown, it's best to use a relative link. For example, if you were writing in `getting-started/high-level-overview.md`, Hugo sees this as a directory on the site of `docs.viam.com/getting-started/high-level-overview/`.
 
-* To link to another markdown file in the same directory as the markdown file, you would do e.g. `[mylink](../installation/)`. **Note the trailing slash as another markdown file is another web directory in hugo**
+* To link to another markdown file in the same directory as the markdown file, you would do e.g. `[mylink](../installation/)`. **Note the trailing slash as another markdown file is another web directory in Hugo**
 * To link to some image in the same directory as the markdown file, you would do e.g. `[mylink](../img/image1.png)`.
 * To link something in a different directory, you would do e.g. `[mylink](../../components/)`
 
@@ -109,22 +109,22 @@ When linking to an image or another page in markdown, it's best to use a relativ
 
 Add “Draft=true” to the Front Matter to set the page to Draft. Hugo will not build draft pages into production. You can commit and push the page and it won’t display in production. This could let you push the page to Main without displaying it in production, but let others access it locally from the git tree without changing the branch. To view the page locally, use `make serve-prod-draft` or `make serve-dev-draft`.
 
-Add “Future=true” to the Front Matter to begin building a page to production on a certain date (e.g., a release date). This allows you to add a page in the production system and only display it from a selected date using Hugo's buildFuture build option in config.toml and the Future=true. To view the page locally prior to the date, use `make serve-prod-future` or `make serve-dev-future`.
+Add “Future=true” to the Front Matter to begin building a page to production on a certain date (e.g., a release date). This allows you to add a page in the production system and only display it from a selected date using Hugo's `buildFuture` build option in `config.toml` and the `Future=true`. To view the page locally prior to the date, use `make serve-prod-future` or `make serve-dev-future`.
 
 #### Other Setup/Config Information
 
-**LH Nav Menu**
+##### LH Nav Menu
 
 Hugo builds the TOC from the pages under docs/. Because our docs use Page Bundles, each directory contains an _index.html file that serves as a landing page into that section. The following image is the_index.html page inside Getting Started:
-<p id="gdcalert2" ><span style="color: red; font-weight: bold">>>>>>  gd2md-html alert: inline image link here (to images/image2.png). Store image on your image server and adjust path/filename/extension if necessary. </span><br>(<a href="#">Back to top</a>)(<a href="#gdcalert3">Next alert</a>)<br><span style="color: red; font-weight: bold">>>>>> </span></p>
+<p id="gdcalert2" ><span style="color: red; font-weight: bold">>>>>>  gd2md-html alert: inline image link here (to images/image2.png). Store images on your image server and adjust path/filename/extension if necessary. </span><br>(<a href="#">Back to top</a>)(<a href="#gdcalert3">Next alert</a>)<br><span style="color: red; font-weight: bold">>>>>> </span></p>
 
 Hugo creates a section in the menu and applies the directory name as the page title for _index.html. Hugo lists all the pages in that section and can also display the descriptions (lead-in paragraph) beneath each link (if I can remember the setting).
 
-**Top Banner Drop-Downs**
+##### Top Banner Drop-Downs
 
 Hugo can build drop-downs for the top banner based on the settings contained in the config.toml file. The content can be pages or links. We aren’t using them yet.
 
-**RH Menu**
+##### RH Menu
 
 This menu is a list of page sections and also has items to print or open a doc issue (not implemented in JIRA yet - We need Eric’s help to add this and feedback).
 
@@ -132,7 +132,7 @@ This menu is a list of page sections and also has items to print or open a doc i
 
 There are two kinds: index.html and _index.html. The index.html works just as you’d expect. The_index.html is found inside page bundles, which are no more than a self-contained directory having the markdown files and image files under the same directory. We’re using_index.html files.
 The_index.html file act as a landing page into the page bundle (i.e., directory). It lists the page title of each page in the bundle (you can have many pages) and can also display the lead-in paragraph (i.e., the description from the Front Matter) for the page.
-The formatting works identically to MkDocs: it’s still markdown. But Hugo is better at handling basic html and the extra html that we need for some layout tasks. So now list indenting works as expected.
+The formatting works identically to MkDocs: it’s still markdown. But Hugo is better at handling basic HTML and the extra HTML that we need for some layout tasks. So now list indenting works as expected.
 
 ### Footnotes
 


### PR DESCRIPTION
Updates:
* Ran the README file through our linter for consistency.
* Added notes on how to use [Pandoc](https://pandoc.org/) to convert a Google Doc into a markdown file.

I would love to hear your feedback on how to improve this workflow.