### PR TITLE
DOCS-716 asses onboarding docs + extra nits

### DIFF
--- a/docs/appendix/glossary/client-application.md
+++ b/docs/appendix/glossary/client-application.md
@@ -8,5 +8,5 @@ aka:
 
 Client applications run business logic to operate your robot.
 
-You can run a client application on the same {{< glossary_tooltip term_id="part" text="part" >}} that runs the viam-server, or on a separate device.
+You can run a client application on the same {{< glossary_tooltip term_id="part" text="part" >}} that runs the `viam-server`, or on a separate device.
 Client applications typically use an {{< glossary_tooltip term_id="sdk" text="SDK" >}} to talk to their robot.

--- a/docs/appendix/glossary/client-application.md
+++ b/docs/appendix/glossary/client-application.md
@@ -8,5 +8,5 @@ aka:
 
 Client applications run business logic to operate your robot.
 
-You can run a client application on the same {{< glossary_tooltip term_id="part" text="part" >}} that runs the `viam-server`, or on a separate device.
+You can run a client application on the same {{< glossary_tooltip term_id="part" text="part" >}} that runs `viam-server`, or on a separate device.
 Client applications typically use an {{< glossary_tooltip term_id="sdk" text="SDK" >}} to talk to their robot.

--- a/docs/installation/_index.md
+++ b/docs/installation/_index.md
@@ -78,7 +78,7 @@ The AppImage is a single, self-contained binary that runs on any Linux system (e
 <ol start="2">
 <li> <strong>Download and install <code>viam-server</code>.</strong>
 
-   Run viam-server locally on your Mac with the config you just downloaded.
+   Run `viam-server` locally on your Mac with the config you just downloaded.
    Replace `<YOUR_ROBOT_NAME>` with the name of your robot from the Viam app.
 
    To determine the CPU architecture (x86_64 or aarch64) of your device, run `uname -m` on the command line.
@@ -143,7 +143,7 @@ If you do not want to run `viam-server` as a service, you can also [run it manua
    This connection allows the robot to pull its full configuration information and allows you to monitor and control your robot from the Viam app.
    Download your robot's config file from the **setup** tab of your robot on the Viam app.
 
-3. **Start `viam-server` on your Mac.** Run viam-server locally on your Mac with the config you just downloaded.
+3. **Start `viam-server` on your Mac.** Run `viam-server` locally on your Mac with the config you just downloaded.
    Replace `<YOUR_ROBOT_NAME>` with the name of your robot from the Viam app.
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}

--- a/docs/installation/prepare/rpi-setup.md
+++ b/docs/installation/prepare/rpi-setup.md
@@ -22,7 +22,7 @@ If you already have a 64-bit Linux distribution installed on your Pi, skip ahead
 {{%expand "Click to check whether the Linux installation on your Raspberry Pi is 64-bit" %}}
 
 If you already have a 64-bit Linux distribution installed on your Pi, you can skip ahead to [installing `viam-server`](../../#install-viam-server).
-To check whether the Linux installation on your Raspberry Pi is 64-bit (required for running viam-server), `ssh` into your Pi and then run `lscpu`.
+To check whether the Linux installation on your Raspberry Pi is 64-bit (required for running `viam-server`), `ssh` into your Pi and then run `lscpu`.
 
 Example output:
 

--- a/docs/installation/update/_index.md
+++ b/docs/installation/update/_index.md
@@ -70,7 +70,7 @@ To upgrade to the *absolute latest* version of `viam-server` run this command:
 brew upgrade viam-server --HEAD
 ```
 
-There is not a way to automatically update viam-server on Mac, so we recommend running `brew upgrade viam-server` on a regular basis.
+There is not a way to automatically update `viam-server` on Mac, so we recommend running `brew upgrade viam-server` on a regular basis.
 
 {{% /tab %}}
 {{% /tabs %}}

--- a/docs/internals/robot-to-robot-comms.md
+++ b/docs/internals/robot-to-robot-comms.md
@@ -5,7 +5,7 @@ weight: 20
 type: "docs"
 description: "Explanation of how a robot and its parts interact at the communication layer."
 ---
-When building a robot application in the Viam app [https://app.viam.com](https://app.viam.com), a user typically begins by configuring their robot which can consist of one or more parts.
+When building a robot application in the [Viam app](https://app.viam.com), a user typically begins by configuring their robot which can consist of one or more parts.
 Next they will test that it is wired up properly using the Viam app's Control page.
 Once they've ensured everything is wired up properly, they will build their main application and the business logic for their robot using one of Viam's language SDKs.
 This SDK-based application is typically run on either the main part of the robot or a separate computer dedicated to running the business logic for the robot.
@@ -18,7 +18,7 @@ To begin, let's define our robot's topology:
 
 ![robot-communication-diagram](../img/robot-to-robot-comms/robot-communication-diagram.png)
 
-This robot is made of two parts and separate SDK-based application, which we'll assume is on a third machine, though it could just as easily run on the main part without any changes.
+This robot is made of two parts and a separate SDK-based application, which we'll assume is on a third machine, though it could just as easily run on the main part without any changes.
 
 * The first and main part, RDK Part 1, consists of a Raspberry Pi and a single USB connected camera called Camera.
 

--- a/docs/program/SDK-as-client.md
+++ b/docs/program/SDK-as-client.md
@@ -12,7 +12,7 @@ aliases:
 
 Viam offers software development kits (SDKs) in popular languages which
 
-- Streamline connection, authentication, and encryption using against a server with {{< glossary_tooltip term_id="webrtc" >}}
+- Streamline connection, authentication, and encryption against a server using {{< glossary_tooltip term_id="webrtc" >}}
 - Enable you to interface with robots without calling the `viam-server` [gRPC APIs for robot controls](https://github.com/viamrobotics/api) directly
 
 <img src="../img/SDK-as-client/image1.png" alt="Diagram showing how a client connects to a robot with Viam. Diagram shows a client as a computer sending commands to a robot. Robot 1 then communicates with other robotic parts over gRPC and WebRTC and communicating that information back to the client.">

--- a/docs/try-viam/_index.md
+++ b/docs/try-viam/_index.md
@@ -30,6 +30,6 @@ If you want to control and automate your rover with Python or Go, use the [Viam 
 Viam also exposes a {{< glossary_tooltip term_id="grpc" text="gRPC" >}} [API for robot controls](https://github.com/viamrobotics/api).
 
 Both the API and the SDKs support {{< glossary_tooltip term_id="webrtc" >}}.
-The SDKs provide a wrapper around the viam-server [gRPC](https://grpc.io/) API and streamline connection, authentication, and encryption against a server.
+The SDKs provide a wrapper around the `viam-server` [gRPC](https://grpc.io/) API and streamline connection, authentication, and encryption against a server.
 
 ## Next steps

--- a/docs/try-viam/rover-resources/_index.md
+++ b/docs/try-viam/rover-resources/_index.md
@@ -15,7 +15,7 @@ description: Get your own Viam rover and set it up.
 ---
 
 {{< alert title="Tip" color="tip" >}}
-If you want a convenient mobile {{% glossary_tooltip term_id="base" text="base"%}} for a variety of robotics projects, you can [order your own Viam rover](https://www.viam.com/resources/rover) now.
+If you want a convenient mobile {{% glossary_tooltip term_id="base" text="base"%}} for a variety of robotics projects, you can now [order your own Viam rover](https://www.viam.com/resources/rover).
 {{< /alert >}}
 
 <div class="container td-max-width-on-larger-screens">

--- a/docs/try-viam/rover-resources/rover-tutorial.md
+++ b/docs/try-viam/rover-resources/rover-tutorial.md
@@ -152,7 +152,7 @@ This is the recommended order to assemble your rover:
 
 1. [Install Raspberry Pi OS on the microSD card.](#install-raspberry-pi-os)
 2. [Unscrew the top of the rover and screw the Pi to the base.](#attach-the-raspberry-pi-to-the-rover)
-3. [Conenct the components.](#connect-the-wires)
+3. [Connect the components.](#connect-the-wires)
 4. [Screw the top of the rover back on and turn the rover on.](#turn-the-rover-on)
 5. [Install `viam-server` and connect to the Viam app.](#connect-to-the-viam-app)
 
@@ -182,7 +182,7 @@ Only attach the paper when the Pi is unplugged.
 To make attaching the paper easier, use a credit card or a small screwdriver.
 {{< /alert >}}
 
-Wire your Pi to the buck converter, the acceleration tilt module, the DC motor driver:
+Wire your Pi to the buck converter, the acceleration tilt module, and the DC motor driver:
 
 ![Closeup of the wiring diagram, showcasing the Pi, motor driver, accelerometer, and buck converter, wired according to the table below.](../img/viam-rover/wiring-diagram.png)
 
@@ -232,7 +232,7 @@ If the Pi has power, the lights on the Raspberry Pi will light up.
 
 While the Pi boots, go to [app.viam.com](https://app.viam.com/robots) and [add a robot](/manage/fleet/robots#add-a-new-robot).
 On the robot's **setup** tab, select `Linux` and `Aarch64`.
-`SSH` into the Pi and follow the instructions on the robot's **setup** tab to download `viam-server` and configure your robot.
+`ssh` into the Pi and follow the instructions on the robot's **setup** tab to download `viam-server` and configure your robot.
 
 To configure your rover so you can start driving it, [add the Viam Fragment to your Robot](/try-viam/rover-resources/rover-tutorial-fragments/).
 

--- a/docs/tutorials/get-started/servo-mousemover.md
+++ b/docs/tutorials/get-started/servo-mousemover.md
@@ -30,7 +30,7 @@ This project is a good place to begin if you're new to robotics and would like t
 
 ### Hardware
 
-- [Raspberry Pi with microSD card](https://a.co/d/bxEdcAT), with viam-server installed per our [installation guide](/installation/)
+- [Raspberry Pi with microSD card](https://a.co/d/bxEdcAT), with `viam-server` installed per our [installation guide](/installation/)
 - microSD card reader
 - [Continuous rotation servo](https://a.co/d/2w0u6rK) (we used the FS90R servo)
 - Wheel or arm for the servo (this comes in some of the FS90R packages)
@@ -55,7 +55,7 @@ This project is a good place to begin if you're new to robotics and would like t
 
 ## Install Viam software
 
-First, install viam-server according to our [installation guide](/installation/)
+First, install `viam-server` according to our [installation guide](/installation/)
 
 Next, run this command in your Raspberry Pi terminal to install the pip package manager. Select "yes" when it asks if you want to continue.
 

--- a/docs/tutorials/projects/integrating-viam-with-openai.md
+++ b/docs/tutorials/projects/integrating-viam-with-openai.md
@@ -189,7 +189,7 @@ Click **Create Component**.
 
 <img src="../../img/ai-integration/servo_component_add.png" style="border:1px solid #000" alt="Adding the servo component." title="Adding the servo component." width="900" />
 
-Now, in the panel for *servo1*, add the following configuration in attributes to tell viam-server that the servo is attached to GPIO pin 8, then press the **Save Config** button.
+Now, in the panel for *servo1*, add the following configuration in attributes to tell `viam-server` that the servo is attached to GPIO pin 8, then press the **Save Config** button.
 
 ``` json
 {

--- a/static/include/try-viam/create-a-reservation.md
+++ b/static/include/try-viam/create-a-reservation.md
@@ -18,5 +18,5 @@
 
 3. **Click "TRY MY ROVER" to use your Viam Rover.**
 
-   You’ll be able to control a Viam Rover in the Viam robotics lab for 15 minutes.
+   You’ll be able to control a Viam Rover in the Viam robotics lab for 10 minutes.
    There is a session timer in the top banner.


### PR DESCRIPTION
Small tweaks to low-hanging fruit where discussion or further consideration is unlikely to be necessary. Kept most changes to within onboarding sections -- Viam in 3 Minutes, Try Viam, and the Installation Guide -- but my monospace efforts for `viam-server` ended up being corpus wide 😅 .

Happy for any corrections if I did something wrong -- thanks!!