### PR TITLE
Replace slack link with discord

### DIFF
--- a/docs/components/arm/_index.md
+++ b/docs/components/arm/_index.md
@@ -512,7 +512,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).
 
-You can also ask questions on the [Viam Community Slack](https://join.slack.com/t/viamrobotics/shared_invite/zt-1f5xf1qk5-TECJc1MIY1MW0d6ZCg~Wnw) and we will be happy to help.
+You can also ask questions on the [Community Discord](https://discord.gg/viam) and we will be happy to help.
 
 ## Next Steps
 


### PR DESCRIPTION
- Replaced obsolete community slack link with community discord link.