### PR TITLE
DOCS-697: align code sample instructions

### DIFF
--- a/docs/components/arm/_index.md
+++ b/docs/components/arm/_index.md
@@ -131,17 +131,9 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 ```go {class="line-numbers linkable-line-numbers"}
 myArm, err := arm.FromRobot(robot, "my_arm")
-if err != nil {
-  logger.Fatalf("cannot get arm: %v", err)
-}
 
 // Get the end position of the arm as a Pose.
 err, pos := myArm.EndPosition(context.Background(), nil)
-
-// Log any errors that occur.
-if err != nil {
-  logger.Fatalf("cannot get end position of arm: %v", err)
-}
 ```
 
 {{% /tab %}}
@@ -199,9 +191,6 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 ```go {class="line-numbers linkable-line-numbers"}
 myArm, err := arm.FromRobot(robot, "my_arm")
-if err != nil {
-  logger.Fatalf("cannot get arm: %v", err)
-}
 
 // Create a Pose for the arm.
 examplePose = []float64{x: 5, y: 5, z: 5, o_x: 5, o_y: 5, o_z: 5, theta:20}
@@ -270,15 +259,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 ```go {class="line-numbers linkable-line-numbers"}
 myArm, err := arm.FromRobot(robot, "my_arm")
-if err != nil {
-  logger.Fatalf("cannot get arm: %v", err)
-}
 
 // Declare an array of values with your desired rotational value for each joint on the arm.
 degrees := []float64{4.0, 5.0, 6.0}
 
 // Declare a new JointPositions with these values.
-jointPos := componentpb.JointPositions{Values= degrees}
+jointPos := componentpb.JointPositions{degrees}
 
 // Move each joint of the arm to the position these values specify.
 myArm.MoveToJointPositions(context.Background(), jointPos, nil)
@@ -331,18 +317,9 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 ```go {class="line-numbers linkable-line-numbers"}
 my_arm, err := arm.FromRobot(robot, "my_arm")
-if err != nil {
-  logger.Fatalf("cannot get arm: %v", err)
-}
 
 // Get the current position of each joint on the arm as JointPositions.
 pos, err := my_arm.JointPositions(context.Background(), nil)
-
-// Log any errors that occur.
-if err != nil {
-  logger.Fatalf("cannot get JointPositions of arm: %v", err)
-}
-
 ```
 
 {{% /tab %}}
@@ -389,9 +366,6 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 ```go {class="line-numbers linkable-line-numbers"}
 myArm, err := arm.FromRobot(robot, "my_arm")
-if err != nil {
-  logger.Fatalf("cannot get arm: %v", err)
-}
 
 // Stop all motion of the arm. It is assumed that the arm stops immediately.
 myArm.Stop(context.Background(), nil)
@@ -443,18 +417,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 ```go {class="line-numbers linkable-line-numbers"}
 myArm, err := arm.FromRobot(robot, "my_arm")
-if err != nil {
-  logger.Fatalf("cannot get arm: %v", err)
-}
 
 // Stop all motion of the arm. It is assumed that the arm stops immediately.
 myArm.Stop(context.Background(), nil)
 
 // Log if the arm is currently moving.
 is_moving, err := myArm.IsMoving(context.Background())
-if err != nil {
-  logger.Fatalf("cannot get if arm is moving: %v", err)
-}
 logger.Info(is_moving)
 ```
 
@@ -501,10 +469,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/#the-do-
 - `error` ([`error`](https://pkg.go.dev/builtin#error)): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-  myArm, err := arm.FromRobot(robot, "my_arm")
+myArm, err := arm.FromRobot(robot, "my_arm")
 
-  command := map[string]interface{}{"cmd": "test", "data1": 500}
-  result, err := myArm.DoCommand(context.Background(), command)
+command := map[string]interface{}{"cmd": "test", "data1": 500}
+result, err := myArm.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/blob/main/resource/resource.go).

--- a/docs/components/arm/_index.md
+++ b/docs/components/arm/_index.md
@@ -61,81 +61,13 @@ Supported arm models include:
 
 ## Control your arm with Viam's client SDK libraries
 
-The following example assumes you have an arm called "my_arm" configured as a component of your robot.
-If your arm has a different name, change the `name` in the example.
+To get started using Viam's SDKs to connect to and control your robot, go to your robot's page on [the Viam app](https://app.viam.com), navigate to the **code sample** tab, select your preferred programming language, and copy the sample code generated.
 
-{{< tabs >}}
-{{% tab name="Python" %}}
+When executed, this sample code will create a connection to your robot as a client.
+Then control your robot programmatically by adding API method calls as shown in the following examples.
 
-```python {class="line-numbers linkable-line-numbers"}
-from viam.components.arm import Arm, JointPositions
-from viam.proto.common import Pose
-
-async def main():
-
-  # Connect to your robot.
-  robot = await connect() # Define a function to connect to your robot: see the CODE SAMPLE tab of your robot's page in app.viam.com.
-
-  # Log an info message with the names of the different resources that are connected to your robot.
-  print('Resources:')
-  print(robot.resource_names)
-
-  # Get your arm from your robot.
-  my_arm = Arm.from_robot(robot=robot, name='my_arm')
-
-  # Disconnect from your robot.
-  await robot.close()
-
-if __name__ == '__main__':
-    asyncio.run(main())
-```
-
-{{% /tab %}}
-{{% tab name="Go" %}}
-
-```go {class="line-numbers linkable-line-numbers"}
-import (
-  "context"
-  "github.com/edaniels/golog"
-
-  "go.viam.com/rdk/components/arm"
-  "go.viam.com/rdk/referenceframe"
-  "go.viam.com/rdk/spatialmath"
-
-  componentpb "go.viam.com/api/component/arm/v1"
-)
-
-func main() {
-
-  // Create an instance of a logger.
-  logger := golog.NewDevelopmentLogger("client")
-
-  // Define a function to connect to your robot: see the CODE SAMPLE tab of your robot's page in app.viam.com.
-  robot, err := client.New( ... )
-
-  // Log any errors that occur.
-  if err != nil {
-      logger.Fatal(err)
-  }
-
-  // Delay closing your connection to your robot until main() exits.
-  defer robot.Close(context.Background())
-
-  // Log an info message with the names of the different resources that are connected to your robot.
-  logger.Info("Resources:")
-  logger.Info(robot.ResourceNames())
-
-  // Get your arm from your robot.
-  myArm, err := arm.FromRobot(robot, "my_arm")
-  if err != nil {
-    logger.Fatalf("cannot get arm: %v", err)
-  }
-
-}
-```
-
-{{% /tab %}}
-{{< /tabs >}}
+These examples assume you have an arm called `"my_arm"` configured as a component of your robot.
+If your arm has a different name, change the `name` in the code.
 
 ## API
 
@@ -173,7 +105,7 @@ Orientation is expressed as an orientation vector, which is represented by o_x, 
 For more information, see the [Python SDK Docs](https://python.viam.dev/_modules/viam/components/arm/arm.html#Arm.get_end_position).
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_arm = Arm.from_robot(robot=robot, name='my_arm')
+my_arm = Arm.from_robot(robot=robot, name="my_arm")
 
 # Get the end position of the arm as a Pose.
 pos = await my_arm.get_end_position()
@@ -238,7 +170,7 @@ Orientation is expressed as an orientation vector, which is represented by o_x, 
 For more information, see the [Python SDK Docs](https://python.viam.dev/_modules/viam/components/arm/arm.html#Arm.move_to_position).
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_arm = Arm.from_robot(robot=robot, name='my_arm')
+my_arm = Arm.from_robot(robot=robot, name="my_arm")
 
 # Create a Pose for the arm.
 examplePose = Pose(x=5, y=5, z=5, o_x=5, o_y=5, o_z=5, theta=20)
@@ -308,7 +240,7 @@ JointPositions can have one attribute, `values`, a list of joint positions with 
 For more information, see the [Python SDK Docs](https://python.viam.dev/_modules/viam/components/arm/arm.html#Arm.move_to_joint_positions)
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_arm = Arm.from_robot(robot=robot, name='my_arm')
+my_arm = Arm.from_robot(robot=robot, name="my_arm")
 
 # Declare a list of values with your desired rotational value for each joint on the arm.
 degrees = [0.0, 45.0, 0.0, 0.0, 0.0]
@@ -375,7 +307,7 @@ JointPositions can have one attribute, `values`, a list of joint positions with 
 For more information, see the [Python SDK Docs](https://python.viam.dev/_modules/viam/components/arm/arm.html#Arm.get_joint_positions)
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_arm = Arm.from_robot(robot=robot, name='my_arm')
+my_arm = Arm.from_robot(robot=robot, name="my_arm")
 
 # Get the current position of each joint on the arm as JointPositions.
 pos = await my_arm.get_joint_positions()
@@ -435,7 +367,7 @@ Stop all motion of the arm.
 For more information, see the [Python SDK Docs](https://python.viam.dev/_modules/viam/components/arm/arm.html#Arm.stop).
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_arm = Arm.from_robot(robot=robot, name='my_arm')
+my_arm = Arm.from_robot(robot=robot, name="my_arm")
 
 # Stop all motion of the arm. It is assumed that the arm stops immediately.
 await my_arm.stop()
@@ -486,7 +418,7 @@ Get if the arm is currently moving.
 For more information, see the [Python SDK Docs](https://python.viam.dev/_modules/viam/components/arm/arm.html#Arm.is_moving).
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_arm = Arm.from_robot(robot=robot, name='my_arm')
+my_arm = Arm.from_robot(robot=robot, name="my_arm")
 
 # Stop all motion of the arm. It is assumed that the arm stops immediately.
 await my_arm.stop()
@@ -547,7 +479,7 @@ If you are implementing your own arm and add features that have no built-in API 
 - `result` (`Dict[str, Any]`): Result of the executed command.
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_arm = Arm.from_robot(robot, "arm1")
+my_arm = Arm.from_robot(robot, "my_arm")
 
 command = {"cmd": "test", "data1": 500}
 result = my_arm.do(command)
@@ -569,7 +501,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/#the-do-
 - `error` ([`error`](https://pkg.go.dev/builtin#error)): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-  myArm, err := arm.FromRobot(robot, "my arm")
+  myArm, err := arm.FromRobot(robot, "my_arm")
 
   command := map[string]interface{}{"cmd": "test", "data1": 500}
   result, err := myArm.DoCommand(context.Background(), command)

--- a/docs/components/base/_index.md
+++ b/docs/components/base/_index.md
@@ -38,91 +38,13 @@ Supported base models include:
 
 ## Control your base with Viam's client SDK libraries
 
-- [Python SDK Documentation](https://python.viam.dev/autoapi/viam/components/base/index.html)
-- [Go SDK Documentation](https://pkg.go.dev/go.viam.com/rdk/components/base)
+To get started using Viam's SDKs to connect to and control your robot, go to your robot's page on [the Viam app](https://app.viam.com), navigate to the **code sample** tab, select your preferred programming language, and copy the sample code generated.
 
-Check out the [Client SDK Libraries Quick Start](/program/sdk-as-client/) documentation for an overview of how to get started connecting to your robot using these libraries.
+When executed, this sample code will create a connection to your robot as a client.
+Then control your robot programmatically by adding API method calls as shown in the following examples.
 
-The following example assumes you have a wheeled base called "my_base" configured as a component of your robot.
-If your base has a different name, change the `name` in the example.
-
-{{< tabs >}}
-{{% tab name="Python" %}}
-
-```python {class="line-numbers linkable-line-numbers"}
-from viam.components.base import BaseClient
-from viam.proto.common import Vector3
-
-async def main():
-    # Connect to your robot.
-    robot = await connect()
-
-    # Log an info message with the names of the different resources that are connected to your robot.
-    print('Resources:')
-    print(robot.resource_names)
-
-    # Connect to your base.
-    my_base = BaseClient.from_robot(robot=robot, name='my_base')
-
-    # Disconnect from your robot.
-    await robot.close()
-
-if __name__ == '__main__':
-    asyncio.run(main())
-```
-
-{{% /tab %}}
-{{% tab name="Go" %}}
-
-```go {class="line-numbers linkable-line-numbers"}
-import (
-  "context"
-
-  "github.com/edaniels/golog"
-
-  "go.viam.com/rdk/components/base"
-  "github.com/golang/geo/r3"
-)
-
-func main() {
-
-  // Create an instance of a logger.
-  logger := golog.NewDevelopmentLogger("client")
-
-  // Connect to your robot.
-  robot, err := client.New(
-      context.Background(),
-      "[ADD YOUR ROBOT ADDRESS HERE. YOU CAN FIND THIS ON THE SECURITY TAB OF THE VIAM APP]",
-      logger,
-      client.WithDialOptions(rpc.WithCredentials(rpc.Credentials{
-          Type:    utils.CredentialsTypeRobotLocationSecret,
-          Payload: "[PLEASE ADD YOUR SECRET HERE. YOU CAN FIND THIS ON THE LOCATION'S PAGE IN THE VIAM APP]",
-      })),
-  )
-
-  // Log any errors that occur.
-  if err != nil {
-      logger.Fatal(err)
-  }
-
-  // Delay closing your connection to your robot until main() exits.
-  defer robot.Close(context.Background())
-
-  // Log an info message with the names of the different resources that are connected to your robot.
-  logger.Info("Resources:")
-  logger.Info(robot.ResourceNames())
-
-  // Connect to your base.
-  myBase, err := base.FromRobot(robot, "my_base")
-  if err != nil {
-    logger.Fatalf("cannot get base: %v", err)
-  }
-
-}
-```
-
-{{% /tab %}}
-{{< /tabs >}}
+These examples assume you have a wheeled base called `"my_base"` configured as a component of your robot.
+If your base has a different name, change the `name` in the code.
 
 ## API
 
@@ -158,13 +80,13 @@ Negative implies backwards.
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/base/client/index.html#viam.components.base.client.BaseClient.move_straight).
 
 ```python {class="line-numbers linkable-line-numbers"}
-myBase = BaseClient.from_robot(robot=robot, name='my_base')
+my_base = BaseClient.from_robot(robot=robot, name="my_base")
 
 # Move the base 10 mm at a velocity of 1 mm/s, forward.
-await myBase.move_straight(distance=10, velocity=1)
+await my_base.move_straight(distance=10, velocity=1)
 
 # Move the base 10 mm at a velocity of -1 mm/s, backward.
-await myBase.move_straight(distance=10, velocity=-1)
+await my_base.move_straight(distance=10, velocity=-1)
 ```
 
 {{% /tab %}}
@@ -222,7 +144,7 @@ Negative implies backwards.
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/base/client/index.html#viam.components.base.client.BaseClient.spin).
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_base = BaseClient.from_robot(robot=robot, name='my_base')
+my_base = BaseClient.from_robot(robot=robot, name="my_base")
 
 # Spin the base 10 degrees at an angular velocity of 1 deg/sec.
 await my_base.spin(angle=10, velocity=1)
@@ -284,7 +206,7 @@ Set the linear and angular power of the base, represented as a percentage of max
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/base/client/index.html#viam.components.base.client.BaseClient.set_power).
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_base = BaseClient.from_robot(robot=robot, name='my_base')
+my_base = BaseClient.from_robot(robot=robot, name="my_base")
 
 # Make your wheeled base move forward. Set linear power to 75%.
 print("move forward")
@@ -381,7 +303,7 @@ Only the Y component of the vector is used for a wheeled base.
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/base/client/index.html#viam.components.base.client.BaseClient.set_velocity).
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_base = BaseClient.from_robot(robot=robot, name='my_base')
+my_base = BaseClient.from_robot(robot=robot, name="my_base")
 
 # Set the angular velocity to 1 mm/sec and the linear velocity to 1 degree/sec.
 await my_base.set_velocity(linear=Vector3(x=0,y=1,z=0), angular=Vector3(x=0,y=0,z=1))
@@ -436,7 +358,7 @@ Stop the base from moving immediately.
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/base/client/index.html#viam.components.base.client.BaseClient.stop).
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_base = BaseClient.from_robot(robot=robot, name='my_base')
+my_base = BaseClient.from_robot(robot=robot, name="my_base")
 
 # Move the base forward 10 mm at a velocity of 1 mm/s.
 await my_base.move_straight(distance=10, velocity=1)

--- a/docs/components/base/_index.md
+++ b/docs/components/base/_index.md
@@ -109,9 +109,6 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 ```go {class="line-numbers linkable-line-numbers"}
 myBase, err := base.FromRobot(robot, "my_base")
-if err != nil {
-  logger.Fatalf("cannot get base: %v", err)
-}
 
 // Move the base forward 10 mm at a velocity of 1 mm/s.
 myBase.MoveStraight(context.Background(), distanceMm: 10, mmPerSec: 1)
@@ -170,9 +167,6 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 ```go {class="line-numbers linkable-line-numbers"}
 myBase, err := base.FromRobot(robot, "my_base")
-if err != nil {
-  logger.Fatalf("cannot get base: %v", err)
-}
 
 // Spin the base 10 degrees at an angular velocity of 1 deg/sec.
 myBase.Spin(context.Background(), angleDeg: 10, degsPerSec: 1)
@@ -247,37 +241,22 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 ```go {class="line-numbers linkable-line-numbers"}
 myBase, err := base.FromRobot(robot, "my_base")
-if err != nil {
-  logger.Fatalf("cannot get base: %v", err)
-}
 
 // Make your wheeled base move forward. Set linear power to 75%.
 logger.Info("move forward")
 err = myBase.SetPower(context.Background(), linear: r3.Vector{Y: .75}, angular: r3.Vector{})
-if err != nil {
-    logger.Fatal(err)
-}
 
 // Make your wheeled base move backward. Set linear power to -100%.
 logger.Info("move backward")
 err = myBase.SetPower(context.Background(), linear: r3.Vector{Y: -1}, angular: r3.Vector{})
-if err != nil {
-    logger.Fatal(err)
-}
 
 // Make your wheeled base spin left. Set angular power to 100%.
 logger.Info("spin left")
 err = myBase.SetPower(context.Background(), linear: r3.Vector{}, angular: r3.Vector{Z: 1})
-if err != nil {
-  logger.Fatal(err)
-}
 
 // Make your wheeled base spin right. Set angular power to -75%.
 logger.Info("spin right")
 err = mybase.SetPower(context.Background(), r3.Vector{}, r3.Vector{Z: -.75}, nil)
-if err != nil {
-  logger.Fatal(err)
-}
 ```
 
 {{% /tab %}}
@@ -329,9 +308,6 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 // import "github.com/golang/geo/r3" ...
 
 myBase, err := base.FromRobot(robot, "my_base")
-if err != nil {
-  logger.Fatalf("cannot get base: %v", err)
-}
 
 // Set the angular velocity to 1 mm/sec and the linear velocity to 1 deg/sec.
 myBase.SetVelocity(context.Background(), linear: r3.Vector{Y: 1}, angular: r3.Vector{Z: 1})
@@ -383,9 +359,6 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 ```go {class="line-numbers linkable-line-numbers"}
 myBase, err := base.FromRobot(robot, "my_base")
-if err != nil {
-  logger.Fatalf("cannot get base: %v", err)
-}
 
 // Move the base forward 10 mm at a velocity of 1 mm/s.
 myBase.MoveStraight(context.Background(), 10, 1)
@@ -437,10 +410,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/#the-do-
 - `error` ([`error`](https://pkg.go.dev/builtin#error)): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-  myBase, err := base.FromRobot(robot, "my_base")
+myBase, err := base.FromRobot(robot, "my_base")
 
-  command := map[string]interface{}{"cmd": "test", "data1": 500}
-  result, err := myBase.DoCommand(context.Background(), command)
+command := map[string]interface{}{"cmd": "test", "data1": 500}
+result, err := myBase.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/blob/main/resource/resource.go).

--- a/docs/components/camera/_index.md
+++ b/docs/components/camera/_index.md
@@ -112,10 +112,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - `err` ([`error`](https://pkg.go.dev/builtin#error)): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-my_camera, err := camera.FromRobot(robot, "my_camera")
+myCamera, err := camera.FromRobot(robot, "my_camera")
 
 // gets the stream from a camera
-stream, err := my_camera.Stream(context.Background())
+stream, err := myCamera.Stream(context.Background())
 
 // gets an image from the camera stream
 img, release, err := stream.Next(context.Background())
@@ -177,9 +177,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - `err` ([`error`](https://pkg.go.dev/builtin#error)): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-my_camera, err := camera.FromRobot(robot, "my_camera")
+myCamera, err := camera.FromRobot(robot, "my_camera")
 
-pointCloud, err := my_camera.NextPointCloud(context.Background())
+pointCloud, err := myCamera.NextPointCloud(context.Background())
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/camera#Camera).
@@ -223,10 +223,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - `err` ([`error`](https://pkg.go.dev/builtin#error)): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-my_camera, err := camera.FromRobot(robot, "my_camera")
+myCamera, err := camera.FromRobot(robot, "my_camera")
 
 // gets the properties from a camera
-properties, err := my_camera.Properties(context.Background())
+properties, err := myCamera.Properties(context.Background())
 
 ```
 
@@ -275,10 +275,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/#the-do-
 - `error` ([`error`](https://pkg.go.dev/builtin#error)): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-  my_camera, err := camera.FromRobot(robot, "my_camera")
+  myCamera, err := camera.FromRobot(robot, "my_camera")
 
   command := map[string]interface{}{"cmd": "test", "data1": 500}
-  result, err := my_camera.DoCommand(context.Background(), command)
+  result, err := myCamera.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/blob/main/resource/resource.go).

--- a/docs/components/camera/_index.md
+++ b/docs/components/camera/_index.md
@@ -51,9 +51,13 @@ For configuration information, click on one of the following models:
 
 ## Control your camera with Viam's client SDK libraries
 
-Check out the [Client SDK Libraries Quick Start](/program/sdk-as-client/) documentation for an overview of how to get started connecting to your robot using these libraries.
+To get started using Viam's SDKs to connect to and control your robot, go to your robot's page on [the Viam app](https://app.viam.com), navigate to the **code sample** tab, select your preferred programming language, and copy the sample code generated.
 
-{{< readfile "/static/include/components/camera-sample.md" >}}
+When executed, this sample code will create a connection to your robot as a client.
+Then control your robot programmatically by adding API method calls as shown in the following examples.
+
+These examples assume you have a camera called `"my_camera"` configured as a component of your robot.
+If your camera has a different name, change the `name` in the code.
 
 ## API
 
@@ -85,7 +89,7 @@ If the server does not know how to return the specified MIME type, the server re
 - `frame` (`Image` or [`RawImage`](https://python.viam.dev/autoapi/viam/components/camera/index.html#viam.components.camera.RawImage)): The requested frame.
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_cam = Camera.from_robot(robot=robot, name='my_camera')
+my_camera = Camera.from_robot(robot=robot, name="my_camera")
 
 frame = await my_cam.get_image()
 ```
@@ -108,13 +112,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - `err` ([`error`](https://pkg.go.dev/builtin#error)): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-myCam, err := camera.FromRobot(robot, cameraName)
-if err != nil {
-  logger.Fatalf("cannot get camera: %v", err)
-}
+my_camera, err := camera.FromRobot(robot, "my_camera")
 
 // gets the stream from a camera
-stream, err := myCam.Stream(context.Background())
+stream, err := my_camera.Stream(context.Background())
 
 // gets an image from the camera stream
 img, release, err := stream.Next(context.Background())
@@ -149,9 +150,9 @@ To deserialize the returned information into a numpy array, use the Open3D libra
 import numpy as np
 import open3d as o3d
 
-my_cam = Camera.from_robot(robot=robot, name='my_camera')
+my_camera= Camera.from_robot(robot=robot, name="my_camera")
 
-data, _ = await my_cam.get_point_cloud()
+data, _ = await my_camera.get_point_cloud()
 
 # write the point cloud into a temporary file
 with open("/tmp/pointcloud_data.pcd", "wb") as f:
@@ -176,12 +177,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - `err` ([`error`](https://pkg.go.dev/builtin#error)): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-myCam, err := camera.FromRobot(robot, cameraName)
-if err != nil {
-  logger.Fatalf("cannot get camera: %v", err)
-}
+my_camera, err := camera.FromRobot(robot, "my_camera")
 
-pointCloud, err := myCam.NextPointCloud(context.Background())
+pointCloud, err := my_camera.NextPointCloud(context.Background())
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/camera#Camera).
@@ -205,9 +203,9 @@ Get the camera intrinsic parameters and camera distortion, as well as whether th
 - `properties` ([`Properties`](https://python.viam.dev/autoapi/viam/components/camera/index.html#viam.components.camera.Camera.Properties)): The properties of the camera.
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_cam = Camera.from_robot(robot=robot, name='my_camera')
+my_camera= Camera.from_robot(robot=robot, name="my_camera")
 
-properties = await my_cam.get_properties()
+properties = await my_camera.get_properties()
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/camera/index.html#viam.components.camera.Camera.get_properties).
@@ -225,13 +223,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - `err` ([`error`](https://pkg.go.dev/builtin#error)): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-myCam, err := camera.FromRobot(robot, cameraName)
-if err != nil {
-  logger.Fatalf("cannot get camera: %v", err)
-}
+my_camera, err := camera.FromRobot(robot, "my_camera")
 
 // gets the properties from a camera
-properties, err := myCam.Properties(context.Background())
+properties, err := my_camera.Properties(context.Background())
 
 ```
 
@@ -258,10 +253,10 @@ If you are implementing your own camera and add features that have no native API
 - `result` (`Dict[str, Any]`): Result of the executed command.
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_cam = Camera.from_robot(robot, "camera0")
+my_camera= Camera.from_robot(robot, "my_camera")
 
 command = {"cmd": "test", "data1": 500}
-result = my_cam.do(command)
+result = my_camera.do(command)
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/#the-do-method).
@@ -280,10 +275,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/#the-do-
 - `error` ([`error`](https://pkg.go.dev/builtin#error)): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-  myCam, err := camera.FromRobot(robot, "my_camera")
+  my_camera, err := camera.FromRobot(robot, "my_camera")
 
   command := map[string]interface{}{"cmd": "test", "data1": 500}
-  result, err := myCam.DoCommand(context.Background(), command)
+  result, err := my_camera.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/blob/main/resource/resource.go).

--- a/docs/components/gantry/_index.md
+++ b/docs/components/gantry/_index.md
@@ -47,7 +47,7 @@ To get started using Viam's SDKs to connect to and control your robot, go to you
 When executed, this sample code will create a connection to your robot as a client.
 Then control your robot programmatically by adding API method calls as shown in the following examples.
 
-These examples assume you have a gantry called "my_gantry" configured as a component of your robot.
+These examples assume you have a gantry called `"my_gantry"` configured as a component of your robot.
 If your gantry has a different name, change the `name` in the code.
 
 ## API

--- a/docs/components/gantry/_index.md
+++ b/docs/components/gantry/_index.md
@@ -82,7 +82,7 @@ Get the current positions of the axis of the gantry (mm).
 For more information, see the [Python SDK Docs](https://python.viam.dev/_modules/viam/components/gantry/gantry.html#Gantry.get_position).
 
 ```python
-my_gantry = Gantry.from_robot(robot=robot, name='my_gantry')
+my_gantry = Gantry.from_robot(robot=robot, name="my_gantry")
 
 # Get the current positions of the axes of the gantry in millimeters.
 positions = await my_gantry.get_position()
@@ -142,7 +142,7 @@ Move the axes of the gantry to the desired positions (mm).
 For more information, see the [Python SDK Docs](https://python.viam.dev/_modules/viam/components/gantry/gantry.html#Gantry.move_to_position).
 
 ```python
-my_gantry = Gantry.from_robot(robot=robot, name='my_gantry')
+my_gantry = Gantry.from_robot(robot=robot, name="my_gantry")
 
 # Create a list of positions for the axes of the gantry to move to. Assume in this example that the gantry is multiaxis, with 3 axes.
 examplePositions = [1, 2, 3]
@@ -201,7 +201,7 @@ Get the lengths of the axes of the gantry (mm).
 For more information, see the [Python SDK Docs](https://python.viam.dev/_modules/viam/components/gantry/gantry.html#Gantry.lengths).
 
 ```python
-my_gantry = Gantry.from_robot(robot=robot, name='my_gantry')
+my_gantry = Gantry.from_robot(robot=robot, name="my_gantry")
 
 # Get the lengths of the axes of the gantry in millimeters.
 lengths_mm = await my_gantry.get_lengths()
@@ -260,7 +260,7 @@ Stop all motion of the gantry.
 For more information, see the [Python SDK Docs](https://python.viam.dev/_modules/viam/components/gantry/gantry.html#Gantry.stop).
 
 ```python
-my_gantry = Gantry.from_robot(robot=robot, name='my_gantry')
+my_gantry = Gantry.from_robot(robot=robot, name="my_gantry")
 
 # Stop all motion of the gantry. It is assumed that the gantry stops immediately.
 await my_gantry.stop()
@@ -311,7 +311,7 @@ Get if the gantry is currently moving.
 For more information, see the [Python SDK Docs](https://python.viam.dev/_modules/viam/components/gantry/gantry.html#Gantry.is_moving).
 
 ```python
-my_gantry = Gantry.from_robot(robot=robot, name='my_gantry')
+my_gantry = Gantry.from_robot(robot=robot, name="my_gantry")
 
 # Stop all motion of the gantry. It is assumed that the gantry stops immediately.
 await my_gantry.stop()

--- a/docs/components/gantry/_index.md
+++ b/docs/components/gantry/_index.md
@@ -105,18 +105,9 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 ```go
 myGantry, err := gantry.FromRobot(robot, "my_gantry")
-if err != nil {
-  logger.Fatalf("cannot get gantry: %v", err)
-}
 
 // Get the current positions of the axes of the gantry in millimeters.
 position, err := myGantry.Position(context.Background(), nil)
-
-// Log any errors that occur.
-if err != nil {
-  logger.Fatalf("cannot get positions of gantry axes: %v", err)
-}
-
 ```
 
 {{% /tab %}}
@@ -168,9 +159,6 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 ```go
 myGantry, err := gantry.FromRobot(robot, "my_gantry")
-if err != nil {
-  logger.Fatalf("cannot get gantry: %v", err)
-}
 
 // Create a list of positions for the axes of the gantry to move to. Assume in this example that the gantry is multiaxis, with 3 axes.
 examplePositions = []float64{1, 2, 3}
@@ -224,18 +212,9 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 ```go
 myGantry, err := gantry.FromRobot(robot, "my_gantry")
-if err != nil {
-  logger.Fatalf("cannot get gantry: %v", err)
-}
 
 // Get the lengths of the axes of the gantry in millimeters.
 lengths_mm, err := myGantry.Lengths(context.Background(), nil)
-
-// Log any errors that occur.
-if err != nil {
-  logger.Fatalf("cannot get axis lengths of gantry: %v", err)
-}
-
 ```
 
 {{% /tab %}}
@@ -282,9 +261,6 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 ```go
 myGantry, err := gantry.FromRobot(robot, "my_gantry")
-if err != nil {
-  logger.Fatalf("cannot get gantry: %v", err)
-}
 
 // Stop all motion of the gantry. It is assumed that the gantry stops immediately.
 myGantry.Stop(context.Background(), nil)
@@ -336,18 +312,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 ```go
 myGantry, err := gantry.FromRobot(robot, "my_gantry")
-if err != nil {
-  logger.Fatalf("cannot get gantry: %v", err)
-}
 
 // Stop all motion of the gantry. It is assumed that the gantry stops immediately.
 myGantry.Stop(context.Background(), nil)
 
 // Log if the gantry is currently moving.
 is_moving, err := myGantry.IsMoving(context.Background())
-if err != nil {
-  logger.Fatalf("cannot get if gantry is moving: %v", err)
-}
 ```
 
 {{% /tab %}}
@@ -393,10 +363,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/#the-do-
 - `error` ([`error`](https://pkg.go.dev/builtin#error)): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-  myGantry, err := gantry.FromRobot(robot, "my_gantry")
+myGantry, err := gantry.FromRobot(robot, "my_gantry")
 
-  command := map[string]interface{}{"cmd": "test", "data1": 500}
-  result, err := myGantry.DoCommand(context.Background(), command)
+command := map[string]interface{}{"cmd": "test", "data1": 500}
+result, err := myGantry.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/blob/main/resource/resource.go).

--- a/docs/components/gripper/_index.md
+++ b/docs/components/gripper/_index.md
@@ -24,65 +24,13 @@ If you have another gripper model, you can [define a custom component](../../pro
 
 ## Control your gripper with Viam's client SDK libraries
 
-The following example assumes you have a gripper called `my_gripper` configured as a component of your robot.
-If your gripper has a different name, change the `name` in the example.
+To get started using Viam's SDKs to connect to and control your robot, go to your robot's page on [the Viam app](https://app.viam.com), navigate to the **code sample** tab, select your preferred programming language, and copy the sample code generated.
 
-{{< tabs >}}
-{{% tab name="Python" %}}
+When executed, this sample code will create a connection to your robot as a client.
+Then control your robot programmatically by adding API method calls as shown in the following examples.
 
-Place the example code in the `main()` function after `robot = await connect()`.
-
-```python {class="line-numbers linkable-line-numbers"}
-from viam.components.gripper import Gripper
-
-robot = await connect() # Refer to CODE SAMPLE tab code
-# Get the gripper from the robot
-my_gripper = Gripper.from_robot(robot, "my_gripper")
-
-# Open the gripper
-await my_gripper.open()
-
-# Grab with the gripper and get whether it grabbed anything
-grabbed = await my_gripper.grab()
-print(f"Grabbed an object: {grabbed}")
-```
-
-{{% /tab %}}
-{{% tab name="Go" %}}
-
-Place the example code in the `main()` function after `robot, err := client.New(...)`.
-
-```go {class="line-numbers linkable-line-numbers"}
-import (
-  "context"
-
-  "go.viam.com/rdk/components/gripper"
-  "github.com/edaniels/golog"
-)
-
-robot, err := client.New() // Refer to CODE SAMPLE tab code
-if err != nil {
-    return nil, err
-}
-// Get the gripper from the robot
-myGripper, err := gripper.FromRobot(robot, "my_gripper")
-if err != nil {
-    return nil, err
-}
-
-// Open the gripper
-myGripper.Open(context.TODO(), nil)
-
-// Grab with the gripper and get whether it grabbed anything
-grabbed, err := myGripper.Grab(context.TODO(), nil)
-if err != nil {
-    return nil, err
-}
-logger.Info("Grabbed an object: %w", grabbed)
-```
-
-{{% /tab %}}
-{{< /tabs >}}
+These examples assume you have a gripper called `"my_gripper"` configured as a component of your robot.
+If your gripper has a different name, change the `name` in the code.
 
 ## API
 
@@ -111,10 +59,8 @@ Opens the gripper.
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/gripper/index.html#viam.components.gripper.Gripper.open).
 
-**Example usage:**
-
 ```python
-my_gripper = Gripper.from_robot(robot=robot, name='my_gripper')
+my_gripper = Gripper.from_robot(robot=robot, name="my_gripper")
 
 # Open the gripper.
 await my_gripper.open()
@@ -133,8 +79,6 @@ await my_gripper.open()
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/gripper#Gripper).
-
-**Example usage:**
 
 ```go
 myGripper, err := gripper.FromRobot(robot, "my_gripper")
@@ -163,10 +107,8 @@ Closes the gripper until it grabs something or closes completely, and returns wh
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/gripper/index.html#viam.components.gripper.Gripper.grab).
 
-**Example usage:**
-
 ```python
-my_gripper = Gripper.from_robot(robot=robot, name='my_gripper')
+my_gripper = Gripper.from_robot(robot=robot, name="my_gripper")
 
 # Grab with the gripper.
 grabbed = await my_gripper.grab()
@@ -186,8 +128,6 @@ grabbed = await my_gripper.grab()
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/gripper#Gripper).
-
-**Example usage:**
 
 ```go
 myGripper, err := gripper.FromRobot(robot, "my_gripper")
@@ -217,10 +157,8 @@ It is assumed that the gripper stops immediately, so `IsMoving` will return fals
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/gripper/index.html#viam.components.gripper.Gripper.stop).
 
-**Example usage:**
-
 ```python
-my_gripper = Gripper.from_robot(robot=robot, name='my_gripper')
+my_gripper = Gripper.from_robot(robot=robot, name="my_gripper")
 
 # Stop the gripper.
 await my_gripper.stop()
@@ -239,8 +177,6 @@ await my_gripper.stop()
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/gripper#Gripper).
-
-**Example usage:**
 
 ```go
 myGripper, err := gripper.FromRobot(robot, "my_gripper")
@@ -269,10 +205,8 @@ Returns whether the gripper is actively moving (or attempting to move) under its
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/gripper/index.html#viam.components.gripper.Gripper.is_moving).
 
-**Example usage:**
-
 ```python
-my_gripper = Gripper.from_robot(robot=robot, name='my_gripper')
+my_gripper = Gripper.from_robot(robot=robot, name="my_gripper")
 
 # Check whether the gripper is currently moving.
 moving = await my_gripper.is_moving()
@@ -292,8 +226,6 @@ print('Moving:', moving)
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#MovingCheckable).
-
-**Example usage:**
 
 ```go
 myGripper, err := gripper.FromRobot(robot, "my_gripper")
@@ -325,7 +257,7 @@ If you are implementing your own gripper and add features that have no built-in 
 - `result` (`Dict[str, Any]`): Result of the executed command.
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_gripper = Gripper.from_robot(robot=robot, name='my_gripper')
+my_gripper = Gripper.from_robot(robot=robot, name="my_gripper")
 
 raw_dict = {
   "command": "raw",

--- a/docs/components/gripper/_index.md
+++ b/docs/components/gripper/_index.md
@@ -84,7 +84,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 myGripper, err := gripper.FromRobot(robot, "my_gripper")
 
 // Open the gripper.
-err := myGripper.Open(context.TODO(), nil)
+err := myGripper.Open(context.Background(), nil)
 ```
 
 {{% /tab %}}
@@ -133,7 +133,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 myGripper, err := gripper.FromRobot(robot, "my_gripper")
 
 // Grab with the gripper.
-grabbed, err := myGripper.Grab(context.TODO(), nil)
+grabbed, err := myGripper.Grab(context.Background(), nil)
 ```
 
 {{% /tab %}}
@@ -182,7 +182,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 myGripper, err := gripper.FromRobot(robot, "my_gripper")
 
 // Stop the gripper.
-err := myGripper.Stop(context.TODO(), nil)
+err := myGripper.Stop(context.Background(), nil)
 ```
 
 {{% /tab %}}
@@ -231,7 +231,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 myGripper, err := gripper.FromRobot(robot, "my_gripper")
 
 // Check whether the gripper is currently moving.
-moving, _ := myGripper.IsMoving(context.TODO())
+moving, _ := myGripper.IsMoving(context.Background())
 logger.Info("Is moving?")
 logger.Info(moving)
 ```

--- a/docs/components/input-controller/_index.md
+++ b/docs/components/input-controller/_index.md
@@ -61,7 +61,6 @@ The input controller component supports the following methods:
 | [Controls](#controls) | Get a list of input `Controls` that this Controller provides. |
 | [Events](#events) | Get the current state of the Controller as a map of the most recent [Event](#event-object) for each [Control](#control-field). |
 | [RegisterControlCallback](#registercontrolcallback) | Define a callback function to execute whenever one of the [`EventTypes`](#eventtype-field) selected occurs on the given [Control](#control-field). |
-<!-- | [TriggerEvent](#triggerevent) | Directly send an [Event](#event-object) to your robot. | -->
 | [DoCommand](#docommand) | Send or receive model-specific commands. |
 
 ### RegisterControlCallback
@@ -97,7 +96,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 ```python {class="line-numbers linkable-line-numbers"}
 # Define a function to handle pressing the Start Menu Button "BUTTON_START" on your controller, printing out the start time.
 def print_start_time(event):
-    print(f'Start Menu Button was pressed at this time:\n{event.time}')
+    print(f"Start Menu Button was pressed at this time:\n{event.time}")
 
 # Define a function that handles the controller.
 async def handle_controller(controller):
@@ -114,6 +113,17 @@ async def handle_controller(controller):
 
     while True:
         await asyncio.sleep(1.0)
+
+async def main():
+    # ... < INSERT CONNECTION CODE FROM ROBOT'S CODE SAMPLE TAB >
+
+    # Get your controller from the robot.
+    my_controller = Controller.from_robot(robot=myRobotWithController, name="my_controller")
+
+    # Run the handleController function.
+    await handleController(my_controller)
+    
+    # ... < INSERT ANY OTHER CODE FOR MAIN FUNCTION >
 ```
 
 {{% /tab %}}
@@ -134,6 +144,7 @@ async def handle_controller(controller):
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/input#Controller).
 
 ```go {class="line-numbers linkable-line-numbers"}
+
 // Define a function that handles the controller.
 func handleController(controller input.Controller) {
 
@@ -146,7 +157,7 @@ func handleController(controller input.Controller) {
     triggers := [1]input.EventType{input.ButtonPress}
 
     // Get the controller's Controls.
-    controls, err := myController.Controls(context.Background(), nil)
+    controls, err := controller.Controls(context.Background(), nil)
 
     // If the "ButtonStart" Control is found, register the function printStartTime to fire when "ButtonStart" has the event "ButtonPress" occur.
     if slices.Contains(controls, Control.ButtonStart) {
@@ -155,6 +166,32 @@ func handleController(controller input.Controller) {
      else {
         logger.Fatalf("Oops! Couldn't find the start button control! Is your controller connected?")
     }
+}
+
+func main() {
+    utils.ContextualMain(mainWithArgs, golog.NewDevelopmentLogger("client"))
+}
+
+
+func mainWithArgs(ctx context.Context, args []string, logger golog.Logger) (err error) {
+    // ... < INSERT CONNECTION CODE FROM ROBOT'S CODE SAMPLE TAB >
+
+    // Get the controller from the robot.
+    myController, err := input.FromRobot(myRobotWithController, "my_controller")
+
+    // Run the handleController function.
+    err := HandleController(myController)
+
+    // Delay closing your connection to your robot.
+    err = myRobotWithController.Start(ctx)
+    defer myRobotWithController.Close(ctx)
+
+    // Wait to exit mainWithArgs() until Context is Done.
+    <-ctx.Done()
+
+    // ... < INSERT ANY OTHER CODE FOR MAIN FUNCTION >
+
+    return nil
 }
 ```
 
@@ -180,11 +217,14 @@ This method returns the current state of the controller as a map of [Event Objec
 For more information, see the [Python SDK Docs](https://python.viam.dev/_modules/viam/components/input/input.html#Controller.get_events).
 
 ```python {class="line-numbers linkable-line-numbers"}
+# Get the controller from the robot.
+my_controller = Controller.from_robot(robot=myRobotWithController, name="my_controller")
+
 # Get the most recent Event for each Control.
-recent_events = await myController.get_events()
+recent_events = await my_controller.get_events()
 
 # Print out the most recent Event for each Control.
-print(f'Recent Events:\n{recent_events}')
+print(f"Recent Events:\n{recent_events}")
 ```
 
 {{% /tab %}}
@@ -203,13 +243,11 @@ print(f'Recent Events:\n{recent_events}')
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/input#Controller).
 
 ```go {class="line-numbers linkable-line-numbers"}
+// Get the controller from the robot.
+myController, err := input.FromRobot(myRobotWithController, "my_controller")
+
 // Get the most recent Event for each Control.
 recent_events, err := myController.Events(context.Background(), nil)
-
-// Log any errors that occur and exit if an error is found.
-if err != nil {
-  logger.Fatalf("cannot get list of recent events from controller: %v", err)
-}
 
 // Log the most recent Event for each Control.
 logger.Info("Recent Events: %v", recent_events)
@@ -237,13 +275,14 @@ Get a list of the [Controls](#control-field) that your controller provides.
 For more information, see the [Python SDK Docs](https://python.viam.dev/_modules/viam/components/input/input.html#Controller.get_position).
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_input_controller = Controller.from_robot(robot=myRobotWithController, name="my_controller") ...
+# Get the controller from the robot.
+my_controller = Controller.from_robot(robot=myRobotWithController, name="my_controller")
 
 # Get the list of Controls provided by the controller.
-controls = await my_input_controller.get_controls()
+controls = await my_controller.get_controls()
 
 # Print the list of Controls provided by the controller.
-print(f'Controls:\n{controls}')
+print(f"Controls:\n{controls}")
 ```
 
 {{% /tab %}}
@@ -262,18 +301,11 @@ print(f'Controls:\n{controls}')
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/input#Controller).
 
 ```go {class="line-numbers linkable-line-numbers"}
-myController, err := controller.FromRobot(myRobotWithController, "my_controller")
-if err != nil {
-  logger.Fatalf("cannot get controller: %v", err)
-} ...
+// Get the controller from the robot.
+myController, err := input.FromRobot(myRobotWithController, "my_controller")
 
 // Get the list of Controls provided by the controller.
 controls, err := myController.Controls(context.Background(), nil)
-
-// Log any errors that occur and exit if an error is found.
-if err != nil {
-  logger.Fatalf("cannot get controls provided by controller: %v", err)
-}
 
 // Log the list of Controls provided by the controller.
 logger.Info("Controls:")
@@ -363,10 +395,11 @@ If you are implementing your own input controller and add features that have no 
 - `result` (`Dict[str, Any]`): Result of the executed command.
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_input_controller = Controller.from_robot(robot, "my_controller")
+# Get the controller from the robot.
+my_controller = Controller.from_robot(robot=myRobotWithController, name="my_controller")
 
 command = {"cmd": "test", "data1": 500}
-result = my_input_controller.do(command)
+result = my_controller.do(command)
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/#the-do-method).
@@ -385,10 +418,11 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/#the-do-
 - `error` ([`error`](https://pkg.go.dev/builtin#error)): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-  myController, err := input.FromRobot(robot, "my_controller")
+// Get the controller from the robot.
+myController, err := input.FromRobot(myRobotWithController, "my_controller")
 
-  command := map[string]interface{}{"cmd": "test", "data1": 500}
-  result, err := myController.DoCommand(context.Background(), command)
+command := map[string]interface{}{"cmd": "test", "data1": 500}
+result, err := myController.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/blob/main/resource/resource.go).

--- a/docs/components/input-controller/_index.md
+++ b/docs/components/input-controller/_index.md
@@ -237,7 +237,7 @@ Get a list of the [Controls](#control-field) that your controller provides.
 For more information, see the [Python SDK Docs](https://python.viam.dev/_modules/viam/components/input/input.html#Controller.get_position).
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_input_controller = Controller.from_robot(robot=myRobotWithController, name='my_controller') ...
+my_input_controller = Controller.from_robot(robot=myRobotWithController, name="my_controller") ...
 
 # Get the list of Controls provided by the controller.
 controls = await my_input_controller.get_controls()

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -113,7 +113,7 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 myMotor, err := motor.FromRobot(robot, "my_motor")
 
 // Set the motor power to 40% forwards.
-myMotor.SetPower(context.TODO(), 0.4, nil)
+myMotor.SetPower(context.Background(), 0.4, nil)
 
 ```
 
@@ -169,7 +169,7 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 myMotor, err := motor.FromRobot(robot, "my_motor")
 
 // Turn the motor 7.2 revolutions at 60 RPM.
-myMotor.GoFor(context.TODO(), 60, 7.2, nil)
+myMotor.GoFor(context.Background(), 60, 7.2, nil)
 ```
 
 {{% /tab %}}
@@ -222,7 +222,7 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 myMotor, err := motor.FromRobot(robot, "my_motor")
 
 // Turn the motor to 8.3 revolutions from home at 75 RPM.
-myMotor.GoTo(context.TODO(), 75, 8.3, nil)
+myMotor.GoTo(context.Background(), 75, 8.3, nil)
 ```
 
 {{% /tab %}}
@@ -271,7 +271,7 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 myMotor, err := motor.FromRobot(robot, "my_motor")
 
 // Set the current position as the new home position with no offset.
-myMotor.ResetZeroPosition(context.TODO(), 0.0, nil)
+myMotor.ResetZeroPosition(context.Background(), 0.0, nil)
 ```
 
 {{% /tab %}}
@@ -322,7 +322,7 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 myMotor, err := motor.FromRobot(robot, "my_motor")
 
 // Get the current position of the motor.
-position, _ := myMotor.Position(context.TODO(), nil)
+position, _ := myMotor.Position(context.Background(), nil)
 ```
 
 {{% /tab %}}
@@ -374,7 +374,7 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 myMotor, err := motor.FromRobot(robot, "my_motor")
 
 // Return whether or not the motor supports certain optional features.
-properties, _ := myMotor.Properties(context.TODO(), nil)
+properties, _ := myMotor.Properties(context.Background(), nil)
 
 // Log the properties.
 logger.Info("Properties:")
@@ -426,7 +426,7 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 myMotor, err := motor.FromRobot(robot, "my_motor")
 
 // Stop the motor.
-myMotor.Stop(context.TODO(), nil)
+myMotor.Stop(context.Background(), nil)
 ```
 
 {{% /tab %}}
@@ -480,7 +480,7 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 myMotor, err := motor.FromRobot(robot, "my_motor")
 
 // Check whether the motor is currently running.
-powered, pct, _ := myMotor.IsPowered(context.TODO(), nil)
+powered, pct, _ := myMotor.IsPowered(context.Background(), nil)
 
 logger.Info("Is powered?")
 logger.Info(powered)
@@ -534,7 +534,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 myMotor, err := motor.FromRobot(robot, "my_motor")
 
 // Check whether the motor is currently moving.
-moving, _ := myMotor.IsMoving(context.TODO())
+moving, _ := myMotor.IsMoving(context.Background())
 
 logger.Info("Is moving?")
 logger.Info(moving)

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -41,61 +41,13 @@ Model | Description <a name="model-table"></a>
 
 ## Control your motor with Viam's client SDK libraries
 
-The following example assumes you have motors called `motor1` and `motor2` configured as components of your robot.
-If your motor has a different name, change the `name` in the example.
+To get started using Viam's SDKs to connect to and control your robot, go to your robot's page on [the Viam app](https://app.viam.com), navigate to the **code sample** tab, select your preferred programming language, and copy the sample code generated.
 
-{{< tabs >}}
-{{% tab name="Python" %}}
+When executed, this sample code will create a connection to your robot as a client.
+Then control your robot programmatically by adding API method calls as shown in the following examples.
 
-Place the example code in the `main()` function after `robot = await connect()`.
-
-```python
-from viam.components.motor import Motor
-
-robot = await connect() # Refer to CODE SAMPLE tab code
-motor1 = Motor.from_robot(robot, "motor1")
-motor2 = Motor.from_robot(robot, "motor2")
-
-# Power motor1 at 100% for 3 seconds
-await motor1.set_power(1)
-await asyncio.sleep(3)
-await motor1.stop()
-
-# Run motor2 at 1000 rpm for 200 rotations
-await motor2.go_for(1000, 200)
-```
-
-{{% /tab %}}
-{{% tab name="Go" %}}
-
-Place the example code in the `main()` function after `robot, err := client.New(...)`.
-
-```go
-import (
-  "context"
-  "time"
-
-  "github.com/edaniels/golog"
-
-  "go.viam.com/rdk/components/motor"
-)
-
-robot, err := client.New() // Refer to CODE SAMPLE tab code
-// Grab the motors from the robot
-m1, err := motor.FromRobot(robot, "motor1")
-m2, err := motor.FromRobot(robot, "motor2")
-
-// Power motor1 at 100% for 3 seconds
-m1.SetPower(context.TODO(), 1, nil)
-time.Sleep(3 * time.Second)
-m1.Stop(context.TODO(), nil)
-
-// Run motor2 at 1000 RPM for 200 rotations
-m2.GoFor(context.TODO(), 1000, 200, nil)
-```
-
-{{% /tab %}}
-{{< /tabs >}}
+These examples assume you have a motor called `"my_motor"` configured as a component of your robot.
+If your motor has a different name, change the `name` in the code.
 
 ## API
 
@@ -135,10 +87,8 @@ Power is expressed as a floating point between -1 and 1 that scales between -100
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/motor/index.html#viam.components.motor.Motor.set_power).
 
-**Example usage:**
-
 ```python
-my_motor = Motor.from_robot(robot=robot, name='my_motor')
+my_motor = Motor.from_robot(robot=robot, name="my_motor")
 
 # Set the power to 40% forwards.
 await my_motor.set_power(power = 0.4)
@@ -159,10 +109,8 @@ await my_motor.set_power(power = 0.4)
 
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
-**Example usage:**
-
 ```go
-myMotor, err := motor.FromRobot(robot, "motor1")
+myMotor, err := motor.FromRobot(robot, "my_motor")
 
 // Set the motor power to 40% forwards.
 myMotor.SetPower(context.TODO(), 0.4, nil)
@@ -192,10 +140,8 @@ If both `rpm` and `revolutions` are negative, the motor spins in the forward dir
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/motor/index.html#viam.components.motor.Motor.go_for).
 
-**Example usage:**
-
 ```python
-my_motor = Motor.from_robot(robot=robot, name='my_motor')
+my_motor = Motor.from_robot(robot=robot, name="my_motor")
 
 # Turn the motor 7.2 revolutions at 60 RPM.
 await my_motor.go_for(rpm=60, revolutions=7.2)
@@ -219,10 +165,8 @@ await my_motor.go_for(rpm=60, revolutions=7.2)
 
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
-**Example usage:**
-
 ```go
-myMotor, err := motor.FromRobot(robot, "motor1")
+myMotor, err := motor.FromRobot(robot, "my_motor")
 
 // Turn the motor 7.2 revolutions at 60 RPM.
 myMotor.GoFor(context.TODO(), 60, 7.2, nil)
@@ -251,10 +195,8 @@ This blocks until the position has been reached.
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/motor/index.html#viam.components.motor.Motor.go_to).
 
-**Example usage:**
-
 ```python
-my_motor = Motor.from_robot(robot=robot, name='my_motor')
+my_motor = Motor.from_robot(robot=robot, name="my_motor")
 
 # Turn the motor to 8.3 revolutions from home at 75 RPM.
 await my_motor.go_to(rpm=75, revolutions=8.3)
@@ -276,10 +218,8 @@ await my_motor.go_to(rpm=75, revolutions=8.3)
 
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
-**Example usage:**
-
 ```go
-myMotor, err := motor.FromRobot(robot, "motor1")
+myMotor, err := motor.FromRobot(robot, "my_motor")
 
 // Turn the motor to 8.3 revolutions from home at 75 RPM.
 myMotor.GoTo(context.TODO(), 75, 8.3, nil)
@@ -305,10 +245,8 @@ Set the current position (modified by `offset`) to be the new zero (home) positi
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/motor/index.html#viam.components.motor.Motor.reset_zero_position).
 
-**Example usage:**
-
 ```python
-my_motor = Motor.from_robot(robot=robot, name='my_motor')
+my_motor = Motor.from_robot(robot=robot, name="my_motor")
 
 # Set the current position as the new home position with no offset.
 await my_motor.reset_zero_position(offset=0.0)
@@ -329,10 +267,8 @@ await my_motor.reset_zero_position(offset=0.0)
 
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
-**Example usage:**
-
 ```go
-myMotor, err := motor.FromRobot(robot, "motor1")
+myMotor, err := motor.FromRobot(robot, "my_motor")
 
 // Set the current position as the new home position with no offset.
 myMotor.ResetZeroPosition(context.TODO(), 0.0, nil)
@@ -360,10 +296,8 @@ This method raises an exception if position reporting is not supported by the mo
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/motor/index.html#viam.components.motor.Motor.get_position).
 
-**Example usage:**
-
 ```python
-my_motor = Motor.from_robot(robot=robot, name='my_motor')
+my_motor = Motor.from_robot(robot=robot, name="my_motor")
 
 # Get the current position of the motor.
 position = await my_motor.get_position()
@@ -384,10 +318,8 @@ position = await my_motor.get_position()
 
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
-**Example usage:**
-
 ```go
-myMotor, err := motor.FromRobot(robot, "motor1")
+myMotor, err := motor.FromRobot(robot, "my_motor")
 
 // Get the current position of the motor.
 position, _ := myMotor.Position(context.TODO(), nil)
@@ -413,15 +345,14 @@ Report a dictionary mapping optional properties to whether it is supported by th
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/motor/index.html#viam.components.motor.Motor.get_properties).
 
-**Example usage:**
-
 ```python
-my_motor = Motor.from_robot(robot=robot, name='my_motor')
+my_motor = Motor.from_robot(robot=robot, name="my_motor")
 
 # Report a dictionary mapping optional properties to whether it is supported by this motor.
 properties = await my_motor.get_properties()
-print('Properties:')
-print(properties)
+
+# Print out the properties.
+print(f'Properties: {properties}')
 ```
 
 {{% /tab %}}
@@ -439,13 +370,13 @@ print(properties)
 
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
-**Example usage:**
-
 ```go
-myMotor, err := motor.FromRobot(robot, "motor1")
+myMotor, err := motor.FromRobot(robot, "my_motor")
 
 // Return whether or not the motor supports certain optional features.
 properties, _ := myMotor.Properties(context.TODO(), nil)
+
+// Log the properties.
 logger.Info("Properties:")
 logger.Info(properties)
 ```
@@ -470,10 +401,8 @@ Cut the power to the motor immediately, without any gradual step down.
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/motor/index.html#viam.components.motor.Motor.stop).
 
-**Example usage:**
-
 ```python
-my_motor = Motor.from_robot(robot=robot, name='my_motor')
+my_motor = Motor.from_robot(robot=robot, name="my_motor")
 
 # Stop the motor.
 await my_motor.stop()
@@ -493,10 +422,8 @@ await my_motor.stop()
 
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
-**Example usage:**
-
 ```go
-myMotor, err := motor.FromRobot(robot, "motor1")
+myMotor, err := motor.FromRobot(robot, "my_motor")
 
 // Stop the motor.
 myMotor.Stop(context.TODO(), nil)
@@ -524,14 +451,13 @@ The float represents the current portion of max power to the motor (between 0 an
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/motor/index.html#viam.components.motor.Motor.is_powered).
 
-**Example usage:**
-
 ```python
-my_motor = Motor.from_robot(robot=robot, name='my_motor')
+my_motor = Motor.from_robot(robot=robot, name="my_motor")
 
 # Check whether the motor is currently running.
 powered = await my_motor.is_powered()
-print('Powered:', powered)
+
+print('Powered: ', powered)
 ```
 
 {{% /tab %}}
@@ -550,13 +476,12 @@ print('Powered:', powered)
 
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
-**Example usage:**
-
 ```go
-myMotor, err := motor.FromRobot(robot, "motor1")
+myMotor, err := motor.FromRobot(robot, "my_motor")
 
 // Check whether the motor is currently running.
 powered, pct, _ := myMotor.IsPowered(context.TODO(), nil)
+
 logger.Info("Is powered?")
 logger.Info(powered)
 logger.Info("Power percent:")
@@ -583,14 +508,12 @@ Returns whether the motor is actively moving (or attempting to move) under its o
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/motor/index.html#viam.components.motor.Motor.is_moving).
 
-**Example usage:**
-
 ```python
-my_motor = Motor.from_robot(robot=robot, name='my_motor')
+my_motor = Motor.from_robot(robot=robot, name="my_motor")
 
 # Check whether the motor is currently moving.
 moving = await my_motor.is_moving()
-print('Moving:', moving)
+print('Moving: ', moving)
 ```
 
 {{% /tab %}}
@@ -607,13 +530,12 @@ print('Moving:', moving)
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#MovingCheckable).
 
-**Example usage:**
-
 ```go
-myMotor, err := motor.FromRobot(robot, "motor1")
+myMotor, err := motor.FromRobot(robot, "my_motor")
 
 // Check whether the motor is currently moving.
 moving, _ := myMotor.IsMoving(context.TODO())
+
 logger.Info("Is moving?")
 logger.Info(moving)
 ```
@@ -639,12 +561,13 @@ If you are implementing your own motor and add features that have no built-in AP
 - `result` (`Dict[str, Any]`): Result of the executed command.
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_motor = Motor.from_robot(robot=robot, name='my_motor')
+my_motor = Motor.from_robot(robot=robot, name="my_motor")
 
 raw_dict = {
   "command": "raw",
   "raw_input": "home"
 }
+
 await my_motor.do_command(raw_dict)
 ```
 
@@ -664,7 +587,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/#the-do-
 - `error` ([`error`](https://pkg.go.dev/builtin#error)): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-myMotor, err := motor.FromRobot(robot, "motor1")
+myMotor, err := motor.FromRobot(robot, "my_motor")
 
 resp, err := myMotor.DoCommand(ctx, map[string]interface{}{"command": "jog", "raw_input": "home"})
 ```

--- a/docs/components/movement-sensor/_index.md
+++ b/docs/components/movement-sensor/_index.md
@@ -560,7 +560,7 @@ readings = await my_movement_sensor.get_readings()
 **Returns:**
 
 - (map[[string]](https://pkg.go.dev/builtin#string)interface{}): A map containing the measurements from the sensor.
-Contents depend on sensor model and can be of any type.
+    Contents depend on sensor model and can be of any type.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 For more information, see the [Go SDK docs for Sensor](https://pkg.go.dev/go.viam.com/rdk/components/sensor#Sensor) (because `Readings` is part of the general sensor API that movement sensor wraps).

--- a/docs/components/movement-sensor/_index.md
+++ b/docs/components/movement-sensor/_index.md
@@ -630,7 +630,7 @@ For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/
 
 ## Next Steps
 
-Try adding a movement sensor to your [mobile robot](/components/base) and writing some code with our [SDKs](/program/sdk-as-client) to implement closed-loop movement control for your robot.
+Try adding a movement sensor to your [mobile robot](../base) and writing some code with our [SDKs](../../program/sdk-as-client) to implement closed-loop movement control for your robot.
 
 Or, try configuring [data capture](../../services/data/) on your movement sensor.
 

--- a/docs/components/movement-sensor/_index.md
+++ b/docs/components/movement-sensor/_index.md
@@ -122,7 +122,7 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 myMovementSensor, err := movementsensor.FromRobot(robot, "my_movement_sensor")
 
 // Get the current position of the movement sensor.
-position, _ := myMovementSensor.Position(context.TODO(), nil)
+position, _ := myMovementSensor.Position(context.Background(), nil)
 ```
 
 {{% /tab %}}
@@ -177,7 +177,7 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 myMovementSensor, err := movementsensor.FromRobot(robot, "my_movement_sensor")
 
 // Get the current linear velocity of the movement sensor.
-linVel, _ := myMovementSensor.LinearVelocity(context.TODO(), nil)
+linVel, _ := myMovementSensor.LinearVelocity(context.Background(), nil)
 ```
 
 {{% /tab %}}
@@ -235,7 +235,7 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 myMovementSensor, err := movementsensor.FromRobot(robot, "my_movement_sensor")
 
 // Get the current angular velocity of the movement sensor.
-angVel, _ := myMovementSensor.AngularVelocity(context.TODO(), nil)
+angVel, _ := myMovementSensor.AngularVelocity(context.Background(), nil)
 
 // Get the y component of angular velocity.
 yAngVel := angVel.Y
@@ -296,7 +296,7 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 myMovementSensor, err := movementsensor.FromRobot(robot, "my_movement_sensor")
 
 // Get the current linear acceleration of the movement sensor.
-linAccel, _ := myMovementSensor.LinearAcceleration(context.TODO(), nil)
+linAccel, _ := myMovementSensor.LinearAcceleration(context.Background(), nil)
 
 // Get the x component of linear acceleration
 xAngVel := linAccel.X
@@ -354,7 +354,7 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 myMovementSensor, err := movementsensor.FromRobot(robot, "my_movement_sensor")
 
 // Get the current compass heading of the movement sensor.
-heading, _ := myMovementSensor.CompassHeading(context.TODO(), nil)
+heading, _ := myMovementSensor.CompassHeading(context.Background(), nil)
 ```
 
 {{% /tab %}}
@@ -405,7 +405,7 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 myMovementSensor, err := movementsensor.FromRobot(robot, "my_movement_sensor")
 
 // Get the current orientation of the movement sensor.
-sensorOrientation, _ := myMovementSensor.Orientation(context.TODO(), nil)
+sensorOrientation, _ := myMovementSensor.Orientation(context.Background(), nil)
 
 // Get the orientation vector (a unit vector pointing in the same direction as the sensor and theta, an angle representing the sensor's rotation about that axis).
 orientation := sensorOrientation.OrientationVectorDegrees()
@@ -463,7 +463,7 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 myMovementSensor, err := movementsensor.FromRobot(robot, "my_movement_sensor")
 
 // Get the supported properties of the movement sensor.
-properties, _ := myMovementSensor.Properties(context.TODO(), nil)
+properties, _ := myMovementSensor.Properties(context.Background(), nil)
 ```
 
 {{% /tab %}}
@@ -516,7 +516,7 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 myMovementSensor, err := movementsensor.FromRobot(robot, "my_movement_sensor")
 
 // Get the accuracy of the movement sensor.
-accuracy, _ := myMovementSensor.Accuracy(context.TODO(), nil)
+accuracy, _ := myMovementSensor.Accuracy(context.Background(), nil)
 ```
 
 {{% /tab %}}
@@ -569,7 +569,7 @@ For more information, see the [Go SDK docs for Sensor](https://pkg.go.dev/go.via
 myMovementSensor, err := movementsensor.FromRobot(robot, "my_movement_sensor")
 
 // Get the latest readings from the movement sensor.
-readings, _ := myMovementSensor.Readings(context.TODO(), nil)
+readings, _ := myMovementSensor.Readings(context.Background(), nil)
 ```
 
 {{% /tab %}}

--- a/docs/components/movement-sensor/_index.md
+++ b/docs/components/movement-sensor/_index.md
@@ -40,57 +40,13 @@ Model | Description <a name="model-table"></a>
 
 ## Control your movement sensor with Viam's client SDK libraries
 
-The following example assumes you have a movement sensor called `my-imu` configured as a component of your robot.
-If your movement sensor has a different name, change the `name` in the example.
+To get started using Viam's SDKs to connect to and control your robot, go to your robot's page on [the Viam app](https://app.viam.com), navigate to the **code sample** tab, select your preferred programming language, and copy the sample code generated.
 
-{{< tabs >}}
-{{% tab name="Python" %}}
+When executed, this sample code will create a connection to your robot as a client.
+Then control your robot programmatically by adding API method calls as shown in the following examples.
 
-Place the example code in `main()` after `robot = await connect()`.
-
-```python
-from viam.components.movement_sensor import MovementSensor
-
-robot = await connect() # Refer to CODE SAMPLE tab code
-my_imu = MovementSensor.from_robot(robot, "my-imu")
-
-# Get the current linear acceleration
-lin_accel = await my_imu.get_linear_acceleration()
-print(f"my-imu linear acceleration in the x direction: {lin_accel.x}")
-```
-
-{{% /tab %}}
-{{% tab name="Go" %}}
-
-Place the example code in the `main()` function after `robot, err := client.New(...)`.
-
-```go
-import (
-  "context"
-  "time"
-
-  "github.com/edaniels/golog"
-
-  "go.viam.com/rdk/components/movementsensor"
-)
-
-robot, err := client.New() // Refer to CODE SAMPLE tab code
-// Grab the movement sensor from the robot
-myIMU, err := movementsensor.FromRobot(robot, "my-imu")
-if err != nil {
-  logger.Fatalf("cannot get movement sensor: %v", err) 
-}
-
-// Get the current linear acceleration
-linAccel, err := myIMU.LinearAcceleration(context.Background(), map[string]interface{}{})
-if err != nil { 
-  logger.Fatalf("cannot get linear acceleration: %v", err) 
-}
-logger.Info("my-imu LinearAcceleration in the x direction: ", linAccel.X)
-```
-
-{{% /tab %}}
-{{< /tabs >}}
+These examples assume you have a movement sensor called `"my_movement_sensor"` configured as a component of your robot.
+If your movement sensor has a different name, change the `name` in the code.
 
 ## API
 
@@ -138,10 +94,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example usage:**
 
 ```python
-my_sensor = MovementSensor.from_robot(robot=robot, name='my_movement_sensor')
+my_movement_sensor = MovementSensor.from_robot(robot=robot, name="my_movement_sensor")
 
 # Get the current position of the movement sensor.
-position = await my_sensor.get_position()
+position = await my_movement_sensor.get_position()
 ```
 
 {{% /tab %}}
@@ -163,10 +119,10 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example usage:**
 
 ```go
-mySensor, err := movementsensor.FromRobot(robot, "sensor1")
+myMovementSensor, err := movementsensor.FromRobot(robot, "my_movement_sensor")
 
 // Get the current position of the movement sensor.
-position, _ := mySensor.Position(context.TODO(), nil)
+position, _ := myMovementSensor.Position(context.TODO(), nil)
 ```
 
 {{% /tab %}}
@@ -194,10 +150,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example usage:**
 
 ```python
-my_sensor = MovementSensor.from_robot(robot=robot, name='my_movement_sensor')
+my_movement_sensor = MovementSensor.from_robot(robot=robot, name="my_movement_sensor")
 
 # Get the current linear velocity of the movement sensor.
-lin_vel = await my_sensor.get_linear_velocity()
+lin_vel = await my_movement_sensor.get_linear_velocity()
 ```
 
 {{% /tab %}}
@@ -218,10 +174,10 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example usage:**
 
 ```go
-mySensor, err := movementsensor.FromRobot(robot, "sensor1")
+myMovementSensor, err := movementsensor.FromRobot(robot, "my_movement_sensor")
 
 // Get the current linear velocity of the movement sensor.
-linVel, _ := mySensor.LinearVelocity(context.TODO(), nil)
+linVel, _ := myMovementSensor.LinearVelocity(context.TODO(), nil)
 ```
 
 {{% /tab %}}
@@ -249,11 +205,12 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example usage:**
 
 ```python
-my_sensor = MovementSensor.from_robot(robot=robot, name='my_movement_sensor')
+my_movement_sensor = MovementSensor.from_robot(robot=robot, name="my_movement_sensor")
 
 # Get the current angular velocity of the movement sensor.
-ang_vel = await my_sensor.get_angular_velocity()
-# Get the y component of angular velocity
+ang_vel = await my_movement_sensor.get_angular_velocity()
+
+# Get the y component of angular velocity.
 y_ang_vel = ang_vel.y
 ```
 
@@ -275,11 +232,12 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example usage:**
 
 ```go
-mySensor, err := movementsensor.FromRobot(robot, "sensor1")
+myMovementSensor, err := movementsensor.FromRobot(robot, "my_movement_sensor")
 
 // Get the current angular velocity of the movement sensor.
-angVel, _ := mySensor.AngularVelocity(context.TODO(), nil)
-// Get the y component of angular velocity
+angVel, _ := myMovementSensor.AngularVelocity(context.TODO(), nil)
+
+// Get the y component of angular velocity.
 yAngVel := angVel.Y
 ```
 
@@ -308,11 +266,12 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example usage:**
 
 ```python
-my_sensor = MovementSensor.from_robot(robot=robot, name='my_movement_sensor')
+my_movement_sensor = MovementSensor.from_robot(robot=robot, name="my_movement_sensor")
 
 # Get the current linear acceleration of the movement sensor.
-lin_accel = await my_sensor.get_linear_acceleration()
-# Get the x component of linear acceleration
+lin_accel = await my_movement_sensor.get_linear_acceleration()
+
+# Get the x component of linear acceleration.
 x_lin_accel = lin_accel.x
 ```
 
@@ -334,10 +293,11 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example usage:**
 
 ```go
-mySensor, err := movementsensor.FromRobot(robot, "sensor1")
+myMovementSensor, err := movementsensor.FromRobot(robot, "my_movement_sensor")
 
 // Get the current linear acceleration of the movement sensor.
-linAccel, _ := mySensor.LinearAcceleration(context.TODO(), nil)
+linAccel, _ := myMovementSensor.LinearAcceleration(context.TODO(), nil)
+
 // Get the x component of linear acceleration
 xAngVel := linAccel.X
 ```
@@ -367,10 +327,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example usage:**
 
 ```python
-my_sensor = MovementSensor.from_robot(robot=robot, name='my_movement_sensor')
+my_movement_sensor = MovementSensor.from_robot(robot=robot, name="my_movement_sensor")
 
 # Get the current compass heading of the movement sensor.
-heading = await my_sensor.get_compass_heading()
+heading = await my_movement_sensor.get_compass_heading()
 ```
 
 {{% /tab %}}
@@ -391,10 +351,10 @@ For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example usage:**
 
 ```go
-mySensor, err := movementsensor.FromRobot(robot, "sensor1")
+myMovementSensor, err := movementsensor.FromRobot(robot, "my_movement_sensor")
 
 // Get the current compass heading of the movement sensor.
-heading, _ := mySensor.CompassHeading(context.TODO(), nil)
+heading, _ := myMovementSensor.CompassHeading(context.TODO(), nil)
 ```
 
 {{% /tab %}}
@@ -419,13 +379,11 @@ Supported by IMU models.
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/movement_sensor/index.html#viam.components.movement_sensor.MovementSensor.get_orientation).
 
-**Example usage:**
-
 ```python
-my_sensor = MovementSensor.from_robot(robot=robot, name='my_movement_sensor')
+my_movement_sensor = MovementSensor.from_robot(robot=robot, name="my_movement_sensor")
 
 # Get the current orientation vector of the movement sensor.
-orientation = await my_sensor.get_orientation()
+orientation = await my_movement_sensor.get_orientation()
 ```
 
 {{% /tab %}}
@@ -438,25 +396,25 @@ orientation = await my_sensor.get_orientation()
 
 **Returns:**
 
-- [(spacialmath.Orientation)](https://pkg.go.dev/go.viam.com/rdk/spatialmath#Orientation): Orientation is an interface used to express the different parameterizations of the orientation of the movement sensor in 3D Euclidean space.
+- [(spatialmath.Orientation)](https://pkg.go.dev/go.viam.com/rdk/spatialmath#Orientation): Orientation is an interface used to express the different parameterizations of the orientation of the movement sensor in 3D Euclidean space.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/movementsensor#MovementSensor).
 
-**Example usage:**
-
 ```go {class="line-numbers linkable-line-numbers"}
-mySensor, err := movementsensor.FromRobot(robot, "sensor1")
+myMovementSensor, err := movementsensor.FromRobot(robot, "my_movement_sensor")
 
 // Get the current orientation of the movement sensor.
-sensorOrientation, _ := mySensor.Orientation(context.TODO(), nil)
-// Get the orientation vector (a unit vector pointing in the same direction as the sensor,
-// plus an angle representing the sensor's rotation about that axis)
-vector := sensorOrientation.OrientationVectorDegrees()
-logger.Info("The x component of the orientation vector: ", vector.OX)
-logger.Info("The y component of the orientation vector: ", vector.OY)
-logger.Info("The z component of the orientation vector: ", vector.OZ)
-logger.Info("The number of degrees that the movement sensor is rotated about the vector: ", vector.OX)
+sensorOrientation, _ := myMovementSensor.Orientation(context.TODO(), nil)
+
+// Get the orientation vector (a unit vector pointing in the same direction as the sensor and theta, an angle representing the sensor's rotation about that axis).
+orientation := sensorOrientation.OrientationVectorDegrees()
+
+// Print out the orientation vector.
+logger.Info("The x component of the orientation vector: ", orientation.OX)
+logger.Info("The y component of the orientation vector: ", orientation.OY)
+logger.Info("The z component of the orientation vector: ", orientation.OZ)
+logger.Info("The number of degrees that the movement sensor is rotated about the vector: ", orientation.OX)
 ```
 
 {{% /tab %}}
@@ -479,13 +437,11 @@ Get the supported properties of this sensor.
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/movement_sensor/index.html#viam.components.movement_sensor.MovementSensor.get_properties).
 
-**Example usage:**
-
 ```python
-my_sensor = MovementSensor.from_robot(robot=robot, name='my_movement_sensor')
+my_movement_sensor = MovementSensor.from_robot(robot=robot, name="my_movement_sensor")
 
 # Get the supported properties of the movement sensor.
-properties = await my_sensor.get_properties()
+properties = await my_movement_sensor.get_properties()
 ```
 
 {{% /tab %}}
@@ -503,13 +459,11 @@ properties = await my_sensor.get_properties()
 
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/movementsensor#MovementSensor).
 
-**Example usage:**
-
 ```go
-mySensor, err := movementsensor.FromRobot(robot, "sensor1")
+myMovementSensor, err := movementsensor.FromRobot(robot, "my_movement_sensor")
 
 // Get the supported properties of the movement sensor.
-properties, _ := mySensor.Properties(context.TODO(), nil)
+properties, _ := myMovementSensor.Properties(context.TODO(), nil)
 ```
 
 {{% /tab %}}
@@ -535,13 +489,11 @@ Supported by GPS models.
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/movement_sensor/index.html#viam.components.movement_sensor.MovementSensor.get_accuracy).
 
-**Example usage:**
-
 ```python
-my_sensor = MovementSensor.from_robot(robot=robot, name='my_movement_sensor')
+my_movement_sensor = MovementSensor.from_robot(robot=robot, name="my_movement_sensor")
 
 # Get the accuracy of the movement sensor.
-accuracy = await my_sensor.get_accuracy()
+accuracy = await my_movement_sensor.get_accuracy()
 ```
 
 {{% /tab %}}
@@ -560,13 +512,11 @@ accuracy = await my_sensor.get_accuracy()
 
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/movementsensor#MovementSensor).
 
-**Example usage:**
-
 ```go
-mySensor, err := movementsensor.FromRobot(robot, "sensor1")
+myMovementSensor, err := movementsensor.FromRobot(robot, "my_movement_sensor")
 
 // Get the accuracy of the movement sensor.
-accuracy, _ := mySensor.Accuracy(context.TODO(), nil)
+accuracy, _ := myMovementSensor.Accuracy(context.TODO(), nil)
 ```
 
 {{% /tab %}}
@@ -587,18 +537,16 @@ If a sensor is not configured to take a certain measurement or fails to read a p
 
 **Returns:**
 
-- ([Mapping](https://docs.python.org/3/glossary.html#term-mapping)[[str](https://docs.python.org/3/library/stdtypes.html#str), Any]): An object containing the measurements from the sensor.
-  Contents depend on sensor model and can be of any type.
+- ([Mapping [str, Any]](https://docs.python.org/3/glossary.html#term-mapping)): An object containing the measurements from the sensor.
+Contents depend on sensor model and can be of any type.
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/movement_sensor/index.html#viam.components.movement_sensor.MovementSensor.get_readings).
 
-**Example usage:**
-
 ```python
-my_sensor = MovementSensor.from_robot(robot=robot, name='my_movement_sensor')
+my_movement_sensor = MovementSensor.from_robot(robot=robot, name="my_movement_sensor")
 
 # Get the latest readings from the movement sensor.
-readings = await my_sensor.get_readings()
+readings = await my_movement_sensor.get_readings()
 ```
 
 {{% /tab %}}
@@ -612,18 +560,16 @@ readings = await my_sensor.get_readings()
 **Returns:**
 
 - (map[[string]](https://pkg.go.dev/builtin#string)interface{}): A map containing the measurements from the sensor.
-  Contents depend on sensor model and can be of any type.
+Contents depend on sensor model and can be of any type.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 For more information, see the [Go SDK docs for Sensor](https://pkg.go.dev/go.viam.com/rdk/components/sensor#Sensor) (because `Readings` is part of the general sensor API that movement sensor wraps).
 
-**Example usage:**
-
 ```go
-mySensor, err := movementsensor.FromRobot(robot, "sensor1")
+myMovementSensor, err := movementsensor.FromRobot(robot, "my_movement_sensor")
 
 // Get the latest readings from the movement sensor.
-readings, _ := mySensor.Readings(context.TODO(), nil)
+readings, _ := myMovementSensor.Readings(context.TODO(), nil)
 ```
 
 {{% /tab %}}
@@ -646,13 +592,14 @@ If you are implementing your own movement sensor and add features that have no b
 - `result` (`Dict[str, Any]`): Result of the executed command.
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_sensor = MovementSensor.from_robot(robot=robot, name='my_movement_sensor')
+my_movement_sensor = MovementSensor.from_robot(robot=robot, name="my_movement_sensor")
 
 reset_dict = {
   "command": "reset",
   "example_param": 30
 }
-do_response = await my_sensor.do_command(reset_dict)
+
+do_response = await my_movement_sensor.do_command(reset_dict)
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/#the-do-method).
@@ -671,9 +618,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/#the-do-
 - `error` ([`error`](https://pkg.go.dev/builtin#error)): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-mySensor, err := movementsensor.FromRobot(robot, "sensor1")
+myMovementSensor, err := movementsensor.FromRobot(robot, "my_movement_sensor")
 
-resp, err := mySensor.DoCommand(ctx, map[string]interface{}{"command": "reset", "example_param": 30})
+resp, err := myMovementSensor.DoCommand(ctx, map[string]interface{}{"command": "reset", "example_param": 30})
 ```
 
 For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/blob/main/resource/resource.go).
@@ -683,7 +630,7 @@ For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/
 
 ## Next Steps
 
-Try adding a movement sensor to your [mobile robot](../base/) and writing some code with our [SDKs](../../program/sdk-as-client/) to implement closed-loop movement control for your robot.
+Try adding a movement sensor to your [mobile robot](/components/base) and writing some code with our [SDKs](/program/sdk-as-client) to implement closed-loop movement control for your robot.
 
 Or, try configuring [data capture](../../services/data/) on your movement sensor.
 

--- a/docs/components/sensor/_index.md
+++ b/docs/components/sensor/_index.md
@@ -53,7 +53,7 @@ To get started using Viam's SDKs to connect to and control your robot, go to you
 When executed, this sample code will create a connection to your robot as a client.
 Then control your robot programmatically by adding API method calls as shown in the following examples.
 
-These examples assume you have a sensor called "my_sensor" configured as a component of your robot.
+These examples assume you have a sensor called `"my_sensor"` configured as a component of your robot.
 If your sensor has a different name, change the `name` in the code.
 
 ## API
@@ -106,10 +106,8 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 ```go
 mySensor, err := sensor.FromRobot(robot, "my_sensor")
-if err != nil {
-  logger.Fatalf("cannot get sensor: %v", err)
-}
 
+// Get the readings provided by the sensor.
 readings, err := mySensor.Readings(context.Background(), nil)
 ```
 

--- a/docs/components/servo.md
+++ b/docs/components/servo.md
@@ -186,9 +186,6 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 ```go {class="line-numbers linkable-line-numbers"}
 myServo, err := servo.FromRobot(robot, "my_servo")
-if err != nil {
-  logger.Fatalf("cannot get servo: %v", err)
-}
 
 // Move the servo from its origin to the desired angle of 10 degrees.
 myServo.Move(context.Background(), 10, nil)
@@ -250,7 +247,7 @@ pos2 = await my_servo.get_position()
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/servo#Servo).
 
 ```go {class="line-numbers linkable-line-numbers"}
-my_servo, err := servo.FromRobot(robot, "my_servo")
+myServo, err := servo.FromRobot(robot, "my_servo")
 
 // Move the servo from its origin to the desired angle of 10 degrees.
 myServo.Move(context.Background(), 10, nil)
@@ -363,10 +360,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/#the-do-
 - `error` ([`error`](https://pkg.go.dev/builtin#error)): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-  myServo, err := servo.FromRobot(robot, "my_servo")
+myServo, err := servo.FromRobot(robot, "my_servo")
 
-  command := map[string]interface{}{"cmd": "test", "data1": 500}
-  result, err := myServo.DoCommand(context.Background(), command)
+command := map[string]interface{}{"cmd": "test", "data1": 500}
+result, err := myServo.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/blob/main/resource/resource.go).

--- a/docs/components/servo.md
+++ b/docs/components/servo.md
@@ -286,7 +286,7 @@ Stop the servo from moving.
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/servo/client/index.html#viam.components.servo.client.ServoClient.stop).
 
-```python {class="line-numbers l inkable-line-numbers"}
+```python {class="line-numbers linkable-line-numbers"}
 my_servo = Servo.from_robot(robot=robot, name="my_servo")
 
 # Move the servo from its origin to the desired angle of 10 degrees.

--- a/docs/components/servo.md
+++ b/docs/components/servo.md
@@ -29,7 +29,7 @@ Most robots with a servo need at least the following hardware:
 {{% alert title="Note" color="note" %}}
 
 Instead of powering the servo with a separate power supply, you may choose to power it using the 5V and ground pins on the board.
-This can work, as long as the servo is not under any significant load.
+This can work as long as the servo is not under any significant load.
 Keep in mind that if the servo draws too much power, it can cause the board to temporarily lose power.
 
 {{% /alert %}}
@@ -108,91 +108,13 @@ The `gpio` model has the following attributes, which are optional to define in y
 
 ## Control your servo with Viam's client SDK libraries
 
-- [Python SDK Documentation](https://python.viam.dev/autoapi/viam/components/servo/index.html)
-- [Go SDK Documentation](https://pkg.go.dev/go.viam.com/rdk/components/servo)
+To get started using Viam's SDKs to connect to and control your robot, go to your robot's page on [the Viam app](https://app.viam.com), navigate to the **code sample** tab, select your preferred programming language, and copy the sample code generated.
 
-{{% alert title="Note" color="note" %}}
+When executed, this sample code will create a connection to your robot as a client.
+Then control your robot programmatically by adding API method calls as shown in the following examples.
 
-The following example assumes you have a servo called "my_servo" configured as a component of your robot, and that your robot is connected on [the Viam app](https://app.viam.com/).
-If your servo has a different name, change the `name` in the example.
-
-Check out the [Client SDK Libraries Quick Start](/program/sdk-as-client/) documentation for an overview of how to get started connecting to your robot using these libraries.
-
-{{% /alert %}}
-
-{{< tabs >}}
-{{% tab name="Python" %}}
-
-```python {class="line-numbers linkable-line-numbers"}
-from viam.components.servo import Servo
-
-async def main():
-    # Connect to your robot.
-    robot = await connect()
-
-    # Log an info message with the names of the different resources that are connected to your robot.
-    print('Resources:')
-    print(robot.resource_names)
-
-    # Connect to your servo.
-    my_servo = Servo.from_robot(robot=robot, name='my_servo')
-
-    # Disconnect from your robot.
-    await robot.close()
-
-if __name__ == '__main__':
-    asyncio.run(main())
-```
-
-{{% /tab %}}
-{{% tab name="Go" %}}
-
-```go {class="line-numbers linkable-line-numbers"}
-import (
-  "context"
-  "github.com/edaniels/golog"
-  "go.viam.com/rdk/components/servo"
-)
-
-func main() {
-
-  // Create an instance of a logger.
-  logger := golog.NewDevelopmentLogger("client")
-
-  // Connect to your robot.
-  robot, err := client.New(
-      context.Background(),
-      "[ADD YOUR ROBOT ADDRESS HERE. YOU CAN FIND THIS ON THE CODE SAMPLE TAB OF THE VIAM APP]",
-      logger,
-      client.WithDialOptions(rpc.WithCredentials(rpc.Credentials{
-          Type:    utils.CredentialsTypeRobotLocationSecret,
-          Payload: "[PLEASE ADD YOUR SECRET HERE. YOU CAN FIND THIS ON THE CODE SAMPLE TAB OF THE VIAM APP]",
-      })),
-  )
-
-  // Log any errors that occur.
-  if err != nil {
-      logger.Fatal(err)
-  }
-
-  // Delay closing your connection to your robot until main() exits.
-  defer robot.Close(context.Background())
-
-  // Log an info message with the names of the different resources that are connected to your robot.
-  logger.Info("Resources:")
-  logger.Info(robot.ResourceNames())
-
-  // Connect to your servo.
-  myServo, err := servo.FromRobot(robot, "my_servo")
-  if err != nil {
-    logger.Fatalf("cannot get servo: %v", err)
-  }
-
-}
-```
-
-{{% /tab %}}
-{{< /tabs >}}
+These examples assume you have a servo called `"my_servo"` configured as a component of your robot.
+If your servo has a different name, change the `name` in the code.
 
 ## API
 
@@ -238,7 +160,7 @@ It is recommended that you test your servo to determine the desired speed.
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/servo/client/index.html#viam.components.servo.client.ServoClient.move).
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_servo = Servo.from_robot(robot=robot, name='my_servo')
+my_servo = Servo.from_robot(robot=robot, name="my_servo")
 
 # Move the servo from its origin to the desired angle of 10 degrees.
 await my_servo.move(10)
@@ -297,7 +219,7 @@ Get the current set angle of the servo in degrees.
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/servo/client/index.html#viam.components.servo.client.ServoClient.get_position).
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_servo = Servo.from_robot(robot=robot, name='my_servo')
+my_servo = Servo.from_robot(robot=robot, name="my_servo")
 
 # Move the servo from its origin to the desired angle of 10 degrees.
 await my_servo.move(10)
@@ -329,9 +251,6 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 ```go {class="line-numbers linkable-line-numbers"}
 my_servo, err := servo.FromRobot(robot, "my_servo")
-if err != nil {
-  logger.Fatalf("cannot get servo: %v", err)
-}
 
 // Move the servo from its origin to the desired angle of 10 degrees.
 myServo.Move(context.Background(), 10, nil)
@@ -368,7 +287,7 @@ Stop the servo from moving.
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/servo/client/index.html#viam.components.servo.client.ServoClient.stop).
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_servo = Servo.from_robot(robot=robot, name='my_servo')
+my_servo = Servo.from_robot(robot=robot, name="my_servo")
 
 # Move the servo from its origin to the desired angle of 10 degrees.
 await my_servo.move(10)
@@ -393,9 +312,6 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 ```go {class="line-numbers linkable-line-numbers"}
 myServo, err := servo.FromRobot(robot, "my_servo")
-if err != nil {
-  logger.Fatalf("cannot get servo: %v", err)
-}
 
 // Move the servo from its origin to the desired angle of 10 degrees.
 myServo.Move(context.Background(), 10, nil)

--- a/docs/components/servo.md
+++ b/docs/components/servo.md
@@ -286,7 +286,7 @@ Stop the servo from moving.
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/servo/client/index.html#viam.components.servo.client.ServoClient.stop).
 
-```python {class="line-numbers linkable-line-numbers"}
+```python {class="line-numbers l inkable-line-numbers"}
 my_servo = Servo.from_robot(robot=robot, name="my_servo")
 
 # Move the servo from its origin to the desired angle of 10 degrees.


### PR DESCRIPTION
- subtask of DOCS-480 alignment
- remove full code samples in favor of directing to code sample tab 
- standardize component names
- standardize code samples