### PR TITLE
fix typos in Jetson Orin documentation

### DIFF
--- a/docs/installation/prepare/jetson-agx-orin-setup.md
+++ b/docs/installation/prepare/jetson-agx-orin-setup.md
@@ -75,9 +75,9 @@ If this command fails, try using `wget http://packages.viam.com/apps/viam-server
 
 | Data Sheet ID | GPIO Header Pin | Viam Bus ID | `jetson-io.py` ID | `/dev` Path ID | Notes |
 | ------------- | --------------- | ----------- | ----------------- | ----------- | ----- |
-| I2C_GP2_DAT, I2C_GP2_CLK | 3, 5 | `1` | `i2c2` | `dev/i2c2` | |
-| I2c_GP5_DAT, I2C_GP5_CLK | 27, 28 | `7` | `i2c8` | `dev/i2c8` | |
-| SPI1_DOUT, SPI1_DIN, SPI1_SCK, SPI1_CS0, SPI1_CS1 | 19, 21, 23, 24, 26 | `0` | `spi1` | `dev/spi1` | Must be enabled, must add `spidev` to `/etc/modules` |
+| I2C_GP2_DAT, I2C_GP2_CLK | 3, 5 | `7` | `i2c2` | `/dev/i2c-2` | |
+| I2c_GP5_DAT, I2C_GP5_CLK | 27, 28 | `1` | `i2c8` | `/dev/i2c-8` | |
+| SPI1_DOUT, SPI1_DIN, SPI1_SCK, SPI1_CS0, SPI1_CS1 | 19, 21, 23, 24, 26 | `0` | `spi1` | `/dev/spidev0.0`, `/dev/spidev0.1` | Must be enabled, must add `spidev` to `/etc/modules` |
 
 ## Troubleshooting
 

--- a/docs/installation/prepare/jetson-agx-orin-setup.md
+++ b/docs/installation/prepare/jetson-agx-orin-setup.md
@@ -76,7 +76,7 @@ If this command fails, try using `wget http://packages.viam.com/apps/viam-server
 | Data Sheet ID | GPIO Header Pin | Viam Bus ID | `jetson-io.py` ID | `/dev` Path ID | Notes |
 | ------------- | --------------- | ----------- | ----------------- | ----------- | ----- |
 | I2C_GP2_DAT, I2C_GP2_CLK | 3, 5 | `7` | `i2c2` | `/dev/i2c-2` | |
-| I2c_GP5_DAT, I2C_GP5_CLK | 27, 28 | `1` | `i2c8` | `/dev/i2c-8` | |
+| I2C_GP5_DAT, I2C_GP5_CLK | 27, 28 | `1` | `i2c8` | `/dev/i2c-8` | |
 | SPI1_DOUT, SPI1_DIN, SPI1_SCK, SPI1_CS0, SPI1_CS1 | 19, 21, 23, 24, 26 | `0` | `spi1` | `/dev/spidev0.0`, `/dev/spidev0.1` | Must be enabled, must add `spidev` to `/etc/modules` |
 
 ## Troubleshooting


### PR DESCRIPTION
The docs didn't quite match up with the Jetson Orin on my desk:
- Pins 3 and 5 are I2C bus 7, as shown by plugging something into those pins and running `i2cdetect -y -a -r 7`
- Pins 27 and 28 are I2C bus 1, as shown by an analogous check.
- I did _not_ swap the I2C `jetson-io.py` IDs, since they look correct (based on running `jetson-io.py` myself).
- The SPI bus is number 0, as found by reading from an ADC plugged into it. I'm happy to share my config if you want; setting this up is more complicated than I'd prefer.
- Things in the `/dev` column should start with slashes, to show that they're absolute paths.
- I changed the device names to the nearest things that actually exist in `/dev`. Are those the right devices? I'm unsure; our code doesn't interact with them directly. but they're the devices that exist on my Orin which are the closest to what was already in the docs, and I trust whoever wrote the previous version. 

I've never made a PR in this repo before. Once it's merged, what else do I need to do to get it deployed?