### PR TITLE
Change GetPosition to Position

### DIFF
--- a/docs/components/encoder/_index.md
+++ b/docs/components/encoder/_index.md
@@ -82,12 +82,12 @@ The encoder component supports the following methods:
 
 Method Name | Description
 ----------- | -----------
-[GetPosition](#getposition) | Get the current position of the encoder.
+[Position](#position) | Get the current position of the encoder.
 [ResetPosition](#resetposition) | Reset the position to zero.
 [GetProperties](#getproperties) | Get the supported properties of this encoder.
 [DoCommand](#docommand) | Send or receive model-specific commands.
 
-### GetPosition
+### Position
 
 Get the current position of the encoder in ticks or degrees.
 Relative encoders return ticks since last zeroing.

--- a/docs/components/encoder/_index.md
+++ b/docs/components/encoder/_index.md
@@ -142,7 +142,7 @@ if err != nil {
 }
 
 // Get the position of the encoder in ticks
-position, posType, err := myEncoder.GetPosition(context.Background(), encoder.PositionTypeTicks, nil)
+position, posType, err := myEncoder.Position(context.Background(), encoder.PositionTypeTicks, nil)
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
`GetPosition` and `GetProperties` in the golang SDK were recently changed to be more in line with other component methods for the golang SDK, I changed where I could find them in the docs. Feel free to add anyone else to this pull request.
