### PR TITLE
Add Type to glossary

### DIFF
--- a/docs/appendix/glossary/model.md
+++ b/docs/appendix/glossary/model.md
@@ -6,5 +6,5 @@ short_description: A particular implementation of a component type. For example,
 aka:
 ---
 
-A particular implementation of a {{< glossary_tooltip term_id="component" text="component" >}} type.
-For example, UR5e is a model of the arm component type.
+A particular implementation of a {{< glossary_tooltip term_id="type" text="component or service type" >}}.
+For example, UR5e is a model of the arm {{< glossary_tooltip term_id="component" text="component" >}} type.

--- a/docs/appendix/glossary/resource.md
+++ b/docs/appendix/glossary/resource.md
@@ -8,7 +8,7 @@ aka:
 
 Resources are individual, addressable elements of a robot.
 
-{{< glossary_tooltip term_id="part" text="Parts" >}} operate multiple types of resources:
+{{< glossary_tooltip term_id="part" text="Parts" >}} operate multiple kinds of resources:
 
 - physical {{< glossary_tooltip term_id="component" text="components" >}}
 - software {{< glossary_tooltip term_id="service" text="services" >}}
@@ -16,4 +16,4 @@ Resources are individual, addressable elements of a robot.
 - {{< glossary_tooltip term_id="process" text="processes" >}}
 
 Each part has local resources and can also have resources from another {{< glossary_tooltip term_id="remote" text="remote">}} robot part.
-The capabilities of each resource are exposed through the part’s API.
+The capabilities of each resource are exposed through the {{< glossary_tooltip term_id="type" text="resource type's" >}} API.

--- a/docs/appendix/glossary/type.md
+++ b/docs/appendix/glossary/type.md
@@ -1,0 +1,13 @@
+---
+title: Type (Resource Type)
+id: type
+full_link:
+short_description: A group of component or service models that share the same API.
+aka:
+---
+
+Every {{< glossary_tooltip term_id="component" text="component" >}} or {{< glossary_tooltip term_id="service" text="service" >}} has a type and a {{< glossary_tooltip term_id="model" text="model" >}}.
+All {{< glossary_tooltip term_id="resource" text="resources" >}} of a given type have the same API.
+Models are subcategories within that type, implementing the common API.
+
+For example, `gpio` and `gpiostepper` are both models of type `motor`, and they are both controlled through the [motor API](/components/motor/#api).


### PR DESCRIPTION
Realized this isn't in there, though model is, and it seems increasingly necessary as we talk about defining new APIs and namespaces and such.
