### PR TITLE
DOCS-583: remove pi

### DIFF
--- a/docs/viam/_index.md
+++ b/docs/viam/_index.md
@@ -29,7 +29,7 @@ Join the [**Viam community**](https://discord.gg/viam) to collaborate during pla
 
 ## Get started
 
-A *robot* in Viam consists of at least one computer, like a [Raspberry Pi](https://www.raspberrypi.com/documentation/computers/raspberry-pi.html) single-board computer, running `viam-server` and communicating with any hardware connected to it by signaling through digital data pins.
+A *robot* in Viam consists of at least one computer, typically a [single-board computer](/installation/prepare/), running `viam-server` and communicating with any hardware connected to it by signaling through digital data pins.
 
 <img src="img/board-viam-server.png" alt="A diagram of a single-board computer running viam-server." style="float: left; max-width:270px; display: block; margin: auto 20px auto auto"></img>
 


### PR DESCRIPTION
* linked to prepare instead of pi
* note that changed wording from "like to" to "typically", think that makes sense w/ wiring description? 