### PR TITLE
DOCS-884: Explore options to hide TOC

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -136,6 +136,16 @@ function toTop() {
     window.scroll({top: 0, left: 0, behavior: 'smooth'});
 }
 
+// script for the hideToc button
+const tdToc = document.getElementById("wholeToc");
+function hideToc() {
+    if (tdToc.style.visibility === "visible") {
+        tdToc.style.visibility = "hidden";
+    } else {
+        tdToc.style.visibility = "visible";
+    }
+}
+
 function btnVisibility(payload) {
     if (payload[0].boundingClientRect.y <= -400) {
         scrollBtn.style.visibility = "visible";

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -717,6 +717,17 @@ footer small {
   float: right;
   a {
     color: #515151;
+    margin-left: 15px;
+    margin-right: 15px;
+  }
+}
+
+#hide-toc {
+  float: right;
+  a {
+    color: #515151;
+    margin-left: 15px;
+    margin-right: 15px;
   }
 }
 

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -20,7 +20,10 @@
           </aside>
           <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
             {{ partial "version-banner.html" . }}
-            {{ partial "edit-on-github.html" . }}
+            {{ partial "hide-toc.html" . }}
+            {{ if not .Site.Params.notoc }}
+               {{ partial "edit-on-github.html" . }}
+            {{ end }}
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
             {{ block "main" . }}{{ end }}
             <!-- <button onclick="toTop()" class="docsbutton" id="scrollButton" title="Go to top" style="visibility: hidden;">

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -21,9 +21,7 @@
           <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
             {{ partial "version-banner.html" . }}
             {{ partial "hide-toc.html" . }}
-            {{ if not .Site.Params.notoc }}
-               {{ partial "edit-on-github.html" . }}
-            {{ end }}
+            {{ partial "edit-on-github.html" . }}
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
             {{ block "main" . }}{{ end }}
             <!-- <button onclick="toTop()" class="docsbutton" id="scrollButton" title="Go to top" style="visibility: hidden;">

--- a/layouts/partials/hide-toc.html
+++ b/layouts/partials/hide-toc.html
@@ -1,3 +1,9 @@
+{{ if not .Params.notoc }}
+{{ with .TableOfContents }}
+{{ if ge (len .) 200 }}
 <div id="hide-toc" title="Hide/show table of contents">
   <i onclick="hideToc()" style="font-size:large;" class="fas fa-list-ul"></i>
 </div>
+{{ end }}
+{{ end }}
+{{ end }}

--- a/layouts/partials/hide-toc.html
+++ b/layouts/partials/hide-toc.html
@@ -1,0 +1,3 @@
+<div id="hide-toc" title="Hide/show table of contents">
+  <i onclick="hideToc()" style="font-size:large;" class="fas fa-list-ul"></i>
+</div>

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,8 +1,10 @@
 {{ if not .Params.notoc }}
 {{ with .TableOfContents }}
 {{ if ge (len .) 200 }}
+<div id="wholeToc">
 <h6>On this page</h6>
 <div class="td-toc">{{ . }}</div>
+</div>
 {{ end }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Add a button to hide the TOC:
- Appears next to GH Edit button, uses same styling
- Not shown if TOC is not shown.

Current issues:
- While it hides the TOC, it does not reclaim the space previously used by the TOC, the primary goal of this effort.
- I am no web designer, I'm sure there's a prettier way to do this.