### PR TITLE
DOCS-845: Clarify coordinate system definitions

### DIFF
--- a/docs/components/base/_index.md
+++ b/docs/components/base/_index.md
@@ -156,9 +156,9 @@ Turn the base in place, rotating it to the given angle (degrees) at the given an
 **Parameters:**
 
 - `angle` [(float)](https://docs.python.org/3/library/functions.html#float): The angle to spin in degrees.
-Positive implies a given number of degrees to the left.
-- `velocity` [(float)](https://docs.python.org/3/library/functions.html#float): The angular velocity at which to spin in degrees per second.
 Positive implies turning to the left.
+- `velocity` [(float)](https://docs.python.org/3/library/functions.html#float): The angular velocity at which to spin in degrees per second.
+Given a positive angle and a positive velocity, the base turns to the left (for built-in base models).
 
 **Returns:**
 
@@ -180,9 +180,9 @@ await my_base.spin(angle=10, velocity=1)
 
 - `ctx` [(Context)](https://pkg.go.dev/context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
 - `angleDeg` [(float64)](https://pkg.go.dev/builtin#float64): The angle to spin in degrees.
-Positive implies a given number of degrees to the left.
-- `degsPerSec` [(float64)](https://pkg.go.dev/builtin#float64): The angular velocity at which to spin in degrees per second.
 Positive implies turning to the left.
+- `degsPerSec` [(float64)](https://pkg.go.dev/builtin#float64): The angular velocity at which to spin in degrees per second.
+Given a positive angle and a positive velocity, the base turns to the left (for built-in base models).
 - `extra` [(map\[string\]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
 
 **Returns:**
@@ -218,7 +218,7 @@ Set the linear and angular power of the base, represented as a percentage of max
 - `angular` [(Vector3)](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.Vector3): The percentage of max power of the base's angular propulsion.
   In the range of -1.0 to 1.0, with 1.0 meaning 100% power.
   Use the Z component of this vector to spin left or right when controlling a wheeled base.
-  Positive "Z" values imply spinning to the left.
+  Positive "Z" values imply spinning to the left (for built-in base models).
 
 **Returns:**
 
@@ -260,7 +260,7 @@ Negative "Y" values imply moving backwards.
 - `angular` [(r3.Vector)](https://pkg.go.dev/github.com/golang/geo/r3#Vector): The percentage of max power of the base's angular propulsion.
 In the range of -1.0 to 1.0, with 1.0 meaning 100% power.
 Use the Z component of this vector to spin left or right when controlling a wheeled base.
-Positive "Z" values imply spinning to the left.
+Positive "Z" values imply spinning to the left (for built-in base models).
 - `extra` [(map\[string\]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
 
 **Returns:**

--- a/docs/components/base/_index.md
+++ b/docs/components/base/_index.md
@@ -91,9 +91,9 @@ Move the base in a straight line across the given distance (mm) at the given vel
 **Parameters:**
 
 - `distance` [(int)](https://docs.python.org/3/library/functions.html#int): The distance to move in millimeters.
-Negative implies backwards.
+Positive implies forwards.
 - `velocity` [(float)](https://docs.python.org/3/library/functions.html#float): The velocity at which to move in millimeters per second.
-Negative implies backwards.
+Positive implies forwards.
 
 **Returns:**
 
@@ -118,9 +118,9 @@ await my_base.move_straight(distance=10, velocity=-1)
 
 - `ctx` [(Context)](https://pkg.go.dev/context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
 - `distanceMm` [(int)](https://pkg.go.dev/builtin#int): The distance to move the base in millimeters.
-Negative implies backwards.
+Positive implies forwards.
 - `mmPerSec` [(float64)](https://pkg.go.dev/builtin#float64): The velocity at which to move the base in millimeters per second.
-Negative implies backwards.
+Positive implies forwards.
 - `extra` [(map\[string\]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
 
 **Returns:**
@@ -152,9 +152,9 @@ Turn the base in place, rotating it to the given angle (degrees) at the given an
 **Parameters:**
 
 - `angle` [(float)](https://docs.python.org/3/library/functions.html#float): The angle to spin in degrees.
-Negative implies backwards.
+Positive implies forwards.
 - `velocity` [(float)](https://docs.python.org/3/library/functions.html#float): The angular velocity at which to spin in degrees per second.
-Negative implies backwards.
+Positive implies forwards.
 
 **Returns:**
 
@@ -176,9 +176,9 @@ await my_base.spin(angle=10, velocity=1)
 
 - `ctx` [(Context)](https://pkg.go.dev/context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
 - `angleDeg` [(float64)](https://pkg.go.dev/builtin#float64): The angle to spin in degrees.
-Negative implies backwards.
+Positive implies forwards.
 - `degsPerSec` [(float64)](https://pkg.go.dev/builtin#float64): The angular velocity at which to spin in degrees per second.
-Negative implies backwards.
+Positive implies forwards.
 - `extra` [(map\[string\]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
 
 **Returns:**
@@ -209,11 +209,11 @@ Set the linear and angular power of the base, represented as a percentage of max
 - `linear` [(Vector3)](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.Vector3): The percentage of max power of the base's linear propulsion.
   In the range of -1.0 to 1.0, with 1.0 meaning 100% power.
   Viam's coordinate system considers +Y to be the forward axis (+/- X left/right, +/- Z up/down), so use the Y component of this vector to move forward and backward when controlling a wheeled base.
-  Negative "Y:" values imply moving backwards.
+  Positive "Y" values imply moving forwards.
 - `angular` [(Vector3)](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.Vector3): The percentage of max power of the base's angular propulsion.
   In the range of -1.0 to 1.0, with 1.0 meaning 100% power.
   Use the Z component of this vector to spin left or right when controlling a wheeled base.
-  Negative "Z:" values imply spinning to the right.
+  Positive "Z" values imply spinning to the left.
 
 **Returns:**
 
@@ -247,12 +247,14 @@ await my_base.set_power(linear=Vector3(x=0,y=0,z=0), angular=Vector3(x=0,y=0,z=-
 **Parameters:**
 
 - `ctx` [(Context)](https://pkg.go.dev/context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
-- `linear` [(r3.Vector)](https://pkg.go.dev/github.com/golang/geo/r3#Vector): The percentage of max power of the base's linear propulsion. In the range of -1.0 to 1.0, with 1.0 meaning 100% power.
+- `linear` [(r3.Vector)](https://pkg.go.dev/github.com/golang/geo/r3#Vector): The percentage of max power of the base's linear propulsion.
+  In the range of -1.0 to 1.0, with 1.0 meaning 100% power.
 Viam's coordinate system considers +Y to be the forward axis (+/- X left/right, +/- Z up/down), so use the Y component of this vector to move forward and backward when controlling a wheeled base.
-Negative "Y:" values imply moving backwards.
+Positive "Y" values imply moving forwards.
 - `angular` [(r3.Vector)](https://pkg.go.dev/github.com/golang/geo/r3#Vector): The percentage of max power of the base's angular propulsion.
 In the range of -1.0 to 1.0, with 1.0 meaning 100% power.
-Use the Z component of this vector to spin left or right when controlling a wheeled base. Negative "Z:" values imply spinning to the right.
+Use the Z component of this vector to spin left or right when controlling a wheeled base.
+Positive "Z" values imply spinning to the left.
 - `extra` [(map\[string\]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
 
 **Returns:**

--- a/docs/components/base/_index.md
+++ b/docs/components/base/_index.md
@@ -152,9 +152,9 @@ Turn the base in place, rotating it to the given angle (degrees) at the given an
 **Parameters:**
 
 - `angle` [(float)](https://docs.python.org/3/library/functions.html#float): The angle to spin in degrees.
-Positive implies forwards.
+Positive implies a given number of degrees to the left.
 - `velocity` [(float)](https://docs.python.org/3/library/functions.html#float): The angular velocity at which to spin in degrees per second.
-Positive implies forwards.
+Positive implies turning to the left.
 
 **Returns:**
 
@@ -176,9 +176,9 @@ await my_base.spin(angle=10, velocity=1)
 
 - `ctx` [(Context)](https://pkg.go.dev/context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
 - `angleDeg` [(float64)](https://pkg.go.dev/builtin#float64): The angle to spin in degrees.
-Positive implies forwards.
+Positive implies a given number of degrees to the left.
 - `degsPerSec` [(float64)](https://pkg.go.dev/builtin#float64): The angular velocity at which to spin in degrees per second.
-Positive implies forwards.
+Positive implies turning to the left.
 - `extra` [(map\[string\]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
 
 **Returns:**

--- a/docs/components/base/_index.md
+++ b/docs/components/base/_index.md
@@ -92,8 +92,10 @@ Move the base in a straight line across the given distance (mm) at the given vel
 
 - `distance` [(int)](https://docs.python.org/3/library/functions.html#int): The distance to move in millimeters.
 Positive implies forwards.
+Negative implies backwards.
 - `velocity` [(float)](https://docs.python.org/3/library/functions.html#float): The velocity at which to move in millimeters per second.
 Positive implies forwards.
+Negative implies backwards.
 
 **Returns:**
 
@@ -119,8 +121,10 @@ await my_base.move_straight(distance=10, velocity=-1)
 - `ctx` [(Context)](https://pkg.go.dev/context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
 - `distanceMm` [(int)](https://pkg.go.dev/builtin#int): The distance to move the base in millimeters.
 Positive implies forwards.
+Negative implies backwards.
 - `mmPerSec` [(float64)](https://pkg.go.dev/builtin#float64): The velocity at which to move the base in millimeters per second.
 Positive implies forwards.
+Negative implies backwards.
 - `extra` [(map\[string\]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
 
 **Returns:**
@@ -210,6 +214,7 @@ Set the linear and angular power of the base, represented as a percentage of max
   In the range of -1.0 to 1.0, with 1.0 meaning 100% power.
   Viam's coordinate system considers +Y to be the forward axis (+/- X left/right, +/- Z up/down), so use the Y component of this vector to move forward and backward when controlling a wheeled base.
   Positive "Y" values imply moving forwards.
+  Negative "Y" values imply moving backwards.
 - `angular` [(Vector3)](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.Vector3): The percentage of max power of the base's angular propulsion.
   In the range of -1.0 to 1.0, with 1.0 meaning 100% power.
   Use the Z component of this vector to spin left or right when controlling a wheeled base.
@@ -251,6 +256,7 @@ await my_base.set_power(linear=Vector3(x=0,y=0,z=0), angular=Vector3(x=0,y=0,z=-
   In the range of -1.0 to 1.0, with 1.0 meaning 100% power.
 Viam's coordinate system considers +Y to be the forward axis (+/- X left/right, +/- Z up/down), so use the Y component of this vector to move forward and backward when controlling a wheeled base.
 Positive "Y" values imply moving forwards.
+Negative "Y" values imply moving backwards.
 - `angular` [(r3.Vector)](https://pkg.go.dev/github.com/golang/geo/r3#Vector): The percentage of max power of the base's angular propulsion.
 In the range of -1.0 to 1.0, with 1.0 meaning 100% power.
 Use the Z component of this vector to spin left or right when controlling a wheeled base.

--- a/docs/components/base/_index.md
+++ b/docs/components/base/_index.md
@@ -212,7 +212,7 @@ Set the linear and angular power of the base, represented as a percentage of max
 
 - `linear` [(Vector3)](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.Vector3): The percentage of max power of the base's linear propulsion.
   In the range of -1.0 to 1.0, with 1.0 meaning 100% power.
-  Viam's coordinate system considers +Y to be the forward axis (+/- X left/right, +/- Z up/down), so use the Y component of this vector to move forward and backward when controlling a wheeled base.
+  Viam's coordinate system considers +Y to be the forward axis (+/- X right/left, +/- Z up/down), so use the Y component of this vector to move forward and backward when controlling a wheeled base.
   Positive "Y" values imply moving forwards.
   Negative "Y" values imply moving backwards.
 - `angular` [(Vector3)](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.Vector3): The percentage of max power of the base's angular propulsion.
@@ -254,7 +254,7 @@ await my_base.set_power(linear=Vector3(x=0,y=0,z=0), angular=Vector3(x=0,y=0,z=-
 - `ctx` [(Context)](https://pkg.go.dev/context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
 - `linear` [(r3.Vector)](https://pkg.go.dev/github.com/golang/geo/r3#Vector): The percentage of max power of the base's linear propulsion.
   In the range of -1.0 to 1.0, with 1.0 meaning 100% power.
-Viam's coordinate system considers +Y to be the forward axis (+/- X left/right, +/- Z up/down), so use the Y component of this vector to move forward and backward when controlling a wheeled base.
+Viam's coordinate system considers +Y to be the forward axis (+/- X right/left, +/- Z up/down), so use the Y component of this vector to move forward and backward when controlling a wheeled base.
 Positive "Y" values imply moving forwards.
 Negative "Y" values imply moving backwards.
 - `angular` [(r3.Vector)](https://pkg.go.dev/github.com/golang/geo/r3#Vector): The percentage of max power of the base's angular propulsion.

--- a/docs/services/frame-system/_index.md
+++ b/docs/services/frame-system/_index.md
@@ -86,6 +86,15 @@ The `Orientation` parameter offers `Types` for ease of configuration, but the Fr
 
 {{% /alert %}}
 
+{{% alert title="Tip" color="tip" %}}
+
+For [base components](../../../components/base/), Viam considers `+X` to be to the right, `+Y` to be forwards, and `+Z` to be up.
+You can use [the right-hand rule](https://en.wikipedia.org/wiki/Right-hand_rule) to understand rotation about any of these axes.
+
+For non-base components, there is no inherent concept of "forward," so it is up to the user to define frames that make sense in their application.
+
+{{% /alert %}}
+
 For more information about determining the appropriate values for these parameters, see these two examples:
 
 - [A Reference Frame:](/services/frame-system/frame-config/) A component attached to a static surface

--- a/docs/services/frame-system/_index.md
+++ b/docs/services/frame-system/_index.md
@@ -86,13 +86,6 @@ The `Orientation` parameter offers `Types` for ease of configuration, but the Fr
 
 {{% /alert %}}
 
-{{% alert title="Tip" color="tip" %}}
-
-Viam's coordinate system considers `+X` to be forward, `+Y` to be left, and `+Z` to be up.
-You can use [the right-hand rule](https://en.wikipedia.org/wiki/Right-hand_rule) to determine the orientation of these axes.
-
-{{% /alert %}}
-
 For more information about determining the appropriate values for these parameters, see these two examples:
 
 - [A Reference Frame:](/services/frame-system/frame-config/) A component attached to a static surface

--- a/docs/services/frame-system/_index.md
+++ b/docs/services/frame-system/_index.md
@@ -88,7 +88,7 @@ The `Orientation` parameter offers `Types` for ease of configuration, but the Fr
 
 {{% alert title="Tip" color="tip" %}}
 
-For [base components](../../../components/base/), Viam considers `+X` to be to the right, `+Y` to be forwards, and `+Z` to be up.
+For [base components](../../components/base/), Viam considers `+X` to be to the right, `+Y` to be forwards, and `+Z` to be up.
 You can use [the right-hand rule](https://en.wikipedia.org/wiki/Right-hand_rule) to understand rotation about any of these axes.
 
 For non-base components, there is no inherent concept of "forward," so it is up to the user to define frames that make sense in their application.


### PR DESCRIPTION
# Description

Clarify base API coordinate system.

Remove note in frame system doc because the frame system has no inherent "forward" etc.; it's all relative and user-defined.