### PR TITLE
DOCS-942: Add documentation for GetProperties() to base component

### DIFF
--- a/docs/components/base/_index.md
+++ b/docs/components/base/_index.md
@@ -80,7 +80,7 @@ The base component supports the following methods:
 | [SetPower](#setpower) | Set the relative power (out of max power) for linear and angular propulsion of the base. |
 | [SetVelocity](#setvelocity) | Set the linear and angular velocity of the base. |
 | [Stop](#stop) | Stop the base. |
-| [GetProperties](#getproperties) | Get the width and turning radius of the base. |
+| [GetProperties](#getproperties) | Get the width and turning radius of the base in meters. |
 | [DoCommand](#docommand) | Send or receive model-specific commands. |
 
 ### MoveStraight

--- a/docs/components/base/_index.md
+++ b/docs/components/base/_index.md
@@ -35,7 +35,6 @@ Supported base models include:
 | [`wheeled`](wheeled/) | Mobile wheeled robot |
 | [`agilex-limo`](agilex-limo/) | [Agilex LIMO Mobile Robot](https://global.agilex.ai/products/limo) |
 | [`fake`](fake/) | A model used for testing, with no physical hardware |
-| `boat` | Mobile boat robot |
 
 ## Control your base with Viam's client SDK libraries
 
@@ -81,6 +80,7 @@ The base component supports the following methods:
 | [SetPower](#setpower) | Set the relative power (out of max power) for linear and angular propulsion of the base. |
 | [SetVelocity](#setvelocity) | Set the linear and angular velocity of the base. |
 | [Stop](#stop) | Stop the base. |
+| [GetProperties](#getproperties) | Get the width and turning radius of the base. |
 | [DoCommand](#docommand) | Send or receive model-specific commands. |
 
 ### MoveStraight
@@ -405,6 +405,71 @@ myBase.Stop(context.Background())
 {{% /tab %}}
 {{< /tabs >}}
 
+### GetProperties
+
+Get the width and turning radius of the base in meters.
+
+{{< alert title="Tip" color="tip" >}}
+These properties are inherent to the {{< glossary_tooltip term_id="model" text="model" >}} of base, so you do not need to [configure](#configuration) them.
+{{< /alert >}}
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `timeout` [(Optional\[float\])](https://docs.python.org/library/typing.html#typing.Optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
+
+**Returns:**
+
+- [(Properties)](https://python.viam.dev/autoapi/viam/components/base/index.html#viam.components.base.Base.Properties): A [dataclass](https://docs.python.org/3/library/dataclasses.html) with two fields, `width` and `turning_radius_meters`, representing the width and turning radius of the physical base in meters *(m)*.
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/base/client/index.html#viam.components.base.client.BaseClient.get_properties).
+
+```python {class="line-numbers linkable-line-numbers"}
+my_base = Base.from_robot(robot=robot, name="my_base")
+
+# Get the width and turning radius of the base 
+properties = await my_base.get_properties()
+
+# Get the width 
+print(f"Width of base in meters: {properties.width}")
+
+# Get the turning radius
+print(f"Turning radius of base in meters: {properties.turning_radius_meters}")
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+**Parameters:**
+
+- `ctx` [(Context)](https://pkg.go.dev/context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
+- `extra` [(map\[string\]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
+
+**Returns:**
+
+- [(Properties)](https://pkg.go.dev/go.viam.com/rdk/components/base#Properties): A structure with two fields, `WidthMeters` and `TurningRadiusMeters`, representing the width and turning radius of the physical base in meters *(m)*.
+- [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
+
+For more information, see the [Go SDK Docs](https://python.viam.dev/autoapi/viam/components/base/client/index.html#viam.components.base.client.BaseClient.get_properties).
+
+```go {class="line-numbers linkable-line-numbers"}
+myBase, err := base.FromRobot(robot, "my_base")
+
+// Get the width and turning radius of the base 
+properties, err := myBase.GetProperties(context.Background(), nil)
+
+// Get the width
+myBaseWidth := properties.WidthMeters
+
+// Get the turning radius
+myBaseTurningRadius := properties.TurningRadiusMeters
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ### DoCommand
 
 Execute model-specific commands that are not otherwise defined by the component API.
@@ -451,7 +516,7 @@ command := map[string]interface{}{"cmd": "test", "data1": 500}
 result, err := myBase.DoCommand(context.Background(), command)
 ```
 
-For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/blob/main/resource/resource.go).
+For more information, see the [Go SDK Docs](https://github.com/viamrobotics/rdk/blob/main/resource/resource.go).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/docs/components/base/_index.md
+++ b/docs/components/base/_index.md
@@ -516,7 +516,7 @@ command := map[string]interface{}{"cmd": "test", "data1": 500}
 result, err := myBase.DoCommand(context.Background(), command)
 ```
 
-For more information, see the [Go SDK Docs](https://github.com/viamrobotics/rdk/blob/main/resource/resource.go).
+For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/blob/main/resource/resource.go).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/docs/components/base/_index.md
+++ b/docs/components/base/_index.md
@@ -407,11 +407,7 @@ myBase.Stop(context.Background())
 
 ### GetProperties
 
-Get the width and turning radius of the base in meters.
-
-{{< alert title="Tip" color="tip" >}}
-These properties are inherent to the {{< glossary_tooltip term_id="model" text="model" >}} of base, so you do not need to [configure](#configuration) them.
-{{< /alert >}}
+Get the width and turning radius of the {{< glossary_tooltip term_id="model" text="model" >}} of base in meters.
 
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/program/apis/_index.md
+++ b/docs/program/apis/_index.md
@@ -221,6 +221,7 @@ The base component supports the following methods:
 | [SetPower](/components/base/#setpower) | Set the relative power (out of max power) for linear and angular propulsion of the base. |
 | [SetVelocity](/components/base/#setvelocity) | Set the linear velocity and angular velocity of the base. |
 | [Stop](/components/base/#stop) | Stop the base. |
+| [GetProperties](/components/base/#getproperties) | Get the width and turning radius of the base. |
 | [DoCommand](/components/base/#docommand) | Send or receive model-specific commands. |
 
 ### Board

--- a/docs/program/apis/_index.md
+++ b/docs/program/apis/_index.md
@@ -221,7 +221,7 @@ The base component supports the following methods:
 | [SetPower](/components/base/#setpower) | Set the relative power (out of max power) for linear and angular propulsion of the base. |
 | [SetVelocity](/components/base/#setvelocity) | Set the linear velocity and angular velocity of the base. |
 | [Stop](/components/base/#stop) | Stop the base. |
-| [GetProperties](/components/base/#getproperties) | Get the width and turning radius of the base. |
+| [GetProperties](/components/base/#getproperties) | Get the width and turning radius of the base in meters. |
 | [DoCommand](/components/base/#docommand) | Send or receive model-specific commands. |
 
 ### Board


### PR DESCRIPTION
Implements the third segment of the changes outlined here: [Docs Changes for GPS Navigation](https://docs.google.com/document/d/1ReL7RU0FoaAe8gyPbMgMovHpgdx3Jy4c3R0LFCVWkKI/edit) (section below "Changes to https://docs.viam.com/components/base/")

* Add the GetProperties() method with small code samples, add info for navigation service usage 