### PR TITLE
DOCS-810 remove blue from monospace toc entries

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -205,6 +205,14 @@ a > code {
   color: #0000EA !important;
 }
 
+.td-toc #TableOfContents ul li li a > code {
+  color: #666666 !important;
+}
+
+.td-toc #TableOfContents ul li a > code {
+  color: #333333 !important;
+}
+
 footer a {
   color: #fff !important;
 }


### PR DESCRIPTION
For TOC entries only: override existing blue monospace code coloring to use same coloring as non-`a` elements.

Two entries:
- `.td-toc #TableOfContents ul li li a > code` for H3s
- `.td-toc #TableOfContents ul li a > code` for H2s

Staging Links:

- Example with H3s: [SLAM Cartographer](https://docs-test.viam.dev/7dad8d5578c8500b9ec7bcccf0ec90ff78c893bd/public/services/slam/cartographer/#adjust-data_dir)
- Example with H2s: [Vision Segmentation](https://docs-test.viam.dev/7dad8d5578c8500b9ec7bcccf0ec90ff78c893bd/public/services/vision/segmentation/#configure-a-radius_clustering_segmenter)