### PR TITLE
DOCS-480: align cameras with other components

### DIFF
--- a/docs/components/camera/align-color-depth-extrinsics.md
+++ b/docs/components/camera/align-color-depth-extrinsics.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure an Align Color Depth Extrinsics View"
-linkTitle: "Align Color Depth Extrinsics"
+linkTitle: "align_color_depth_extrinsics"
 weight: 38
 type: "docs"
 description: "Use the intrinsics of the color and depth camera, as well as the extrinsic pose between them, to align two images."
@@ -75,17 +75,17 @@ Fill in the attributes for your align color depth extrinsics view:
 {{% /tab %}}
 {{< /tabs >}}
 
-The following attributes are available for align color depth extrinsics views:
+The following attributes are available for `align_color_depth_extrinsics` views:
 
 | Name | Inclusion | Description |
 | ---- | --------- | ----------- |
-| `camera_system` | *Required* | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>color_intrinsic_parameters</code>: The model uses the color camera intrinsics to project the 3D points to a 2D depth map, but "as if" it was taken from the POV of the color camera. </li> <li> <code>depth_intrinsic_parameters</code>: The model uses the depth camera intrinsics to de-project the 2D depth points to 3D points, from the point of view of the depth camera. </li> <li> <code>depth_to_color_extrinsic_parameters</code>: The model uses the extrinsic parameters to shift the 3D depth points to be from the POV of the color camera. </li> </ul> |
-| `intrinsic_parameters` | *Required* | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
-| `output_image_type` | *Required* | Specify `color` or `depth` for the output stream. |
-| `color_camera_name` | *Required* | Name of the color camera to pull images from. |
-| `depth_camera_name` | *Required* | Name of the depth camera to pull images from. |
-| `distortion_parameters` | *Optional* | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
-| `debug` | *Optional* | Enables the debug outputs from the camera if `true`. Defaults to `false`. |
+| `camera_system` | **Required** | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>color_intrinsic_parameters</code>: The model uses the color camera intrinsics to project the 3D points to a 2D depth map, but "as if" it was taken from the POV of the color camera. </li> <li> <code>depth_intrinsic_parameters</code>: The model uses the depth camera intrinsics to de-project the 2D depth points to 3D points, from the point of view of the depth camera. </li> <li> <code>depth_to_color_extrinsic_parameters</code>: The model uses the extrinsic parameters to shift the 3D depth points to be from the POV of the color camera. </li> </ul> |
+| `intrinsic_parameters` | **Required** | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
+| `output_image_type` | **Required** | Specify `color` or `depth` for the output stream. |
+| `color_camera_name` | **Required** | `name` of the color camera to pull images from. |
+| `depth_camera_name` | **Required** | `name` of the depth camera to pull images from. |
+| `distortion_parameters` | Optional | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
+| `debug` | Optional | Enables the debug outputs from the camera if `true`. <br> Default: `false`. |
 
 ## View the camera stream
 

--- a/docs/components/camera/align-color-depth-homography.md
+++ b/docs/components/camera/align-color-depth-homography.md
@@ -65,7 +65,7 @@ Fill in the attributes for your align color depth homography view:
 {{% /tab %}}
 {{< /tabs >}}
 
-The following attributes are available for `align_color_depth_homograph` views:
+The following attributes are available for `align_color_depth_homography` views:
 
 | Name | Inclusion | Description |
 | ---- | --------- | ----------- |

--- a/docs/components/camera/align-color-depth-homography.md
+++ b/docs/components/camera/align-color-depth-homography.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure an Align Color Depth Homography View"
-linkTitle: "Align Color Depth Homography"
+linkTitle: "align_color_depth_homography"
 weight: 38
 type: "docs"
 description: "Use a homography matrix to align the color and depth images."
@@ -65,17 +65,17 @@ Fill in the attributes for your align color depth homography view:
 {{% /tab %}}
 {{< /tabs >}}
 
-The following attributes are available for align color depth homography views:
+The following attributes are available for `align_color_depth_homograph` views:
 
 | Name | Inclusion | Description |
 | ---- | --------- | ----------- |
-| `intrinsic_parameters` | *Required* | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
-| `homography` | *Required* | Parameters that morph the depth points to overlay the color points and align the images: <ul> <li> <code>transform</code>: 9 floats representing the 3x3 homography matrix of the depth to color, or color to depth camera. </li> <li> <code>depth_to_color</code>: Whether to transform depth camera points to color camera points. </li> <li> <code>rotate_depth_degs</code>: Degrees by which to rotate the depth camera image. </li> </ul> |
-| `color_camera_name` | *Required* | Name of the color camera to pull images from. |
-| `depth_camera_name` | *Required* | Name of the depth camera to pull images from. |
-| `output_image_type` | *Required* | Specify `color` or `depth` for the output stream. |
-| `distortion_parameters` | *Optional* | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
-| `debug` | *Optional* | Enables the debug outputs from the camera if `true`. Defaults to `false`. |
+| `intrinsic_parameters` | **Required** | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
+| `homography` | **Required** | Parameters that morph the depth points to overlay the color points and align the images: <ul> <li> <code>transform</code>: 9 floats representing the 3x3 homography matrix of the depth to color, or color to depth camera. </li> <li> <code>depth_to_color</code>: Whether to transform depth camera points to color camera points. </li> <li> <code>rotate_depth_degs</code>: Degrees by which to rotate the depth camera image. </li> </ul> |
+| `color_camera_name` | **Required** | `name` of the color camera to pull images from. |
+| `depth_camera_name` | **Required** | `name` of the depth camera to pull images from. |
+| `output_image_type` | **Required** | Specify `color` or `depth` for the output stream. |
+| `distortion_parameters` | Optional | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
+| `debug` | Optional | Enables the debug outputs from the camera if `true`. <br> Default: `false` |
 
 ## View the camera stream
 

--- a/docs/components/camera/calibrate.md
+++ b/docs/components/camera/calibrate.md
@@ -1,7 +1,7 @@
 ---
 title: "Calibrate a Camera"
 linkTitle: "Calibrate a Camera"
-weight: 50
+weight: 80
 type: "docs"
 description: "Calibrate a camera and extract the intrinsic and distortion parameters."
 tags: ["camera", "components"]

--- a/docs/components/camera/dual-stream.md
+++ b/docs/components/camera/dual-stream.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure a Dual Stream Camera"
-linkTitle: "Dual Stream"
+linkTitle: "dual_stream"
 weight: 37
 type: "docs"
 description: "Combine the streams of two camera servers to create colorful point clouds."
@@ -59,16 +59,16 @@ Fill in the attributes for dual stream camera:
 {{% /tab %}}
 {{< /tabs >}}
 
-The following attributes are available for dual stream cameras views:
+The following attributes are available for `dual_stream` cameras views:
 
 | Name | Inclusion | Description |
 | ---- | --------- | ----------- |
-| `intrinsic_parameters` | *Optional* | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
-| `distortion_parameters` | *Optional* | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
-| `stream` | *Required* | `color` or `depth`. The image to be returned when you call `Next()` or `NextPointCloud()`. |
-| `debug` | *Optional* | Enables the debug outputs from the camera if `true`. Defaults to `false`. |
-| `color_url` | *Required* | The color stream url. |
-| `depth_url` | *Required* | The depth stream url. |
+| `stream` | **Required** | `color` or `depth`. The image stream to return when you call `Next()` or `NextPointCloud()`. |
+| `color_url` | **Required** | The color stream url. |
+| `depth_url` | **Required** | The depth stream url. |
+| `intrinsic_parameters` | Optional | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
+| `distortion_parameters` | Optional | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
+| `debug` | Optional | Enables the debug outputs from the camera if `true`. <br> Default: `false` |
 
 ## View the camera stream
 

--- a/docs/components/camera/fake.md
+++ b/docs/components/camera/fake.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure a Fake Camera"
-linkTitle: "Fake"
+linkTitle: "fake"
 weight: 35
 type: "docs"
 description: Configure a camera to use for testing."
@@ -46,12 +46,12 @@ Fill in the attributes for your join color depth view:
 {{% /tab %}}
 {{< /tabs >}}
 
-The following attributes are available for fake cameras:
+The following attributes are available for `fake` cameras:
 
 | Name | Inclusion | Description |
 | ---- | --------- | ----------- |
-| `width` | *Optional* | The width of the image in pixels. The default resolution is 1280 x 720. If you specify either width or height, the image gets scaled to preserve 16:9 aspect ratio. You cannot specify both `width` and `height`. |
-| `height` | *Optional* | The width of the image in pixels. The default resolution is 1280 x 720. If you specify either width or height, the image gets scaled to preserve 16:9 aspect ratio. You cannot specify both `width` and `height` |
+| `width` | Optional | The width of the image in pixels. The default resolution is 1280 x 720. If you specify either width or height, the image gets scaled to preserve 16:9 aspect ratio. You cannot specify both `width` and `height`. |
+| `height` | Optional | The width of the image in pixels. The default resolution is 1280 x 720. If you specify either width or height, the image gets scaled to preserve 16:9 aspect ratio. You cannot specify both `width` and `height` |
 
 ## View the camera stream
 

--- a/docs/components/camera/ffmpeg.md
+++ b/docs/components/camera/ffmpeg.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure a FFmpeg Camera"
-linkTitle: "FFmpeg"
+linkTitle: "ffmpeg"
 weight: 30
 type: "docs"
 description: "Uses a camera, a video file, or a stream as a camera."
@@ -65,17 +65,17 @@ Fill in the attributes for your ffmpeg camera:
 {{% /tab %}}
 {{< /tabs >}}
 
-The following attributes are available for ffmpeg cameras:
+The following attributes are available for `ffmpeg` cameras:
 
 | Name | Inclusion | Description |
 | ---- | --------- | ----------- |
-| `intrinsic_parameters` | *Optional* | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
-| `distortion_parameters` | *Optional* | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
-| `debug` | *Optional* | Enables the debug outputs from the camera if `true`. Defaults to `false`. |
-| `video_path` | *Required* | The file path to the color image. |
-| `input_kw_args` | *Optional* | The input keyword arguments. |
-| `filters` | *Optional* | The file path to the depth image. Array of filter objects that specify: <ul> <li> <code>name</code>: The name of the filter. </li> <li> <code>args</code>: The arguments for the filter. </li> <li> <code>kw_args</code>: The kw arugments for the filter ???. </li> </ul> |
-| `output_kw_args` | *Optional* | The output keyword arguments. |
+| `video_path` | **Required** | The file path to the color image. |
+| `intrinsic_parameters` | Optional | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
+| `distortion_parameters` | Optional | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
+| `debug` | Optional | Enables the debug outputs from the camera if `true`. <br> Default: `false` |
+| `input_kw_args` | Optional | The input keyword arguments. |
+| `filters` | Optional | The file path to the depth image. Array of filter objects that specify: <ul> <li> <code>name</code>: The name of the filter. </li> <li> <code>args</code>: The arguments for the filter. </li> <li> <code>kw_args</code>: Any keyword arguments for the filter. </li> </ul> |
+| `output_kw_args` | Optional | The output keyword arguments. |
 
 ## View the camera stream
 

--- a/docs/components/camera/image-file.md
+++ b/docs/components/camera/image-file.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure an Image File Camera"
-linkTitle: "Image File"
+linkTitle: "image_file"
 weight: 31
 type: "docs"
 description: "Configure a camera that gets color or depth images frames from a file path."
@@ -58,15 +58,15 @@ Fill in the attributes for your image file camera:
 {{% /tab %}}
 {{< /tabs >}}
 
-The following attributes are available for image file cameras:
+The following attributes are available for `image_file` cameras:
 
 | Name | Inclusion | Description |
 | ---- | --------- | ----------- |
-| `intrinsic_parameters` | *Optional* | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
-| `distortion_parameters` | *Optional* | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
-| `debug` | *Optional* | Enables the debug outputs from the camera if `true`. Defaults to `false`. |
-| `color_image_file_path` | *Optional* | The file path to the color image. |
-| `depth_image_file_path` | *Optional* | The file path to the depth image. |
+| `intrinsic_parameters` | Optional | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
+| `distortion_parameters` | Optional | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
+| `debug` | Optional | Enables the debug outputs from the camera if `true`. <br> Default: `false` |
+| `color_image_file_path` | Optional | The file path to the color image. |
+| `depth_image_file_path` | Optional | The file path to the depth image. |
 
 You must specify `color_image_file_path` or `depth_image_file_path`.
 

--- a/docs/components/camera/join-color-depth.md
+++ b/docs/components/camera/join-color-depth.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure a Join Color Depth View"
-linkTitle: "Join Color Depth"
+linkTitle: "join_color_depth"
 weight: 39
 type: "docs"
 description: "Combine and align the streams of a color and a depth camera."
@@ -61,16 +61,16 @@ Fill in the attributes for your join color depth view:
 {{% /tab %}}
 {{< /tabs >}}
 
-The following attributes are available for join color depth views:
+The following attributes are available for `join_color_depth` views:
 
 | Name | Inclusion | Description |
 | ---- | --------- | ----------- |
-| `output_image_type` | *Required* | Specify `color` or `depth` for the output stream. |
-| `color_camera_name` | *Required* | Name of the color camera to pull images from. |
-| `depth_camera_name` | *Required* | Name of the depth camera to pull images from. |
-| `intrinsic_parameters` | *Required* | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
-| `distortion_parameters` | *Optional* | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
-| `debug` | *Optional* | Enables the debug outputs from the camera if `true`. Defaults to `false`. |
+| `output_image_type` | **Required** | Specify `color` or `depth` for the output stream. |
+| `color_camera_name` | **Required** | Name of the color camera to pull images from. |
+| `depth_camera_name` | **Required** | Name of the depth camera to pull images from. |
+| `intrinsic_parameters` | **Required** | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
+| `distortion_parameters` | Optional | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
+| `debug` | Optional | Enables the debug outputs from the camera if `true`. <br> Default: `false`. |
 
 ## View the camera stream
 

--- a/docs/components/camera/join-pointclouds.md
+++ b/docs/components/camera/join-pointclouds.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure a Join Point Clouds View"
-linkTitle: "Join Point Clouds"
+linkTitle: "join_pointclouds"
 weight: 40
 type: "docs"
 description: "Combine the point clouds from multiple camera sources and project them to be from the point of view of target_frame."
@@ -59,17 +59,17 @@ Fill in the attributes for your join point clouds view:
 {{% /tab %}}
 {{< /tabs >}}
 
-The following attributes are available for join point clouds views:
+The following attributes are available for `join_pointclouds` views:
 
 | Name | Inclusion | Description |
 | ---- | --------- | ----------- |
-| `target_frame` | *Required* | The frame of reference for the points in the merged point cloud. |
-| `source_cameras` | *Required* | The camera sources to combine. |
+| `target_frame` | **Required** | The frame of reference for the points in the merged point cloud. |
+| `source_cameras` | **Required** | The camera sources to combine. |
 | `proximity_threshold_mm` | *Optional* | Defines the biggest distance 2 points can have in mm to be considered the same point when merged. |
-| `merge_method` | *Optional* | `naive` or `icp`. Defaults to `naive`. |
-| `intrinsic_parameters` | *Required* | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
-| `distortion_parameters` | *Optional* | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
-| `debug` | *Optional* | Enables the debug outputs from the camera if `true`. Defaults to `false`. |
+| `intrinsic_parameters` | **Required** | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
+| `merge_method` | Optional | `naive` or `icp`. Defaults to `naive`. |
+| `distortion_parameters` | Optional | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
+| `debug` | Optional | Enables the debug outputs from the camera if `true`. <br> Default: `false` |
 
 ## View the camera stream
 

--- a/docs/components/camera/rtsp.md
+++ b/docs/components/camera/rtsp.md
@@ -1,6 +1,6 @@
 ---
-title: "Configure an RTSP camera"
-linkTitle: "RTSP"
+title: "Configure an RSTP camera"
+linkTitle: "rstp"
 weight: 34
 type: "docs"
 description: "Configure a streaming camera with an MJPEG track."
@@ -56,13 +56,13 @@ Fill in the attributes for your RTSP camera:
 {{% /tab %}}
 {{< /tabs >}}
 
-The following attributes are available for RTSP cameras:
+The following attributes are available for `rstp` cameras:
 
 | Name | Inclusion | Description |
 | ---- | --------- | ----------- |
-| `rtsp_address` | *Required* | The RTSP address where the camera streams. |
-| `intrinsic_parameters` | *Optional* | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
-| `distortion_parameters` | *Optional* | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
+| `rtsp_address` | **Required** | The RTSP address where the camera streams. |
+| `intrinsic_parameters` | Optional | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
+| `distortion_parameters` | Optional | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
 
 ## View the camera stream
 

--- a/docs/components/camera/rtsp.md
+++ b/docs/components/camera/rtsp.md
@@ -1,6 +1,6 @@
 ---
-title: "Configure an RSTP camera"
-linkTitle: "rstp"
+title: "Configure an RTSP camera"
+linkTitle: "rtsp"
 weight: 34
 type: "docs"
 description: "Configure a streaming camera with an MJPEG track."

--- a/docs/components/camera/rtsp.md
+++ b/docs/components/camera/rtsp.md
@@ -56,7 +56,7 @@ Fill in the attributes for your RTSP camera:
 {{% /tab %}}
 {{< /tabs >}}
 
-The following attributes are available for `rstp` cameras:
+The following attributes are available for `rtsp` cameras:
 
 | Name | Inclusion | Description |
 | ---- | --------- | ----------- |

--- a/docs/components/camera/single-stream.md
+++ b/docs/components/camera/single-stream.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure a Single Stream Camera"
-linkTitle: "Single Stream"
+linkTitle: "single_stream"
 weight: 36
 type: "docs"
 description: "Configure a camera that streams image data from an HTTP endpoint."
@@ -67,15 +67,15 @@ Fill in the attributes for your single stream camera:
 {{% /tab %}}
 {{< /tabs >}}
 
-The following attributes are available for single stream cameras:
+The following attributes are available for `single_stream` cameras:
 
 | Name | Inclusion | Description |
 | ---- | --------- | ----------- |
-| `intrinsic_parameters` | *Optional* | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
-| `distortion_parameters` | *Optional* | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
-| `stream` | *Required* | `color` or `depth`. The image to be returned when you call `Next()` or `NextPointCloud()`. |
-| `debug` | *Optional* | Enables the debug outputs from the camera if `true`. Defaults to `false`. |
-| `url` | *Required* | The color or depth stream url. |
+| `url` | **Required** | The color or depth stream url. |
+| `intrinsic_parameters` | Optional | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
+| `distortion_parameters` | Optional | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
+| `stream` | **Required** | `color` or `depth`. The image to be returned when you call `Next()` or `NextPointCloud()`. |
+| `debug` | Optional | Enables the debug outputs from the camera if `true`. <br> Default: `false` |
 
 If you have a camera that uses its own SDK to access its images and point clouds (like an Intel RealSense camera), you can attach a camera server as a remote component to your robot.
 These remote cameras show up just like regular cameras on your robot.

--- a/docs/components/camera/transform.md
+++ b/docs/components/camera/transform.md
@@ -1,6 +1,6 @@
 ---
 title: "Transform a Camera"
-linkTitle: "Transform a Camera"
+linkTitle: "transform"
 weight: 60
 type: "docs"
 description: "Instructions for transforming a camera."
@@ -9,7 +9,7 @@ tags: ["camera", "components"]
 ---
 
 Use the transform model to apply transformations to input source images.
-The transformations are applied in the order they are written in the pipeline.
+The transformations are applied in the order they are written in the `pipeline`.
 
 {{< tabs name="Example transform view" >}}
 {{% tab name="Config Builder" %}}
@@ -61,17 +61,17 @@ Fill in the attributes for your transform view:
 {{% /tab %}}
 {{< /tabs >}}
 
-The following attributes are available for transform views:
+The following attributes are available for `transform` views:
 
 | Name | Inclusion | Description |
 | ---- | --------- | ----------- |
-| `intrinsic_parameters` | *Optional* | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
-| `distortion_parameters` | *Optional* | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
-| `debug` | *Optional* | Enables the debug outputs from the camera if `true`. Defaults to `false`. |
-| `source` | *Required* | Specify the name of the camera to transform. |
-| `pipeline` | *Required* | Specify and array of transformation objects. |
+| `source` | **Required** | `name` of the camera to transform. |
+| `pipeline` | **Required** | Specify an array of transformation objects. |
+| `intrinsic_parameters` | Optional | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
+| `distortion_parameters` | Optional | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
+| `debug` | Optional | Enables the debug outputs from the camera if `true`. <br> Default: `false` |
 
-The following are the available transformations:
+The following are the transformation objects available for the `pipeline`:
 
 {{< tabs >}}
 {{% tab name="Identity"%}}

--- a/docs/components/camera/velodyne.md
+++ b/docs/components/camera/velodyne.md
@@ -46,7 +46,7 @@ The following attributes are available for `velodyne` cameras:
 
 | Name | Inclusion | Description |
 | ---- | --------- | ----------- |
-| `port` | **Required** | Port the velodyne camera is running on. |
+| `port` | **Required** | The port the Velodyne camera is running on. |
 | `ttl_ms` | **Required** | Frequency in milliseconds to output the [TTL signal](https://en.wikipedia.org/wiki/Transistor%E2%80%93transistor_logic) from the camera. |
 
 ## View the camera stream

--- a/docs/components/camera/velodyne.md
+++ b/docs/components/camera/velodyne.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure a Velodyne Camera"
-linkTitle: "Velodyne"
+linkTitle: "velodyne"
 weight: 32
 type: "docs"
 description: "Configure a camera that uses velodyne lidar."
@@ -42,12 +42,12 @@ Fill in the attributes for your velodyne camera:
 {{% /tab %}}
 {{< /tabs >}}
 
-The following attributes are available for velodyne cameras:
+The following attributes are available for `velodyne` cameras:
 
 | Name | Inclusion | Description |
 | ---- | --------- | ----------- |
-| `port` | *Required* | Specify the port the velodyne camera is running on. |
-| `ttl_ms` | *Required* | Specify the  milliseconds ???. |
+| `port` | **Required** | Port the velodyne camera is running on. |
+| `ttl_ms` | **Required** | Frequency in milliseconds to output the [TTL signal](https://en.wikipedia.org/wiki/Transistor%E2%80%93transistor_logic) from the camera. |
 
 ## View the camera stream
 

--- a/docs/components/camera/webcam.md
+++ b/docs/components/camera/webcam.md
@@ -1,6 +1,6 @@
 ---
 title: "Configure a Webcam"
-linkTitle: "Webcam"
+linkTitle: "webcam"
 weight: 33
 type: "docs"
 description: "Configure a standard camera that streams camera data."
@@ -77,17 +77,17 @@ Use the following configuration and fill in the attributes for your webcam:
 {{% /tab %}}
 {{< /tabs >}}
 
-The following attributes are available for webcams:
+The following attributes are available for `webcam` cameras:
 
 | Name | Inclusion | Description |
 | ---- | --------- | ----------- |
-| `intrinsic_parameters` | *Optional* | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> `width_px`: The expected width of the aligned image in pixels. </li> <li> `height_px`: The expected height of the aligned image in pixels. </li> <li> `fx`: The image center x point. </li> <li> `fy`: The image center y point. </li> <li> `ppx`: The image focal x. </li> <li> `ppy`: The image focal y. </li> </ul> |
-| `distortion_parameters` | *Optional* | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> `rk1`: The radial distortion x. </li> <li> `rk2`: The radial distortion y. </li> <li> `rk3`: The radial distortion z. </li> <li> `tp1`: The tangential distortion x. </li> <li> `tp2`: The tangential distortion y. </li> </ul> |
-| `debug` | *Optional* | Enables the debug outputs from the camera if `true`. Defaults to `false`. |
-| `format` | *Optional* | The camera image format, used with video_path to find camera. |
-| `video_path` | *Optional* | The id of or the path to the webcam. Often `video0`. If you don't provide a `video_path`, it defaults to the first valid video path it finds. Using the id of a webcam is more consistent than the path. |
-| `width_px` | *Optional* | The camera image width in pixels, used with video_path to find camera with this resolution. Defaults to the closest possible value to closest to 480. |
-| `height_px` | *Optional* | The camera image height in pixels, used with video_path to find camera with this resolution. Defaults to the closest possible value to closest to 640. |
+| `intrinsic_parameters` | Optional | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> `width_px`: The expected width of the aligned image in pixels. </li> <li> `height_px`: The expected height of the aligned image in pixels. </li> <li> `fx`: The image center x point. </li> <li> `fy`: The image center y point. </li> <li> `ppx`: The image focal x. </li> <li> `ppy`: The image focal y. </li> </ul> |
+| `distortion_parameters` | Optional | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> `rk1`: The radial distortion x. </li> <li> `rk2`: The radial distortion y. </li> <li> `rk3`: The radial distortion z. </li> <li> `tp1`: The tangential distortion x. </li> <li> `tp2`: The tangential distortion y. </li> </ul> |
+| `debug` | Optional | Enables the debug outputs from the camera if `true`. <br> Default: `false` |
+| `format` | Optional | The camera image format, used with video_path to find camera. |
+| `video_path` | Optional | The id of or the path to the webcam. Often `video0`. If you don't provide a `video_path`, it defaults to the first valid video path it finds. Using the id of a webcam is more consistent than the path. |
+| `width_px` | Optional | The camera image width in pixels, used with `video_path` to find camera with this resolution. <br> Default: Closest possible value to `480` |
+| `height_px` | Optional | The camera image height in pixels, used with `video_path` to find a camera with this resolution. <br> Default: Closest possible value to `640` |
 
 ## View the camera stream
 


### PR DESCRIPTION

* align titles as names-- align & join look ugly but I think it still helps for quick reference alongside ui 
* make required attributes bold vs. all italics, and put on top of table
* <br> defaults> 
* Configuration `name` for JSON when referencing another component 