### PR TITLE
DOCS-920: update gps-nmea config page and connection configs snippet 

### DIFF
--- a/docs/components/movement-sensor/gps/gps-nmea.md
+++ b/docs/components/movement-sensor/gps/gps-nmea.md
@@ -96,9 +96,9 @@ Note that the example `"serial_path"` filepath is specific to serial devices con
       "type": "movement_sensor",
       "model": "gps-nmea",
       "attributes": {
-        "board": "local",
         "connection_type": "I2C",
         "i2c_attributes": {
+          "board": "local",
           "i2c_baud_rate": 115200,
           "i2c_addr": 111,
           "i2c_bus": "<name_of_bus_on_board>"
@@ -118,7 +118,6 @@ Note that the example `"serial_path"` filepath is specific to serial devices con
 Name | Type | Inclusion | Description |
 ---- | ---- | --------- | ----------- |
 `connection_type` | string | **Required** |`"I2C"` or `"serial"`. See [connection configuration info](#connection-attributes).
-`board` | string | depends on connection type | The `name` of the [board](/components/board/) connected to the chip. Required for NMEA over [I<sup>2</sup>C](/components/board/#i2cs). Not required for serial communication.
 `disable_nmea` | boolean | Optional | If set to `true`, changes the NMEA message protocol to RTCM when using a chip as a base station. <br> Default: `false`
 
 ### Connection Attributes

--- a/static/include/components/movement-sensor/connection.md
+++ b/static/include/components/movement-sensor/connection.md
@@ -11,13 +11,11 @@ Then create a struct within `attributes` for either `serial_attributes` or `i2c_
 
 For a movement sensor communicating over serial, you'll need to include a `serial_attributes` field containing:
 
-Name | Type | Default Value | Description
----- | ---- | ------------- | -----
-`serial_path` | string | - | The name of the port through which the sensor communicates with the computer.
-`serial_baud_rate` | int | 115200 | The rate at which data is sent from the sensor. Optional.
+Name | Type | Inclusion | Description
+---- | ---- | --------- | -----------
+`serial_path` | string | **Required** | The name of the port through which the sensor communicates with the computer.
+`serial_baud_rate` | int | Optional | The rate at which data is sent from the sensor. <br> Default: `115200`
 ---
-
-Serial communication uses a filepath instead of relying on any specific piece of board hardware, so no "board" attribute is needed when configuring a movement sensor with this communication method.
 
 ```json {class="line-numbers linkable-line-numbers"}
 {
@@ -42,14 +40,13 @@ Serial communication uses a filepath instead of relying on any specific piece of
 
 For a movement sensor communicating over I<sup>2</sup>C, you'll need a `i2c_attributes` field containing:
 
-Name | Type | Default Value | Description
----- | ---- | ------------- | -----
-`i2c_bus` | string | - | The name of I<sup>2</sup>C bus wired to the sensor.
-`i2c_addr` | int | - | The device's I<sup>2</sup>C address.
-`i2c_baud_rate` | int | 115200 | The rate at which data is sent from the sensor. Optional.
+Name | Type | Inclusion | Description
+---- | ---- | --------- | -----------
+`board` | string | **Required** | The `name` of the [board](/components/board/) to which the [I<sup>2</sup>C](/components/board/#i2cs) connection is being made. This attribute is only required for the [`gps-nmea`](/components/movement-sensor/gps-nmea/) model.
+`i2c_bus` | string | **Required** | The name of the [I<sup>2</sup>C bus](/components/board/#i2cs) wired to the sensor.
+`i2c_addr` | int | **Required** | The device's I<sup>2</sup>C address.
+`i2c_baud_rate` | int | Optional | The rate at which data is sent from the sensor. Optional. <br> Default: `115200`
 ---
-
-You'll also need to configure the `board` attribute with the name of the board to which the I<sup>2</sup>C connection is being made.
 
 ```json {class="line-numbers linkable-line-numbers"}
 {
@@ -57,12 +54,13 @@ You'll also need to configure the `board` attribute with the name of the board t
     "type": "<TYPE>",
     "model": "<MODEL>",
     "attributes": {
-        "board": "<name of board, e.g. local>",
         "<whatever other attributes>": "<example>",
         "connection_type": "I2C",
+        // "board": "<name of board, e.g. local>"  Include if "model": "gps-rtk"
         "i2c_attributes": {
             "i2c_addr": 111,
-            "i2c_bus": "1"
+            "i2c_bus": "1",
+            // "board": "<name of board, e.g. local>"  Include if "model": "gps-nmea"
         }
     }
 }


### PR DESCRIPTION
Update movement sensor's gps-nmea model docs based on breaking updates to configuration shared in eng-breaking-changes:
*  "board" is now part of the i2c attribute 
* "serial_correction_path" and "serial_correction_baud_rate" have been removed from the serial attribute.
* Make attribute tables in snippet's formatting more standard.

See Jira ticket for full slack thread