### PR TITLE
DOCS-886: Improve Go modular resource code template by adding module with contextual main

### DIFF
--- a/docs/extend/modular-resources/_index.md
+++ b/docs/extend/modular-resources/_index.md
@@ -110,8 +110,11 @@ For example:
 {{< tabs name="Base Model Modules" >}}
 {{% tab name="Go" %}}
 
-This example module code is adapted from the full demo module available on the [Viam GitHub](https://github.com/viamrobotics/rdk/blob/main/examples/customresources/models/mybase/mybase.go), and creates a singular modular resource implementing Viam's built-in Base API (rdk:service:base).
+This example custom model code (<file>mybase.go</file>) and module (<file>mymodule.go</file>) is adapted from the full demo module available on the [Viam GitHub](https://github.com/viamrobotics/rdk/blob/main/examples/customresources/models/mybase/mybase.go), and creates a singular modular resource implementing Viam's built-in Base API (rdk:service:base).
+
 See [Base API Methods](/components/base/#api) and [Motor API Methods](/components/motor/#api) for more information.
+
+<file>mybase.go</file>
 
 ``` go {class="line-numbers linkable-line-numbers"}
 // Package mybase implements a base that only supports SetPower (basic forward/back/turn controls), IsMoving (check if in motion), and Stop (stop all motion).
@@ -276,6 +279,55 @@ func init() {
             return config.TransformAttributeMapToStruct(&conf, attributes)
         },
         &MyBaseConfig{})
+}
+```
+
+<file>mymodule.go</file>
+
+``` go {class="line-numbers linkable-line-numbers"}
+// Package main is a module which serves the mybase custom model type.
+package main
+
+import (
+    "context"
+
+    "github.com/edaniels/golog"
+
+    "go.viam.com/rdk/components/base"
+    "go.viam.com/rdk/module"
+    "go.viam.com/utils"
+
+    // NOTE: You must update the following line to import your local package "mybase"
+    "go.viam.com/rdk/examples/customresources/models/mybase"
+)
+
+func main() {
+    // NewLoggerFromArgs will create a golog.Logger at "DebugLevel" if
+    // "--log-level=debug" is the third argument in os.Args and at "InfoLevel"
+    // otherwise.
+    utils.ContextualMain(mainWithArgs, module.NewLoggerFromArgs("complexmodule"))
+}
+
+func mainWithArgs(ctx context.Context, args []string, logger golog.Logger) (err error) {
+    myMod, err := module.NewModuleFromArgs(ctx, logger)
+    if err != nil {
+        return err
+    }
+
+    // Models and APIs add helpers to the registry during their init().
+    // They can then be added to the module here.
+    err = myMod.AddModelFromRegistry(ctx, base.API, mybase.Model)
+    if err != nil {
+        return err
+    }
+
+    err = myMod.Start(ctx)
+    defer myMod.Close(ctx)
+    if err != nil {
+        return err
+    }
+    <-ctx.Done()
+    return nil
 }
 ```
 
@@ -449,6 +501,7 @@ To add a module to your robot, you need to have an [executable file](https://en.
 Your options for completing this step are flexible, as this file does not need to be in a raw binary format.
 
 If using the Go SDK, Go will build a binary when you compile your module.
+Expand the [Go module examples](#code-your-module) to view <file>mymodule.go</file> as an example of a module you can run that initializes a custom model <file>myBase.go</file> from the registry.
 
 If using the Python SDK, one option is to create and save a new shell script (<file>.sh</file>) that runs your module.
 For example:

--- a/docs/extend/modular-resources/_index.md
+++ b/docs/extend/modular-resources/_index.md
@@ -110,7 +110,7 @@ For example:
 {{< tabs name="Base Model Modules" >}}
 {{% tab name="Go" %}}
 
-The example custom model code (<file>mybase.go</file>) and module (<file>mymodule.go</file>) are adapted from the full demo module available on the [Viam GitHub](https://github.com/viamrobotics/rdk/blob/main/examples/customresources/models/mybase/mybase.go), and creates a singular modular resource implementing Viam's built-in Base API (rdk:service:base).
+The example custom model code (<file>mybase.go</file>) and module (<file>mymodule.go</file>) are adapted from the full demo module available on the [Viam GitHub](https://github.com/viamrobotics/rdk/blob/main/examples/customresources/models/mybase/mybase.go), and creates a modular resource implementing Viam's built-in Base API (rdk:service:base).
 
 See [Base API Methods](/components/base/#api) and [Motor API Methods](/components/motor/#api) for more information.
 
@@ -303,8 +303,7 @@ import (
 
 func main() {
     // NewLoggerFromArgs will create a golog.Logger at "DebugLevel" if
-    // "--log-level=debug" is the third argument in os.Args and at "InfoLevel"
-    // otherwise.
+    // "--log-level=debug" is an argument in os.Args and at "InfoLevel" otherwise.
     utils.ContextualMain(mainWithArgs, module.NewLoggerFromArgs("yourmodule"))
 }
 

--- a/docs/extend/modular-resources/_index.md
+++ b/docs/extend/modular-resources/_index.md
@@ -305,7 +305,7 @@ func main() {
     // NewLoggerFromArgs will create a golog.Logger at "DebugLevel" if
     // "--log-level=debug" is the third argument in os.Args and at "InfoLevel"
     // otherwise.
-    utils.ContextualMain(mainWithArgs, module.NewLoggerFromArgs("complexmodule"))
+    utils.ContextualMain(mainWithArgs, module.NewLoggerFromArgs("yourmodule"))
 }
 
 func mainWithArgs(ctx context.Context, args []string, logger golog.Logger) (err error) {

--- a/docs/extend/modular-resources/_index.md
+++ b/docs/extend/modular-resources/_index.md
@@ -110,7 +110,8 @@ For example:
 {{< tabs name="Base Model Modules" >}}
 {{% tab name="Go" %}}
 
-The example custom model code (<file>mybase.go</file>) and module (<file>mymodule.go</file>) are adapted from the full demo module available on the [Viam GitHub](https://github.com/viamrobotics/rdk/blob/main/examples/customresources/models/mybase/mybase.go), and creates a modular resource implementing Viam's built-in Base API (rdk:service:base).
+The code for this custom model (<file>mybase.go</file>) and module (<file>mymodule.go</file>) is adapted from the full demo modules available on the [Viam GitHub](https://github.com/viamrobotics/rdk/blob/main/examples/customresources/models/mybase/mybase.go).
+The module registers a modular resource implementing Viam's built-in Base API (rdk:service:base).
 
 See [Base API Methods](/components/base/#api) and [Motor API Methods](/components/motor/#api) for more information.
 

--- a/docs/extend/modular-resources/_index.md
+++ b/docs/extend/modular-resources/_index.md
@@ -110,7 +110,7 @@ For example:
 {{< tabs name="Base Model Modules" >}}
 {{% tab name="Go" %}}
 
-This example custom model code (<file>mybase.go</file>) and module (<file>mymodule.go</file>) is adapted from the full demo module available on the [Viam GitHub](https://github.com/viamrobotics/rdk/blob/main/examples/customresources/models/mybase/mybase.go), and creates a singular modular resource implementing Viam's built-in Base API (rdk:service:base).
+The example custom model code (<file>mybase.go</file>) and module (<file>mymodule.go</file>) are adapted from the full demo module available on the [Viam GitHub](https://github.com/viamrobotics/rdk/blob/main/examples/customresources/models/mybase/mybase.go), and creates a singular modular resource implementing Viam's built-in Base API (rdk:service:base).
 
 See [Base API Methods](/components/base/#api) and [Motor API Methods](/components/motor/#api) for more information.
 

--- a/docs/extend/modular-resources/_index.md
+++ b/docs/extend/modular-resources/_index.md
@@ -501,7 +501,7 @@ To add a module to your robot, you need to have an [executable file](https://en.
 Your options for completing this step are flexible, as this file does not need to be in a raw binary format.
 
 If using the Go SDK, Go will build a binary when you compile your module.
-Expand the [Go module examples](#code-your-module) to view <file>mymodule.go</file> as an example of a module you can run that initializes a custom model <file>myBase.go</file> from the registry.
+Expand the [Go module examples](#code-your-module) to view <file>mymodule.go</file> as an example of a module you can run that initializes a custom model <file>mybase.go</file> from the registry.
 
 If using the Python SDK, one option is to create and save a new shell script (<file>.sh</file>) that runs your module.
 For example:


### PR DESCRIPTION
* Apply Alan's feedback for compiling a go module 
* Add code in from the Viam examples repo's [complexmodule module.go](https://github.com/viamrobotics/rdk/blob/a0dec7d74085139fe77a637335ba43640355ca47/examples/customresources/demos/complexmodule/module.go) 
* Try to clear up module execution