### PR TITLE
Make spacing lint rule warning not error

### DIFF
--- a/.github/vale/styles/Viam/Spacing.yml
+++ b/.github/vale/styles/Viam/Spacing.yml
@@ -1,7 +1,7 @@
 # Based on: https://github.com/errata-ai/Microsoft/blob/master/Microsoft/Spacing.yml
 extends: existence
 message: "'%s' should have one space."
-level: error
+level: warning
 nonword: true
 tokens:
   - '[a-z][.?!] {2,}[A-Z]'


### PR DESCRIPTION
Because this blocks merging on some things like Resource.name
