### PR TITLE
Continue markdown lint GH Action even on fail

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   markdown_lint:
     name: Check Markdown files
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
`continue-on-error: true` will continue the tests even on fail.

Here are the GH docs: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast