### PR TITLE
Fix motion constraints syntax

### DIFF
--- a/docs/services/motion/constraints.md
+++ b/docs/services/motion/constraints.md
@@ -25,7 +25,6 @@ This has the following sub-options:
 | line_tolerance_mm | float | 0.1 | Max linear deviation from straight-line between start and goal, in mm. |
 | orientation_tolerance_degs | float | 2.0 | Allowable deviation from Slerp between start/goal orientations, in degrees. |
 
-
 **Example usage**:
 
 ```python {class="line-numbers linkable-line-numbers"}
@@ -51,7 +50,6 @@ If set to zero, a movement with identical starting and ending orientations will 
 | Parameter Name | Type | Default | Description |
 | -------------- | ---- | ------- | ----------- |
 | orientation_tolerance_degs | float | 2.0 | Allowable deviation from Slerp between start/goal orientations, in degrees. |
-
 
 **Example usage**:
 

--- a/docs/services/motion/constraints.md
+++ b/docs/services/motion/constraints.md
@@ -22,8 +22,8 @@ This has the following sub-options:
 
 | Parameter Name | Type | Default | Description |
 | -------------- | ---- | ------- | ----------- |
-| line_tolerance | float | 0.1 | Max linear deviation from straight-line between start and goal, in mm. |
-| orient_tolerance | float | 0.05 | Allowable deviation from Slerp between start/goal orientations, unit is the norm of the R3AA between start and goal. |
+| line_tolerance_mm | float | 0.1 | Max linear deviation from straight-line between start and goal, in mm. |
+| orientation_tolerance_degs | float | 0.05 | Allowable deviation from Slerp between start/goal orientations, unit is the norm of the R3AA between start and goal. |
 
 **Example usage**:
 
@@ -49,7 +49,7 @@ If set to zero, a movement with identical starting and ending orientations will 
 
 | Parameter Name | Type | Default | Description |
 | -------------- | ---- | ------- | ----------- |
-| tolerance | float | 0.05 | Allowable deviation from Slerp between start/goal orientations, unit is the norm of the R3AA between start and goal. |
+| orientation_tolerance_degs | float | 0.05 | Allowable deviation from Slerp between start/goal orientations, unit is the norm of the R3AA between start and goal. |
 
 **Example usage**:
 

--- a/docs/services/motion/constraints.md
+++ b/docs/services/motion/constraints.md
@@ -23,7 +23,8 @@ This has the following sub-options:
 | Parameter Name | Type | Default | Description |
 | -------------- | ---- | ------- | ----------- |
 | line_tolerance_mm | float | 0.1 | Max linear deviation from straight-line between start and goal, in mm. |
-| orientation_tolerance_degs | float | 0.05 | Allowable deviation from Slerp between start/goal orientations, unit is the norm of the R3AA between start and goal. |
+| orientation_tolerance_degs | float | 2.0 | Allowable deviation from Slerp between start/goal orientations, in degrees. |
+
 
 **Example usage**:
 
@@ -49,7 +50,8 @@ If set to zero, a movement with identical starting and ending orientations will 
 
 | Parameter Name | Type | Default | Description |
 | -------------- | ---- | ------- | ----------- |
-| orientation_tolerance_degs | float | 0.05 | Allowable deviation from Slerp between start/goal orientations, unit is the norm of the R3AA between start and goal. |
+| orientation_tolerance_degs | float | 2.0 | Allowable deviation from Slerp between start/goal orientations, in degrees. |
+
 
 **Example usage**:
 

--- a/docs/services/motion/constraints.md
+++ b/docs/services/motion/constraints.md
@@ -36,8 +36,7 @@ moved = await motion.move(
         pose=goal_pose), 
     world_state=worldState, 
     constraints={
-        "motion_profile": "linear", 
-        "line_tolerance": 0.2
+        Constraints(linear_constraint = [LinearConstraint(line_tolerance_mm=0.2)])
      },
      extra={})
 ```
@@ -62,9 +61,11 @@ moved = await motion.move(
         reference_frame="myFrame",
         pose=goal_pose),
     world_state=worldState,
-    constraints={"motion_profile": "orientation"},
+    constraints = Constraints(orientation_constraint = [OrientationConstraint()])
     extra={})
 ```
+
+You can find more information in the [Python SDK Docs](https://python.viam.dev/autoapi/viam/gen/service/motion/v1/motion_pb2/index.html#viam.gen.service.motion.v1.motion_pb2.Constraints).
 
 <!--
 ## Next steps


### PR DESCRIPTION
Fix the Python stuff because it's currently broken, and add link. Go will come in another PR.