### PR TITLE
Improve components landing page

### DIFF
--- a/docs/components/camera/_index.md
+++ b/docs/components/camera/_index.md
@@ -3,7 +3,7 @@ title: "Camera Component"
 linkTitle: "Camera"
 weight: 40
 type: "docs"
-description: "Explanation of camera configuration and usage in Viam."
+description: "Explanation of cameras (including webcams, depth cameras, and lidar) in Viam."
 tags: ["camera", "components"]
 # SMEs: Bijan, vision team
 ---

--- a/docs/components/movement-sensor.md
+++ b/docs/components/movement-sensor.md
@@ -3,7 +3,7 @@ title: "Movement Sensor Component"
 linkTitle: "Movement Sensor"
 weight: 70
 type: "docs"
-description: "Explanation of movement sensor configuration and usage in Viam."
+description: "Explanation of movement sensors (including GPS and IMU) in Viam."
 tags: ["movement sensor", "gps", "imu", "sensor", "components"]
 # SME: Rand
 ---


### PR DESCRIPTION
https://docs.viam.com/components/ pulls its descriptions from the description field of each component doc. they should probably be thoughtfully re-written at some point. here's a hasty fix to better surface components that folks ask if we support.