### PR TITLE
Align Community landing page card with other cards

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -48,11 +48,9 @@ Learn about [the Viam platform in 3 minutes](viam).
     </div>
     <div class="col landing-hover-card">
         <div class="landing-hover-card-padding pink">
-        <a href="https://discord.gg/viam">
             <h4>Community</h4>
-            <p style="text-align: left;">Have questions, or want to meet other people working on robots? Join us in the Community Discord!</p>
+            <p style="text-align: left;">Have questions, or want to meet other people working on robots? <a href="https://discord.gg/viam">Join us in the Community Discord!</a></p>
             {{<gif webm_src="img/heart.webm" mp4_src="img/heart.mp4" alt="A robot drawing a heart">}}
-        </a>
         </div>
     </div>
     </div>


### PR DESCRIPTION
The other cards on this page aren't clickable but rather include body text links, so it seems like the Community one should be the same.