### PR TITLE
DOCS-491: add clarification for ticks_per_rotation and change attributes on encoded motor

### DIFF
--- a/docs/components/motor/gpio/encoded-motor.md
+++ b/docs/components/motor/gpio/encoded-motor.md
@@ -17,7 +17,7 @@ See the [encoder component documentation](/components/encoder/) for more informa
 Viam supports `gpio` model motors with encoders.
 To configure an encoded motor, you must configure the encoder [per the encoder documentation](/components/encoder) and then configure a `gpio` motor with an `encoder` attribute in addition to the [standard `gpio` model attributes](/components/motor/gpio/).
 
-<a id="encoder-config>"
+<a id="encoder-config">
 {{< tabs >}}
 {{% tab name="Config Builder" %}}
 

--- a/docs/components/motor/gpio/encoded-motor.md
+++ b/docs/components/motor/gpio/encoded-motor.md
@@ -17,7 +17,7 @@ See the [encoder component documentation](/components/encoder/) for more informa
 Viam supports `gpio` model motors with encoders.
 To configure an encoded motor, you must configure the encoder [per the encoder documentation](/components/encoder) and then configure a `gpio` motor with an `encoder` attribute in addition to the [standard `gpio` model attributes](/components/motor/gpio/).
 
-<a id="encoder-config">
+<a id="encoder-config>"
 {{< tabs >}}
 {{% tab name="Config Builder" %}}
 
@@ -32,31 +32,31 @@ Here’s an example configuration:
 {
   "components": [
     {
-      "name": <"your-board-name">,
+      "name": "<your-board-name>",
       "type": "board",
-      "model": <"your-board-model">,
+      "model": "<your-board-model>",
       "attributes": {},
       "depends_on": []
     },
     {
-      "name": <"your-encoder=name">,
+      "name": "<your-encoder-name>",
       "type": "encoder",
-      "model": <"your-encoder-model">,
+      "model": "<your-encoder-model>",
       "attributes": {
         ... // insert encoder model specific attributes
       },
       "depends_on": []
     },
     {
-      "name": <"your-motor-name">,
+      "name": "<your-motor-name>",
       "type": "motor",
       "model": "gpio",
       "attributes": {
-        "board": <"your-board-name">,
+        "board": "<your-board-name>",
         "pins": {
-          <...>
+          <...> // insert pins struct
         },
-        "encoder": <"your-encoder-name">,
+        "encoder": "<your-encoder-name>",
         "ticks_per_rotation": <#>
       },
       "depends_on": []

--- a/docs/components/motor/gpio/encoded-motor.md
+++ b/docs/components/motor/gpio/encoded-motor.md
@@ -32,16 +32,16 @@ Here’s an example configuration:
 {
   "components": [
     {
-      "name": <board_name>,
+      "name": <your-board-name>,
       "type": "board",
-      "model": <board_model>,
+      "model": <your-board-model>,
       "attributes": {},
       "depends_on": []
     },
     {
-      "name": <encoder_name>,
+      "name": <your-encoder=name>,
       "type": "encoder",
-      "model": "incremental",
+      "model": <encoder-model>,
       "attributes": {
         "board": <board_name>,
         "pins": {
@@ -52,11 +52,11 @@ Here’s an example configuration:
       "depends_on": []
     },
     {
-      "name": <motor_name>,
+      "name": <your-motor-name>,
       "type": "motor",
       "model": "gpio",
       "attributes": {
-        "board": <board_name>,
+        "board": <your-board-name>,
         "pins": {
           <...>
         },
@@ -130,11 +130,13 @@ In addition to the [attributes for a non-encoded motor](/components/motor/gpio),
 | ---- | ---- | --------- | ----------- |
 | `encoder` | string | **Required** | `name` of the encoder. |
 | `ticks_per_rotation` | string | **Required** | Number of ticks in a full rotation of the encoder and motor shaft. |
-| `ramp_rate` | number | Optional | How fast to ramp power to motor when using RPM control. 0.01 ramps very slowly; 1 ramps instantaneously. Range is (0.0, 1.0]. <br> Default = `0.2` |
+| `ramp_rate` | number | Optional | Rate to increase the motor's input voltage (power supply) per second when increasing the speed the motor rotates (RPM). <br> Range = `(0.0, 1.0]` <br> Default = `0.2` |
 
 {{% alert title="Note" color="note" %}}
 
 The attribute [`max_rpm`](/components/motor/gpio) is not required or available for encoded `gpio` motors.
+
+If `encoder` is model [`AM5-AS5048`](/components/encoder/ams-as5048/),`ticks_per_rotation` must be `"1"`, as `AM5-AS5048` is an absolute encoder which provides angular measurements directly.
 
 {{% /alert %}}
 

--- a/docs/components/motor/gpio/encoded-motor.md
+++ b/docs/components/motor/gpio/encoded-motor.md
@@ -127,7 +127,7 @@ In addition to the [attributes for a non-encoded motor](/components/motor/gpio),
 | ---- | ---- | --------- | ----------- |
 | `encoder` | string | **Required** | `name` of the encoder. |
 | `ticks_per_rotation` | int | **Required** | Number of ticks in a full rotation of the encoder and motor shaft. |
-| `ramp_rate` | float | Optional | Rate to increase the motor's input voltage (power supply) per second when increasing the speed the motor rotates (RPM). <br> Range = `(0.0, 1.0]` <br> Default = `0.2` |
+| `ramp_rate` | float | Optional | Rate to increase the motor's input voltage (power supply) per second when increasing the speed the motor rotates (RPM). <br> Range = (`0.0`, `1.0`] <br> Default = `0.2` |
 
 {{% alert title="Note" color="note" %}}
 

--- a/docs/components/motor/gpio/encoded-motor.md
+++ b/docs/components/motor/gpio/encoded-motor.md
@@ -133,7 +133,7 @@ In addition to the [attributes for a non-encoded motor](/components/motor/gpio),
 
 The attribute [`max_rpm`](/components/motor/gpio) is not required or available for encoded `gpio` motors.
 
-If `encoder` is model [`AM5-AS5048`](/components/encoder/ams-as5048/),`ticks_per_rotation` must be `"1"`, as `AM5-AS5048` is an absolute encoder which provides angular measurements directly.
+If `encoder` is model [`AM5-AS5048`](/components/encoder/ams-as5048/),`ticks_per_rotation` must be `1`, as `AM5-AS5048` is an absolute encoder which provides angular measurements directly.
 
 {{% /alert %}}
 

--- a/docs/components/motor/gpio/encoded-motor.md
+++ b/docs/components/motor/gpio/encoded-motor.md
@@ -32,35 +32,32 @@ Here’s an example configuration:
 {
   "components": [
     {
-      "name": <your-board-name>,
+      "name": <"your-board-name">,
       "type": "board",
-      "model": <your-board-model>,
+      "model": <"your-board-model">,
       "attributes": {},
       "depends_on": []
     },
     {
-      "name": <your-encoder=name>,
+      "name": <"your-encoder=name">,
       "type": "encoder",
-      "model": <encoder-model>,
+      "model": <"your-encoder-model">,
       "attributes": {
-        "board": <board_name>,
-        "pins": {
-          "a": <first_pin_number>,
-          "b": <second_pin_number>
-        }
+        ... // insert encoder model specific attributes
       },
       "depends_on": []
     },
     {
-      "name": <your-motor-name>,
+      "name": <"your-motor-name">,
       "type": "motor",
       "model": "gpio",
       "attributes": {
-        "board": <your-board-name>,
+        "board": <"your-board-name">,
         "pins": {
           <...>
         },
-        <...other_board_attributes...>
+        "encoder": <"your-encoder-name">,
+        "ticks_per_rotation": <#>
       },
       "depends_on": []
     }
@@ -129,8 +126,8 @@ In addition to the [attributes for a non-encoded motor](/components/motor/gpio),
 | Name | Type | Inclusion | Description |
 | ---- | ---- | --------- | ----------- |
 | `encoder` | string | **Required** | `name` of the encoder. |
-| `ticks_per_rotation` | string | **Required** | Number of ticks in a full rotation of the encoder and motor shaft. |
-| `ramp_rate` | number | Optional | Rate to increase the motor's input voltage (power supply) per second when increasing the speed the motor rotates (RPM). <br> Range = `(0.0, 1.0]` <br> Default = `0.2` |
+| `ticks_per_rotation` | int | **Required** | Number of ticks in a full rotation of the encoder and motor shaft. |
+| `ramp_rate` | float | Optional | Rate to increase the motor's input voltage (power supply) per second when increasing the speed the motor rotates (RPM). <br> Range = `(0.0, 1.0]` <br> Default = `0.2` |
 
 {{% alert title="Note" color="note" %}}
 


### PR DESCRIPTION
- quick win
- changed attributes format & clarified model specification
- changed description of ticks_per_rotation attribute to make meaning of rpm control / rate specification clearer