### PR TITLE
DOCS-815: Expand ML intro copy

### DIFF
--- a/docs/manage/ml/_index.md
+++ b/docs/manage/ml/_index.md
@@ -21,7 +21,7 @@ To make use of ML models with your robot, you can use the built-in [ML model ser
 
 Once you have [deployed the ML model service](/services/ml/#create-an-ml-model-service) to your robot, you can then add another service to make use of the model.
 
-* For object detection and classification you can use the [Vision Service](/services/vision) [mlmodel detector](https://docs.viam.com/services/vision/detection/#configure-a-mlmodel-detector) or [mlmodel classifier](https://docs.viam.com/services/vision/classification/#configure-a-mlmodel-classifier).
+* For object detection and classification, you can use the [Vision Service](/services/vision), which provides both [mlmodel detector](/services/vision/detection/#configure-a-mlmodel-detector) and [mlmodel classifier](/services/vision/classification/#configure-a-mlmodel-classifier) models.
 * For other usage, you can create a [modular resource](/program/extend/modular-resources/) to integrate it with your robot.
 
 The video below shows the training process for an object detection model using a bounding box:

--- a/docs/manage/ml/_index.md
+++ b/docs/manage/ml/_index.md
@@ -14,14 +14,14 @@ Common use cases include object detection, image classification, natural languag
 
 Viam natively supports [TensorFlow Lite](https://www.tensorflow.org/lite) ML models as long as your models adhere to the [model requirements](/services/ml/#tflite_cpu-limitations).
 
-You can [add existing models](/manage/ml/upload-model/) or [train image classification models](/manage/ml/train-model/) for object detection and classification within the platform using data from the [Data Management Service](../../services/data/).
-Training detection and classification models enables robots to detect people, animals, plants or other objects with bounding boxes and perform actions when they are detected.
+You can [add existing models](/manage/ml/upload-model/) or [train your own image classification models](/manage/ml/train-model/) for object detection and classification within the platform using data from the [Data Management Service](../../services/data/).
+Object detection and classification models are commonly used to enable robots to detect people, animals, plants, or other objects with bounding boxes, and to perform actions when they are detected.
 
 To make use of ML models with your robot, you can use the built-in [ML model service](/services/ml/) to deploy and run the model.
 
 ### Object detection and classification
 
-Once you have [deployed the ML model service](/services/ml/#create-an-ml-model-service) for your robot, you can then add another service to make use of the model.
+Once you have [deployed the ML model service](/services/ml/#create-an-ml-model-service) to your robot, you can then add another service to make use of the model.
 
 * For object detection and classification you can use the [Vision Service](/services/vision) [mlmodel detector](https://docs.viam.com/services/vision/detection/#configure-a-mlmodel-detector) or [mlmodel classifier](https://docs.viam.com/services/vision/classification/#configure-a-mlmodel-classifier).
 * For other usage, you can create a [modular resource](/program/extend/modular-resources/) to integrate it with your robot.

--- a/docs/manage/ml/_index.md
+++ b/docs/manage/ml/_index.md
@@ -14,7 +14,7 @@ Common use cases include object detection, image classification, natural languag
 
 Viam natively supports [TensorFlow Lite](https://www.tensorflow.org/lite) ML models as long as your models adhere to the [model requirements](/services/ml/#tflite_cpu-limitations).
 
-You can [add existing models](/manage/ml/upload-model/) or [train your own image classification models](/manage/ml/train-model/) for object detection and classification within the platform using data from the [Data Management Service](../../services/data/).
+You can [train your own image classification models](/manage/ml/train-model/) or [add an existing model](/manage/ml/upload-model/) for object detection and classification within the platform using data from the [Data Management Service](../../services/data/).
 Object detection and classification models are commonly used to enable robots to detect people, animals, plants, or other objects with bounding boxes, and to perform actions when they are detected.
 
 To make use of ML models with your robot, you can use the built-in [ML model service](/services/ml/) to deploy and run the model.
@@ -25,6 +25,8 @@ Once you have [deployed the ML model service](/services/ml/#create-an-ml-model-s
 
 * For object detection and classification you can use the [Vision Service](/services/vision) [mlmodel detector](https://docs.viam.com/services/vision/detection/#configure-a-mlmodel-detector) or [mlmodel classifier](https://docs.viam.com/services/vision/classification/#configure-a-mlmodel-classifier).
 * For other usage, you can create a [modular resource](/program/extend/modular-resources/) to integrate it with your robot.
+
+The video below shows the training process for an object detection model using a bounding box:
 
 {{<youtube embed_url="https://www.youtube-nocookie.com/embed/CP14LR0Pq64">}}
 

--- a/docs/manage/ml/_index.md
+++ b/docs/manage/ml/_index.md
@@ -19,8 +19,6 @@ Object detection and classification models are commonly used to enable robots to
 
 To make use of ML models with your robot, you can use the built-in [ML model service](/services/ml/) to deploy and run the model.
 
-### Object detection and classification
-
 Once you have [deployed the ML model service](/services/ml/#create-an-ml-model-service) to your robot, you can then add another service to make use of the model.
 
 * For object detection and classification you can use the [Vision Service](/services/vision) [mlmodel detector](https://docs.viam.com/services/vision/detection/#configure-a-mlmodel-detector) or [mlmodel classifier](https://docs.viam.com/services/vision/classification/#configure-a-mlmodel-classifier).

--- a/docs/manage/ml/_index.md
+++ b/docs/manage/ml/_index.md
@@ -12,22 +12,21 @@ description: "Use Viam's built-in machine learning capabilities to train image c
 Viam includes a built-in [machine learning (ML) service](/services/ml/) which provides your robot with the ability to learn from data and adjust its behavior based on insights gathered from that data.
 Common use cases include object detection, image classification, natural language processing, and speech recognition and synthesis, but your robot can make use of machine learning with nearly any kind of data.
 
-Viam natively supports [TensorFlow Lite](https://www.tensorflow.org/lite) ML models, but you can use other models as well as long as your models adhere to the [model requirements](/services/ml/#tflite_cpu-limitations).
+Viam natively supports [TensorFlow Lite](https://www.tensorflow.org/lite) ML models as long as your models adhere to the [model requirements](/services/ml/#tflite_cpu-limitations).
 
-To make use of ML models with your robot, you can use the built-in ML model service to train image classification models for object detection and classification or create a [modular resource](/program/extend/modular-resources/) to integrate it with your robot.
+You can [add existing models](/manage/ml/upload-model/) or [train image classification models](/manage/ml/train-model/) for object detection and classification within the platform using data from the [Data Management Service](../../services/data/).
+Training detection and classification models enables robots to detect people, animals, plants or other objects with bounding boxes and perform actions when they are detected.
+
+To make use of ML models with your robot, you can use the built-in [ML model service](/services/ml/) to deploy and run the model.
 
 ### Object detection and classification
 
-Once you have [created the ML model service](/services/ml/#create-an-ml-model-service) for your robot, you can [train image classification models](train-model/) to enable it to detect people, animals, plants or other objects with bounding boxes and perform actions when they are detected.
+Once you have [deployed the ML model service](/services/ml/#create-an-ml-model-service) for your robot, you can then add another service to make use of the model.
 
-![Gif of a dog being labeled](/tutorials/img/pet-treat-dispenser/app-data-images.png)
+* For object detection and classification you can use the [Vision Service](/services/vision) [mlmodel detector](https://docs.viam.com/services/vision/detection/#configure-a-mlmodel-detector) or [mlmodel classifier](https://docs.viam.com/services/vision/classification/#configure-a-mlmodel-classifier).
+* For other usage, you can create a [modular resource](/program/extend/modular-resources/) to integrate it with your robot.
 
-When training machine learning models, it is important to supply a variety of different data about the subject. In the case of object detection, it is important to provide images of the object in different situations, such as from different angles or in different lighting situations. The more varied the provided data set, the more accurate the resulting model becomes.
-
-You can also [upload and use existing models](upload-model/).
-
-To capture and synchronize data to the platform, see [Data Management Service](../../services/data/).
-To view or export captured data, see [Data Management](../data/).
+{{<youtube embed_url="https://www.youtube-nocookie.com/embed/CP14LR0Pq64">}}
 
 ## Next Steps
 

--- a/docs/manage/ml/_index.md
+++ b/docs/manage/ml/_index.md
@@ -9,6 +9,13 @@ description: "Use Viam's built-in machine learning capabilities to train image c
 # SME: Aaron Casas
 ---
 
+Machine learning is an approach to programming where you provide an algorithm with a large data set, and train it to discover patterns in that data on its own.
+The more data you provide to it, the better it becomes at identifying patterns across that data set, and the more accurate it becomes at guessing characteristics of any new data provided.
+
+For example, say you have a collection of pictures of your cat.
+As you train your algorithm on just a few pictures, it might not be able to determine that a picture of your cat's face and a picture of your cat sleeping are the same cat.
+As you train the algorithm on more and more pictures, it might be able to recognize your cat from any angle, or to differentiate between multiple different cats.
+
 You can use Viam's built-in machine learning capabilities to [train image classification models](train-model/) and [deploy these models to your robots](../../services/ml/).
 You can also [upload and use existing models](upload-model/).
 

--- a/docs/manage/ml/_index.md
+++ b/docs/manage/ml/_index.md
@@ -9,14 +9,21 @@ description: "Use Viam's built-in machine learning capabilities to train image c
 # SME: Aaron Casas
 ---
 
-Machine learning is an approach to programming where you provide an algorithm with a large data set, and train it to discover patterns in that data on its own.
-The more data you provide to it, the better it becomes at identifying patterns across that data set, and the more accurate it becomes at guessing characteristics of any new data provided.
+Viam includes a built-in [machine learning (ML) service](/services/ml/) which provides your robot with the ability to learn from data and adjust its behavior based on insights gathered from that data.
+Common use cases include object detection, image classification, natural language processing, and speech recognition and synthesis, but your robot can make use of machine learning with nearly any kind of data.
 
-For example, say you have a collection of pictures of your cat.
-As you train your algorithm on just a few pictures, it might not be able to determine that a picture of your cat's face and a picture of your cat sleeping are the same cat.
-As you train the algorithm on more and more pictures, it might be able to recognize your cat from any angle, or to differentiate between multiple different cats.
+Viam natively supports [TensorFlow Lite](https://www.tensorflow.org/lite) ML models, but you can use other models as well as long as your models adhere to the [model requirements](/services/ml/#tflite_cpu-limitations).
 
-You can use Viam's built-in machine learning capabilities to [train image classification models](train-model/) and [deploy these models to your robots](../../services/ml/).
+To make use of ML models with your robot, you can use the built-in ML model service to train image classification models for object detection and classification or create a [modular resource](/program/extend/modular-resources/) to integrate it with your robot.
+
+### Object detection and classification
+
+Once you have [created the ML model service](/services/ml/#create-an-ml-model-service) for your robot, you can [train image classification models](train-model/) to enable it to detect people, animals, plants or other objects with bounding boxes and perform actions when they are detected.
+
+![Gif of a dog being labeled](/tutorials/img/pet-treat-dispenser/app-data-images.png)
+
+When training machine learning models, it is important to supply a variety of different data about the subject. In the case of object detection, it is important to provide images of the object in different situations, such as from different angles or in different lighting situations. The more varied the provided data set, the more accurate the resulting model becomes.
+
 You can also [upload and use existing models](upload-model/).
 
 To capture and synchronize data to the platform, see [Data Management Service](../../services/data/).
@@ -28,4 +35,5 @@ To view or export captured data, see [Data Management](../data/).
   {{% card link="/manage/ml/train-model" size="small" %}}
   {{% card link="/manage/ml/upload-model" size="small" %}}
   {{% card link="/services/ml" size="small" custom="Deploy Model" %}}
+  {{% card link="/tutorials/projects/pet-treat-dispenser/" size="small" custom="Tutorial: Smart Pet Feeder" %}}
 {{< /cards >}}

--- a/docs/manage/ml/_index.md
+++ b/docs/manage/ml/_index.md
@@ -21,8 +21,8 @@ To make use of ML models with your robot, you can use the built-in [ML model ser
 
 Once you have [deployed the ML model service](/services/ml/#create-an-ml-model-service) to your robot, you can then add another service to make use of the model.
 
-* For object detection and classification, you can use the [Vision Service](/services/vision), which provides both [mlmodel detector](/services/vision/detection/#configure-a-mlmodel-detector) and [mlmodel classifier](/services/vision/classification/#configure-a-mlmodel-classifier) models.
-* For other usage, you can create a [modular resource](/program/extend/modular-resources/) to integrate it with your robot.
+* For object detection and classification, you can use the [Vision Service](/services/vision/), which provides both [mlmodel detector](/services/vision/detection/#configure-a-mlmodel-detector) and [mlmodel classifier](/services/vision/classification/#configure-a-mlmodel-classifier) models.
+* For other usage, you can create a [modular resource](/extend/modular-resources/) to integrate it with your robot.
 
 The video below shows the training process for an object detection model using a bounding box:
 

--- a/docs/manage/ml/train-model.md
+++ b/docs/manage/ml/train-model.md
@@ -14,6 +14,10 @@ You can label or add bounding boxes to [images collected](../../../services/data
 
 {{<youtube embed_url="https://www.youtube-nocookie.com/embed/CP14LR0Pq64">}}
 
+When training machine learning models, it is important to supply a variety of different data about the subject.
+In the case of image classification, it is important to provide images of the object being identified in different situations, such as from different angles or in different lighting situations.
+The more varied the provided data set, the more accurate the resulting model becomes.
+
 ## Train a model
 
 After [annotating your images](/manage/data/label/), click on the **TRAIN MODEL** button in the top right corner.

--- a/docs/services/ml/_index.md
+++ b/docs/services/ml/_index.md
@@ -11,7 +11,7 @@ icon: "/services/img/icons/ml.svg"
 # SME: Aaron Casas
 ---
 
-The ML Models service allows you to deploy machine learning models to your robots.
+The ML Model service allows you to deploy machine learning models to your robots.
 
 ## Create an ML model service
 

--- a/docs/tutorials/projects/integrating-viam-with-openai.md
+++ b/docs/tutorials/projects/integrating-viam-with-openai.md
@@ -213,7 +213,7 @@ Click the **Config** tab and then the **Services** subtab.
 From there, scroll to the bottom and create a new service of **type** `ML Models`, **model** `tflite_cpu` named 'stuff_detector'.
 Your robot will register this as a machine learning model and make it available for use.
 
-<img src="../../img/ai-integration/mlmodels_service_add.png" style="border:1px solid #000" alt="Adding the ML Models Service." title="Adding the ML Models Service." width="500" />
+<img src="../../img/ai-integration/mlmodels_service_add.png" style="border:1px solid #000" alt="Adding the ML Models Service." title="Adding the ML Model Service." width="500" />
 
 Make sure `Path to Existing Model on Robot` is selected.
 

--- a/docs/tutorials/projects/tipsy.md
+++ b/docs/tutorials/projects/tipsy.md
@@ -377,7 +377,7 @@ Click on the **Services** subtab and navigate to the **Create service** menu.
 
     ![Create service panel, with the type attribute filled as mlmodel, name attribute filled as people, and model attribute filled as tflite_cpu.](../../img/tipsy/app-service-ml-create.png)
 
-    In the new ML Models service panel, configure your service.
+    In the new ML Model service panel, configure your service.
 
     ![mlmodel service panel with empty sections for Model Path, and Optional Settings such as Label Path and Number of threads.](../../img/tipsy/app-service-ml-before.png)
 


### PR DESCRIPTION
Expand ML landing page intro copy with explanatory description and simple example.

- Maybe just a little too much for the Manage section? Remove the cat pictures example?