### PR TITLE
DOCS-779: Add C++ ML modular resource tutorial

### DIFF
--- a/docs/extend/modular-resources/examples/_index.md
+++ b/docs/extend/modular-resources/examples/_index.md
@@ -20,10 +20,10 @@ Once you have created a modular resource, you can test your custom resource usin
 ## Tutorials
 
 {{< cards >}}
-    {{% card link="/extend/modular-resources/examples/rplidar" customTitle="Add an RPlidar camera as a Modular Resource" %}}
-    {{% card link="/extend/modular-resources/examples/odrive" customTitle="Add an ODrive motor as a Modular Resource" %}}
-    {{% card link="/extend/modular-resources/examples/custom-arm" %}}
-    {{% card link="/extend/modular-resources/examples/add-tflite-module.md/" %}}
+    {{% card link="/extend/modular-resources/examples/rplidar/" customTitle="Add an RPlidar camera as a Modular Resource" %}}
+    {{% card link="/extend/modular-resources/examples/odrive/" customTitle="Add an ODrive motor as a Modular Resource" %}}
+    {{% card link="/extend/modular-resources/examples/custom-arm/" %}}
+    {{% card link="/extend/modular-resources/examples/tflite-module/" customTitle="Add a TensorFlow Lite Modular Service"  %}}
     {{% card link="/tutorials/custom/custom-base-dog/" %}}
     {{% card link="/tutorials/custom/controlling-an-intermode-rover-canbus/" %}}
 {{< /cards >}}

--- a/docs/extend/modular-resources/examples/_index.md
+++ b/docs/extend/modular-resources/examples/_index.md
@@ -23,6 +23,7 @@ Once you have created a modular resource, you can test your custom resource usin
     {{% card link="/extend/modular-resources/examples/rplidar" customTitle="Add an RPlidar camera as a Modular Resource" %}}
     {{% card link="/extend/modular-resources/examples/odrive" customTitle="Add an ODrive motor as a Modular Resource" %}}
     {{% card link="/extend/modular-resources/examples/custom-arm" %}}
+    {{% card link="/extend/modular-resources/examples/add-tflite-module.md/" %}}
     {{% card link="/tutorials/custom/custom-base-dog/" %}}
     {{% card link="/tutorials/custom/controlling-an-intermode-rover-canbus/" %}}
 {{< /cards >}}

--- a/docs/extend/modular-resources/examples/add-tflite-module.md
+++ b/docs/extend/modular-resources/examples/add-tflite-module.md
@@ -205,8 +205,7 @@ Next, install `viam-server` on your robot, if you have not done so already.
 
 ## Generate your robot configuration
 
-When you built the C++ SDK, the build process also built the `example_audio_classification_client` binary.
-The `example_audio_classification_client` binary includes a `--generate` function which determines and creates the necessary robot configuration to support this example.
+When you built the C++ SDK, the build process also built the `example_audio_classification_client` binary, which includes a `--generate` function that determines and creates the necessary robot configuration to support this example.
 
 To generate your robot's configuration using `example_audio_classification_client`:
 
@@ -301,24 +300,22 @@ What follows is a high-level overview of the steps it takes when executed:
 
 Similarly, the `example_mlmodelservice_tflite` module can be found at <file>src/viam/examples/modules/example_mlmodelservice_tflite.cpp</file> and also offers rich comments explaining its features and considerations.
 
-## Next Steps
+## Next steps
 
 This tutorial explores audio classification using the `yamnet/classification` TensorFlow Lite model, but the `MLModelService` modular resource provided by the `example_mlmodelservice_tflite` module can accept any TensorFlow Lite model so long as it fulfils the [TFLite model constraints](https://www.tensorflow.org/lite/models/build#model_design_constraints).
 
-Once you have run the example and examined the module and client code, you could explore the following:
+Once you have run the example and examined the module and client code, you might explore the following next steps:
 
 - Write a client similar to `example_audio_classification_client` that generates a different kind of data and provides a suitable TensorFlow Lite model for that data to the `MLModelService` modular resource.
   For example, you might find a new [pre-trained TensorFlow Lite model](https://www.tensorflow.org/lite/models/trained) that analyzes [speech waveforms](https://tfhub.dev/s?deployment-format=lite&module-type=audio-speech-synthesis) and write a client to provide these waveform samples to the `MLModelService` modular resource and interpret the results returned.
 - Write a client similar to `example_audio_classification_client` that [trains its own model](/manage/ml/train-model/) on existing or incoming data, as long as that model fulfils the TFLite model constraints.
   For example, you might add a [movement sensor](components/movement-sensor/) component to your robot that captures sensor readings to the built-in [data management service](/services/data/).
-  Then you could write a client that trains a new model based on the collected sensor reading dataset, provides the model and new sensor data readings to the `MLModelService` modular resource, and interprets the results returned.
-- Write a module similar to `example_mlmodelservice_tflite` that accepts models for other inference engines besides TFLite, then write a client that provides a valid model and source data for that inference engine.
+  Then you could write a client that trains a new model based on the collected data, provides the model and new sensor data readings to the `MLModelService` modular resource, and interprets the results returned.
+- Write a module similar to `example_mlmodelservice_tflite` that accepts models for other inference engines besides TensorFlow Lite, then write a client that provides a valid model and source data for that inference engine.
 
 ## Troubleshooting and additional documentation
 
-* If you experience issues building the C++ SDK, see [C++ SDK: Limitations, Known Issues, and Troubleshooting](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md).
-* To customize your C++ build process or make adjustments to fit your platform or deployment requirements, see [C++ SDK: Options to Configure or Customize the Build](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#options-to-configure-or-customize-the-build)
+- If you experience issues building the C++ SDK, see [C++ SDK: Limitations, Known Issues, and Troubleshooting](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md).
+- To customize your C++ build process or make adjustments to fit your platform or deployment requirements, see [C++ SDK: Options to Configure or Customize the Build](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#options-to-configure-or-customize-the-build)
 
 You can find additional reference material in the [C++ SDK documentation](https://cpp.viam.dev/).
-
-{{< snippet "social.md" >}}

--- a/docs/extend/modular-resources/examples/add-tflite-module.md
+++ b/docs/extend/modular-resources/examples/add-tflite-module.md
@@ -11,15 +11,15 @@ tags: ["ml", "model training", "services"]
 Viam provides an example [modular resource](extend/modular-resources) written in C++ that extends the [ML model](/services/ml/) service to run any TensorFlow Lite model.
 The example includes an inference client program as well, which generates audio samples and uses the modular resource to classify the audio samples based on a pre-trained model.
 
-This example is intended to demonstrate the design, implementation, and usage of a custom module to serve as a guide to help you write your own.
+This tutorial walks you through everything necessary to start using these example files with your robot, including building the C++ SDK, configuring your robot and installing `viam-server`, and generating results with the example inference client program.
+
+The provided example code demonstrates the design, implementation, and usage of a custom module to help you write your own.
 This code is for instructional purposes only, and is not intended for production use.
 
 You can find the example files in the [Viam C++ SDK](https://github.com/viamrobotics/viam-cpp-sdk):
 
 - [`example_mlmodelservice_tflite.cpp`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/src/viam/examples/modules/example_mlmodelservice_tflite.cpp) - an example module which provides the `MLModelService` modular resource capable of running any TensorFlow Lite model.
 - [`example_audio_classification_client.cpp`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/src/viam/examples/mlmodel/example_audio_classification_client.cpp) - an example inference client which generates audio samples and invokes the `example_mlmodelservice_tflite` module to classify those samples using the [`yamnet/classification` TensorFlow Lite model](https://tfhub.dev/google/lite-model/yamnet/classification/tflite/1).
-
-This tutorial walks you through everything necessary to start using these example files with your robot, including building the C++ SDK, configuring your robot and installing `viam-server`, and generating results with the example inference client program.
 
 ## Build the C++ SDK
 
@@ -39,21 +39,21 @@ While your specific build steps may differ slightly, your installation should ge
    brew install abseil cmake boost grpc protobuf xtensor pkg-config ninja buf
    ```
 
-1. Create a new <file>example_workspace</file> directory for this tutorial and clone the Viam C++ SDK:
+1. Create a new <file>example_workspace</file> directory for this tutorial, and create an <file>opt</file> directory within it to house the build artifacts:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    mkdir -p ~/example_workspace
    cd ~/example_workspace
-   git clone git@github.com:viamrobotics/viam-cpp-sdk.git
+   mkdir -p opt
    ```
 
-1. Create an <file>opt</file> directory to install the build artifacts to:
+1. Within the <file>~/example_workspace</file> directory, clone the Viam C++ SDK:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-   mkdir -p ~/example_workspace/opt
+    git clone git@github.com:viamrobotics/viam-cpp-sdk.git
    ```
 
-1. Create a <file>build</file> directory to house the build:
+1. Change directory into the SDK, and create a <file>build</file> directory to house the build:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    cd viam-cpp-sdk/
@@ -134,7 +134,7 @@ While your specific build steps may differ slightly, your installation should ge
    mkdir -p ~/example_workspace/opt
    ```
 
-1. Create a <file>build</file> directory to house the build:
+1. Within the <file>viam-cpp-sdk</file> directory, create a <file>build</file> directory to house the build:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    mkdir build

--- a/docs/extend/modular-resources/examples/add-tflite-module.md
+++ b/docs/extend/modular-resources/examples/add-tflite-module.md
@@ -16,7 +16,7 @@ This code is for instructional purposes only, and is not intended for production
 
 You can find the example files in the [Viam C++ SDK](https://github.com/viamrobotics/viam-cpp-sdk):
 
-- [`example_mlmodelservice_tflite.cpp`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/src/viam/examples/modules/example_mlmodelservice_tflite.cpp) - an example module which provides a `MLModelService` modular resource capable of running any TensorFlow Lite model.
+- [`example_mlmodelservice_tflite.cpp`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/src/viam/examples/modules/example_mlmodelservice_tflite.cpp) - an example module which provides the `MLModelService` modular resource capable of running any TensorFlow Lite model.
 - [`example_audio_classification_client.cpp`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/src/viam/examples/mlmodel/example_audio_classification_client.cpp) - an example inference client which generates audio samples and invokes the `example_mlmodelservice_tflite` module to classify those samples using the [`yamnet/classification` TensorFlow Lite model](https://tfhub.dev/google/lite-model/yamnet/classification/tflite/1).
 
 This tutorial walks you through everything necessary to start using these example files with your robot, including building the C++ SDK, configuring your robot and installing `viam-server`, and generating results with the example inference client program.
@@ -75,7 +75,7 @@ While your specific build steps may differ slightly, your installation should ge
    ninja install
    ```
 
-   This tutorial passes three flags to the build process to configure the build:
+   For this tutorial, the build process uses the following configuration options. See [Viam C++ SDK Build Instructions](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md) for more information:
 
    - `VIAMCPPSDK_BUILD_TFLITE_EXAMPLE_MODULE` to request building the example module for this tutorial.
    - [`VIAMCPPSDK_USE_DYNAMIC_PROTOS`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#viamcppsdk_use_dynamic_protos) to request that proto generation happen along with the build.
@@ -94,7 +94,7 @@ While your specific build steps may differ slightly, your installation should ge
    git clone git@github.com:viamrobotics/viam-cpp-sdk.git
    ```
 
-1. Build and run the `bullseye` development Docker container included with the SDK:
+1. Build and run the `bullseye` development Docker container included with the SDK. If you haven't already, first [install Docker Engine](https://docs.docker.com/engine/install/).
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    cd viam-cpp-sdk/
@@ -118,7 +118,8 @@ While your specific build steps may differ slightly, your installation should ge
    ```
 
    If the version returned is `3.25` or later, skip to the next step.
-   Otherwise, run the following commands to add the `bullseye-backports` repository and install the version of `cmake` provided there:
+   Otherwise, download and install `cmake 3.25` or later from your system's package manager.
+   For example, if using Debian, you can run the following commands to add the `bullseye-backports` repository and install the version of `cmake` provided there:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    sudo apt-get install software-properties-common
@@ -130,7 +131,7 @@ While your specific build steps may differ slightly, your installation should ge
 1. Create an <file>opt</file> directory to install the build artifacts to:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-   mkdir -p ~/example_workspace/opt/
+   mkdir -p ~/example_workspace/opt
    ```
 
 1. Create a <file>build</file> directory to house the build:
@@ -148,7 +149,7 @@ While your specific build steps may differ slightly, your installation should ge
    ninja install
    ```
 
-   This tutorial passes three flags to the build process to configure the build:
+   For this tutorial, the build process uses the following configuration options. See [Viam C++ SDK Build Instructions](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md) for more information:
 
    - `VIAMCPPSDK_BUILD_TFLITE_EXAMPLE_MODULE` to request building the example module for this tutorial.
    - [`VIAMCPPSDK_USE_DYNAMIC_PROTOS`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#viamcppsdk_use_dynamic_protos) to request that proto generation happen along with the build.
@@ -207,6 +208,8 @@ Next, install `viam-server` on your robot, if you have not done so already:
 
 1. Once complete, verify that step 3 on the **Setup** tab indicates that your robot has successfully connected.
 
+1. Stop `viam-server` by pressing CTL C on your keyboard.
+
 ## Generate your robot configuration
 
 When you built the C++ SDK, the build process also built the `example_audio_classification_client` binary, which includes a `--generate` function that determines and creates the necessary robot configuration to support this example.
@@ -248,6 +251,21 @@ With everything configured and running, you can now run the inference client tha
    The location secret resembles `abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234` and the robot address resembles `my-robot-main.abcdefg123.viam.cloud`.
 
    {{%  snippet "secret-share.md" %}}
+
+1. Next, start `viam-server` once more on your robot:
+
+   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+   viam-server -config /etc/viam.json
+   ```
+
+   {{< alert title="Important" color="note" >}}
+   If you are working within the Docker container, run the following command instead, from within the directory you installed `viam-server` to:
+
+   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+   ./viam-server --appimage-extract-and-run -config /etc/viam.json
+   ```
+
+   {{< /alert >}}
 
 1. Then, run the following to start the inference client, providing the necessary access credentials and the path to the labels file extracted earlier:
 
@@ -319,7 +337,7 @@ Once you have run the example and examined the module and client code, you might
 
 ## Troubleshooting and additional documentation
 
-- If you experience issues building the C++ SDK, see [C++ SDK: Limitations, Known Issues, and Troubleshooting](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md).
+- If you experience issues building the C++ SDK, see [C++ SDK: Limitations, Known Issues, and Troubleshooting](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#limitations-known-issues-and-troubleshooting).
 - To customize your C++ build process or make adjustments to fit your platform or deployment requirements, see [C++ SDK: Options to Configure or Customize the Build](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#options-to-configure-or-customize-the-build)
 
 You can find additional reference material in the [C++ SDK documentation](https://cpp.viam.dev/).

--- a/docs/extend/modular-resources/examples/add-tflite-module.md
+++ b/docs/extend/modular-resources/examples/add-tflite-module.md
@@ -9,11 +9,15 @@ tags: ["ml", "model training", "services"]
 ---
 
 Viam provides an example [modular resource](extend/modular-resources) written in C++ that extends the [ML model](/services/ml/) service to run any TensorFlow Lite model.
+The example includes an inference client program as well, which generates audio samples and uses the modular resource to classify the audio samples based on a pre-trained model.
 
-The example files can be found in the [Viam C++ SDK](https://github.com/viamrobotics/viam-cpp-sdk):
+This example is intended to demonstrate the design, implementation, and usage of a custom module to serve as a guide to help you write your own.
+This code is for instructional purposes only, and is not intended for production use.
+
+You can find the example files in the [Viam C++ SDK](https://github.com/viamrobotics/viam-cpp-sdk):
 
 - [`example_mlmodelservice_tflite.cpp`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/src/viam/examples/modules/example_mlmodelservice_tflite.cpp) - an example module which provides a `MLModelService` modular resource capable of running any TensorFlow Lite model.
-- [`example_audio_classification_client.cpp`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/src/viam/examples/mlmodel/example_audio_classification_client.cpp) - an example inference client which generates audio samples and invokes the `example_mlmodelservice_tflite` module to classify those samples using the `yamnet/classification` TensorFlow Lite model.
+- [`example_audio_classification_client.cpp`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/src/viam/examples/mlmodel/example_audio_classification_client.cpp) - an example inference client which generates audio samples and invokes the `example_mlmodelservice_tflite` module to classify those samples using the [`yamnet/classification` TensorFlow Lite model](https://tfhub.dev/google/lite-model/yamnet/classification/tflite/1).
 
 This tutorial walks you through everything necessary to start using these example files with your robot, including building the C++ SDK, configuring your robot and installing `viam-server`, and generating results with the example inference client program.
 
@@ -177,7 +181,7 @@ This example uses the `yamnet/classification` TensorFlow Lite model for audio cl
 
 ## Install `viam-server`
 
-Next, install `viam-server` on your robot, if you have not done so already.
+Next, install `viam-server` on your robot, if you have not done so already:
 
 1. Navigate to [the Viam app](https://app.viam.com) in your browser and [add a new robot](/manage/fleet/robots/#add-a-new-robot).
 
@@ -215,7 +219,7 @@ To generate your robot's configuration using `example_audio_classification_clien
 1. Next, determine the full path to the `example_mlmodelservice_tflite` modular resource example provided with the Viam C++ SDK.
    If you followed the instructions above, this path is: <file>~/example_workspace/opt/bin/example_mlmodelservice_tflite</file>.
 
-1. Run the `example_audio_classification_client` binary, proving both paths to the `--generate` function in the following fashion:
+1. Run the `example_audio_classification_client` binary, providing both paths to the `--generate` function in the following fashion:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    cd ~/example_workspace/opt/bin
@@ -309,7 +313,7 @@ Once you have run the example and examined the module and client code, you might
 - Write a client similar to `example_audio_classification_client` that generates a different kind of data and provides a suitable TensorFlow Lite model for that data to the `MLModelService` modular resource.
   For example, you might find a new [pre-trained TensorFlow Lite model](https://www.tensorflow.org/lite/models/trained) that analyzes [speech waveforms](https://tfhub.dev/s?deployment-format=lite&module-type=audio-speech-synthesis) and write a client to provide these waveform samples to the `MLModelService` modular resource and interpret the results returned.
 - Write a client similar to `example_audio_classification_client` that [trains its own model](/manage/ml/train-model/) on existing or incoming data, as long as that model fulfils the TFLite model constraints.
-  For example, you might add a [movement sensor](components/movement-sensor/) component to your robot that captures sensor readings to the built-in [data management service](/services/data/).
+  For example, you might add a [movement sensor](components/movement-sensor/) component to your robot that captures sensor readings to the built-in [Data Management Service](/services/data/).
   Then you could write a client that trains a new model based on the collected data, provides the model and new sensor data readings to the `MLModelService` modular resource, and interprets the results returned.
 - Write a module similar to `example_mlmodelservice_tflite` that accepts models for other inference engines besides TensorFlow Lite, then write a client that provides a valid model and source data for that inference engine.
 

--- a/docs/extend/modular-resources/examples/add-tflite-module.md
+++ b/docs/extend/modular-resources/examples/add-tflite-module.md
@@ -8,14 +8,14 @@ tags: ["ml", "model training", "services"]
 # SMEs: Andrew Morrow
 ---
 
-Viam provides an example of a [custom module](extend/modular-resources) written in the Viam C++ SDK that extends the [ML model](/services/ml/) service to support audio classification.
+Viam provides an example [custom module](extend/modular-resources) written in C++ that extends the [ML model](/services/ml/) service to support audio classification using TensorFlow Lite.
 
 The example files can be found in the [Viam C++ SDK](https://github.com/viamrobotics/viam-cpp-sdk):
 
 - [`example_mlmodelservice_tflite.cpp`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/src/viam/examples/modules/example_mlmodelservice_tflite.cpp) - a custom module that provides an example `MLModelService` instance which runs TensorFlow Lite models.
 - [`example_audio_classification_client.cpp`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/src/viam/examples/mlmodel/example_audio_classification_client.cpp) - an example client instance which generates audio samples and invokes the `example_mlmodelservice_tflite` custom module to classify those samples.
 
-This tutorial walks you through everything you need to start using these example files with your robot, including building the C++ SDK, procuring the necessary support files, configuring your robot and installing `viam-server`, and running the compiled binary example.
+This tutorial walks you through everything necessary to start using these example files with your robot, including building the C++ SDK, procuring the necessary support files, configuring your robot and installing `viam-server`, and running the compiled binary example.
 
 ## Build the C++ SDK
 
@@ -29,7 +29,7 @@ Follow the [Viam C++ SDK build instructions](https://github.com/viamrobotics/via
 
 While your specific build steps may differ slightly, your installation should generally resemble the following:
 
-1. Install the mandatory and optional dependencies to support the Viam C++ SDK:
+1. Install all listed dependencies to support the Viam C++ SDK:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    brew install abseil cmake boost grpc protobuf xtensor pkg-config ninja buf
@@ -43,7 +43,7 @@ While your specific build steps may differ slightly, your installation should ge
    git clone git@github.com:viamrobotics/viam-cpp-sdk.git
    ```
 
-1. Create a `build` directory to house the build target:
+1. Create a <file>build</file> directory to house the build target:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    cd viam-cpp-sdk/
@@ -51,13 +51,14 @@ While your specific build steps may differ slightly, your installation should ge
    cd build
    ```
 
-1. Determine the version of `openssl` you are running on your macOS computer:
+1. The Viam C++ SDK requires a specific version of `openssl` in order to build successfully.
+   Determine the version of `openssl` you are running on your macOS computer:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    brew list | grep openssl
    ```
 
-   If the command returns `openssl@1.1`, proceed to the next step. If the command returns a different `openssl` version, install the correct version first:
+   If the command returns `openssl@1.1`, proceed to the next step. If the command returns a different `openssl` version, install version `openssl@1.1` specifically:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    brew install openssl@1.1
@@ -70,8 +71,11 @@ While your specific build steps may differ slightly, your installation should ge
    ```
 
 1. Build the C++ SDK.
-   We are using two flags to help us compile successfully: [`VIAMCPPSDK_USE_DYNAMIC_PROTOS`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#viamcppsdk_use_dynamic_protos) to request that proto generation happen along with the build, and [`CMAKE_INSTALL_PREFIX`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#cmake_install_prefix) to install to `/usr/local/` instead of the default `./install` location.
-   To write to the restricted location `/usr/local/`, we'll also need to use `sudo` for the second `ninja` invocation:
+   We are using two flags to help us compile successfully:
+
+   - [`VIAMCPPSDK_USE_DYNAMIC_PROTOS`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#viamcppsdk_use_dynamic_protos) to request that proto generation happen along with the build.
+   - [`CMAKE_INSTALL_PREFIX`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#cmake_install_prefix) to install to <file>/usr/local/</file> instead of the default <file>./install</file> location.
+     To write to the restricted location <file>/usr/local/</file>, we'll also need to use `sudo` for the second `ninja` invocation:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    cmake .. -DVIAMCPPSDK_USE_DYNAMIC_PROTOS=ON -DCMAKE_INSTALL_PREFIX=/usr/local -G Ninja
@@ -90,12 +94,12 @@ TODO: Linux instructions here. Currently failing at requiring tflite C headers: 
 ## Download the `yamnet/classification` model file
 
 This example uses the `yamnet/classification` TensorFlow Lite model for audio classification.
-We are using a pre-trained model for this example, but you can also [train your own model](/manage/ml/train-model/).
+This is a pre-trained model suitable for this example, but you can also [train your own model](/manage/ml/train-model/).
 
 1. Download the `yamnet/classification` TensorFlow Lite model file: [yamnet classification tflite model](https://tfhub.dev/google/lite-model/yamnet/classification/tflite/1).
 
 1. Copy the downloaded file into a more permanent location.
-   For this example, place the model file in the `~/example_workspace` directory from earlier:
+   For this example, place the model file in the <file>~/example_workspace</file> directory from earlier:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    cp ~/Downloads/lite-model_yamnet_classification_tflite_1.tflite ~/example_workspace/
@@ -160,7 +164,7 @@ This generated configuration features the minimum required configuration to supp
 
 ## Run the inference client
 
-With everything configured and running, we can now run the inference client that connects to `viam-server` and uses the `example_mlmodelservice_tflite` custom module.
+With everything configured and running, you can now run the inference client that connects to `viam-server` and uses the `example_mlmodelservice_tflite` custom module.
 
 1. First, determine your robot address and location secret. To do so, navigate to [the Viam app](https://app.viam.com), select the **Code sample** tab, and toggle **Include secret**.
    The location secret resembles `abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234` and the robot address resembles `my-robot-main.abcdefg123.viam.cloud`.
@@ -187,12 +191,14 @@ With everything configured and running, we can now run the inference client that
    Inference latency (seconds), Var : 0.000164449
    ```
 
-   The labels shown in the example output require that you have provided the <file>yamnet_label_list.txt</file> labels file to the `example_audio_classification_client` client using the `--model-label-path` flag.
+   The labels shown in the example output require that you have provided the <file>yamnet_label_list.txt</file> labels file to `example_audio_classification_client` using the `--model-label-path` flag.
    If you have omitted the labels file, the computed scores will be returned without labels.
 
-## Understanding the client
+## Understanding the code
 
-The code in `src/viam/examples/mlmodel/example_audio_classification_client.cpp` is richly commented to explain each step it takes in generating and analyzing the data provided. What follows is a high-level overview of the steps it takes when executed:
+All example code is provided in the Viam C++ SDK in the <file>src/viam/examples/</file> directory.
+
+The code in <file>src/viam/examples/mlmodel/example_audio_classification_client.cpp</file> is richly commented to explain each step it takes in generating and analyzing the data provided. What follows is a high-level overview of the steps it takes when executed:
 
 1. The inference client generates two signals that meet the input requirements of the `yamnet/classification` model: the first signal is silence, while the second is noise.
    As written, the example analyzes only the noise signal, but you can change which signal is classified by changing which is assigned to the `samples` variable in the code.
@@ -201,9 +207,9 @@ The code in `src/viam/examples/mlmodel/example_audio_classification_client.cpp` 
    The tensor must be named according to the configured value under `tensor_name_remappings` in your robot configuration.
    If you followed the instructions above to [generate your robot configuration](#generate-your-robot-configuration), the value `sample` was pre-populated for you in your generated robot configuration.
 
-1. The client invokes the `infer` method provided by the `MLModelService` custom module, providing it with the `sample` input tensor data it generated earlier.
+1. The client invokes the `infer` method provided by the `example_mlmodelservice_tflite` custom module, providing it with the `sample` input tensor data it generated earlier.
 
-1. The `MLModelService` custom module returns a map of response tensors as a result.
+1. The `example_mlmodelservice_tflite` custom module returns a map of response tensors as a result.
 
 1. The client validates the result, including its expected type: a vector of `float` values.
    The expected output must be defined under `tensor_name_remappings` in your robot configuration for validation to succeed.
@@ -213,7 +219,7 @@ The code in `src/viam/examples/mlmodel/example_audio_classification_client.cpp` 
 
 1. Finally, the client runs 100 rounds of inference using the determined label and score pairs, and returns the results of the rounds, including mean and variance values.
 
-Similarly, the custom module that provides the `MLModelService` module can be found at `src/viam/examples/modules/example_mlmodelservice_tflite.cpp` and also offers rich comments explaining its features and considerations.
+Similarly, the `example_mlmodelservice_tflite` custom module can be found at <file>src/viam/examples/modules/example_mlmodelservice_tflite.cpp</file> and also offers rich comments explaining its features and considerations.
 
 ## Troubleshooting
 

--- a/docs/extend/modular-resources/examples/add-tflite-module.md
+++ b/docs/extend/modular-resources/examples/add-tflite-module.md
@@ -156,7 +156,6 @@ While your specific build steps may differ slightly, your installation should ge
 ## Download the `yamnet/classification` model file
 
 This example uses the `yamnet/classification` TensorFlow Lite model for audio classification.
-This is a pre-trained model suitable for this example, but when working with your own programs you can also [train your own model](/manage/ml/train-model/).
 
 1. Download the `yamnet/classification` TensorFlow Lite model file and place it in your <file>example_workspace</file> directory:
 

--- a/docs/extend/modular-resources/examples/add-tflite-module.md
+++ b/docs/extend/modular-resources/examples/add-tflite-module.md
@@ -1,0 +1,222 @@
+---
+title: "Add an Audio Classification Service as a Modular Resource"
+linkTitle: "Add an Audio Classification Service as a Modular Resource"
+weight: 70
+type: "docs"
+description: "Add a custom MLModel modular-resource-based service which uses TensorFlow Lite to classify audio samples."
+tags: ["ml", "model training", "services"]
+# SMEs: Andrew Morrow
+---
+
+Viam provides an example of a [custom module](extend/modular-resources) written in the Viam C++ SDK that extends the [ML model](/services/ml/) service to support audio classification.
+
+The example files can be found in the [Viam C++ SDK](https://github.com/viamrobotics/viam-cpp-sdk):
+
+- [`example_mlmodelservice_tflite.cpp`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/src/viam/examples/modules/example_mlmodelservice_tflite.cpp) - a custom module that provides an example `MLModelService` instance which runs TensorFlow Lite models.
+- [`example_audio_classification_client.cpp`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/src/viam/examples/mlmodel/example_audio_classification_client.cpp) - an example client instance which generates audio samples and invokes the `example_mlmodelservice_tflite` custom module to classify those samples.
+
+This tutorial walks you through everything you need to start using these example files with your robot, including building the C++ SDK, procuring the necessary support files, configuring your robot and installing `viam-server`, and running the compiled binary example.
+
+## Build the C++ SDK
+
+To build the Viam C++ SDK, you will need a macOS or Linux computer.
+Follow the instructions below for your platform:
+
+{{< tabs >}}
+{{% tab name="macOS" %}}
+
+Follow the [Viam C++ SDK build instructions](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md) to build the SDK on your macOS computer using the `brew` package manager.
+
+While your specific build steps may differ slightly, your installation should generally resemble the following:
+
+1. Install the mandatory and optional dependencies to support the Viam C++ SDK:
+
+   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+   brew install abseil cmake boost grpc protobuf xtensor pkg-config ninja buf
+   ```
+
+1. Clone the Viam C++ SDK to your computer:
+
+   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+   mkdir -p ~/example_workspace
+   cd ~/example_workspace
+   git clone git@github.com:viamrobotics/viam-cpp-sdk.git
+   ```
+
+1. Create a `build` directory to house the build target:
+
+   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+   cd viam-cpp-sdk/
+   mkdir build
+   cd build
+   ```
+
+1. Determine the version of `openssl` you are running on your macOS computer:
+
+   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+   brew list | grep openssl
+   ```
+
+   If the command returns `openssl@1.1`, proceed to the next step. If the command returns a different `openssl` version, install the correct version first:
+
+   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+   brew install openssl@1.1
+   ```
+
+1. Create an environment variable `PKG_CONFIG_PATH` which points to the version of `openssl` we will use for the Viam C++ SDK build:
+
+   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+   export PKG_CONFIG_PATH="/opt/homebrew/opt/openssl@1.1/lib/pkgconfig"
+   ```
+
+1. Build the C++ SDK.
+   We are using two flags to help us compile successfully: [`VIAMCPPSDK_USE_DYNAMIC_PROTOS`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#viamcppsdk_use_dynamic_protos) to request that proto generation happen along with the build, and [`CMAKE_INSTALL_PREFIX`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#cmake_install_prefix) to install to `/usr/local/` instead of the default `./install` location.
+   To write to the restricted location `/usr/local/`, we'll also need to use `sudo` for the second `ninja` invocation:
+
+   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+   cmake .. -DVIAMCPPSDK_USE_DYNAMIC_PROTOS=ON -DCMAKE_INSTALL_PREFIX=/usr/local -G Ninja
+   ninja all
+   sudo ninja install
+   ```
+
+{{% /tab %}}
+{{% tab name="Linux" %}}
+
+TODO: Linux instructions here. Currently failing at requiring tflite C headers: I have not yet been able to successfully [build the tflite headers on Linux](https://www.tensorflow.org/lite/guide/build_cmake#build_tensorflow_lite_c_library).
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Download the `yamnet/classification` model file
+
+This example uses the `yamnet/classification` TensorFlow Lite model for audio classification.
+We are using a pre-trained model for this example, but you can also [train your own model](/manage/ml/train-model/).
+
+1. Download the `yamnet/classification` TensorFlow Lite model file: [yamnet classification tflite model](https://tfhub.dev/google/lite-model/yamnet/classification/tflite/1).
+
+1. Copy the downloaded file into a more permanent location.
+   For this example, place the model file in the `~/example_workspace` directory from earlier:
+
+   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+   cp ~/Downloads/lite-model_yamnet_classification_tflite_1.tflite ~/example_workspace/
+   ```
+
+1. Extract the labels file <file>yamnet_label_list.txt</file> from the downloaded model file:
+
+   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+   unzip ~/example_workspace/lite-model_yamnet_classification_tflite_1.tflite
+   ```
+
+   The labels file provides pre-populated labels for the calculated scores, so that output scores can be associated and returned with their matching labels.
+   You can omit this file if desired, which will cause the client to return the computed scores without labels.
+
+## Install `viam-server`
+
+Next, install `viam-server` on your robot, if you have not done so already.
+
+1. Navigate to [the Viam app](https://app.viam.com) in your browser and [add a new robot](/manage/fleet/robots/#add-a-new-robot).
+
+1. Switch to the **Setup** tab, and select your platform from the **Mode** selection at the top.
+   If you are installing on a Linux system, additionally select your system's **Architecture**.
+
+1. Follow the steps listed under the **Setup** tab to install `viam-server` on your system.
+
+1. Once complete, verify that step 3 on the **Setup** tab indicates that your robot has successfully connected.
+
+## Generate your robot configuration
+
+When you built the C++ SDK, the build process also built the `example_audio_classification_client` binary.
+The `example_audio_classification_client` binary includes a `--generate` function which determines and creates the necessary robot configuration to support this example.
+
+To generate your robot's configuration using `example_audio_classification_client`:
+
+1. First, determine the full path to the `yamnet/classification` model you just downloaded.
+   If you followed the instructions above, this path is: <file>~/example_workspace/lite-model_yamnet_classification_tflite_1.tflite</file>.
+
+1. Next, determine the full path to the `example_mlmodelservice_tflite` modular resource example provided with the Viam C++ SDK.
+   If you followed the instructions above, this path is: <file>/usr/local/bin/example_mlmodelservice_tflite</file>.
+
+1. Run the `example_audio_classification_client` binary, proving both paths to the `--generate` function in the following fashion:
+
+   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+   example_audio_classification_client --generate --model-path ~/example_workspace/lite-model_yamnet_classification_tflite_1.tflite --tflite-module-path /usr/local/bin/example_mlmodelservice_tflite > ~/example_workspace/viam-example-mlmodel-config.json
+   ```
+
+   If you did not use the [`CMAKE_INSTALL_PREFIX`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#cmake_install_prefix) option when building the C++ SDK, you may need to provide the full path to the `example_audio_classification_client` binary for this step.
+
+1. Verify that the resulting configuration file was created successfully:
+
+   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+   cat ~/example_workspace/viam-example-mlmodel-config.json
+   ```
+
+1. Copy the contents of this file.
+   Then return to your robot's page on [the Viam app](https://app.viam.com), select the **Config** tab, select **Raw JSON**, and paste the configuration into the text area.
+
+1. Click the **Save config** button at the bottom of the page.
+   Now, when you switch back to **Builder** mode, you can see the new configuration settings under the **Services** and **Modules** subtabs.
+
+This generated configuration features the minimum required configuration to support this tutorial: a `services` definition for the [ML model](/services/ml/) service and a `modules` definition for our `example_mlmodelservice_tflite` [custom module](extend/modular-resources/#configure-your-modular-resource).
+
+## Run the inference client
+
+With everything configured and running, we can now run the inference client that connects to `viam-server` and uses the `example_mlmodelservice_tflite` custom module.
+
+1. First, determine your robot address and location secret. To do so, navigate to [the Viam app](https://app.viam.com), select the **Code sample** tab, and toggle **Include secret**.
+   The location secret resembles `abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234` and the robot address resembles `my-robot-main.abcdefg123.viam.cloud`.
+
+   {{%  snippet "secret-share.md" %}}
+
+1. On the command line of the system you built the Viam C++ SDK on, run the following to start the inference client, providing the necessary access credentials and the path to the labels file we extracted earlier:
+
+   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+   example_audio_classification_client --model-label-path ~/example_workspace/yamnet_label_list.txt --robot-host my-robot-main.abcdefg123.viam.cloud --robot-secret abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234
+   ```
+
+   The command should return output similar to:
+
+   ```sh {id="terminal-prompt" class="command-line"}
+   0: Static                               0.5
+   1: Noise                                0.332031
+   2: White noise                          0.261719
+   3: Cacophony                            0.109375
+   4: Pink noise                           0.0585938
+
+   Measuring inference latency ...
+   Inference latency (seconds), Mean: 0.012795
+   Inference latency (seconds), Var : 0.000164449
+   ```
+
+   The labels shown in the example output require that you have provided the <file>yamnet_label_list.txt</file> labels file to the `example_audio_classification_client` client using the `--model-label-path` flag.
+   If you have omitted the labels file, the computed scores will be returned without labels.
+
+## Understanding the client
+
+The code in `src/viam/examples/mlmodel/example_audio_classification_client.cpp` is richly commented to explain each step it takes in generating and analyzing the data provided. What follows is a high-level overview of the steps it takes when executed:
+
+1. The inference client generates two signals that meet the input requirements of the `yamnet/classification` model: the first signal is silence, while the second is noise.
+   As written, the example analyzes only the noise signal, but you can change which signal is classified by changing which is assigned to the `samples` variable in the code.
+
+1. The client then populates an input tensor named `sample` as a `tensor_view` over the provided sample data.
+   The tensor must be named according to the configured value under `tensor_name_remappings` in your robot configuration.
+   If you followed the instructions above to [generate your robot configuration](#generate-your-robot-configuration), the value `sample` is already pre-populated for you.
+
+1. The client invokes the `infer` method provided by the `MLModelService` custom module, providing it with the `sample` input tensor data it generated earlier.
+
+1. The `MLModelService` custom module returns a map of response tensors as a result.
+
+1. The client validates the result, including its expected type: a vector of `float` values.
+   The expected output must be defined under `tensor_name_remappings` in your robot configuration for validation to succeed.
+   If you followed the instructions above to [generate your robot configuration](#generate-your-robot-configuration), the value `categories` is already pre-populated for you.
+
+1. If a labels file was provided, labels are read in as a vector of `string` values and the top 5 scores are associated with their labels.
+
+1. Finally, the client runs 100 rounds of inference using the determined label and score pairs, and returns the results of the rounds, including mean and variance values.
+
+Similarly, the custom module that provides the `MLModelService` model can be found at `src/viam/examples/modules/example_mlmodelservice_tflite.cpp` and also offers rich comments explaining its features and considerations.
+
+## Troubleshooting
+
+You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/), and additional reference material in the [C++ SDK Documentation](https://cpp.viam.dev/).
+
+{{< snippet "social.md" >}}

--- a/docs/extend/modular-resources/examples/add-tflite-module.md
+++ b/docs/extend/modular-resources/examples/add-tflite-module.md
@@ -221,8 +221,11 @@ The code in <file>src/viam/examples/mlmodel/example_audio_classification_client.
 
 Similarly, the `example_mlmodelservice_tflite` custom module can be found at <file>src/viam/examples/modules/example_mlmodelservice_tflite.cpp</file> and also offers rich comments explaining its features and considerations.
 
-## Further reading
+## Troubleshooting and additional documentation
 
-You can find additional reference material in the [C++ SDK documentation](https://cpp.viam.dev/), and specific guidance on the C++ build process in the [C++ SDK repository](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md).
+* If you experience issues building the C++ SDK, see [C++ SDK: Limitations, Known Issues, and Troubleshooting](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md).
+* To customize your C++ build process or make adjustments to fit your platform or deployment requirements, see [C++ SDK: Options to Configure or Customize the build](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#options-to-configure-or-customize-the-build)
+
+You can find additional reference material in the [C++ SDK documentation](https://cpp.viam.dev/).
 
 {{< snippet "social.md" >}}

--- a/docs/extend/modular-resources/examples/add-tflite-module.md
+++ b/docs/extend/modular-resources/examples/add-tflite-module.md
@@ -1,6 +1,6 @@
 ---
-title: "Add Audio Classification as a Modular Service"
-linkTitle: "Add Audio Classification as a Modular Service"
+title: "Add a TensorFlow Lite Modular Service"
+linkTitle: "Add a TensorFlow Lite Modular Service"
 weight: 70
 type: "docs"
 description: "Add a custom MLModel modular-resource-based service which uses TensorFlow Lite to classify audio samples."

--- a/docs/extend/modular-resources/examples/add-tflite-module.md
+++ b/docs/extend/modular-resources/examples/add-tflite-module.md
@@ -202,7 +202,7 @@ Next, install `viam-server` on your robot, if you have not done so already:
 
 1. Once complete, verify that step 3 on the **Setup** tab indicates that your robot has successfully connected.
 
-1. Stop `viam-server` by pressing CTL C on your keyboard.
+1. Stop `viam-server` by pressing CTL-C on your keyboard from within the terminal window where you entered the commands from step 3 above.
 
 ## Generate your robot configuration
 

--- a/docs/extend/modular-resources/examples/add-tflite-module.md
+++ b/docs/extend/modular-resources/examples/add-tflite-module.md
@@ -199,7 +199,7 @@ The code in `src/viam/examples/mlmodel/example_audio_classification_client.cpp` 
 
 1. The client then populates an input tensor named `sample` as a `tensor_view` over the provided sample data.
    The tensor must be named according to the configured value under `tensor_name_remappings` in your robot configuration.
-   If you followed the instructions above to [generate your robot configuration](#generate-your-robot-configuration), the value `sample` is already pre-populated for you.
+   If you followed the instructions above to [generate your robot configuration](#generate-your-robot-configuration), the value `sample` was pre-populated for you in your generated robot configuration.
 
 1. The client invokes the `infer` method provided by the `MLModelService` custom module, providing it with the `sample` input tensor data it generated earlier.
 
@@ -207,13 +207,13 @@ The code in `src/viam/examples/mlmodel/example_audio_classification_client.cpp` 
 
 1. The client validates the result, including its expected type: a vector of `float` values.
    The expected output must be defined under `tensor_name_remappings` in your robot configuration for validation to succeed.
-   If you followed the instructions above to [generate your robot configuration](#generate-your-robot-configuration), the value `categories` is already pre-populated for you.
+   If you followed the instructions above to [generate your robot configuration](#generate-your-robot-configuration), the value `categories` was pre-populated for you in your generated robot configuration.
 
 1. If a labels file was provided, labels are read in as a vector of `string` values and the top 5 scores are associated with their labels.
 
 1. Finally, the client runs 100 rounds of inference using the determined label and score pairs, and returns the results of the rounds, including mean and variance values.
 
-Similarly, the custom module that provides the `MLModelService` model can be found at `src/viam/examples/modules/example_mlmodelservice_tflite.cpp` and also offers rich comments explaining its features and considerations.
+Similarly, the custom module that provides the `MLModelService` module can be found at `src/viam/examples/modules/example_mlmodelservice_tflite.cpp` and also offers rich comments explaining its features and considerations.
 
 ## Troubleshooting
 

--- a/docs/extend/modular-resources/examples/add-tflite-module.md
+++ b/docs/extend/modular-resources/examples/add-tflite-module.md
@@ -198,12 +198,6 @@ Next, install `viam-server` on your robot, if you have not done so already:
    curl https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-stable-x86_64.AppImage -o viam-server && chmod 755 viam-server && sudo ./viam-server --appimage-extract-and-run -config /etc/viam.json
    ```
 
-   Once installed within the Docker container, you can later run `viam-server` with the following command, from within the directory you installed it to:
-
-   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-   ./viam-server --appimage-extract-and-run -config /etc/viam.json
-   ```
-
    {{< /alert >}}
 
 1. Once complete, verify that step 3 on the **Setup** tab indicates that your robot has successfully connected.

--- a/docs/extend/modular-resources/examples/add-tflite-module.md
+++ b/docs/extend/modular-resources/examples/add-tflite-module.md
@@ -221,7 +221,7 @@ To generate your robot's configuration using `example_audio_classification_clien
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    cd ~/example_workspace/opt/bin
-   example_audio_classification_client --generate --model-path ~/example_workspace/lite-model_yamnet_classification_tflite_1.tflite --tflite-module-path ~/example_workspace/opt/bin/example_mlmodelservice_tflite > ~/example_workspace/viam-example-mlmodel-config.json
+   ./example_audio_classification_client --generate --model-path ~/example_workspace/lite-model_yamnet_classification_tflite_1.tflite --tflite-module-path ~/example_workspace/opt/bin/example_mlmodelservice_tflite > ~/example_workspace/viam-example-mlmodel-config.json
    ```
 
 1. Verify that the resulting configuration file was created successfully:
@@ -250,7 +250,8 @@ With everything configured and running, you can now run the inference client tha
 1. On the command line of the system you built the Viam C++ SDK on, run the following to start the inference client, providing the necessary access credentials and the path to the labels file we extracted earlier:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-   example_audio_classification_client --model-label-path ~/example_workspace/yamnet_label_list.txt --robot-host my-robot-main.abcdefg123.viam.cloud --robot-secret abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234
+   cd ~/example_workspace/opt/bin
+   ./example_audio_classification_client --model-label-path ~/example_workspace/yamnet_label_list.txt --robot-host my-robot-main.abcdefg123.viam.cloud --robot-secret abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234
    ```
 
    The command should return output similar to:
@@ -274,7 +275,8 @@ With everything configured and running, you can now run the inference client tha
 
 All example code is provided in the Viam C++ SDK in the <file>src/viam/examples/</file> directory.
 
-The code in <file>src/viam/examples/mlmodel/example_audio_classification_client.cpp</file> is richly commented to explain each step it takes in generating and analyzing the data provided. What follows is a high-level overview of the steps it takes when executed:
+The code in <file>src/viam/examples/mlmodel/example_audio_classification_client.cpp</file> is richly commented to explain each step it takes in generating and analyzing the data provided.
+What follows is a high-level overview of the steps it takes when executed:
 
 1. The inference client generates two signals that meet the input requirements of the `yamnet/classification` model: the first signal is silence, while the second is noise.
    As written, the example analyzes only the noise signal, but you can change which signal is classified by changing which is assigned to the `samples` variable in the code.

--- a/docs/extend/modular-resources/examples/add-tflite-module.md
+++ b/docs/extend/modular-resources/examples/add-tflite-module.md
@@ -223,6 +223,6 @@ Similarly, the `example_mlmodelservice_tflite` custom module can be found at <fi
 
 ## Troubleshooting
 
-You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/), and additional reference material in the [C++ SDK Documentation](https://cpp.viam.dev/).
+You can find additional reference material in the [C++ SDK Documentation](https://cpp.viam.dev/), and specific guidance on the C++ build process in the [C++ SDK repository](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md).
 
 {{< snippet "social.md" >}}

--- a/docs/extend/modular-resources/examples/add-tflite-module.md
+++ b/docs/extend/modular-resources/examples/add-tflite-module.md
@@ -252,17 +252,17 @@ With everything configured and running, you can now run the inference client tha
 
    {{%  snippet "secret-share.md" %}}
 
-1. Next, start `viam-server` once more on your robot:
+1. Next, start `viam-server` once more on your robot, this time as a background process:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-   viam-server -config /etc/viam.json
+   viam-server -config /etc/viam.json &
    ```
 
    {{< alert title="Important" color="note" >}}
    If you are working within the Docker container, run the following command instead, from within the directory you installed `viam-server` to:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-   ./viam-server --appimage-extract-and-run -config /etc/viam.json
+   ./viam-server --appimage-extract-and-run -config /etc/viam.json &
    ```
 
    {{< /alert >}}

--- a/docs/extend/modular-resources/examples/add-tflite-module.md
+++ b/docs/extend/modular-resources/examples/add-tflite-module.md
@@ -1,6 +1,6 @@
 ---
-title: "Add an Audio Classification Service as a Modular Resource"
-linkTitle: "Add an Audio Classification Service as a Modular Resource"
+title: "Add Audio Classification as a Modular Service"
+linkTitle: "Add Audio Classification as a Modular Service"
 weight: 70
 type: "docs"
 description: "Add a custom MLModel modular-resource-based service which uses TensorFlow Lite to classify audio samples."

--- a/docs/extend/modular-resources/examples/add-tflite-module.md
+++ b/docs/extend/modular-resources/examples/add-tflite-module.md
@@ -221,8 +221,8 @@ The code in <file>src/viam/examples/mlmodel/example_audio_classification_client.
 
 Similarly, the `example_mlmodelservice_tflite` custom module can be found at <file>src/viam/examples/modules/example_mlmodelservice_tflite.cpp</file> and also offers rich comments explaining its features and considerations.
 
-## Troubleshooting
+## Further reading
 
-You can find additional reference material in the [C++ SDK Documentation](https://cpp.viam.dev/), and specific guidance on the C++ build process in the [C++ SDK repository](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md).
+You can find additional reference material in the [C++ SDK documentation](https://cpp.viam.dev/), and specific guidance on the C++ build process in the [C++ SDK repository](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md).
 
 {{< snippet "social.md" >}}

--- a/docs/extend/modular-resources/examples/add-tflite-module.md
+++ b/docs/extend/modular-resources/examples/add-tflite-module.md
@@ -224,7 +224,7 @@ Similarly, the `example_mlmodelservice_tflite` custom module can be found at <fi
 ## Troubleshooting and additional documentation
 
 * If you experience issues building the C++ SDK, see [C++ SDK: Limitations, Known Issues, and Troubleshooting](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md).
-* To customize your C++ build process or make adjustments to fit your platform or deployment requirements, see [C++ SDK: Options to Configure or Customize the build](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#options-to-configure-or-customize-the-build)
+* To customize your C++ build process or make adjustments to fit your platform or deployment requirements, see [C++ SDK: Options to Configure or Customize the Build](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#options-to-configure-or-customize-the-build)
 
 You can find additional reference material in the [C++ SDK documentation](https://cpp.viam.dev/).
 

--- a/docs/extend/modular-resources/examples/add-tflite-module.md
+++ b/docs/extend/modular-resources/examples/add-tflite-module.md
@@ -70,18 +70,19 @@ While your specific build steps may differ slightly, your installation should ge
    export PKG_CONFIG_PATH="/opt/homebrew/opt/openssl@1.1/lib/pkgconfig"
    ```
 
-1. Build the C++ SDK.
-   We are using two flags to help us compile successfully:
-
-   - [`VIAMCPPSDK_USE_DYNAMIC_PROTOS`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#viamcppsdk_use_dynamic_protos) to request that proto generation happen along with the build.
-   - [`CMAKE_INSTALL_PREFIX`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#cmake_install_prefix) to install to <file>/usr/local/</file> instead of the default <file>./install</file> location.
-     To write to the restricted location <file>/usr/local/</file>, we'll also need to use `sudo` for the second `ninja` invocation:
+1. Build the C++ SDK by running the following commands:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    cmake .. -DVIAMCPPSDK_USE_DYNAMIC_PROTOS=ON -DCMAKE_INSTALL_PREFIX=/usr/local -G Ninja
    ninja all
    sudo ninja install
    ```
+
+   This tutorial passes two flags to the build process to help compile successfully:
+
+   - [`VIAMCPPSDK_USE_DYNAMIC_PROTOS`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#viamcppsdk_use_dynamic_protos) to request that proto generation happen along with the build.
+   - [`CMAKE_INSTALL_PREFIX`](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md#cmake_install_prefix) to install to <file>/usr/local/</file> instead of the default <file>./install</file> location.
+     To write to the restricted location <file>/usr/local/</file>, the second `ninja` invocation must also use `sudo`.
 
 {{% /tab %}}
 {{% tab name="Linux" %}}
@@ -179,7 +180,7 @@ With everything configured and running, you can now run the inference client tha
 
    The command should return output similar to:
 
-   ```sh {id="terminal-prompt" class="command-line"}
+   ```sh {id="terminal-prompt"}
    0: Static                               0.5
    1: Noise                                0.332031
    2: White noise                          0.261719

--- a/docs/extend/modular-resources/examples/tflite-module.md
+++ b/docs/extend/modular-resources/examples/tflite-module.md
@@ -1,6 +1,6 @@
 ---
 title: "Add a TensorFlow Lite Modular Service"
-linkTitle: "Add a TensorFlow Lite Modular Service"
+linkTitle: "TensorFlow Lite Modular Service"
 weight: 70
 type: "docs"
 description: "Add a MLModel modular-resource-based service which uses TensorFlow Lite to classify audio samples."
@@ -8,7 +8,7 @@ tags: ["ml", "model training", "services"]
 # SMEs: Andrew Morrow
 ---
 
-Viam provides an example [modular resource](extend/modular-resources) written in C++ that extends the [ML model](/services/ml/) service to run any TensorFlow Lite model.
+Viam provides an example [modular resource](/extend/modular-resources) written in C++ that extends the [ML model](/services/ml/) service to run any TensorFlow Lite model.
 The example includes an inference client program as well, which generates audio samples and uses the modular resource to classify the audio samples based on a pre-trained model.
 
 This tutorial walks you through everything necessary to start using these example files with your robot, including building the C++ SDK, configuring your robot and installing `viam-server`, and generating results with the example inference client program.
@@ -50,7 +50,7 @@ While your specific build steps may differ slightly, your installation should ge
 1. Within the <file>~/example_workspace</file> directory, clone the Viam C++ SDK:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-    git clone git@github.com:viamrobotics/viam-cpp-sdk.git
+   git clone git@github.com:viamrobotics/viam-cpp-sdk.git
    ```
 
 1. Change directory into the SDK, and create a <file>build</file> directory to house the build:
@@ -325,7 +325,7 @@ Once you have run the example and examined the module and client code, you might
 - Write a client similar to `example_audio_classification_client` that generates a different kind of data and provides a suitable TensorFlow Lite model for that data to the `MLModelService` modular resource.
   For example, you might find a new [pre-trained TensorFlow Lite model](https://www.tensorflow.org/lite/models/trained) that analyzes [speech waveforms](https://tfhub.dev/s?deployment-format=lite&module-type=audio-speech-synthesis) and write a client to provide these waveform samples to the `MLModelService` modular resource and interpret the results returned.
 - Write a client similar to `example_audio_classification_client` that [trains its own model](/manage/ml/train-model/) on existing or incoming data, as long as that model fulfils the TFLite model constraints.
-  For example, you might add a [movement sensor](components/movement-sensor/) component to your robot that captures sensor readings to the built-in [Data Management Service](/services/data/).
+  For example, you might add a [movement sensor](/components/movement-sensor/) component to your robot that captures sensor readings to the built-in [Data Management Service](/services/data/).
   Then you could write a client that trains a new model based on the collected data, provides the model and new sensor data readings to the `MLModelService` modular resource, and interprets the results returned.
 - Write a module similar to `example_mlmodelservice_tflite` that accepts models for other inference engines besides TensorFlow Lite, then write a client that provides a valid model and source data for that inference engine.
 

--- a/docs/extend/modular-resources/examples/tflite-module.md
+++ b/docs/extend/modular-resources/examples/tflite-module.md
@@ -264,7 +264,7 @@ With everything configured and running, you can now run the inference client tha
    ```
 
    {{< alert title="Important" color="note" >}}
-   If you are working within the Docker container, run the following command *instead* of the above, from within the directory you installed `viam-server` to:
+   If you are working within the `bullseye` Docker container on Linux, run the following command *instead* of the above, from within the directory you installed `viam-server` to:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    ./viam-server --appimage-extract-and-run -config /etc/viam.json &

--- a/docs/extend/modular-resources/examples/tflite-module.md
+++ b/docs/extend/modular-resources/examples/tflite-module.md
@@ -223,6 +223,17 @@ To generate your robot's configuration using `example_audio_classification_clien
    ./example_audio_classification_client --generate --model-path ~/example_workspace/lite-model_yamnet_classification_tflite_1.tflite --tflite-module-path ~/example_workspace/opt/bin/example_mlmodelservice_tflite > ~/example_workspace/viam-example-mlmodel-config.json
    ```
 
+   {{< alert title="Important" color="note" >}}
+   If you are running on macOS, use the following commands *instead* of the above:
+
+   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+   cd ~/example_workspace/opt/bin
+   DYLD_LIBRARY_PATH=~/example_workspace/opt/lib/ ./example_audio_classification_client --generate --model-path ~/example_workspace/lite-model_yamnet_classification_tflite_1.tflite --tflite-module-path ~/example_workspace/opt/bin/example_mlmodelservice_tflite > ~/example_workspace/viam-example-mlmodel-config.json
+   ```
+
+   If you installed the SDK build artifacts to a directory other than <file>~/example_workspace/opt</file>, update the path provided to `DYLD_LIBRARY_PATH` accordingly.
+   {{< /alert >}}
+
 1. Verify that the resulting configuration file was created successfully:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
@@ -253,7 +264,7 @@ With everything configured and running, you can now run the inference client tha
    ```
 
    {{< alert title="Important" color="note" >}}
-   If you are working within the Docker container, run the following command instead, from within the directory you installed `viam-server` to:
+   If you are working within the Docker container, run the following command *instead* of the above, from within the directory you installed `viam-server` to:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    ./viam-server --appimage-extract-and-run -config /etc/viam.json &

--- a/docs/extend/modular-resources/examples/tflite-module.md
+++ b/docs/extend/modular-resources/examples/tflite-module.md
@@ -8,7 +8,7 @@ tags: ["ml", "model training", "services"]
 # SMEs: Andrew Morrow
 ---
 
-Viam provides an example [modular resource](/extend/modular-resources) written in C++ that extends the [ML model](/services/ml/) service to run any TensorFlow Lite model.
+Viam provides an example [modular resource](/extend/modular-resources/) written in C++ that extends the [ML model](/services/ml/) service to run any TensorFlow Lite model.
 The example includes an inference client program as well, which generates audio samples and uses the modular resource to classify the audio samples based on a pre-trained model.
 
 This tutorial walks you through everything necessary to start using these example files with your robot, including building the C++ SDK, configuring your robot and installing `viam-server`, and generating results with the example inference client program.

--- a/docs/extend/modular-resources/examples/tflite-module.md
+++ b/docs/extend/modular-resources/examples/tflite-module.md
@@ -260,7 +260,7 @@ With everything configured and running, you can now run the inference client tha
 1. Next, start `viam-server` once more on your robot, this time as a background process:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-   viam-server -config /etc/viam.json &
+   viam-server -config /etc/viam.json
    ```
 
    {{< alert title="Important" color="note" >}}

--- a/docs/extend/modular-resources/examples/tflite-module.md
+++ b/docs/extend/modular-resources/examples/tflite-module.md
@@ -174,7 +174,7 @@ This example uses the `yamnet/classification` TensorFlow Lite model for audio cl
 1. Extract the labels file <file>yamnet_label_list.txt</file> from the downloaded model file:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-   unzip ~/example_workspace/lite-model_yamnet_classification_tflite_1.tflite
+   unzip ~/example_workspace/lite-model_yamnet_classification_tflite_1.tflite -d ~/example_workspace/
    ```
 
    The labels file provides pre-populated labels for the calculated scores, so that output scores can be associated and returned with their matching labels.


### PR DESCRIPTION
Add C++ Modular Resource tutorial showcasing example ML module for classifying audio samples using TensorFlow Lite.

Workarounds:

- Using `--appimage-extract-and-run` to workaround lacking FUSE support in our [`bullseye` docker image](https://github.com/viamrobotics/viam-cpp-sdk/tree/main/etc/docker). Also backgrounding `viam-server` because of this.
- Using `VIAMCPPSDK_USE_DYNAMIC_PROTOS=ON` until RSDK-4295 is addressed.
- Supplying `DYLD_LIBRARY_PATH` env var before running `example_audio_classification_client` on macOS until RSDK-1996 is addressed.

Staging:

- [add-tflite-module.md](https://docs-test.viam.dev/b08be992cf0b70cc97a22ef88ed8371f2cd74d5c/public/extend/modular-resources/examples/tflite-module/)