### PR TITLE
Update pr-deploy-and-comment.yml

### DIFF
--- a/.github/workflows/pr-deploy-and-comment.yml
+++ b/.github/workflows/pr-deploy-and-comment.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           echo url_latest_version = \"https://docs-test.viam.dev/${{ github.event.pull_request.head.sha }}/public\" > config_pr.toml
           echo baseURL = \"https://docs-test.viam.dev/${{ github.event.pull_request.head.sha }}/public\" >> config_pr.toml
+          echo relativeURLs = true >> config_pr.toml
 
       - name: Build
         run: make build-pr


### PR DESCRIPTION
Testing configuring the stage build pipeline with `relativeURLS = true` directly. Can't test a change to the staging pipeline by attempting to stage it! Any staging modifications are only available to the non-local builder once they reside in `main` (example: I just staged this very PR, which [does not reflect](https://github.com/viamrobotics/docs/actions/runs/4995844704/jobs/8948237619?pr=1231#step:5:1) the changes I made to the staging pipeline)