### PR TITLE
Define list order weights of data vs fleet

### DIFF
--- a/docs/manage/data-management/_index.md
+++ b/docs/manage/data-management/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Data Management"
 linkTitle: "Data Management"
-weight: 30
+weight: 40
 no_list: true
 type: "docs"
 tags: ["data management", "data", "services"]


### PR DESCRIPTION
Fleet and data both have a weight of 30, but data shows up first (at least sometimes?). I just want to not leave it to chance, and have fleet show up above data since I think logically that makes sense. Can swap the other way around if people disagree.