### PR TITLE
DOCS-480: standardize links with title names motor

### DIFF
--- a/docs/components/motor/28byj48.md
+++ b/docs/components/motor/28byj48.md
@@ -1,9 +1,9 @@
 ---
-title: "Configure a 28BYJ-48 stepper motor"
-linkTitle: "28BYJ-48"
+title: "Configure a 28byj48 stepper motor"
+linkTitle: "28byj48"
 weight: 22
 type: "docs"
-description: "Configure a small unipolar 28BYJ-48 stepper motor driven by a ULN2003 driver."
+description: "Configure a small unipolar 28byj48 stepper motor driven by a ULN2003 driver."
 # SMEs: Rand, James
 ---
 

--- a/docs/components/motor/28byj48.md
+++ b/docs/components/motor/28byj48.md
@@ -3,7 +3,7 @@ title: "Configure a 28byj48 stepper motor"
 linkTitle: "28byj48"
 weight: 22
 type: "docs"
-description: "Configure a small unipolar 28byj48 stepper motor driven by a ULN2003 driver."
+description: "Configure a small unipolar 28BYJ-48 stepper motor driven by a ULN2003 driver."
 # SMEs: Rand, James
 ---
 

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -34,7 +34,7 @@ Model | Supported hardware <a name="model-table"></a>
 ---------- | ------------------
 [`gpio`](./gpio/) | [Standard brushed or brushless DC motor](https://en.wikipedia.org/wiki/DC_motor)
 [`gpiostepper`](./gpiostepper/) | Bipolar stepper motor with current regulation and 1/32 microstepping driven by a basic driver like [DRV8825](https://www.ti.com/product/DRV8825) or [TMC2209](https://www.trinamic.com/support/eval-kits/details/tmc2209-bob/)
-[`28byj48`](./28byj48/) | Small unipolar 28byj48 stepper motor driven by a [ULN2003](https://www.ti.com/product/ULN2003A) driver
+[`28byj48`](./28byj48/) | Small unipolar 28BYJ-48 stepper motor driven by a [ULN2003](https://www.ti.com/product/ULN2003A) driver
 [`TMC5072`](./tmc5072/) | Stepper motor driven by [the TMC5072 chip](https://www.trinamic.com/support/eval-kits/details/tmc5072-bob/)
 [`DMC4000`](./dmc4000/) | Stepper motor driven by a [DMC-40x0 series motion controller](https://www.galil.com/motion-controllers/multi-axis/dmc-40x0)
 [`fake`](./fake/) | Used to test code without hardware

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -34,7 +34,7 @@ Model | Supported hardware <a name="model-table"></a>
 ---------- | ------------------
 [`gpio`](./gpio/) | [Standard brushed or brushless DC motor](https://en.wikipedia.org/wiki/DC_motor)
 [`gpiostepper`](./gpiostepper/) | Bipolar stepper motor with current regulation and 1/32 microstepping driven by a basic driver like [DRV8825](https://www.ti.com/product/DRV8825) or [TMC2209](https://www.trinamic.com/support/eval-kits/details/tmc2209-bob/)
-[`28byj48`](./28byj-48/) | Small unipolar 28BYJ-48 stepper motor driven by a [ULN2003](https://www.ti.com/product/ULN2003A) driver
+[`28byj48`](./28byj48/) | Small unipolar 28byj48 stepper motor driven by a [ULN2003](https://www.ti.com/product/ULN2003A) driver
 [`TMC5072`](./tmc5072/) | Stepper motor driven by [the TMC5072 chip](https://www.trinamic.com/support/eval-kits/details/tmc5072-bob/)
 [`DMC4000`](./dmc4000/) | Stepper motor driven by a [DMC-40x0 series motion controller](https://www.galil.com/motion-controllers/multi-axis/dmc-40x0)
 [`fake`](./fake/) | Used to test code without hardware

--- a/docs/components/motor/tmc5072.md
+++ b/docs/components/motor/tmc5072.md
@@ -11,7 +11,7 @@ This model supports stepper motors controlled by the [TMC5072 chip](https://www.
 
 Whereas a basic low-level stepper driver supported by the [`gpiostepper` model](/components/motor/gpiostepper/) sends power to a stepper motor based on PWM signals from GPIO pins, the TMC5072 chip uses SPI bus to communicate with the board, does some processing on the chip itself, and provides convenient features including StallGuard2<sup>TM</sup>.
 
-To configure a `gpiostepper` motor as a component of your robot, first configure the [board](/components/board/) to which the motor driver is wired.
+To configure a `TMC5072` motor as a component of your robot, first configure the [board](/components/board/) to which the motor driver is wired.
 Then, add the motor:
 
 {{< tabs >}}
@@ -19,7 +19,7 @@ Then, add the motor:
 
 Navigate to the **config** tab of your robot's page in [the Viam app](https://app.viam.com).
 Click on the **Components** subtab and navigate to the **Create component** menu.
-Enter a name for your motor, select the type `motor`, and select the `tmc5072` model.
+Enter a name for your motor, select the type `motor`, and select the `TMC5072` model.
 
 Click **Create component** and then fill in the attributes for your model:
 


### PR DESCRIPTION
* another, smaller alignment pr to standardize links w/ title names on motor page
* typo model name fixes