### PR TITLE
Tweak motor config builder image widths

### DIFF
--- a/docs/components/motor/dmc4000.md
+++ b/docs/components/motor/dmc4000.md
@@ -26,7 +26,7 @@ Example configuration for a stepper motor controlled by a DMC-40x0 motion contro
 {{< tabs >}}
 {{% tab name="Config Builder" %}}
 
-<img src="../../img/motor/dmc4000-config-ui.png" alt="Screenshot of a DMC4000 motor config with the attributes configured per the Raw JSON on the next tab in this doc." style="max-width:800px;width:100%" >
+<img src="../../img/motor/dmc4000-config-ui.png" alt="Screenshot of a DMC4000 motor config with the attributes configured per the Raw JSON on the next tab in this doc." style="max-width:900px;width:100%" >
 
 {{% /tab %}}
 {{% tab name="Raw JSON" %}}

--- a/docs/components/motor/gpiostepper.md
+++ b/docs/components/motor/gpiostepper.md
@@ -24,7 +24,7 @@ Here’s an example of a basic stepper driver config:
 {{< tabs name="gpiostepper-config">}}
 {{% tab name="Config Builder" %}}
 
-<img src="../../img/motor/gpiostepper-config-ui.png" alt="Screenshot of a gpiostepper motor config with the step and dir pins configured to pins 13 and 15, respectively." style="max-width:800px;width:100%" >
+<img src="../../img/motor/gpiostepper-config-ui.png" alt="Screenshot of a gpiostepper motor config with the step and dir pins configured to pins 13 and 15, respectively." style="max-width:900px;width:100%" >
 
 {{% /tab %}}
 {{% tab name="Raw JSON" %}}

--- a/docs/components/motor/tmc5072.md
+++ b/docs/components/motor/tmc5072.md
@@ -23,7 +23,7 @@ An example configuration for a `tmc5072` motor driver and the [board](/component
 {{< tabs >}}
 {{% tab name="Config Builder" %}}
 
-![Config panel for a TMC5072 motor with attributes filled in according to the Raw JSON tab.](../../img/motor/tmc5072-config-ui.png)
+<img src="../../img/motor/tmc5072-config-ui.png" alt="Config panel for a TMC5072 motor with attributes filled in according to the Raw JSON tab." style="max-width:900px;width:100%">
 
 {{% /tab %}}
 {{% tab name="Raw JSON" %}}


### PR DESCRIPTION
TMC needed a max width, and I realized some of these are pretty small if limited to 800px