### PR TITLE
DOCS-859: Clarify viam-cartographer as modular resource

### DIFF
--- a/docs/program/extend/modular-resources/_index.md
+++ b/docs/program/extend/modular-resources/_index.md
@@ -590,6 +590,7 @@ This means that you can compose a robot of any number of parts running in differ
 Custom models of the [arm](/components/arm/) component type are not yet supported, as kinematic information is not currently exposed through the arm API.
 
 {{< cards >}}
+    {{% card link="/services/slam/cartographer/" size="small" %}}
     {{% card link="/program/extend/modular-resources/examples/add-rplidar-module" size="small" %}}
     {{% card link="/tutorials/custom/controlling-an-intermode-rover-canbus/" size="small" %}}
 {{< /cards >}}

--- a/docs/services/slam/cartographer/_index.md
+++ b/docs/services/slam/cartographer/_index.md
@@ -1,9 +1,9 @@
 ---
-title: "Cartographer Integrated Library"
+title: "Cartographer Modular Resource"
 linkTitle: "Cartographer"
 weight: 70
 type: "docs"
-description: "Configure a SLAM service with the Cartographer library."
+description: "Configure a SLAM service with the Cartographer modular resource."
 tags: ["slam", "services"]
 aliases:
   - "/services/slam/run-slam-cartographer"
@@ -12,9 +12,11 @@ aliases:
 
 [The Cartographer Project](https://github.com/cartographer-project) performs dense SLAM using LIDAR data.
 
+To easily integrate Cartographer into the Viam ecosystem, Viam provides [`viam-cartographer`](https://github.com/viamrobotics/viam-cartographer) which wraps Cartographer as a [modular resource](/program/extend/modular-resources/) named `cartographer-module`.
+
 ## Requirements
 
-Install the binary required to utilize the `cartographer` library on your machine and make it executable by running the following commands according to your machine's architecture:
+Install the binary required to utilize the `cartographer-module` modular resource on your machine and make it executable by running the following commands according to your machine's architecture:
 
 {{< tabs >}}
 {{% tab name="Linux aarch64" %}}

--- a/docs/services/slam/cartographer/_index.md
+++ b/docs/services/slam/cartographer/_index.md
@@ -11,8 +11,6 @@ aliases:
 # SMEs: Kat, Jeremy
 ---
 
-services/img/icons/slam.svg
-
 [The Cartographer Project](https://github.com/cartographer-project) performs dense SLAM using LIDAR data.
 
 To easily integrate Cartographer into the Viam ecosystem, Viam provides the [`viam-cartographer`](https://github.com/viamrobotics/viam-cartographer) module which wraps Cartographer as a [modular resource](/program/extend/modular-resources/) in the form of a custom SLAM service.

--- a/docs/services/slam/cartographer/_index.md
+++ b/docs/services/slam/cartographer/_index.md
@@ -15,7 +15,8 @@ services/img/icons/slam.svg
 
 [The Cartographer Project](https://github.com/cartographer-project) performs dense SLAM using LIDAR data.
 
-To easily integrate Cartographer into the Viam ecosystem, Viam provides [`viam-cartographer`](https://github.com/viamrobotics/viam-cartographer), a [modular resource](/program/extend/modular-resources/) which wraps Cartographer. This resource provides the `cartographer-module` binary for use directly on your SLAM-enabled robot.
+To easily integrate Cartographer into the Viam ecosystem, Viam provides the [`viam-cartographer`](https://github.com/viamrobotics/viam-cartographer) module which wraps Cartographer as a [modular resource](/program/extend/modular-resources/) in the form of a custom SLAM service.
+This module provides the `cartographer-module` binary, which runs in addition to `viam-server`.
 
 ## Requirements
 

--- a/docs/services/slam/cartographer/_index.md
+++ b/docs/services/slam/cartographer/_index.md
@@ -13,7 +13,8 @@ aliases:
 
 [The Cartographer Project](https://github.com/cartographer-project) performs dense SLAM using LIDAR data.
 
-To easily integrate Cartographer into the Viam ecosystem, use the [`viam-cartographer`](https://github.com/viamrobotics/viam-cartographer) library, which wraps Cartographer as a [modular resource](/program/extend/modular-resources/). `viam-cartographer` provides the `cartographer-module` module, which includes the `viam:slam:cartographer` custom SLAM service [model](/program/extend/modular-resources/#models).
+To easily integrate Cartographer into the Viam ecosystem, use the [`viam-cartographer`](https://github.com/viamrobotics/viam-cartographer) library, which wraps Cartographer as a [modular resource](/program/extend/modular-resources/). 
+`viam-cartographer` provides the `cartographer-module` module, which includes the `viam:slam:cartographer` custom SLAM service [model](/program/extend/modular-resources/#models).
 
 ## Requirements
 

--- a/docs/services/slam/cartographer/_index.md
+++ b/docs/services/slam/cartographer/_index.md
@@ -13,7 +13,7 @@ aliases:
 
 [The Cartographer Project](https://github.com/cartographer-project) performs dense SLAM using LIDAR data.
 
-To easily integrate Cartographer into the Viam ecosystem, use the [`viam-cartographer`](https://github.com/viamrobotics/viam-cartographer) library, which wraps Cartographer as a [modular resource](/program/extend/modular-resources/). 
+To easily integrate Cartographer into the Viam ecosystem, use the [`viam-cartographer`](https://github.com/viamrobotics/viam-cartographer) library, which wraps Cartographer as a [modular resource](/program/extend/modular-resources/).
 `viam-cartographer` provides the `cartographer-module` module, which includes the `viam:slam:cartographer` custom SLAM service [model](/program/extend/modular-resources/#models).
 
 ## Requirements

--- a/docs/services/slam/cartographer/_index.md
+++ b/docs/services/slam/cartographer/_index.md
@@ -12,11 +12,11 @@ aliases:
 
 [The Cartographer Project](https://github.com/cartographer-project) performs dense SLAM using LIDAR data.
 
-To easily integrate Cartographer into the Viam ecosystem, Viam provides [`viam-cartographer`](https://github.com/viamrobotics/viam-cartographer), a [modular resource](/program/extend/modular-resources/) which wraps Cartographer. This resource provides the `cartographer-module` binary.
+To easily integrate Cartographer into the Viam ecosystem, Viam provides [`viam-cartographer`](https://github.com/viamrobotics/viam-cartographer), a [modular resource](/program/extend/modular-resources/) which wraps Cartographer. This resource provides the `cartographer-module` binary for use directly on your SLAM-enabled robot.
 
 ## Requirements
 
-Install the binary required to utilize the `cartographer-module` modular resource on your machine and make it executable by running the following commands according to your machine's architecture:
+To use Cartographer with Viam, install the `cartographer-module` binary on your machine and make it executable by running the following commands according to your machine's architecture:
 
 {{< tabs >}}
 {{% tab name="Linux aarch64" %}}

--- a/docs/services/slam/cartographer/_index.md
+++ b/docs/services/slam/cartographer/_index.md
@@ -5,10 +5,13 @@ weight: 70
 type: "docs"
 description: "Configure a SLAM service with the Cartographer modular resource."
 tags: ["slam", "services"]
+icon: "/services/img/icons/slam.svg"
 aliases:
   - "/services/slam/run-slam-cartographer"
 # SMEs: Kat, Jeremy
 ---
+
+services/img/icons/slam.svg
 
 [The Cartographer Project](https://github.com/cartographer-project) performs dense SLAM using LIDAR data.
 

--- a/docs/services/slam/cartographer/_index.md
+++ b/docs/services/slam/cartographer/_index.md
@@ -13,12 +13,11 @@ aliases:
 
 [The Cartographer Project](https://github.com/cartographer-project) performs dense SLAM using LIDAR data.
 
-To easily integrate Cartographer into the Viam ecosystem, Viam provides the [`viam-cartographer`](https://github.com/viamrobotics/viam-cartographer) module which wraps Cartographer as a [modular resource](/program/extend/modular-resources/) in the form of a custom SLAM service.
-This module provides the `cartographer-module` binary, which runs in addition to `viam-server`.
+To easily integrate Cartographer into the Viam ecosystem, use the [`viam-cartographer`](https://github.com/viamrobotics/viam-cartographer) library, which wraps Cartographer as a [modular resource](/program/extend/modular-resources/). `viam-cartographer` provides the `cartographer-module` module, which includes the `viam:slam:cartographer` custom SLAM service [model](/program/extend/modular-resources/#models).
 
 ## Requirements
 
-To use Cartographer with Viam, install the `cartographer-module` binary on your machine and make it executable by running the following commands according to your machine's architecture:
+To use Cartographer with Viam, install the `cartographer-module` module on your machine and make it executable by running the following commands according to your machine's architecture:
 
 {{< tabs >}}
 {{% tab name="Linux aarch64" %}}

--- a/docs/services/slam/cartographer/_index.md
+++ b/docs/services/slam/cartographer/_index.md
@@ -12,7 +12,7 @@ aliases:
 
 [The Cartographer Project](https://github.com/cartographer-project) performs dense SLAM using LIDAR data.
 
-To easily integrate Cartographer into the Viam ecosystem, Viam provides [`viam-cartographer`](https://github.com/viamrobotics/viam-cartographer) which wraps Cartographer as a [modular resource](/program/extend/modular-resources/) named `cartographer-module`.
+To easily integrate Cartographer into the Viam ecosystem, Viam provides [`viam-cartographer`](https://github.com/viamrobotics/viam-cartographer), a [modular resource](/program/extend/modular-resources/) which wraps Cartographer. This resource provides the `cartographer-module` binary.
 
 ## Requirements
 


### PR DESCRIPTION
In discussion to https://viam.atlassian.net/browse/DOCS-851, Tess mentioned that viam-cartographer should be described as a modular resource, not an integrated library.

Question:
- Does the same apply to [ORB-SLAM3](https://docs-test.viam.dev/2e25d1f27d016afc5861925853fa7739b9725542/public/services/slam/orbslamv3/), (currently a draft doc, not public, just getting ahead of future questions, thanks!)