### PR TITLE
Link to fixed properties link from movement sensor API

### DIFF
--- a/docs/components/movement-sensor/_index.md
+++ b/docs/components/movement-sensor/_index.md
@@ -475,7 +475,7 @@ Get the supported properties of this sensor.
 
 **Returns:**
 
-- ([Properties](https://python.viam.dev/autoapi/viam/components/movement_sensor/index.html#viam.components.movement_sensor.MovementSensor.Properties))<!--this link isn't very useful -->: The supported properties of the movement sensor.
+- ([Properties](https://python.viam.dev/autoapi/viam/components/movement_sensor/movement_sensor/index.html#viam.components.movement_sensor.movement_sensor.MovementSensor.Properties)): The supported properties of the movement sensor.
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/movement_sensor/index.html#viam.components.movement_sensor.MovementSensor.get_properties).
 


### PR DESCRIPTION
This https://viam.atlassian.net/browse/RSDK-2634 got fixed so now we have a better link to link to