### PR TITLE
DOCS-784: Add Raspberry Pi 3 to carousel & board docs

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -43,6 +43,12 @@ Viam supports a wide variety of systems, including:
     </a>
   </div>
   <div class="col">
+    <a href="installation/prepare/rpi-setup/">
+        <img src="installation/img/thumbnails/rpi-3.png" alt="Raspberry Pi 3" width="100%">
+        <h6>Raspberry Pi 3</h6>
+    </a>
+  </div>
+  <div class="col">
     <a href="installation/prepare/jetson-agx-orin-setup/">
         <img src="installation/img/jetson-agx-orin-setup/jetson-agx-orin-dev-kit.png" alt="Jetson A G X Orin Developer Kit" width="100%">
         <h6>NVIDIA Jetson AGX Orin</h6>

--- a/docs/components/board/_index.md
+++ b/docs/components/board/_index.md
@@ -32,7 +32,7 @@ For model-specific configuration information, click on one of the following mode
 
 | Model | Description |
 | ----- | ----------- |
-| [`pi`](pi) | [Raspberry Pi 4](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/) or [Raspberry Pi Zero 2 W](https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/) |
+| [`pi`](pi) | [Raspberry Pi 4](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/), [Raspberry Pi 3](https://www.raspberrypi.com/products/raspberry-pi-3-model-b/) or [Raspberry Pi Zero 2 W](https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/) |
 | [`ti`](ti) | [Texas Instruments TDA4VM](https://devices.amazonaws.com/detail/a3G8a00000E2QErEAN/TI-TDA4VM-Starter-Kit-for-Edge-AI-vision-systems) |
 | [`beaglebone`](beaglebone) | [BeagleBoard's BeagleBone AI 64](https://beagleboard.org/ai-64) |
 | [`jetson`](jetson) | [NVIDIA Jetson AGX Orin](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/), [NVIDIA Jetson Xavier NX](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-agx-xavier/), [NVIDIA Jetson  Nano](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-nano/) |

--- a/docs/components/board/pi.md
+++ b/docs/components/board/pi.md
@@ -15,7 +15,7 @@ Follow this [setup guide](/installation/prepare/rpi-setup/) to prepare your Pi f
 
 {{% /alert %}}
 
-Configure a `pi` board to integrate a [Raspberry Pi 4](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/) or [Raspberry Pi Zero 2 W](https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/) into your robot:
+Configure a `pi` board to integrate a [Raspberry Pi 4](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/), [Raspberry Pi 3](https://www.raspberrypi.com/products/raspberry-pi-3-model-b/) or [Raspberry Pi Zero 2 W](https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/) into your robot:
 
 {{< tabs name="Configure an pi Board" >}}
 {{% tab name="Config Builder" %}}


### PR DESCRIPTION
* Add as an image to board carousel
* Add to board documentation where supported models of RPI are mentioned