### PR TITLE
fix mislabel in i2c configuration

### DIFF
--- a/docs/components/board.md
+++ b/docs/components/board.md
@@ -360,7 +360,7 @@ The attributes section of a board using SPI will contain the following:
 Name | Type | Default Value | Description
 -------------- | ---- | ------------- | ---------------
 |`name`| string|--| Choose a name for the SPI bus. Note that a component that uses this bus must then have this same name configured in its attributes.
-|`bus_select`| string|--| A Raspberry Pi has two SPI buses: `0` and `1`. See data sheet for specifics on other boards.
+|`bus_select`| string|--| A Raspberry Pi has two SPI buses: `0` and `1`. See your board's data sheet for specifics on its SPI wiring.
 
 #### I2C
 

--- a/docs/components/board.md
+++ b/docs/components/board.md
@@ -360,7 +360,7 @@ The attributes section of a board using SPI will contain the following:
 Name | Type | Default Value | Description
 -------------- | ---- | ------------- | ---------------
 |`name`| string|--| Choose a name for the SPI bus. Note that a component that uses this bus must then have this same name configured in its attributes.
-|`bus_select`| string|--| A Raspberry Pi has two SPI buses: 0 and 1. See data sheet for specifics on other boards.
+|`bus_select`| string|--| A Raspberry Pi has two SPI buses: `0` and `1`. See data sheet for specifics on other boards.
 
 #### I2C
 
@@ -388,8 +388,8 @@ Review the [instructions in our documentation](/installation/prepare/rpi-setup/#
 
 Name | Type | Default Value | Description
 -------------- | ---- | ------------- | ---------------
-|`name`| string|--| Choose a name for the SPI bus. Note that a component that uses this bus must then have this same name configured in its attributes.
-|`bus`| string|--| Usually a number such as 1. See board data sheet for specifics on its I2C wiring. Raspberry Pi recommends using bus 1.
+|`name`| string|--| Choose a name for the I2C bus. Note that a component that uses this bus must then have this same name configured in its attributes.
+|`bus`| string|--| Usually a number. Raspberry Pi recommends using bus `1`. See your board's data sheet for specifics on its I2C wiring.
 
 ## Implementation
 


### PR DESCRIPTION
this should soon be refactored anyways but thought i'd fix for now!

* change SPI bus to I2C bus (assume was copy/pasted)
* add code styling to values