### PR TITLE
fix caps on rplidar title and linktitle 

### DIFF
--- a/docs/program/extend/modular-resources/examples/add-rplidar-module.md
+++ b/docs/program/extend/modular-resources/examples/add-rplidar-module.md
@@ -1,6 +1,6 @@
 ---
-title: "Add a Rplidar as a Modular Component"
-linkTitle: "Add a Rplidar as a Modular Component"
+title: "Add an RPlidar as a Modular Component"
+linkTitle: "Add an RPlidar as a Modular Component"
 weight: 40
 type: "docs"
 description: "How to add an RPlidar as a modular component of your robot."


### PR DESCRIPTION
- update “A Rplidar” to “An RPlidar” to match the rest of the document
