### PR TITLE
Fix dropdown menu code to button name in try color detection tutorial

### DIFF
--- a/docs/tutorials/services/try-viam-color-detection.md
+++ b/docs/tutorials/services/try-viam-color-detection.md
@@ -51,7 +51,7 @@ To create a [Vision Service](/services/vision/):
 
 1. Select `vision` as the **Type**.
 2. Enter `my_color_detector` as the **Name**.
-3. Select `color_detector` as the **Model**.
+3. Select **Color Detector** as the **Model**.
 4. Click **Create Service**.
 
 In your Vision Service's panel, fill in the **Attributes** field.


### PR DESCRIPTION
Quickfix from DOCS-911: 

* Change attribute name to button to reflect UI dropdown menu change-- now auto populates **Color Detector** instead of using `color_detector` which could introduce confusion 