### PR TITLE
DOCS-574: make frame system description match

### DIFF
--- a/docs/services/frame-system.md
+++ b/docs/services/frame-system.md
@@ -1,7 +1,7 @@
 ---
 title: "The Robot Frame System"
 linkTitle: "Frame System"
-description: "Explanation of the Robot Frame System service, its configuration, and its functionality."
+description: "Explanation of the Frame System service, its configuration, and its functionality."
 type: docs
 weight: 45
 tags: ["frame system", "services"]


### PR DESCRIPTION
* tiny pr to make text boxes in https://docs.viam.com/services/ follow same format 