### PR TITLE
Update run-slam-cartographer.md

### DIFF
--- a/docs/services/slam/run-slam-cartographer.md
+++ b/docs/services/slam/run-slam-cartographer.md
@@ -152,7 +152,7 @@ At this point, your complete configuration should look like:
     "modules": [
       {
         "name": "rplidar_module",
-        "executable_path": "/home/<YOUR_USERNAME>/rplidar-module-local-aarch64.AppImage"
+        "executable_path": "/usr/local/bin/rplidar-module"
       }
     ],
     "components": [
@@ -181,7 +181,7 @@ At this point, your complete configuration should look like:
           ],
           "port": "localhost:8083",
           "data_dir": "/home/<YOUR_USERNAME>/<CARTOGRAPHER_DIR>",
-          "map_rate_sec": 60,
+          "map_rate_sec": 60
         },
         "model": "cartographer",
         "name": "run-slam"


### PR DESCRIPTION
# Description

The Rplidar docs https://docs.viam.com/program/extend/modular-resources/add-rplidar-module/ say to install rplidar-module in `/usr/local/bin` on Linux. But the carographer sample config is currently pointing to `/home/<YOUR_USERNAME>/rplidar-module-local-aarch64.AppImage`. This is confusing and forces the user to edit the sample config.

This also removes a trailing comma