### PR TITLE
fix broken camera link

### DIFF
--- a/docs/components/camera.md
+++ b/docs/components/camera.md
@@ -62,7 +62,7 @@ Follow the <a href="https://github.com/viam-labs/camera-calibration" target="_bl
 ### Webcam
 
 `webcam` is a model that streams the camera data from a camera connected to the hardware.
-See our [How to Configure a Camera](/tutorials/configure-a-camera.md/) tutorial for a guide to configuring webcams.
+See our [How to Configure a Camera](/tutorials/configure-a-camera/) tutorial for a guide to configuring webcams.
 
 {{% alert title="Note" color="note"%}}
 In Viam parlance, webcams are standard, USB camera devices.


### PR DESCRIPTION
Link from camera component doc to webcam configuration tutorial was broken. This should fix.