### PR TITLE
DOCS-839: Explore welcome page intro

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -107,7 +107,7 @@ Viam is a complete software platform for robots that runs on Linux and macOS and
 </div>
 <br>
 
-Explore the following resources to jump right in:
+Explore the following to learn more about the Viam platform or to try it out for yourself:
 
 <div class="container td-max-width-on-larger-screens">
   <div class="row">
@@ -127,7 +127,7 @@ Explore the following resources to jump right in:
             <ol style="padding-inline-start: 1.1rem">
             <li><a href="manage/configuration/">Configure your robot<a> or <a href="manage/fleet/">fleet</a></li>
             <li><a href="installation/">Install Viam on your robot</a></li>
-            <li>Configure robot <a href="components/">components</a> and add <a href="services/">services</a></li>
+            <li><a href="components/">Configure robot components</a> and <a href="services/">add services</a></li>
             <li><a href="manage/fleet/robots/#control">Control and test your robot</a></li>
             </ol>
             {{<gif webm_src="img/blink.webm" mp4_src="img/blink.mp4" alt="A blinking L.E.D. connected to a Raspberry Pi">}}

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -11,7 +11,6 @@ sitemap:
 ---
 
 Welcome to the Viam Documentation!
-
 Viam is a complete software platform for robots that runs on any 64-bit Linux OS and macOS.
 Viam supports a wide variety of systems, including:
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -11,63 +11,7 @@ sitemap:
 ---
 
 Welcome to the Viam Documentation!
-Viam is a complete software platform for robots that runs on any 64-bit Linux OS and macOS.
-
-Explore the following resources to jump right in:
-
-<div class="container td-max-width-on-larger-screens">
-  <div class="row">
-    <div class="col landing-hover-card">
-        <div class="landing-hover-card-padding yellow">
-            <h4>Learn and Try</h4>
-            <p style="text-align: left;">
-            Learn about <a href="viam/">the Viam platform in 3 minutes</a> and then
-            <a href="try-viam/">drive a Viam rover</a> from the comfort of your home or follow along with a <a href="tutorials/"> tutorial</a>.</p>
-            {{<gif webm_src="img/rover.webm" mp4_src="img/rover.mp4" alt="A Viam Rover moving about">}}
-        </div>
-    </div>
-    <div class="col landing-hover-card ">
-        <div class="landing-hover-card-padding purple">
-        <h4>Configure your robots</h4>
-        <div style="text-align: left">
-            <ol style="padding-inline-start: 1.1rem">
-            <li><a href="/manage/fleet/robots/">Set up your robot</a> or<a href="manage/fleet/"> fleet</a></li>
-            <li><a href="installation/">Install Viam on your robot</a></li>
-            <li><a href="manage/configuration/">Configure your robot</a></li>
-            <li><a href="manage/fleet/robots/#control">Test your robot</a></li>
-            </ol>
-            {{<gif webm_src="img/blink.webm" mp4_src="img/blink.mp4" alt="A blinking L.E.D. connected to a Raspberry Pi">}}
-        </div>
-    </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col landing-hover-card">
-        <div class="landing-hover-card-padding teal">
-        <h4>Program your robots</h4>
-        <p style="text-align: left;">
-            Program and control your robots in <a href="program/sdks/"> the languages you already know</a> like <a href="https://python.viam.dev/">Python</a>, <a href="https://pkg.go.dev/go.viam.com/rdk">Go</a>, or <a href="https://ts.viam.dev/">TypeScript</a>.
-        </p>
-        <img src="img/code.png" alt="Robot code">
-        </div>
-    </div>
-    <div class="col landing-hover-card">
-        <div class="landing-hover-card-padding pink">
-            <h4>Community</h4>
-            <p style="text-align: left;">Have questions, or want to meet other people working on robots? <a href="https://discord.gg/viam">Join us in the Community Discord!</a></p>
-            {{<gif webm_src="img/heart.webm" mp4_src="img/heart.mp4" alt="A robot drawing a heart">}}
-        </div>
-    </div>
-    </div>
-</div>
-<br>
-
-Viam includes pre-configured software integration for many popular [boards](/installation/#preparation) and robotics [components](/components/) out of the box, and includes many popular [services](/services/) you might want to use with your robot.
-Click the selections below to learn more:
-
-#### Supported boards
-
-Viam supports the following [boards](/installation/#preparation) out of the box:
+Viam is a complete software platform for robots that runs on Linux and macOS and supports a wide variety of popular systems, including:
 
 <div id="board-carousel" class="carousel td-max-width-on-larger-screens">
   <ul tabindex="0">
@@ -161,160 +105,56 @@ Viam supports the following [boards](/installation/#preparation) out of the box:
   <div class="prev" style="display: block">‹</div>
   <div class="next" style="display: block">›</div>
 </div>
+<br>
 
-#### Supported components
+Viam is designed to be flexible and extensible, and to save you time from prototype to production.
+Explore the following resources to jump right in:
 
-Viam offers pre-defined integration with the following [components](/components/):
-
-<div id="board-carousel" class="carousel td-max-width-on-larger-screens">
-  <ul tabindex="0">
-   <li id="c2_slide1">
-    <a href="components/arm/">
-        <img src="components/img/components/arm.svg" alt="Arm component" width="100%">
-        <h6>Arm</h6>
-    </a>
-  </li>
-  <li id="c2_slide2">
-    <a href="components/base/">
-        <img src="components/img/components/base.svg" alt="Base component" width="100%">
-        <h6>Base</h6>
-    </a>
-  </li>
-  <li id="c2_slide3">
-    <a href="components/board/">
-        <img src="components/img/components/board.svg" alt="Board component" width="100%">
-        <h6>Board</h6>
-    </a>
-  </li>
-  <li id="c2_slide4">
-    <a href="components/camera/">
-        <img src="components/img/components/camera.svg" alt="Camera component" width="100%">
-        <h6>Camera</h6>
-    </a>
-  </li>
-  <li id="c2_slide5">
-    <a href="components/encoder/">
-        <img src="components/img/components/encoder.svg" alt="Encoder component" width="100%">
-        <h6>Encoder</h6>
-    </a>
-  </li>
-  <li id="c2_slide6">
-    <a href="components/gantry/">
-        <img src="components/img/components/gantry.svg" alt="Gantry component" width="100%">
-        <h6>Gantry</h6>
-    </a>
-  </li>
-  <li id="c2_slide7">
-    <a href="components/gripper/">
-        <img src="components/img/components/gripper.svg" alt="Gripper component" width="100%">
-        <h6>Gripper</h6>
-    </a>
-  </li>
-  <li id="c2_slide8">
-    <a href="components/input-controller/">
-        <img src="components/img/components/controller.svg" alt="Input controller component" width="100%">
-        <h6>Input Controller</h6>
-    </a>
-  </li>
-  <li id="c2_slide9">
-    <a href="components/motor/">
-        <img src="components/img/components/motor.svg" alt="Motor component" width="100%">
-        <h6>Motor</h6>
-    </a>
-  </li>
-  <li id="c2_slide10">
-    <a href="components/movement-sensor/">
-        <img src="components/img/components/imu.svg" alt="Movement sensor component" width="100%">
-        <h6>Movement Sensor</h6>
-    </a>
-  </li>
-  <li id="c2_slide11">
-    <a href="components/sensor/">
-        <img src="components/img/components/sensor.svg" alt="Sensor component" width="100%">
-        <h6>Sensor</h6>
-    </a>
-  </li>
-  <li id="c2_slide12">
-    <a href="components/servo/">
-        <img src="components/img/components/servo.svg" alt="Servo component" width="100%">
-        <h6>Servo</h6>
-    </a>
-  </li>
-  </ul>
-  <ol style="visibility: hidden" aria-hidden="true">
-    <li><a href="#c2_slide1">Arm</a></li>
-    <li><a href="#c2_slide2">Base</a></li>
-    <li><a href="#c2_slide3">Board</a></li>
-    <li><a href="#c2_slide4">Camera</a></li>
-    <li><a href="#c2_slide5">Encoder</a></li>
-    <li><a href="#c2_slide6">Gantry</a></li>
-    <li><a href="#c2_slide7">Gripper</a></li>
-    <li><a href="#c2_slide8">Input Controller</a></li>
-    <li><a href="#c2_slide9">Motor</a></li>
-    <li><a href="#c2_slide10">Movement Sensor</a></li>
-    <li><a href="#c2_slide11">Sensor</a></li>
-    <li><a href="#c2_slide12">Servo</a></li>
-  </ol>
-  <div class="prev" style="display: block">‹</div>
-  <div class="next" style="display: block">›</div>
+<div class="container td-max-width-on-larger-screens">
+  <div class="row">
+    <div class="col landing-hover-card">
+        <div class="landing-hover-card-padding yellow">
+            <h4>Learn and Try</h4>
+            <p style="text-align: left;">
+            Learn about <a href="viam/">the Viam platform in 3 minutes</a> and then
+            <a href="try-viam/">drive a Viam rover</a> from the comfort of your home or follow along with a <a href="tutorials/"> tutorial</a>.</p>
+            {{<gif webm_src="img/rover.webm" mp4_src="img/rover.mp4" alt="A Viam Rover moving about">}}
+        </div>
+    </div>
+    <div class="col landing-hover-card ">
+        <div class="landing-hover-card-padding purple">
+        <h4>Configure your robots</h4>
+        <div style="text-align: left">
+            <ol style="padding-inline-start: 1.1rem">
+            <li><a href="installation/">Install Viam on your robot</a></li>
+            <li><a href="manage/configuration/">Configure your robot<a> or <a href="manage/fleet/">fleet</a></li>
+            <li>Configure robot <a href="components/">components</a> and add built-in <a href="services/">services</a></li>
+            <li><a href="manage/fleet/robots/#control">Control and test your robot</a></li>
+            </ol>
+            {{<gif webm_src="img/blink.webm" mp4_src="img/blink.mp4" alt="A blinking L.E.D. connected to a Raspberry Pi">}}
+        </div>
+    </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col landing-hover-card">
+        <div class="landing-hover-card-padding teal">
+        <h4>Program your robots</h4>
+        <p style="text-align: left;">
+            Program and control your robots in <a href="program/sdks/"> the languages you already know</a> like <a href="https://python.viam.dev/">Python</a>, <a href="https://pkg.go.dev/go.viam.com/rdk">Go</a>, or <a href="https://ts.viam.dev/">TypeScript</a>.
+        </p>
+        <img src="img/code.png" alt="Robot code">
+        </div>
+    </div>
+    <div class="col landing-hover-card">
+        <div class="landing-hover-card-padding pink">
+            <h4>Community</h4>
+            <p style="text-align: left;">Have questions, or want to meet other people working on robots? <a href="https://discord.gg/viam">Join us in the Community Discord!</a></p>
+            {{<gif webm_src="img/heart.webm" mp4_src="img/heart.mp4" alt="A robot drawing a heart">}}
+        </div>
+    </div>
+    </div>
 </div>
-
-#### Included services
-
-Viam includes the following [services](/services/) for use with your robot:
-
-<div id="board-carousel" class="carousel td-max-width-on-larger-screens">
-  <ul tabindex="0">
-   <li id="c3_slide1">
-    <a href="services/data/">
-        <img src="services/img/icons/data-capture.svg" alt="Data capture service" width="100%">
-        <h6>Data Capture</h6>
-    </a>
-  </li>
-  <li id="c3_slide2">
-    <a href="services/motion/">
-        <img src="services/img/icons/motion.svg" alt="Motion service" width="100%">
-        <h6>Motion</h6>
-    </a>
-  </li>
-  <li id="c3_slide3">
-    <a href="services/frame-system/">
-        <img src="services/img/icons/frame-system.svg" alt="Frame system service" width="100%">
-        <h6>Frame System</h6>
-    </a>
-  </li>
-  <li id="c3_slide4">
-    <a href="services/ml/">
-        <img src="services/img/icons/ml.svg" alt="Machine learning service" width="100%">
-        <h6>Machine Learning</h6>
-    </a>
-  </li>
-  <li id="c3_slide5">
-    <a href="services/slam/">
-        <img src="services/img/icons/slam.svg" alt="SLAM service" width="100%">
-        <h6>SLAM</h6>
-    </a>
-  </li>
-  <li id="c3_slide6">
-    <a href="services/vision/">
-        <img src="services/img/icons/vision.svg" alt="Vision service" width="100%">
-        <h6>Vision</h6>
-    </a>
-  </li>
-  </ul>
-  <ol style="visibility: hidden" aria-hidden="true">
-    <li><a href="#c3_slide1">Arm</a></li>
-    <li><a href="#c3_slide2">Base</a></li>
-    <li><a href="#c3_slide3">Board</a></li>
-    <li><a href="#c3_slide4">Camera</a></li>
-    <li><a href="#c3_slide5">Encoder</a></li>
-    <li><a href="#c3_slide6">Gantry</a></li>
-  </ol>
-</div>
-
-#### Extend Viam
-
-You can also [create your own custom components or services](/program/extend/) for use with Viam, or use one of our [SDKs](/program/sdks/) to integrate a Viam robot with your own software application.
 
 <script type="text/javascript" src="js/carousel-min.js"></script>
 <link rel="stylesheet" href="css/carousel-min.css">

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Welcome to the Viam Documentation"
+title: "Viam Documentation"
 linkTitle: "Viam Documentation"
 description: "Viam is a complete software platform for robots that runs on any 64-bit Linux OS and macOS."
 weight: 1
@@ -9,6 +9,8 @@ hide_feedback: true
 sitemap:
   priority: 1.0
 ---
+
+Welcome to the Viam Documentation!
 
 Viam is a complete software platform for robots that runs on any 64-bit Linux OS and macOS.
 Viam supports a wide variety of systems, including:

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -107,7 +107,6 @@ Viam is a complete software platform for robots that runs on Linux and macOS and
 </div>
 <br>
 
-Viam is designed to be flexible and extensible, and to save you time from prototype to production.
 Explore the following resources to jump right in:
 
 <div class="container td-max-width-on-larger-screens">
@@ -126,9 +125,9 @@ Explore the following resources to jump right in:
         <h4>Configure your robots</h4>
         <div style="text-align: left">
             <ol style="padding-inline-start: 1.1rem">
-            <li><a href="installation/">Install Viam on your robot</a></li>
             <li><a href="manage/configuration/">Configure your robot<a> or <a href="manage/fleet/">fleet</a></li>
-            <li>Configure robot <a href="components/">components</a> and add built-in <a href="services/">services</a></li>
+            <li><a href="installation/">Install Viam on your robot</a></li>
+            <li>Configure robot <a href="components/">components</a> and add <a href="services/">services</a></li>
             <li><a href="manage/fleet/robots/#control">Control and test your robot</a></li>
             </ol>
             {{<gif webm_src="img/blink.webm" mp4_src="img/blink.mp4" alt="A blinking L.E.D. connected to a Raspberry Pi">}}

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -12,7 +12,62 @@ sitemap:
 
 Welcome to the Viam Documentation!
 Viam is a complete software platform for robots that runs on any 64-bit Linux OS and macOS.
-Viam supports a wide variety of systems, including:
+
+Explore the following resources to jump right in:
+
+<div class="container td-max-width-on-larger-screens">
+  <div class="row">
+    <div class="col landing-hover-card">
+        <div class="landing-hover-card-padding yellow">
+            <h4>Learn and Try</h4>
+            <p style="text-align: left;">
+            Learn about <a href="viam/">the Viam platform in 3 minutes</a> and then
+            <a href="try-viam/">drive a Viam rover</a> from the comfort of your home or follow along with a <a href="tutorials/"> tutorial</a>.</p>
+            {{<gif webm_src="img/rover.webm" mp4_src="img/rover.mp4" alt="A Viam Rover moving about">}}
+        </div>
+    </div>
+    <div class="col landing-hover-card ">
+        <div class="landing-hover-card-padding purple">
+        <h4>Configure your robots</h4>
+        <div style="text-align: left">
+            <ol style="padding-inline-start: 1.1rem">
+            <li><a href="/manage/fleet/robots/">Set up your robot</a> or<a href="manage/fleet/"> fleet</a></li>
+            <li><a href="installation/">Install Viam on your robot</a></li>
+            <li><a href="manage/configuration/">Configure your robot</a></li>
+            <li><a href="manage/fleet/robots/#control">Test your robot</a></li>
+            </ol>
+            {{<gif webm_src="img/blink.webm" mp4_src="img/blink.mp4" alt="A blinking L.E.D. connected to a Raspberry Pi">}}
+        </div>
+    </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col landing-hover-card">
+        <div class="landing-hover-card-padding teal">
+        <h4>Program your robots</h4>
+        <p style="text-align: left;">
+            Program and control your robots in <a href="program/sdks/"> the languages you already know</a> like <a href="https://python.viam.dev/">Python</a>, <a href="https://pkg.go.dev/go.viam.com/rdk">Go</a>, or <a href="https://ts.viam.dev/">TypeScript</a>.
+        </p>
+        <img src="img/code.png" alt="Robot code">
+        </div>
+    </div>
+    <div class="col landing-hover-card">
+        <div class="landing-hover-card-padding pink">
+            <h4>Community</h4>
+            <p style="text-align: left;">Have questions, or want to meet other people working on robots? <a href="https://discord.gg/viam">Join us in the Community Discord!</a></p>
+            {{<gif webm_src="img/heart.webm" mp4_src="img/heart.mp4" alt="A robot drawing a heart">}}
+        </div>
+    </div>
+    </div>
+</div>
+<br>
+
+Viam includes pre-configured software integration for many popular [boards](/installation/#preparation) and robotics [components](/components/) out of the box, and includes many popular [services](/services/) you might want to use with your robot.
+Click the selections below to learn more:
+
+#### Supported boards
+
+Viam supports the following [boards](/installation/#preparation) out of the box:
 
 <div id="board-carousel" class="carousel td-max-width-on-larger-screens">
   <ul tabindex="0">
@@ -107,54 +162,159 @@ Viam supports a wide variety of systems, including:
   <div class="next" style="display: block">›</div>
 </div>
 
-<br>
-Explore the links below to learn more about Viam, or to jump right in:
+#### Supported components
 
-<div class="container td-max-width-on-larger-screens">
-  <div class="row">
-    <div class="col landing-hover-card">
-        <div class="landing-hover-card-padding yellow">
-            <h4>Learn and Try</h4>
-            <p style="text-align: left;">
-            Learn about <a href="viam/">the Viam platform in 3 minutes</a> and then
-            <a href="try-viam/">drive a Viam rover</a> from the comfort of your home or follow along with a <a href="tutorials/"> tutorial</a>.</p>
-            {{<gif webm_src="img/rover.webm" mp4_src="img/rover.mp4" alt="A Viam Rover moving about">}}
-        </div>
-    </div>
-    <div class="col landing-hover-card ">
-        <div class="landing-hover-card-padding purple">
-        <h4>Configure your robots</h4>
-        <div style="text-align: left">
-            <ol style="padding-inline-start: 1.1rem">
-            <li><a href="/manage/fleet/robots/">Set up your robot</a> or<a href="manage/fleet/"> fleet</a></li>
-            <li><a href="installation/">Install Viam on your robot</a></li>
-            <li><a href="manage/configuration/">Configure your robot</a></li>
-            <li><a href="manage/fleet/robots/#control">Test your robot</a></li>
-            </ol>
-            {{<gif webm_src="img/blink.webm" mp4_src="img/blink.mp4" alt="A blinking L.E.D. connected to a Raspberry Pi">}}
-        </div>
-    </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col landing-hover-card">
-        <div class="landing-hover-card-padding teal">
-        <h4>Program your robots</h4>
-        <p style="text-align: left;">
-            Program and control your robots in <a href="program/sdks/"> the languages you already know</a> like <a href="https://python.viam.dev/">Python</a>, <a href="https://pkg.go.dev/go.viam.com/rdk">Go</a>, or <a href="https://ts.viam.dev/">TypeScript</a>.
-        </p>
-        <img src="img/code.png" alt="Robot code">
-        </div>
-    </div>
-    <div class="col landing-hover-card">
-        <div class="landing-hover-card-padding pink">
-            <h4>Community</h4>
-            <p style="text-align: left;">Have questions, or want to meet other people working on robots? <a href="https://discord.gg/viam">Join us in the Community Discord!</a></p>
-            {{<gif webm_src="img/heart.webm" mp4_src="img/heart.mp4" alt="A robot drawing a heart">}}
-        </div>
-    </div>
-    </div>
+Viam offers pre-defined integration with the following [components](/components/):
+
+<div id="board-carousel" class="carousel td-max-width-on-larger-screens">
+  <ul tabindex="0">
+   <li id="c2_slide1">
+    <a href="components/arm/">
+        <img src="components/img/components/arm.svg" alt="Arm component" width="100%">
+        <h6>Arm</h6>
+    </a>
+  </li>
+  <li id="c2_slide2">
+    <a href="components/base/">
+        <img src="components/img/components/base.svg" alt="Base component" width="100%">
+        <h6>Base</h6>
+    </a>
+  </li>
+  <li id="c2_slide3">
+    <a href="components/board/">
+        <img src="components/img/components/board.svg" alt="Board component" width="100%">
+        <h6>Board</h6>
+    </a>
+  </li>
+  <li id="c2_slide4">
+    <a href="components/camera/">
+        <img src="components/img/components/camera.svg" alt="Camera component" width="100%">
+        <h6>Camera</h6>
+    </a>
+  </li>
+  <li id="c2_slide5">
+    <a href="components/encoder/">
+        <img src="components/img/components/encoder.svg" alt="Encoder component" width="100%">
+        <h6>Encoder</h6>
+    </a>
+  </li>
+  <li id="c2_slide6">
+    <a href="components/gantry/">
+        <img src="components/img/components/gantry.svg" alt="Gantry component" width="100%">
+        <h6>Gantry</h6>
+    </a>
+  </li>
+  <li id="c2_slide7">
+    <a href="components/gripper/">
+        <img src="components/img/components/gripper.svg" alt="Gripper component" width="100%">
+        <h6>Gripper</h6>
+    </a>
+  </li>
+  <li id="c2_slide8">
+    <a href="components/input-controller/">
+        <img src="components/img/components/controller.svg" alt="Input controller component" width="100%">
+        <h6>Input Controller</h6>
+    </a>
+  </li>
+  <li id="c2_slide9">
+    <a href="components/motor/">
+        <img src="components/img/components/motor.svg" alt="Motor component" width="100%">
+        <h6>Motor</h6>
+    </a>
+  </li>
+  <li id="c2_slide10">
+    <a href="components/movement-sensor/">
+        <img src="components/img/components/imu.svg" alt="Movement sensor component" width="100%">
+        <h6>Movement Sensor</h6>
+    </a>
+  </li>
+  <li id="c2_slide11">
+    <a href="components/sensor/">
+        <img src="components/img/components/sensor.svg" alt="Sensor component" width="100%">
+        <h6>Sensor</h6>
+    </a>
+  </li>
+  <li id="c2_slide12">
+    <a href="components/servo/">
+        <img src="components/img/components/servo.svg" alt="Servo component" width="100%">
+        <h6>Servo</h6>
+    </a>
+  </li>
+  </ul>
+  <ol style="visibility: hidden" aria-hidden="true">
+    <li><a href="#c2_slide1">Arm</a></li>
+    <li><a href="#c2_slide2">Base</a></li>
+    <li><a href="#c2_slide3">Board</a></li>
+    <li><a href="#c2_slide4">Camera</a></li>
+    <li><a href="#c2_slide5">Encoder</a></li>
+    <li><a href="#c2_slide6">Gantry</a></li>
+    <li><a href="#c2_slide7">Gripper</a></li>
+    <li><a href="#c2_slide8">Input Controller</a></li>
+    <li><a href="#c2_slide9">Motor</a></li>
+    <li><a href="#c2_slide10">Movement Sensor</a></li>
+    <li><a href="#c2_slide11">Sensor</a></li>
+    <li><a href="#c2_slide12">Servo</a></li>
+  </ol>
+  <div class="prev" style="display: block">‹</div>
+  <div class="next" style="display: block">›</div>
 </div>
+
+#### Included services
+
+Viam includes the following [services](/services/) for use with your robot:
+
+<div id="board-carousel" class="carousel td-max-width-on-larger-screens">
+  <ul tabindex="0">
+   <li id="c3_slide1">
+    <a href="services/data/">
+        <img src="services/img/icons/data-capture.svg" alt="Data capture service" width="100%">
+        <h6>Data Capture</h6>
+    </a>
+  </li>
+  <li id="c3_slide2">
+    <a href="services/motion/">
+        <img src="services/img/icons/motion.svg" alt="Motion service" width="100%">
+        <h6>Motion</h6>
+    </a>
+  </li>
+  <li id="c3_slide3">
+    <a href="services/frame-system/">
+        <img src="services/img/icons/frame-system.svg" alt="Frame system service" width="100%">
+        <h6>Frame System</h6>
+    </a>
+  </li>
+  <li id="c3_slide4">
+    <a href="services/ml/">
+        <img src="services/img/icons/ml.svg" alt="Machine learning service" width="100%">
+        <h6>Machine Learning</h6>
+    </a>
+  </li>
+  <li id="c3_slide5">
+    <a href="services/slam/">
+        <img src="services/img/icons/slam.svg" alt="SLAM service" width="100%">
+        <h6>SLAM</h6>
+    </a>
+  </li>
+  <li id="c3_slide6">
+    <a href="services/vision/">
+        <img src="services/img/icons/vision.svg" alt="Vision service" width="100%">
+        <h6>Vision</h6>
+    </a>
+  </li>
+  </ul>
+  <ol style="visibility: hidden" aria-hidden="true">
+    <li><a href="#c3_slide1">Arm</a></li>
+    <li><a href="#c3_slide2">Base</a></li>
+    <li><a href="#c3_slide3">Board</a></li>
+    <li><a href="#c3_slide4">Camera</a></li>
+    <li><a href="#c3_slide5">Encoder</a></li>
+    <li><a href="#c3_slide6">Gantry</a></li>
+  </ol>
+</div>
+
+#### Extend Viam
+
+You can also [create your own custom components or services](/program/extend/) for use with Viam, or use one of our [SDKs](/program/sdks/) to integrate a Viam robot with your own software application.
 
 <script type="text/javascript" src="js/carousel-min.js"></script>
 <link rel="stylesheet" href="css/carousel-min.css">

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -107,7 +107,7 @@ Viam is a complete software platform for robots that runs on Linux and macOS and
 </div>
 <br>
 
-Explore the following to learn more about the Viam platform or to try it out for yourself:
+Explore more about the Viam platform or try it out for yourself:
 
 <div class="container td-max-width-on-larger-screens">
   <div class="row">

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -108,6 +108,9 @@ Viam supports a wide variety of systems, including:
   <div class="next" style="display: block">›</div>
 </div>
 
+<br>
+Explore the links below to learn more about Viam, or to jump right in:
+
 <div class="container td-max-width-on-larger-screens">
   <div class="row">
     <div class="col landing-hover-card">


### PR DESCRIPTION
Consider some alternate options to how we introduce our Welcome page.

Staged options to choose from:

- [Absolute basic](https://docs-test.viam.dev/438c5ec82347f0e731417b7295117700e9182672/public/index.html)
	- Swapped title to first sentence, and trimmed title to absolute minimal.
- [Absolute basic, with text separator](https://docs-test.viam.dev/93439c77e90d2553e45e10edf2c92f6752d03a6c/public/index.html)
	- Same as above, but with single intro sentence between two image sections.
- [Two more carousels](https://docs-test.viam.dev/e66668c9d417e75a4a871134273097d539e9c7a2/public/index.html)
	- Added image carousels for components and services, and swapped board to be below getting started tiles.

Questions for team:

- Do we find additional carousels useful? Is the single sentence text intro to each necessary?
- Is the paragraph break between getting started tiles and the components carousel useful, or duplicative?
	- I felt that two large image scroll sections (getting started tiles & three image carousels) blend together without a text separator
- How do we feel about the order of presented resources? Should the 4 getting started tiles should be before or after the carousels?
	- My thoughts: before, given content, but after, given space consumed; with a lean towards before (content is king, they say).

TODO:

- Investigate why there is an extra newline between the components and services carousels!