### PR TITLE
DOCS-760: Document Get_image helper function bytes_to_depth_array on Camera API 

### DIFF
--- a/docs/components/camera/_index.md
+++ b/docs/components/camera/_index.md
@@ -128,7 +128,7 @@ For example:
 frame = await my_cam.get_image()
 
 # Convert "frame" to a standard 2D image representation.
-# Remove the 1st 3x8 bytes and reshape the raw bytes to List[List[Int]]].
+# Remove the 1st 3x8 bytes and reshape the raw bytes to List[List[Int]].
 standard_frame frame.bytes_to_depth_array()
 ```
 

--- a/docs/components/camera/_index.md
+++ b/docs/components/camera/_index.md
@@ -119,7 +119,7 @@ frame = await my_cam.get_image()
 
 <br>
 
-If the `mime_type` of your image is `image/vnd.viam.dep`, pass the returned image data to the Viam Python SDK's [RawImage.bytes_to_depth_array()](https://python.viam.dev/autoapi/viam/media/video/index.html#viam.media.video.RawImage.bytes_to_depth_array) method to decode the raw image data to a standard 2D image representation.
+If the `mime_type` of your image is `image/vnd.viam.dep`, pass the returned image data to the Viam Python SDK's [`RawImage.bytes_to_depth_array()`](https://python.viam.dev/autoapi/viam/media/video/index.html#viam.media.video.RawImage.bytes_to_depth_array) method to decode the raw image data to a standard 2D image representation.
 
 For example:
 
@@ -129,7 +129,7 @@ frame = await my_cam.get_image()
 
 # Convert "frame" to a standard 2D image representation.
 # Remove the 1st 3x8 bytes and reshape the raw bytes to List[List[Int].
-standard_frame  frame.bytes_to_depth_array()
+standard_frame frame.bytes_to_depth_array()
 ```
 
 {{% alert title="Note" color="note" %}}

--- a/docs/components/camera/_index.md
+++ b/docs/components/camera/_index.md
@@ -128,7 +128,7 @@ For example:
 frame = await my_cam.get_image()
 
 # Convert "frame" to a standard 2D image representation.
-# Remove the 1st 3x8 bytes and reshape the raw bytes to List[List[Int].
+# Remove the 1st 3x8 bytes and reshape the raw bytes to List[List[Int]]].
 standard_frame frame.bytes_to_depth_array()
 ```
 

--- a/docs/components/camera/_index.md
+++ b/docs/components/camera/_index.md
@@ -117,7 +117,26 @@ my_camera = Camera.from_robot(robot=robot, name="my_camera")
 frame = await my_cam.get_image()
 ```
 
+<br>
+
+If the `mime_type` of your image is `image/vnd.viam.dep`, pass the returned image data to the Viam Python SDK's [RawImage.bytes_to_depth_array()](https://python.viam.dev/autoapi/viam/media/video/index.html#viam.media.video.RawImage.bytes_to_depth_array) method to decode the raw image data to a standard 2D image representation.
+
+For example:
+
+```python {class="line-numbers linkable-line-numbers"}
+# Assume "frame" has a mime_type of "image/vnd.viam.dep"
+frame = await my_cam.get_image()
+
+# Convert "frame" to a standard 2D image representation.
+# Remove the 1st 3x8 bytes and reshape the raw bytes to List[List[Int].
+standard_frame  frame.bytes_to_depth_array()
+```
+
+{{% alert title="Note" color="note" %}}
+
 Be sure to close the image when finished.
+
+{{% /alert %}}
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/camera/index.html#viam.components.camera.Camera.get_image).
 
@@ -164,7 +183,7 @@ The consumer of this call should decode the bytes into the format suggested by t
 
 **Returns:**
 
-- [(Tuple[bytes,str])](https://docs.python.org/3/library/stdtypes.html#bytes): The pointcloud data as bytes paired with a string representing the mimetype of the pointcloud (for example, PCD).
+- [(Tuple[bytes,str])](https://docs.python.org/3/library/stdtypes.html#bytes): The pointcloud data as bytes paired with a string representing the MIME type of the pointcloud (for example, PCD).
 
 To deserialize the returned information into a numpy array, use the Open3D library:
 


### PR DESCRIPTION
* Document the use case for the RawImage helper function `bytes_to_depth_array`: converting images of `viam.dep` MIME type to a standard image representation 
* Document a code snippet to show conversion to standard image data

NOTE: re. ticket this functionality will eventually be added to all SDKs