### PR TITLE
DOCS-352: Add wifi to pi install doc

### DIFF
--- a/docs/installation/prepare/rpi-setup.md
+++ b/docs/installation/prepare/rpi-setup.md
@@ -204,7 +204,7 @@ The steps are explained below.
 
 3. Save the file and eject the microSD card.
 
-4. Put the microSD card back into the Pi and boot the Pi. 
+4. Put the microSD card back into the Pi and boot the Pi.
 
 The `wpa_supplicant.conf` file will be read by the Pi on boot, and the file will disappear but the Wifi credentials will be updated.
 


### PR DESCRIPTION
Adding the additional Wifi credentials section to the Pi install docs