### PR TITLE
DOCS-419: add code style on fake arm sentences

### DIFF
--- a/docs/components/arm/fake.md
+++ b/docs/components/arm/fake.md
@@ -89,7 +89,8 @@ Refer to the following JSON examples for differences in configuration between th
 {{% /tab %}}
 {{< /tabs >}}
 
-Once you have successfully configured your `fake` arm, you can navigate to the **CONTROL** tab of [the Viam app](https://app.viam.com). A drop-down menu should appear with the name of your arm that allows you to toggle the fake arm's joint positions and Cartesian end positions to dynamically test motion planning:
+Once you have successfully configured your `fake` arm, you can navigate to the **CONTROL** tab of [the Viam app](https://app.viam.com).
+A drop-down menu should appear with the name of your arm that allows you to toggle the fake arm's joint positions and Cartesian end positions to dynamically test motion planning:
 
 <img src="../img/fake-arm-ui-remote-control.png" alt="Motion planning remote-control of a fake ur5e arm in the Viam app control tab." style="max-width:800px" />
 


### PR DESCRIPTION
* quickfix, realized code formatting wasn't coming out properly on 2 words inside tabs after merging 419