### PR TITLE
DOCS-608 - add zendesk chat

### DIFF
--- a/docs/components/servo.md
+++ b/docs/components/servo.md
@@ -215,7 +215,7 @@ If you are using a continuous rotation servo, you can use the `Move` command, bu
 
 The speed will be related to the "angle" you pass in as a linear approximation.
 90 degrees represents stop, 91 to 180 represents counter-clockwise rotation from slowest to fastest, and 89 to 1 represents clockwise from slowest to fastest.  
-You will need to determine from your hardware which "angle" represents your desired speed.
+It is recommended that you test your servo to determine desired speed.
 
 {{% /alert %}}
 

--- a/docs/components/servo.md
+++ b/docs/components/servo.md
@@ -214,8 +214,8 @@ Move the servo to the desired angle in degrees.
 If you are using a continuous rotation servo, you can use the `Move` command, but instead of moving to a given position, the servo will start moving at a set speed.
 
 The speed will be related to the "angle" you pass in as a linear approximation.
-90 degrees represents stop, 91 to 180 represents counter-clockwise rotation from slowest to fastest, and 89 to 1 represents clockwise from slowest to fastest.
-It is recommended that you test your servo to determine the desired speed.
+90 degrees represents stop, 91 to 180 represents counter-clockwise rotation from slowest to fastest, and 89 to 1 represents clockwise from slowest to fastest.  
+You will need to determine from your hardware which "angle" represents your desired speed.
 
 {{% /alert %}}
 

--- a/docs/components/servo.md
+++ b/docs/components/servo.md
@@ -215,7 +215,7 @@ If you are using a continuous rotation servo, you can use the `Move` command, bu
 
 The speed will be related to the "angle" you pass in as a linear approximation.
 90 degrees represents stop, 91 to 180 represents counter-clockwise rotation from slowest to fastest, and 89 to 1 represents clockwise from slowest to fastest.  
-It is recommended that you test your servo to determine desired speed.
+It is recommended that you test your servo to determine the desired speed.
 
 {{% /alert %}}
 

--- a/docs/tutorials/integrating-viam-with-openai.md
+++ b/docs/tutorials/integrating-viam-with-openai.md
@@ -271,7 +271,7 @@ To use ElevenLabs, add your ElevenLabs API key to `run.sh` as follows:
 export ELEVENLABS_KEY=mykey
 ```
 
-You can then assign voices to Rosey or any characters by adding the Elevenlabs voice name (including names of voices you have created with the [ElevenLabs VoiceLab](https://beta.elevenlabs.io/voice-lab)) in params.py.
+You can then assign voices to Rosey or any characters by adding the ElevenLabs voice name (including names of voices you have created with the [ElevenLabs VoiceLab](https://beta.elevenlabs.io/voice-lab)) in <file>params.py</file>.
 For example:
 
 ``` json

--- a/docs/tutorials/integrating-viam-with-openai.md
+++ b/docs/tutorials/integrating-viam-with-openai.md
@@ -271,7 +271,7 @@ To use ElevenLabs, add your ElevenLabs API key to `run.sh` as follows:
 export ELEVENLABS_KEY=mykey
 ```
 
-You can then assign voices to Rosey or any characters by adding the ElevenLabs voice name (including names of voices you have created with the [ElevenLabs VoiceLab](https://beta.elevenlabs.io/voice-lab)) in <file>params.py</file>.
+You can then assign voices to Rosey or any characters by adding the Elevenlabs voice name (including names of voices you have created with the [ElevenLabs VoiceLab](https://beta.elevenlabs.io/voice-lab)) in params.py.
 For example:
 
 ``` json

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -47,6 +47,9 @@
 
 {{/* To comply with GDPR, cookie consent scripts places in head-end must execute before Google Analytics is enabled */ -}}
 {{ if hugo.IsProduction -}}
+  <!-- Start of viam Zendesk Widget script -->
+  <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=6fb554be-87df-42b2-8d8f-bed8df3f886f">
+  </script> <!-- End of viam Zendesk Widget script -->
   {{ if hasPrefix .Site.GoogleAnalytics "G-" -}}
     {{ template "_internal/google_analytics.html" . -}}
   {{ else -}}


### PR DESCRIPTION
@npentrel - note that this is on the right side of the screen.  It could in some cases cover the jump to top of doc widget.  I think if we need to adjust it to go to the bottom left, we may have to make a change in Zendesk settings: https://support.zendesk.com/hc/en-us/articles/4408828059546-Customizing-the-appearance-of-your-chat-widget

I tested on mobile, it is very easy to scroll to the point where it is not covering the "jump up", so I am not too concerned with launching like this (Charlotte is hoping to do so late AM) and we could decide to change it later...
