### PR TITLE
RSDK-2961 Also remove troubleshooting note for dataset mode

### DIFF
--- a/docs/services/slam/cartographer/_index.md
+++ b/docs/services/slam/cartographer/_index.md
@@ -317,10 +317,4 @@ When generating a larger map, it will take longer for Cartographer to return the
 This can result in errors or failed requests for a map, however, this will not affect the `viam-server` or `cartographer-module` process.
 Re-requesting the map can and should be successful, although there is currently a fundamental limit for the size of map that can be transmitted to the UI and this issue will become more common as you approach it.
 
-#### Dataset mode produces an error
-
-If there is a saved map in <file>data_dir/map</file> and saved data in <file>data_dir/data</file> from a previous run, then running SLAM with an existing dataset may raise an error at startup since the data has already been incorporated into the map.
-
-If that occurs, you can clear <file>data_dir/map</file> and restart the service.
-
 You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).


### PR DESCRIPTION
This extra bit should have also been removed as part of https://github.com/viamrobotics/docs/commit/6083fbe6f5faf8eebf5bedc04b2b6dbd5af7b7d6