### PR TITLE
Fix typos in rpi setup doc

### DIFF
--- a/docs/installation/prepare/rpi-setup.md
+++ b/docs/installation/prepare/rpi-setup.md
@@ -21,15 +21,15 @@ This tutorial requires the following hardware:
 
 {{% alert title="Note" color="note" %}}
 
-If you already have a 64-bit Linux distrubution installed on your Pi, you can skip ahead to [installing viam-server](/installation/install/linux-install/).
+If you already have a 64-bit Linux distribution installed on your Pi, you can skip ahead to [installing viam-server](/installation/install/linux-install/).
 To check whether the Linux installation on your Raspberry Pi is 64-bit (required for running viam-server):
 
 `ssh` into your Pi and then run `lscpu`.
 Example output:
 
-![Screenshot of a terminal running the "lscpu" command. The output lists of this command on a Raspbery Pi. A red box highlights the command and the top of the output which reads "Architecture: aarch64."](/installation/img/rpi-setup/lscpu-output.png)
+![Screenshot of a terminal running the "lscpu" command. The output lists of this command on a Raspberry Pi. A red box highlights the command and the top of the output which reads "Architecture: aarch64."](/installation/img/rpi-setup/lscpu-output.png)
 
-If the value of “Architecture: _'xxxxxx'_” ends in "64", you can skip ahead to [installing viam-server](/installation/install/linux-install/).
+If the value of “Architecture: _'xxxxxx'_” ends in "64", you can skip ahead to [installing `viam-server`](/installation/install/linux-install/).
 
 {{% /alert %}}
 
@@ -52,7 +52,7 @@ You should be greeted with a window that looks like:
 ![Raspberry Pi Imager launcher window showing a "Choose OS" and "Choose Storage" buttons.](/installation/img/rpi-setup/imager-launch-screen.png)
 
 Select `CHOOSE OS`.
-Since you need a 64-bit version of Linux, you will need to select it from the `Rapsberry Pi OS (other)` menu.
+Since you need a 64-bit version of Linux, you will need to select it from the `Raspberry Pi OS (other)` menu.
 
 ![Raspberry Pi Imager window showing "Raspberry Pi OS (Other) is selected.](/installation/img/rpi-setup/select-other-custom-os.png)
 
@@ -104,7 +104,7 @@ In the past, malware infected thousands of Raspberry Pi devices that were using 
 Source: <a href="https://www.zdnet.com/article/linux-malware-enslaves-raspberry-pi-to-mine-cryptocurrency/" target="_blank">ht<span></span>tps://www.zdnet.com/article/linux-malware-enslaves-raspberry-pi-to-mine-cryptocurrency/</a>
 {{< /alert >}}
 
-Lastly, you should connect your Pi to Wi-Fi, so that you can run viam-server wirelessly.
+Lastly, you should connect your Pi to Wi-Fi, so that you can run `viam-server` wirelessly.
 Check `Configure wireless LAN` and enter your wireless network credentials.
 SSID (short for Service Set Identifier) is your Wi-Fi network name, and password is the network password.
 Change the section `Wireless LAN country` to where your router is currently being operated and then hit save:
@@ -135,7 +135,7 @@ After granting permissions to the Imager, it will begin writing and then verifyi
 
 Remove the microSD card from your computer when it is complete:
 
-![You will be notified with a dialouge box informing you that Raspberry Pi OS Lite has been written successfully."](/installation/img/rpi-setup/imager-done.png)
+![You will be notified with a dialogue box informing you that Raspberry Pi OS Lite has been written successfully."](/installation/img/rpi-setup/imager-done.png)
 
 Place the SD card into your Raspberry Pi and boot the Pi by plugging it in to an outlet.
 A red LED will turn on to indicate that the Pi is connected to power.
@@ -230,4 +230,4 @@ priority=20
 
 ## Next Steps
 
-Now that your Pi has a Viam-compatible operating system installed, and you learned how to enable specific communication protocols and add additional Wifi credentials, continue to our [viam-server installation guide](/installation/install/).
+Now that your Pi has a Viam-compatible operating system installed, and you learned how to enable specific communication protocols and add additional Wifi credentials, continue to our [`viam-server` installation guide](/installation/install/).


### PR DESCRIPTION
Counting the ways we spell "raspberry" :D and changed viam-server -> `viam-server` while I was at it