### PR TITLE
Exclude softroboticsinc from htmltest

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -20,6 +20,7 @@ IgnoreURLs:
 - "numato.com"
 - "nvidia.com"
 - "slamtec.com"
+- "softroboticsinc.com"
 - "universal-robots.com"
 - "ufactory.cc"
 IgnoreDirs:


### PR DESCRIPTION
Link: https://www.softroboticsinc.com/products/mgrip-modular-gripping-solution-for-food-automation/

404s on their end, I reported to them, but for now we omit from htmltest.

Discovered in https://github.com/viamrobotics/docs/pull/1393