### PR TITLE
change cartographer capitalization in linkTitle

### DIFF
--- a/docs/services/slam/cartographer/_index.md
+++ b/docs/services/slam/cartographer/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Cartographer Integrated Library"
-linkTitle: "cartographer"
+linkTitle: "Cartographer"
 weight: 70
 type: "docs"
 description: "Configure a SLAM service with the Cartographer library."


### PR DESCRIPTION
- all the other service tabs are capitalized
