### PR TITLE
DAD-291 make top of pi setup doc less confusing

### DIFF
--- a/docs/installation/rpi-setup.md
+++ b/docs/installation/rpi-setup.md
@@ -18,7 +18,7 @@ This tutorial requires the following hardware:
 * An internet-connected computer
 * A way to connect the microSD card to the computer (e.g., microSD slot or microSD reader)
 
-{{% alert title="Tip" color="tip" %}}
+{{% alert title="Note" color="note" %}}
 
 If you already have a 64-bit Linux distrubution installed on your Pi, you can skip ahead to [installing viam-server](#follow-the-steps-on-the-setup-tab).
 To check whether the Linux installation on your Raspberry Pi is 64-bit (required for running viam-server):


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/DAD-291?atlOrigin=eyJpIjoiM2JiNDhlMWE5MTIzNGNiZGJlZmExMjc0MDI0OTZhZmMiLCJwIjoiaiJ9

RE the part about not knowing what SSH'ing is, if someone already has a pi with Linux on it hopefully they either know that already, can google it, or will click to where we describe it later in the doc. I didn't want to get into a description of SSH'ing on what should be a brief sidenote but open to suggestions if there's a concise way to handle that feedback!

Rendered comparison:
![image](https://user-images.githubusercontent.com/75634662/210118688-512cea51-1760-44bc-b8c7-a9a1ea884def.png)
