### PR TITLE
DAD-280 tighten up Try Viam tutorial

### DIFF
--- a/docs/getting-started/try-viam.md
+++ b/docs/getting-started/try-viam.md
@@ -13,16 +13,19 @@ Watch the tutorial video below for a quick walkthrough of Try Viam, including ho
 
 ## Getting Started with Viam
 
-When you try Viam for the first time, you'll want to get a feel for how it works. The best way to do that is to take over a Viam Rover in our robotics lab for 15 minutes. You'll be able to drive the robot around, see what it sees, and control its sensors and actuators. You could try things like:
+When you try Viam for the first time, you'll want to get a feel for how it works.
+The best way to do that is to take over a Viam Rover in our robotics lab for 15 minutes.
+You'll be able to drive the robot around, see what it sees, and control its sensors and actuators.
+You could try things like:
 
 - Teleoperating the rover from wherever you are!
 - Writing some code to control the rover
 - Using services like computer vision or data management
-- See how the rover's components are set up in the intuitive configuration interface
+- Seeing how the rover's components are set up in the intuitive configuration interface
 
 Find more detailed instructions in our [Try Viam tutorial](/tutorials/try-viam/).
 
-For a limited time, you can pre-order your own Viam Rover [here](http://viam.com/resources/rover?utm_source=slack&utm_medium=social&utm_campaign=try-viam).
+For a limited time, you can [pre-order your own Viam Rover here](http://viam.com/resources/rover?utm_source=slack&utm_medium=social&utm_campaign=try-viam).
 
 ## Getting started with the SDKs
 

--- a/docs/tutorials/try-viam.md
+++ b/docs/tutorials/try-viam.md
@@ -10,8 +10,8 @@ tags: ["try viam", "app"]
 _Try Viam_ is a way to try out the Viam platform without setting up any hardware yourself.
 You can take over a Viam Rover in our robotics lab for 15 minutes to play around!
 
-This tutorial will guide you through controlling a Viam rover.
-The Viam rover is made up of a chassis with a Raspberry Pi single board computer, two motors, encoders, and a camera.
+This tutorial will guide you through controlling a Viam Rover.
+The rental rover is made up of a chassis with a Raspberry Pi 4B single board computer, two motors, encoders, and a camera.
 The Try Viam area also has an overhead camera to provide a view of the rental rover, allowing you to view its movements in real time.
 
 ## Using the reservation system
@@ -278,7 +278,7 @@ The system provides an alert when your session is over.
 
 Your rover rental location now contains your robot with the final configuration from the now ended session.
 
-## Connecting to a Viam rover with the Viam SDK
+## Connecting to a Viam Rover with the Viam SDK
 
 You can write your own code to control the Viam robot using Viam's SDKs.
 Learn how to use a Viam SDK to make the Viam Rover drive in a square in our [using the Viam SDK to control your Viam Rover tutorial](/tutorials/try-viam-sdk/).


### PR DESCRIPTION

- Various rewordings, corrections and small reorganizations
- Removed lots of the images of the try viam landing page UI since that should be self-explanatory
- Removed lots of information from the motor config section since this tutorial is about using Try Viam, not about how to configure a Viam rover you bought yourself. I think more could come out still but wasn't sure.
- Moved encoder up to before motors since the motor configuration requires the encoders to be configured first ([DAD-288](https://viam.atlassian.net/browse/DAD-288?atlOrigin=eyJpIjoiMGMzNGEyODI5YTVjNDM5ZGE2YTJlZGQzN2EzMmVkNWEiLCJwIjoiaiJ9))
- Added a brief section on the board configuration panel
- Removed the bit about how to install SDKs since that's included in the linked tutorial
- Added some alt text
- Added a link from the try viam overview page to this tutorial
- Added a link to preorder your own in the Next Steps section

Note on depends-on:
Currently, the Try Viam rover config contains a lot of "depends_on" configuration that isn't necessary because most dependencies are now implicit (i.e. if a motor has a "board" attribute, it doesn't also need a depends_on "board" configured). Product is interested in updating this soon. That's why I took out some depends_on stuff here.

Note on images:
If these changes are approved, I'll make a separate PR to remove unused images, rename the remaining ones with more descriptive names instead of "image#", and add more alt text.