### PR TITLE
make navigation doc a draft

### DIFF
--- a/docs/services/navigation.md
+++ b/docs/services/navigation.md
@@ -2,6 +2,7 @@
 title: "Navigation Service"
 linkTitle: "Navigation"
 weight: 30
+draft: true
 type: "docs"
 description: "Explanation of the navigation service, its configuration, and its functionality."
 tags: ["navigation", "services"]


### PR DESCRIPTION
since it doesn't contain any useful information and we don't link to it from anywhere else in the docs anyway