### PR TITLE
DOCS-878: Apply Matt Vella's feedback to extra params

### DIFF
--- a/docs/program/use-extra-params.md
+++ b/docs/program/use-extra-params.md
@@ -14,11 +14,11 @@ How to [utilize](#utilize) and [define](#define) the `extra` parameters that man
 
 ## Utilize
 
-You can use `extra` parameters with modular {{< glossary_tooltip term_id="resource" text="resource" >}} implementations that are new *models* of built-in resource types.
+You can use `extra` parameters with modular {{< glossary_tooltip term_id="resource" text="resource" >}} implementations that are *models* of built-in resource types.
 
 For example, a new model of [sensor](/components/sensor/), or a new model of [SLAM Service](/services/slam/).
 
-The `extra` parameters in that built-in resource type's [API](/extend/modular-resources/#apis) give users the option to pass information to a resource's driver that isn't specified as a parameter for all models of the resource type.
+The `extra` parameters in that built-in resource type's [API](/extend/modular-resources/#apis) allow users to pass information to a resource's driver that isn't specified as a parameter for all models of the resource type.
 This is necessary to keep the API of resource types consistent across, for example, all models of [motor](/components/motor/) or all models of [camera](/components/camera/).
 
 Send extra information in an API call in `extra` parameters as follows:

--- a/docs/program/use-extra-params.md
+++ b/docs/program/use-extra-params.md
@@ -10,16 +10,25 @@ aliases:
   - "/program/sdks/use-extra-params"
 ---
 
-How to [utilize](#utilize) and [define](#define) the `extra` parameters that many {{< glossary_tooltip term_id="resource" text="resource" >}} API methods offer in the Go and Python SDKs.
+How to [define](#define) and [utilize](#utilize) the `extra` parameters that many {{< glossary_tooltip term_id="resource" text="resource" >}} [API methods](/program/apis/) offer in the Go and Python SDKs.
 
-## Utilize
+## Define
 
-Use `extra` parameters to pass information to a {{< glossary_tooltip term_id="resource" text="resource's" >}} driver that is not explicitly specified as a parameter in the [built-in resource type's API specification](/extend/modular-resources/#apis).
+You can use `extra` parameters with modular {{< glossary_tooltip term_id="resource" text="resource" >}} implementations that are new *models* of built-in resource types.
 
-To do this, you must code your own modified implementation of the resource type's API for a model.
-See [Extend Viam with Modular Resources](/extend/modular-resources/) for more information and [instructions](/extend/modular-resources/#use-a-modular-resource-with-your-robot) on modifying API specifications.
+For example, a new model of [sensor](/components/sensor/), or a new model of [SLAM Service](/services/slam/).
 
-An example of how to check the values of keys in an `extra` parameter of a [built-in resource API method](/program/apis/), the sensor component's [Readings](/components/sensor/#readings):
+The `extra` parameters in that built-in resource type's [API](/extend/modular-resources/#apis) give users the option to pass information to a resource's driver that isn't specified as a parameter for all models of the resource type.
+This is necessary to keep the API of resource types consistent across, for example, all models of [motor](/components/motor/) or all models of [camera](/components/camera).
+
+If `extra` information must be passed to a resource, it is handled within a new, *modular* resource model's [custom API](/extend/modular-resources/#apis) wrapper.
+
+{{%expand "Click for instructions on defining a custom model to utilize extra params" %}}
+
+To do this, define a custom implementation of the resource's API as a new *model*, and modify the resource's API methods to handle the `extra` information you send.
+Follow [these instructions](/extend/modular-resources/#code-your-module) to do so.
+
+For an example of how to check the values of keys in an `extra` parameter of a built-in resource [API method](/program/apis/), reference this modification to the built-in [sensor](/components/sensor/) resource type's [Readings](/components/sensor/#readings) method in the code of a [new sensor model](/extend/modular-resources/):
 
 {{< tabs >}}
 {{% tab name="Python" %}}
@@ -79,7 +88,13 @@ func (s *mySensor) Readings(ctx context.Context, extra map[string]interface{}) (
 {{% /tab %}}
 {{% /tabs %}}
 
-## Define
+See [Extend Viam with Modular Resources](/extend/modular-resources/) for more information and [instructions](/extend/modular-resources/#use-a-modular-resource-with-your-robot) on modifying built-in API specifications.
+
+{{% /expand%}}
+
+## Utilize
+
+Send extra information in an API call in `extra` parameters as follows:
 
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/program/use-extra-params.md
+++ b/docs/program/use-extra-params.md
@@ -10,9 +10,9 @@ aliases:
   - "/program/sdks/use-extra-params"
 ---
 
-How to [define](#define) and [utilize](#utilize) the `extra` parameters that many {{< glossary_tooltip term_id="resource" text="resource" >}} [API methods](/program/apis/) offer in the Go and Python SDKs.
+How to [utilize](#utilize) and [define](#define) the `extra` parameters that many {{< glossary_tooltip term_id="resource" text="resource" >}} [API methods](/program/apis/) offer in the Go and Python SDKs.
 
-## Define
+## Utilize
 
 You can use `extra` parameters with modular {{< glossary_tooltip term_id="resource" text="resource" >}} implementations that are new *models* of built-in resource types.
 
@@ -20,6 +20,71 @@ For example, a new model of [sensor](/components/sensor/), or a new model of [SL
 
 The `extra` parameters in that built-in resource type's [API](/extend/modular-resources/#apis) give users the option to pass information to a resource's driver that isn't specified as a parameter for all models of the resource type.
 This is necessary to keep the API of resource types consistent across, for example, all models of [motor](/components/motor/) or all models of [camera](/components/camera).
+
+Send extra information in an API call in `extra` parameters as follows:
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+[`Optional[Dict[str, Any]]`](https://docs.python.org/3/library/typing.html#typing.Optional) indicates you are required to pass in an object of either type `Dict[str, Any]` or `None` as a parameter when calling this method.
+
+An object of type `Dict[str, Any]` is a [dictionary](https://docs.python.org/3/tutorial/datastructures.html#dictionaries) with keys of type [`str`](https://docs.python.org/3/library/stdtypes.html#str) and values of [`any type`](https://docs.python.org/3/library/typing.html#typing.Any),
+
+For example:
+
+``` python {class="line-numbers linkable-line-numbers"}
+async def main():
+    ... # Connect to the robot.
+
+    # Get your sensor resource from the robot.
+    your_sensor = YourSensor.from_robot(robot, "your-sensor")
+    
+    # Define a dictionary containing extra information.
+    your_info = {"type": "temperature", "description": "more info", "id": 123}
+
+    # Send this information in an call to the sensor resource's API.
+    await your_sensor.get_readings(extra=your_info)
+```
+
+{{% alert title="Note" color="note" %}}
+
+If passing an object of type `None`, you do not have to specify `None` in the method call.
+
+{{% /alert %}}
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+`extra (map[string]interface{})` indicates you are required to pass in an object of either type `map[string]interface{}` or `nil` as a parameter when calling this method.
+
+An object of type `map[string]interface{}` is an [map](https://go.dev/blog/maps) with keys of type [`string`](https://go.dev/blog/strings) and values of [any type that you have cast to an interface](https://jordanorelli.com/post/32665860244/how-to-use-interfaces-in-go).
+
+For example:
+
+```go {class="line-numbers linkable-line-numbers"}
+func main() {
+    ... // Connect to the robot
+
+    // Get your sensor resource from the robot.
+    yourSensor, err := YourSensor.FromRobot(robot, "your-sensor")
+
+    // Define a map containing extra information.
+    your_info := map[string]interface{}{"type": "temperature", "description": "more info", "id": 123}
+
+    // Send this information in an call to the sensor resource's API.
+    err := yourSensor.Readings(context.Background(), your_info)
+}
+```
+
+{{% alert title="Note" color="note" %}}
+
+If passing an object of type `nil`, you must specify `nil` in the method call or the method will fail.
+
+{{% /alert %}}
+{{% /tab %}}
+{{% /tabs %}}
+
+## Define
 
 If `extra` information must be passed to a resource, it is handled within a new, *modular* resource model's [custom API](/extend/modular-resources/#apis) wrapper.
 
@@ -91,68 +156,3 @@ func (s *mySensor) Readings(ctx context.Context, extra map[string]interface{}) (
 See [Extend Viam with Modular Resources](/extend/modular-resources/) for more information and [instructions](/extend/modular-resources/#use-a-modular-resource-with-your-robot) on modifying built-in API specifications.
 
 {{% /expand%}}
-
-## Utilize
-
-Send extra information in an API call in `extra` parameters as follows:
-
-{{< tabs >}}
-{{% tab name="Python" %}}
-
-[`Optional[Dict[str, Any]]`](https://docs.python.org/3/library/typing.html#typing.Optional) indicates you are required to pass in an object of either type `Dict[str, Any]` or `None` as a parameter when calling this method.
-
-An object of type `Dict[str, Any]` is a [dictionary](https://docs.python.org/3/tutorial/datastructures.html#dictionaries) with keys of type [`str`](https://docs.python.org/3/library/stdtypes.html#str) and values of [`any type`](https://docs.python.org/3/library/typing.html#typing.Any),
-
-For example:
-
-``` python {class="line-numbers linkable-line-numbers"}
-async def main():
-    ... # Connect to the robot.
-
-    # Get your sensor resource from the robot.
-    your_sensor = YourSensor.from_robot(robot, "your-sensor")
-    
-    # Define a dictionary containing extra information.
-    your_info = {"type": "temperature", "description": "more info", "id": 123}
-
-    # Send this information in an call to the sensor resource's API.
-    await your_sensor.get_readings(extra=your_info)
-```
-
-{{% alert title="Note" color="note" %}}
-
-If passing an object of type `None`, you do not have to specify `None` in the method call.
-
-{{% /alert %}}
-
-{{% /tab %}}
-{{% tab name="Go" %}}
-
-`extra (map[string]interface{})` indicates you are required to pass in an object of either type `map[string]interface{}` or `nil` as a parameter when calling this method.
-
-An object of type `map[string]interface{}` is an [map](https://go.dev/blog/maps) with keys of type [`string`](https://go.dev/blog/strings) and values of [any type that you have cast to an interface](https://jordanorelli.com/post/32665860244/how-to-use-interfaces-in-go).
-
-For example:
-
-```go {class="line-numbers linkable-line-numbers"}
-func main() {
-    ... // Connect to the robot
-
-    // Get your sensor resource from the robot.
-    yourSensor, err := YourSensor.FromRobot(robot, "your-sensor")
-
-    // Define a map containing extra information.
-    your_info := map[string]interface{}{"type": "temperature", "description": "more info", "id": 123}
-
-    // Send this information in an call to the sensor resource's API.
-    err := yourSensor.Readings(context.Background(), your_info)
-}
-```
-
-{{% alert title="Note" color="note" %}}
-
-If passing an object of type `nil`, you must specify `nil` in the method call or the method will fail.
-
-{{% /alert %}}
-{{% /tab %}}
-{{% /tabs %}}

--- a/docs/program/use-extra-params.md
+++ b/docs/program/use-extra-params.md
@@ -19,7 +19,7 @@ You can use `extra` parameters with modular {{< glossary_tooltip term_id="resour
 For example, a new model of [sensor](/components/sensor/), or a new model of [SLAM Service](/services/slam/).
 
 The `extra` parameters in that built-in resource type's [API](/extend/modular-resources/#apis) give users the option to pass information to a resource's driver that isn't specified as a parameter for all models of the resource type.
-This is necessary to keep the API of resource types consistent across, for example, all models of [motor](/components/motor/) or all models of [camera](/components/camera).
+This is necessary to keep the API of resource types consistent across, for example, all models of [motor](/components/motor/) or all models of [camera](/components/camera/).
 
 Send extra information in an API call in `extra` parameters as follows:
 


### PR DESCRIPTION
* Switch "utilize" and "define" use cases
* Change wording to make this more clear that this is meant to be used by users who implement modular components (later on should go with broader changes when registry is ready) 
* Hide "utilize" code steps in expand 