### PR TITLE
RSDK-2847 State that attributes not needed for rplidar on Linux

### DIFF
--- a/docs/program/extend/modular-resources/examples/add-rplidar-module.md
+++ b/docs/program/extend/modular-resources/examples/add-rplidar-module.md
@@ -59,7 +59,7 @@ Add a component with type `camera`, model `viam:lidar:rplidar`, and a name of yo
 
 ![adding rplidar component](../../img/add-rplidar/add-rplidar-component-ui.png)
 
-Paste the following into the **Attributes** field of your new component according to your machine's architecture:
+Paste the following into the **Attributes** field of your new component according to your machine's architecture (none needed for Linux):
 
 {{< tabs name="Add Rplidar Configs">}}
 {{% tab name="MacOS x86_64" %}}


### PR DESCRIPTION
While QA'ing for SLAM, I noticed it might be confusing why there is no sub-tab to set the attributes / device_path for an rplidar on Linux. I added a note saying it's not needed on Linux.