### PR TITLE
Add `purge` directive to Make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ SERVE_OPTIONS=--baseURL http://localhost
 clean:
 	rm -rf public resources dist
 
+purge:
+	npm cache clean --force && hugo mod clean --all && rm -rf public resources dist node_modules themes .hugo_build.lock
+
 build-prod: clean setup
 	hugo $(PROD_OPTIONS)
 


### PR DESCRIPTION
Added new `purge` make target as an experimental fix for needing to restart to fix certain build error situations.

_Usage:_ `make purge` from within the docs repo. Then run your usual build command, such as `make serve-dev`

**Note:** I have not been able to replicate the build errors that seem to necessitate a restart, so this is a best guess. All deletions made via `purge` are completely rebuilt by the usual build commands, so running `make purge && make serve-dev` for example, should be idempotent (i.e. run as many times as you like, safe to break midway and re-run, etc).

**Warning:** I have _not_ tested this on a system that builds other things, like other `node` or `hugo` properties. Building `viam-server` locally should be unaffected, as it is `go`.  I think we're clear overall, but cannot be sure.