### PR TITLE
Remove text shadow from code-terminal

### DIFF
--- a/static/css/prism.css
+++ b/static/css/prism.css
@@ -126,6 +126,7 @@ div.code-toolbar > .toolbar > .toolbar-item > span {
   border: 1px solid black;
   background-color: #333;
   margin-bottom: 1rem;
+  text-shadow: none;
 }
 
 .code-terminal > pre[class*="language-"] {


### PR DESCRIPTION
Testing a CSS fix to the code shadows in `code-terminal` code blocks.