### PR TITLE
DOCS-946: Deal with camera SDK differences

### DIFF
--- a/docs/components/camera/_index.md
+++ b/docs/components/camera/_index.md
@@ -145,6 +145,14 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 {{% /tab %}}
 {{% tab name="Go" %}}
 
+{{% alert title="Info" color="info" %}}
+
+Unlike most Viam [component APIs](/program/apis/#component-apis), the methods of the Go camera client do not map exactly to the Python SDK camera methods.
+`Stream` works somewhat differently from the Python `get_image` method.
+In the example below, note how a stream is constructed before the next image is gotten from the stream.
+
+{{% /alert %}}
+
 **Parameters:**
 
 - `ctx` [(Context)](https://pkg.go.dev/context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.

--- a/docs/components/camera/_index.md
+++ b/docs/components/camera/_index.md
@@ -147,9 +147,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% alert title="Info" color="info" %}}
 
-Unlike most Viam [component APIs](/program/apis/#component-apis), the methods of the Go camera client do not map exactly to the Python SDK camera methods.
-`Stream` works somewhat differently from the Python `get_image` method.
-In the example below, note how a stream is constructed before the next image is gotten from the stream.
+Unlike most Viam [component APIs](/program/apis/#component-apis), the methods of the Go camera client do not map exactly to the names of the other SDK's camera methods.
+To get an image in the Go SDK, you first need to construct a `Stream` and then you can get the next image from that stream.
 
 {{% /alert %}}
 


### PR DESCRIPTION
The camera API varies much more widely between languages than most of the APIs. I think we should address that in some way. I'm not sure whether this is the way--very open to other ideas but had a thought and wanted to make a suggestion!

I'll make a ticket to discuss.
