### PR TITLE
Make it clearer that you don't need a Viam rover to use Viam

### DIFF
--- a/docs/try-viam/rover-resources/_index.md
+++ b/docs/try-viam/rover-resources/_index.md
@@ -11,7 +11,7 @@ description: Get your own Viam rover and set it up.
 ---
 
 {{< alert title="Tip" color="tip" >}}
-If you want to try Viam, you can [order your own Viam rover](https://www.viam.com/resources/rover) now.
+If you want a convenient mobile base for a variety of robotics projects, you can [order your own Viam rover](https://www.viam.com/resources/rover) now.
 {{< /alert >}}
 
 <div class="container td-max-width-on-larger-screens">


### PR DESCRIPTION
Other suggestions for what this should say are welcome, but I think that the current phrasing makes it sound like the only way to use Viam is to buy a Viam rover