### PR TITLE
Add SDK definition to drive rover tutorial

### DIFF
--- a/docs/tutorials/get-started/try-viam-sdk.md
+++ b/docs/tutorials/get-started/try-viam-sdk.md
@@ -21,7 +21,7 @@ cost: "0"
 
 {{<youtube embed_url="https://www.youtube-nocookie.com/embed/daU5iNsSO0w">}}
 
-The Viam {{< glossary_tooltip term_id="SDKs" text="sdk" >}} allow you to write code in Python, Go, or TypeScript to control a Viam-connected robot like the [Viam Rover](https://app.viam.com/try).
+The Viam {{< glossary_tooltip term_id="sdk" text="SDKs" >}} allow you to write code in Python, Go, or TypeScript to control a Viam-connected robot like the [Viam Rover](https://app.viam.com/try).
 You can follow this tutorial with a [rented Viam Rover](https://app.viam.com/try) or with [your own Viam Rover](/try-viam/rover-resources/).
 
 <div class="td-max-width-on-larger-screens">

--- a/docs/tutorials/get-started/try-viam-sdk.md
+++ b/docs/tutorials/get-started/try-viam-sdk.md
@@ -21,7 +21,7 @@ cost: "0"
 
 {{<youtube embed_url="https://www.youtube-nocookie.com/embed/daU5iNsSO0w">}}
 
-The Viam SDKs allow you to write code in Python, Go, or TypeScript to control a Viam-connected robot like the [Viam Rover](https://app.viam.com/try).
+The Viam {{< glossary_tooltip term_id="SDKs" text="sdk" >}} allow you to write code in Python, Go, or TypeScript to control a Viam-connected robot like the [Viam Rover](https://app.viam.com/try).
 You can follow this tutorial with a [rented Viam Rover](https://app.viam.com/try) or with [your own Viam Rover](/try-viam/rover-resources/).
 
 <div class="td-max-width-on-larger-screens">


### PR DESCRIPTION
This is an entry-level tutorial and we don't define SDK here.