### PR TITLE
Add padding to top of tabbed content

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -624,6 +624,7 @@ td > ul, td > ol {
 }
 
 .tab-content {
+  padding-top: .7rem;
   border-top: 1px solid black;
   border-bottom: 1px solid black;
 }

--- a/docs/installation/_index.md
+++ b/docs/installation/_index.md
@@ -146,7 +146,7 @@ If you do not want to run `viam-server` as a service, you can also [run it manua
 </li>
 </ol>
 
-1. **Connect and configure.** Go to the **SETUP** page on the Viam app and wait for confirmation that your robot has successfully connected.
+3. **Connect and configure.** Go to the **SETUP** page on the Viam app and wait for confirmation that your robot has successfully connected.
 
 {{% /tab %}}
 {{% tab name="macOS"%}}

--- a/docs/installation/_index.md
+++ b/docs/installation/_index.md
@@ -87,8 +87,6 @@ Once you have a compatible operating system on your computer, you are ready to i
 {{< tabs name="Detailed Installation Instructions" >}}
 {{% tab name="Linux"%}}
 
-<br>
-
 `viam-server` is distributed as an AppImage.
 The AppImage is a single, self-contained binary that runs on any Linux system (except FUSE) with the correct CPU architecture, with no need to install any dependencies.
 
@@ -109,8 +107,6 @@ The AppImage is a single, self-contained binary that runs on any Linux system (e
 {{< tabs name="different-architectures" >}}
 {{% tab name="Aarch64"%}}
 
-<br>
-
 Stable:
 
 ```bash
@@ -127,8 +123,6 @@ curl http://packages.viam.com/apps/viam-server/viam-server-latest-aarch64.AppIma
 
 {{% /tab %}}
 {{% tab name="X86_64"%}}
-
-<br>
 
 Stable:
 
@@ -152,12 +146,10 @@ If you do not want to run `viam-server` as a service, you can also [run it manua
 </li>
 </ol>
 
-3. **Connect and configure.** Go to the **SETUP** page on the Viam app and wait for confirmation that your robot has successfully connected.
+1. **Connect and configure.** Go to the **SETUP** page on the Viam app and wait for confirmation that your robot has successfully connected.
 
 {{% /tab %}}
 {{% tab name="macOS"%}}
-
-<br>
 
 `viam-server` is available for macOS users through [Homebrew](https://docs.brew.sh/Installation).
 


### PR DESCRIPTION
This way we won't have to manually add a `<br>` at the top of every tab.

Before:
<img width="636" alt="image" src="https://user-images.githubusercontent.com/75634662/229258076-2e62a11b-61d9-4123-8464-e82b3ef1be6b.png">

<img width="656" alt="image" src="https://user-images.githubusercontent.com/75634662/229258229-0364ec87-4bb4-4126-8124-4bfa2dfab244.png">

After:
<img width="645" alt="image" src="https://user-images.githubusercontent.com/75634662/229258299-ce33aa1e-4727-45ee-b62b-936c31b8a0f3.png">

<img width="657" alt="image" src="https://user-images.githubusercontent.com/75634662/229258254-1fb7a562-6281-42e2-9fc1-1a76a8ca0f3b.png">
