### PR TITLE
Take ordered list rule out of linter

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -16,6 +16,9 @@ MD024:
   # Only check sibling headings
   siblings_only: true
 
+# List numbering
+MD029: false
+
 # MD033/no-inline-html - Inline HTML
 MD033: false
 


### PR DESCRIPTION
since it's causing problems due to the indented alert formatting bug