### PR TITLE
Ignore themes dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ public
 .hugo_build.lock
 resources
 node_modules
+themes/*
 config_pr.toml
 .vscode
 dist


### PR DESCRIPTION
This dir managed as a `git submodule` instead, should be safe to exclude. Testing now (and with `make purge`)