### PR TITLE
remove encoded motor link fragment

### DIFF
--- a/docs/components/motor/gpio/encoded-motor.md
+++ b/docs/components/motor/gpio/encoded-motor.md
@@ -142,6 +142,6 @@ Name | Type | Description
 ## Wiring Example
 
 Here's an example of an encoded DC motor wired with [the MAX14870 Single Brushed DC Motor Driver Carrier](https://www.pololu.com/product/2961).
-This wiring example corresponds to the [example config above](#encoder-config).
+This wiring example corresponds to the example config above.
 
 ![motor-encoded-dc-wiring](../../../img/motor/motor-encoded-dc-wiring.png)


### PR DESCRIPTION
Noticed this was failing my check on DOCS-496 quickfix & realized the subsection doesn't exist in merged doc.

not sure why this seems to have passed before now, but I think the link fragment must have used to be a subsection?