### PR TITLE
DOCS-901: Convert glossary links to tooltips

### DIFF
--- a/docs/components/board/_index.md
+++ b/docs/components/board/_index.md
@@ -17,7 +17,7 @@ A *board* is the signal wire hub of a robot that provides access to general purp
 You can control the flow of electricity to these pins to change their state between "high" (active) and "low" (inactive), and wire them to send [digital signals](https://en.wikipedia.org/wiki/Digital_signal) to and from other hardware.
 
 This control is simplified with [`viam-server`](/installation/).
-When Viam's software is running on a computer with GPIO pins accessible to external hardware [components](/components/), it manages GPIO signaling to abstract control to [resource](/appendix/glossary/#term-resource) APIs.
+When Viam's software is running on a computer with GPIO pins accessible to external hardware [components](/components/), it manages GPIO signaling to abstract control to {{< glossary_tooltip term_id="resource" text="resource" >}} APIs.
 
 {{% figure src="img/board-comp-options.png" alt="Image showing two board options: First, running viam-server locally and second, running via a peripheral plugged into the USB port of a computer that is running the viam-server." title="Two different board options: a single-board computer with GPIO pins running `viam-server` locally, or a GPIO peripheral plugged into a desktop computer's USB port, with the computer running `viam-server`." %}}
 
@@ -250,7 +250,7 @@ The following properties are available for `spis`:
 
 {{% alert title="WIRING WITH SPI" color="tip" %}}
 
-Refer to your board's pinout diagram or data sheet for SPI bus indexes and corresponding CS/MOSI/MISO/SCLK [pin numbers](/appendix/glossary/#term-pin-number).
+Refer to your board's pinout diagram or data sheet for SPI bus indexes and corresponding CS/MOSI/MISO/SCLK {{< glossary_tooltip term_id="pin-number" text="pin numbers" >}}.
 
 Refer to your peripheral device's data sheet for CS/MOSI/MISO/SLCK pin layouts.
 
@@ -318,7 +318,7 @@ The following properties are available for `i2cs`:
 
 {{% alert title="WIRING WITH I<sup>2</sup>C" color="tip" %}}
 
-Refer to your board's pinout diagram or data sheet for I<sup>2</sup>C bus indexes and corresponding SDA/SCL [pin numbers](/appendix/glossary/#term-pin-number).
+Refer to your board's pinout diagram or data sheet for I<sup>2</sup>C bus indexes and corresponding SDA/SCL {{< glossary_tooltip term_id="pin-number" text="pin numbers" >}}.
 
 Refer to your peripheral device's data sheet for SDA/SCL pin layouts.
 
@@ -510,7 +510,7 @@ Get a `GPIOPin` by {{< glossary_tooltip term_id="pin-number" text="pin number" >
 **Parameters:**
 
 - `name` [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Pin number of the GPIO pin you want to retrieve as a `GPIOPin` interface.
-Refer to the pinout diagram and data sheet of your [board model](#configuration) for [pin numbers](/appendix/glossary/#term-pin-number) and orientation.
+Refer to the pinout diagram and data sheet of your [board model](#configuration) for {{< glossary_tooltip term_id="pin-number" text="pin numbers" >}}.
 
 **Returns:**
 
@@ -531,7 +531,7 @@ pin = await my_board.GPIO_pin_by_name(name="15")
 **Parameters:**
 
 - `name` [(string)](https://pkg.go.dev/builtin#string): {{< glossary_tooltip term_id="pin-number" text="pin number" >}} of the GPIO pin you want to retrieve as a `GPIOPin` interface.
-Refer to the pinout diagram and data sheet of your [board model](#configuration) for [pin numbers](/appendix/glossary/#term-pin-number) and orientation.
+Refer to the pinout diagram and data sheet of your [board model](#configuration) for {{< glossary_tooltip term_id="pin-number" text="pin numbers" >}}.
 
 **Returns:**
 

--- a/docs/extend/custom-components-remotes.md
+++ b/docs/extend/custom-components-remotes.md
@@ -38,7 +38,7 @@ To add a custom resource as a [remote](/manage/parts-and-remotes/):
 1. Code a new model of a built-in resource type. You can do this by creating a new interface that implements required methods. The new model must implement any functions of the built-in resource type marked as required in its RDK API definition.
 2. Register the custom component on a new gRPC server instance and start the server.
 3. Add the server as a [remote](/manage/parts-and-remotes/) of your robot.
-4. Configure a command to launch this remote server as a [process](/appendix/glossary/#term-process) of your robot to make sure the remote server is always running alongside the rest of your robot.
+4. Configure a command to launch this remote server as a {{< glossary_tooltip term_id="process" text="process" >}} of your robot to make sure the remote server is always running alongside the rest of your robot.
 
 Each remote server can host one or many custom components.
 
@@ -51,7 +51,7 @@ The new model must implement any functions of the built-in resource type marked 
 1. Register the custom component on a new gRPC server instance and start the server.
 You can do this with the [`viam.rpc` library](https://python.viam.dev/autoapi/viam/rpc/index.html) by creating a new `rpc.server.Server` instance.
 1. Add the server as a [remote](/manage/parts-and-remotes/) of your robot.
-2. Configure a command to launch this remote server as a [process](/appendix/glossary/#term-process) of your robot to make sure the remote server is always running alongside the rest of your robot.
+2. Configure a command to launch this remote server as a {{< glossary_tooltip term_id="process" text="process" >}} of your robot to make sure the remote server is always running alongside the rest of your robot.
 
 Each remote server can host one or many custom components.
 

--- a/docs/extend/modular-resources/_index.md
+++ b/docs/extend/modular-resources/_index.md
@@ -10,7 +10,7 @@ aliases:
     - "/program/extend/modular-resources/"
 ---
 
-The Viam module system allows you to integrate custom [resources](/appendix/glossary/#term-resource) ([components](/components/) and [services](/services/)) into any robot running on Viam.
+The Viam module system allows you to integrate custom {{< glossary_tooltip term_id="resource" text="resources" >}}, ([components](/components/), and [services](/services/)) into any robot running on Viam.
 
 With modular resources, you can:
 

--- a/docs/program/apis/_index.md
+++ b/docs/program/apis/_index.md
@@ -227,7 +227,7 @@ The board component supports the following methods:
 | ----------- | ----------- |
 | [AnalogReaderByName](/components/board/#analogreaderbyname) | Get an [`AnalogReader`](/components/board/#analogs) by `name`. |
 | [DigitalInterruptByName](/components/board/#digitalinterruptbyname) | Get a [`DigitalInterrupt`](/components/board/#digital_interrupts) by `name`. |
-| [GPIOPinByName](/components/board/#gpiopinbyname) | Get a `GPIOPin` by its [pin number](/appendix/glossary/#term-pin-number). |
+| [GPIOPinByName](/components/board/#gpiopinbyname) | Get a `GPIOPin` by its {{< glossary_tooltip term_id="pin-number" text="pin number" >}}. |
 | [AnalogReaderNames](/components/board/#analogreadernames) | Get the `name` of every [`AnalogReader`](/components/board/#analogs). |
 | [DigitalInterruptNames](/components/board/#digitalinterruptnames) | Get the `name` of every [`DigitalInterrupt`](/components/board/#digital_interrupts). |
 | [Status](/components/board/#status) | Get the current status of this board. |

--- a/docs/services/data/_index.md
+++ b/docs/services/data/_index.md
@@ -31,7 +31,7 @@ Viam does not impose a lower or upper limit on the frequency of data collection.
 However, in practice, your hardware may impose limits on the frequency of data collection.
 
 You can change the frequency of data capture at any time for individual components.
-If you use [fragments](../../appendix/glossary/), you can change the frequency of data capture in real time for some or all robots in a fleet at the component or robot level.
+If you use {{< glossary_tooltip term_id="fragment" text="fragments" >}}, you can change the frequency of data capture in real time for some or all robots in a fleet at the component or robot level.
 
 For example, consider a tomato picking robot with a 3D camera and an arm.
 When you configure the robot, you may set the camera to capture point cloud data at a frequency of 30Hz.


### PR DESCRIPTION
- Converted a few direct links to glossary to use tooltip shortcode instead.