### PR TITLE
DOCS-673: fix executable path in SLAM docs

### DIFF
--- a/docs/program/extend/modular-resources/add-rplidar-module.md
+++ b/docs/program/extend/modular-resources/add-rplidar-module.md
@@ -78,6 +78,12 @@ Now, add the Rplidar as a modular component of your robot in the [Viam app](http
 
   ```json
   {
+    "modules": [
+      {
+        "executable_path": "/Users/<YOUR_USERNAME>/Library/Caches/Homebrew/rplidar-module--git",
+        "name": "rplidar_module"
+      }
+    ],
     "components": [
       {
         "namespace": "rdk",
@@ -88,12 +94,6 @@ Now, add the Rplidar as a modular component of your robot in the [Viam app](http
           "device_path": "/dev/tty.SLAB_USBtoUART"
         },
         "name": "rplidar"
-      }
-    ],
-    "modules": [
-      {
-        "executable_path": "/usr/local/bin/rplidar-module",
-        "name": "rplidar_module"
       }
     ]
   }

--- a/docs/program/extend/modular-resources/add-rplidar-module.md
+++ b/docs/program/extend/modular-resources/add-rplidar-module.md
@@ -80,7 +80,7 @@ Now, add the Rplidar as a modular component of your robot in the [Viam app](http
   {
     "modules": [
       {
-        "executable_path": "/Users/<YOUR_USERNAME>/Library/Caches/Homebrew/rplidar-module--git",
+        "executable_path": "/usr/local/bin/rplidar-module",
         "name": "rplidar_module"
       }
     ],

--- a/docs/program/extend/modular-resources/add-rplidar-module.md
+++ b/docs/program/extend/modular-resources/add-rplidar-module.md
@@ -55,6 +55,12 @@ Now, add the Rplidar as a modular component of your robot in the [Viam app](http
 
   ```json
   {
+    "modules": [
+      {
+        "executable_path": "/usr/local/bin/rplidar-module",
+        "name": "rplidar-module"
+      }
+    ],
     "components": [
       {
         "namespace": "rdk",
@@ -62,12 +68,6 @@ Now, add the Rplidar as a modular component of your robot in the [Viam app](http
         "depends_on": [],
         "model": "viam:lidar:rplidar",
         "name": "rplidar"
-      }
-    ],
-    "modules": [
-      {
-        "executable_path": "/usr/local/bin/rplidar-module",
-        "name": "rplidar-module"
       }
     ]
   }

--- a/docs/services/slam/_index.md
+++ b/docs/services/slam/_index.md
@@ -217,7 +217,7 @@ To run Cartographer in live mode, follow [these instructions](../../program/exte
 {
   "modules": [
     {
-      "executable_path": "/Users/<YOUR_USERNAME>/Library/Caches/Homebrew/rplidar-module--git",
+      "executable_path": "/usr/local/bin/rplidar-module",
       "name": "rplidar_module"
     }
   ],

--- a/docs/services/slam/_index.md
+++ b/docs/services/slam/_index.md
@@ -172,7 +172,7 @@ To run Cartographer in live mode, follow [these instructions](../../program/exte
   "modules": [
     {
       "name": "rplidar_module",
-      "executable_path": "/home/<YOUR_USERNAME>/rplidar-module-local-aarch64.AppImage"
+      "executable_path": "/usr/local/bin/rplidar-module"
     }
   ],
   "components": [
@@ -215,6 +215,12 @@ To run Cartographer in live mode, follow [these instructions](../../program/exte
 
 ``` json
 {
+  "modules": [
+    {
+      "executable_path": "/Users/<YOUR_USERNAME>/Library/Caches/Homebrew/rplidar-module--git",
+      "name": "rplidar_module"
+    }
+  ],
   "components": [
     {
       "namespace": "rdk",
@@ -248,12 +254,6 @@ To run Cartographer in live mode, follow [these instructions](../../program/exte
       "model": "cartographer",
       "name": "run-slam",
       "type": "slam"
-    }
-  ],
-  "modules": [
-    {
-      "executable_path": "/Users/<YOUR_USERNAME>/rplidar/bin/rplidar-module",
-      "name": "rplidar_module"
     }
   ]
 }

--- a/docs/services/slam/run-slam-cartographer.md
+++ b/docs/services/slam/run-slam-cartographer.md
@@ -197,7 +197,7 @@ At this point, your complete configuration should look like:
   {
     "modules": [
       {
-        "executable_path": "/Users/<YOUR_USERNAME>/Library/Caches/Homebrew/rplidar-module--git",
+        "executable_path": "/usr/local/bin/rplidar-module",
         "name": "rplidar_module"
       }
     ],

--- a/docs/services/slam/run-slam-cartographer.md
+++ b/docs/services/slam/run-slam-cartographer.md
@@ -195,6 +195,12 @@ At this point, your complete configuration should look like:
 
   ``` json
   {
+    "modules": [
+      {
+        "executable_path": "/Users/<YOUR_USERNAME>/Library/Caches/Homebrew/rplidar-module--git",
+        "name": "rplidar_module"
+      }
+    ],
     "components": [
       {
         "namespace": "rdk",
@@ -222,18 +228,12 @@ At this point, your complete configuration should look like:
             "max_range": "12"
           },
           "port": "localhost:8083",
-          "data_dir": "/Users/<YOUR_USERNAME>/<CARTOGRAPHER_DIR<",
+          "data_dir": "/Users/<YOUR_USERNAME>/<CARTOGRAPHER_DIR>",
           "delete_processed_data": false
         },
         "model": "cartographer",
         "name": "run-slam",
         "type": "slam"
-      }
-    ],
-    "modules": [
-      {
-        "executable_path": "/Users/<YOUR_USERNAME>/rplidar/bin/rplidar-module",
-        "name": "rplidar_module"
       }
     ]
   }


### PR DESCRIPTION
* Fixed issue on linux tabs
* macOS needs SME validation, this is what I found when I tested on MacOS