### PR TITLE
Fix a few more JSON misquotes

### DIFF
--- a/docs/components/arm/eva.md
+++ b/docs/components/arm/eva.md
@@ -18,7 +18,7 @@ Configure an `eva` arm as follows:
 
 ```json {class="line-numbers linkable-line-numbers"}
 {
-    "name": "<arm_name">",
+    "name": "<arm_name>",
     "type": "arm",
     "model": "eva",
     "attributes": {

--- a/docs/components/arm/fake.md
+++ b/docs/components/arm/fake.md
@@ -63,7 +63,7 @@ Refer to the following JSON examples for differences in configuration between th
 
 ```json {class="line-numbers linkable-line-numbers"}
 {
-    "name": "<arm-name">",
+    "name": "<arm-name>",
     "type": "arm",
     "model": "fake",
     "attributes": {

--- a/docs/components/arm/yahboom-dofbot.md
+++ b/docs/components/arm/yahboom-dofbot.md
@@ -18,7 +18,7 @@ Configure a `yahboom-dofbot` arm as follows:
 
 ```json {class="line-numbers linkable-line-numbers"}
 {
-    "name": "<arm_name">",
+    "name": "<arm_name>",
     "type": "arm",
     "model": "yahboom-dofbot",
     "attributes": {

--- a/docs/components/board/beaglebone.md
+++ b/docs/components/board/beaglebone.md
@@ -32,7 +32,7 @@ Enter a name for your board, select the type `board`, and select the `beaglebone
 {
   "components": [
     {
-      "name": "<your-beaglebone-board">,
+      "name": "<your-beaglebone-board>",
       "type": "board",
       "model": "beaglebone",
       "attributes": {},


### PR DESCRIPTION
Fixed a few more JSON quote mismatches. VSCode Regex: `"[A-Za-z0-9]*": "<[A-Za-z0-9_-]*"`