### PR TITLE
RSDK-2961 Remove offline mode from slam public documentation

### DIFF
--- a/docs/services/slam/cartographer/_index.md
+++ b/docs/services/slam/cartographer/_index.md
@@ -54,7 +54,7 @@ Before adding a SLAM service, you must follow [these instructions](/program/exte
 
 ### Add a SLAM Service
 
-{{< tabs name="Add the Cartographer Service Live">}}
+{{< tabs name="Add the Cartographer Service">}}
 {{% tab name="Config Builder" %}}
 
 Go to your robot's page on the [Viam app](https://app.viam.com/).
@@ -66,7 +66,7 @@ Add a service with type `slam`, model `viam:slam:cartographer`, and a name of yo
 
 Paste the following into the **Attributes** field of your new service:
 
-{{< tabs name="Add Cartographer Service Live Configs">}}
+{{< tabs name="Add Cartographer Service Configs">}}
 {{% tab name="Linux" %}}
 
 ```json
@@ -100,7 +100,7 @@ Paste the following into the **Attributes** field of your new service:
 
 Click on the **Modules** subtab. Add the cartographer module with a name of your choice and an executable path that points to the location of your installed `cartographer-module` binary:
 
-{{< tabs name="Add Cartographer Service Live Module">}}
+{{< tabs name="Add Cartographer Service Module">}}
 {{% tab name="Linux/MacOS x86_64" %}}
 
 ![adding cartographer module linux](../img/run_slam/add-cartographer-module-ui-linux.png)
@@ -121,7 +121,7 @@ Go to your robot's page on the [Viam app](https://app.viam.com/).
 Navigate to the **Config** tab.
 Select the **Raw JSON** mode, then copy/paste the following `"services"` and `"modules"` JSON to add to your existing RPlidar configuration:
 
-{{< tabs name="Add the Cartographer Service Live Config JSON OSs">}}
+{{< tabs name="Add the Cartographer Service Config JSON OSs">}}
 {{% tab name="Linux" %}}
 
 ```json

--- a/docs/services/slam/cartographer/_index.md
+++ b/docs/services/slam/cartographer/_index.md
@@ -44,22 +44,13 @@ brew tap viamrobotics/brews && brew install cartographer-module
 
 ## Configuration
 
-How you configure `cartographer-module` depends on whether you want the SLAM service to build your map with data collected live by a [RPlidar](https://www.slamtec.com/en/Lidar/A3) or with LIDAR data provided in a dataset at runtime.
-
-Select from the following modes to obtain the correct instructions to configure the service:
-
-{{% tabs name="Modes"%}}
-{{% tab name="Live Data Collection" %}}
-
 {{% alert title="REQUIREMENTS" color="tip" %}}
 
-Running `cartographer-module` in Live Data Collection mode requires a [RPlidar A1](https://www.slamtec.com/en/Lidar/A1) or [RPlidar A3](https://www.slamtec.com/en/Lidar/A3) LIDAR scanning device. The default ['config_params'](#config_params) for the cartographer library, and the example robot config shown below (which uses the default 'config_params'), show nominal parameters one can use for an RPlidar A3. See the notes next to the 'config_params' for recommended settings for an RPlidar A1.
+Running `cartographer-module` requires a [RPlidar A1](https://www.slamtec.com/en/Lidar/A1) or [RPlidar A3](https://www.slamtec.com/en/Lidar/A3) LIDAR scanning device. The default ['config_params'](#config_params) for the cartographer library, and the example robot config shown below (which uses the default 'config_params'), show nominal parameters one can use for an RPlidar A3. See the notes next to the 'config_params' for recommended settings for an RPlidar A1.
 
 Before adding a SLAM service, you must follow [these instructions](/program/extend/modular-resources/examples/add-rplidar-module) to add your RPlidar device as a modular component of your robot.
 
 {{% /alert %}}
-
-<br>
 
 ### Add a SLAM Service
 
@@ -82,7 +73,6 @@ Paste the following into the **Attributes** field of your new service:
 {
   "data_dir": "/home/<YOUR_USERNAME>/<CARTOGRAPHER_DIR>",
   "delete_processed_data": true,
-  "use_live_data": true,
   "sensors": ["<YOUR_RPLIDAR_COMPONENT_NAME>"],
   "config_params": {
     "mode": "2d"
@@ -98,7 +88,6 @@ Paste the following into the **Attributes** field of your new service:
 {
   "data_dir": "/Users/<YOUR_USERNAME>/<CARTOGRAPHER_DIR>",
   "delete_processed_data": true,
-  "use_live_data": true,
   "sensors": ["<YOUR_RPLIDAR_COMPONENT_NAME>"],
   "config_params": {
     "mode": "2d"
@@ -152,7 +141,6 @@ Select the **Raw JSON** mode, then copy/paste the following `"services"` and `"m
     "attributes": {
       "data_dir": "/home/<YOUR_USERNAME>/<CARTOGRAPHER_DIR>",
       "delete_processed_data": true,
-      "use_live_data": true,
       "sensors": ["<YOUR_RPLIDAR_COMPONENT_NAME>"],
       "config_params": {
         "mode": "2d"
@@ -182,7 +170,6 @@ Select the **Raw JSON** mode, then copy/paste the following `"services"` and `"m
     "attributes": {
       "data_dir": "/Users/<YOUR_USERNAME>/<CARTOGRAPHER_DIR>",
       "delete_processed_data": true,
-      "use_live_data": true,
       "sensors": ["<YOUR_RPLIDAR_COMPONENT_NAME>"],
       "config_params": {
         "mode": "2d"
@@ -212,7 +199,6 @@ Select the **Raw JSON** mode, then copy/paste the following `"services"` and `"m
     "attributes": {
       "data_dir": "/Users/<YOUR_USERNAME>/<CARTOGRAPHER_DIR>",
       "delete_processed_data": true,
-      "use_live_data": true,
       "sensors": ["<YOUR_RPLIDAR_COMPONENT_NAME>"],
       "config_params": {
         "mode": "2d"
@@ -276,261 +262,12 @@ If this directory structure is not present at runtime, the SLAM Service creates 
 
 {{% /alert %}}
 
-{{% /tab %}}
-{{% tab name="Dataset" %}}
-
-<br>
-
-### Add a SLAM Service
-
-{{< tabs name="Add the Cartographer Service with Dataset">}}
-
-{{% tab name="Config Builder" %}}
-
-Go to your robot's page on the [Viam app](https://app.viam.com/).
-Navigate to the **Config** tab on your robot's page, and click on the **Services** subtab.
-
-Add a service with type `slam`, model `viam:slam:cartographer`, and a name of your choice:
-
-![adding cartographer slam service](../img/run_slam/add-cartographer-service-ui.png)
-
-Paste the following into the **Attributes** field of your new service:
-
-{{< tabs name="Add the Cartographer Service with Dataset Configs">}}
-{{% tab name="Linux" %}}
-
-```json
-{
-    "data_dir": "/home/<YOUR_USERNAME>/<CARTOGRAPHER_DIR>",
-    "delete_processed_data": false,
-    "use_live_data": false
-    "config_params": {
-        "mode": "2d"
-    },
-}
-```
-
-{{% /tab %}}
-
-{{% tab name="MacOS" %}}
-
-```json
-{
-    "data_dir": "/Users/<YOUR_USERNAME>/<CARTOGRAPHER_DIR>",
-    "delete_processed_data": false,
-    "use_live_data": false
-    "config_params": {
-        "mode": "2d"
-    },
-}
-```
-
-{{% /tab %}}
-{{< /tabs >}}
-
-Select the **Raw JSON** mode and copy/paste the following `"modules"` JSON to your existing SLAM configuration:
-
-{{< tabs name="Add Cartographer Service with Dataset Module">}}
-{{% tab name="Linux/MacOS x86_64" %}}
-
-```json
-"modules": [
-  // { ...}, YOUR RPLIDAR MODULE,
-  {
-    "executable_path": "/usr/local/bin/cartographer-module",
-    "name": "cartographer-module"
-  }
-],
-// "components": [ ...], YOUR RPLIDAR MODULAR COMPONENT,
-// "services": [ ...], YOUR SLAM SERVICE
-```
-
-{{% /tab %}}
-
-{{% tab name="MacOS ARM64 (M1 & M2)" %}}
-
-```json
-"modules": [
-  // { ...}, YOUR RPLIDAR MODULE,
-  {
-    "executable_path": "/opt/homebrew/bin/cartographer-module",
-    "name": "cartographer-module"
-  }
-],
-// "components": [ ...], YOUR RPLIDAR MODULAR COMPONENT,
-// "services": [ ...], YOUR SLAM SERVICE
-```
-
-{{% /tab %}}
-{{< /tabs >}}
-
-{{% /tab %}}
-{{% tab name="JSON Template" %}}
-
-Go to your robot's page on the [Viam app](https://app.viam.com/).
-Navigate to the **Config** tab.
-Select the **Raw JSON** mode, then copy/paste the following `"services"` JSON to add to your existing configuration:
-
-{{< tabs name="Add the Cartographer Service with Dataset JSON OSs">}}
-{{% tab name="Linux" %}}
-
-``` json
-"modules": [
-  {
-    "executable_path": "/usr/local/bin/cartographer-module",
-    "name": "cartographer-module"
-  }
-],
-"services": [
-{
-    "type": "slam",
-    "name": "<your-service-name>",
-    "model": "cartographer",
-    "attributes": {
-    "config_params": {
-        "mode": "2d"
-    },
-    "data_dir": "/home/<YOUR_USERNAME>/<CARTOGRAPHER_DIR>",
-    "delete_processed_data": false,
-    "use_live_data": false,
-    }
-}
-]
-```
-
-{{% /tab %}}
-{{% tab name="MacOS x86_64" %}}
-
-``` json
-"modules": [
-  {
-    "executable_path": "/usr/local/bin/cartographer-module",
-    "name": "cartographer-module"
-  }
-],
-"services": [
-{
-    "type": "slam",
-    "name": "<your-service-name>",
-    "model": "cartographer",
-    "attributes": {
-    "config_params": {
-        "mode": "2d"
-    },
-    "data_dir": "/Users/<YOUR_USERNAME>/<CARTOGRAPHER_DIR>",
-    "delete_processed_data": false,
-    "use_live_data": false,
-    }
-}
-]
-```
-
-{{% /tab %}}
-{{% tab name="MacOS ARM64 (M1 & M2)" %}}
-
-``` json
-"modules": [
-  {
-    "executable_path": "/opt/homebrew/bin/cartographer-module",
-    "name": "cartographer-module"
-  }
-],
-"services": [
-{
-    "type": "slam",
-    "name": "<your-service-name>",
-    "model": "cartographer",
-    "attributes": {
-    "config_params": {
-        "mode": "2d"
-    },
-    "data_dir": "/Users/<YOUR_USERNAME>/<CARTOGRAPHER_DIR>",
-    "delete_processed_data": false,
-    "use_live_data": false,
-    }
-}
-]
-```
-
-{{% /tab %}}
-{{% /tab %}}
-{{< /tabs >}}
-{{< /tabs >}}
-
-### Adjust `data_dir`
-
-Change the `data_dir` attribute to point to a directory on your machine where you want to save the sensor data your SLAM service uses and the maps and config files it produces.
-
-This directory must be structured as follows:
-
-<pre>
-.
-└──\(<file>CARTOGRAPHER_DIR</file>)
-    ├── <file>map</file>
-    ├── <file>data</file>
-    └── <file>config</file>
-</pre>
-
-Click through the following tabs to see the usage of each folder in this directory:
-
-{{% tabs name="Folders 2"%}}
-{{% tab name="/map" %}}
-
-Whether mapping data is present in <file>map</file> at runtime and the attribute `map_rate_sec` determines the SLAM mapping mode:
-
-### Mapping Modes
-
-| Mode | Description | Runtime Dictation |
-| ---- | ----------- | ------- |
-| PURE MAPPING | Generate a new map. | No map is found in <file>/map</file>. |
-| UPDATING | Update an existing map with new <file>/data</file>. | A map is found in <file>/map</file> + [`map_rate_sec > 0`](#attributes).|
-| LOCALIZING | Localize the robot on an existing map without changing the map itself. | A map is found in <file>/map</file> + [`map_rate_sec = 0`](#attributes). |
-
-{{% /tab %}}
-{{% tab name="/data" %}}
-
-The <file>data</file> folder stores the LIDAR data used for SLAM.
-
-{{% /tab %}}
-{{% tab name="/config" %}}
-
-The <file>config</file> folder stores any Cartographer specific config files created.
-These are generated at runtime, so there is no need to add anything to this folder.
-
-{{% /tab %}}
-{{< /tabs >}}
-
-### Obtain your Dataset
-
-As you are configuring SLAM to run without live data collection, you need to make sure the <file>/data</file> folder in `data_dir` contains LIDAR data for the service to generate <map>/map</file> output from when you run SLAM.
-
-If you do not already have a dataset from running SLAM live or another dataset you want to use as <file>/data</file>, follow these instructions to use a sample dataset from Viam's lab:
-
-1. Download Viam's [lab dataset](https://storage.googleapis.com/viam-labs-datasets/viam-old-office-small-pcd.zip).
-
-2. Copy the zipped file to the machine running `viam-server` and unzip it. For example:
-
-    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-    scp ~/Downloads/viam-old-office-small-pcd.zip <YOUR_USERNAME>@<YOUR_MACHINE>.local:~/.
-    unzip viam-old-office-small-pcd.zip
-    ```
-
-3. Rename the unzipped folder to <file>data</file> and place inside of the folder at <file>data_dir</file>. For example:
-
-    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-    cd /home/YOUR_USERNAME/<CARTOGRAPHER_DIR>
-    mv ~/Downloads/viam-old-office-small-pcd data/
-    ```
-
-{{% /tab %}}
-{{< /tabs >}}
-
 ### View the Map
 
 After saving your config and connecting to your robot, navigate to the **Control** tab on your robot's page and click on the drop-down menu matching the `name` of the service you created.
 
 Change the **Refresh frequency** to your desired frequency.
-If in live data collection mode, move your RPlidar around slowly.
+Move your RPlidar around slowly.
 Watch a map start to appear.
 
 ### Attributes
@@ -539,20 +276,11 @@ Watch a map start to appear.
 | ---- | --------- | --------- | ----------- |
 | `data_dir` | string | **Required** | Path to [the directory](#mapping-modes) used for saving input LIDAR data in <file>/data</file> and output mapping data in <file>/map</file>. |
 | `sensors` | string[] | **Required** | Names of configured RPlidar devices providing data to the SLAM service. |
-| `use_live_data` | bool | **Required** | <p>Whether to run in Live Data Collection mode.</p> <ul> `true`: Use data collected live by `sensors`to generate <file>/map</file>. </ul><ul>`false`: Use a dataset provided in <file>/data</file> to generate <file>/map</file>. </ul> |
 | `map_rate_sec` | int | Optional | Rate of <file>/map</file> generation *(seconds)*. <ul> Default: `60`. </ul> |
 | `data_rate_msec` | int | Optional | Rate of <file>/data</file> collection from `sensors` *(milliseconds)*. <ul>Default: `200`.</ul> |
 | `port` | string | Optional | Port for SLAM gRPC server. If running locally, this should be in the form "localhost:<PORT>". If no value is specified a random available port is assigned. |
 | `delete_processed_data` | bool | Optional | <p>Setting this to `true` helps to reduce the amount of memory required to run SLAM.</p> <ul> `true`: sensor data is deleted after the SLAM algorithm has processed it. </ul><ul> `false`: sensor data is not deleted after the SLAM algorithm has processed it. </ul> |
 | `config_params` |  map[string] string | Optional | Parameters available to fine-tune the `cartographer` algorithm: [read more below](#config_params). |
-
-{{% alert title="Caution" color="caution" %}}
-
-- If `use_live_data: true`, `delete_processed_data: true` by default.
-- If `use_live_data: false`, `delete_processed_data: false` by default.
-
-Setting `delete_processed_data: true` and `use_live_data: false` is invalid and will result in an error.
-{{% /alert %}}
 
 ### `config_params`
 


### PR DESCRIPTION
We realized if [full modularization](https://viam.atlassian.net/browse/RSDK-2210) finishes before [cloud story](https://viam.atlassian.net/browse/RSDK-2262), we’ll temporarily not be able to support offline slam for customers (because we’ll only support offline with a replay camera, and only support a replay camera in the cloud).

We're taking offline mode out of the public docs so no one new starts depending on it until we can support it in the cloud again.

Has to be merged after https://github.com/viamrobotics/slam/pull/193 is merged, a new version of the slam repo is tagged, the viam-cartographer repo is updated to import the new version of the slam repo, and a new stable version of viam-cartographer is tagged.