### PR TITLE
Change rplidar component name in slam tutorial

### DIFF
--- a/docs/services/slam/cartographer/_index.md
+++ b/docs/services/slam/cartographer/_index.md
@@ -83,7 +83,7 @@ Paste the following into the **Attributes** field of your new service:
   "data_dir": "/home/<YOUR_USERNAME>/<CARTOGRAPHER_DIR>",
   "delete_processed_data": true,
   "use_live_data": true,
-  "sensors": ["rplidar"],
+  "sensors": ["<YOUR_RPLIDAR_COMPONENT_NAME>"],
   "config_params": {
     "mode": "2d"
   }
@@ -99,7 +99,7 @@ Paste the following into the **Attributes** field of your new service:
   "data_dir": "/Users/<YOUR_USERNAME>/<CARTOGRAPHER_DIR>",
   "delete_processed_data": true,
   "use_live_data": true,
-  "sensors": ["rplidar"],
+  "sensors": ["<YOUR_RPLIDAR_COMPONENT_NAME>"],
   "config_params": {
     "mode": "2d"
   }
@@ -153,7 +153,7 @@ Select the **Raw JSON** mode, then copy/paste the following `"services"` and `"m
       "data_dir": "/home/<YOUR_USERNAME>/<CARTOGRAPHER_DIR>",
       "delete_processed_data": true,
       "use_live_data": true,
-      "sensors": ["rplidar"],
+      "sensors": ["<YOUR_RPLIDAR_COMPONENT_NAME>"],
       "config_params": {
         "mode": "2d"
       }
@@ -183,7 +183,7 @@ Select the **Raw JSON** mode, then copy/paste the following `"services"` and `"m
       "data_dir": "/Users/<YOUR_USERNAME>/<CARTOGRAPHER_DIR>",
       "delete_processed_data": true,
       "use_live_data": true,
-      "sensors": ["rplidar"],
+      "sensors": ["<YOUR_RPLIDAR_COMPONENT_NAME>"],
       "config_params": {
         "mode": "2d"
       }
@@ -213,7 +213,7 @@ Select the **Raw JSON** mode, then copy/paste the following `"services"` and `"m
       "data_dir": "/Users/<YOUR_USERNAME>/<CARTOGRAPHER_DIR>",
       "delete_processed_data": true,
       "use_live_data": true,
-      "sensors": ["rplidar"],
+      "sensors": ["<YOUR_RPLIDAR_COMPONENT_NAME>"],
       "config_params": {
         "mode": "2d"
       }


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-2910

Problem:
* The slam tutorial had instructions to have `"sensors": ["rplidar"]`, whereas in the rplidar tutorial we're telling the user to pick a name of their choice. 
    * This can easily lead to slam not working if the user named their rplidar component anything else except for `"rplidar"`

Solution:
* Indicate to the user that they have to refer to their rplidar component name by changing the `"sensors"` reference to: `"sensors": ["<YOUR_RPLIDAR_COMPONENT_NAME>"]`
