### PR TITLE
Tweak purge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ clean:
 	rm -rf public resources dist
 
 purge:
-	npm cache clean --force && hugo mod clean --all && rm -rf public resources dist node_modules themes .hugo_build.lock
+	npm cache clean --force && hugo mod clean --all && rm -rf public resources dist node_modules themes/docsy/* themes/docsy/.[a-zA-Z0-9]* .hugo_build.lock
 
 build-prod: clean setup
 	hugo $(PROD_OPTIONS)


### PR DESCRIPTION
Now properly clearing docsy theme content without touching parent folder. Together with recent .gitignore change, this seems to restore expected git status output for both post-purge, and after next site build.

Wonky double `themes` `rm` call is due to `rm` complaining about `.` and `..`, which, obviously, should not be removed ;). I could have used something like `2 > /dev/null` to ignore, but this avoids the warning altogether, and is a bit more explicit about our deletions; always good.