### PR TITLE
Shorten SCUTTLE tutorial title

### DIFF
--- a/docs/tutorials/configure/scuttlebot.md
+++ b/docs/tutorials/configure/scuttlebot.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure a SCUTTLE Robot with a Camera"
+title: "Configure a SCUTTLE Robot"
 linkTitle: "Configure a SCUTTLE Robot"
 weight: 15
 type: "docs"


### PR DESCRIPTION
The current title makes it sound as though you're adding a camera to an already configured SCUTTLE. Basically all SCUTTLEs have cameras so I think it's better to take this off.