### PR TITLE
Fix motion attribute formatting on navigation service 

### DIFF
--- a/docs/services/navigation/_index.md
+++ b/docs/services/navigation/_index.md
@@ -110,9 +110,7 @@ The following attributes are available for `Navigation` services:
 | `store` | obj | **Required** | The type and configuration of data storage to use. Either type `"memory"`, where no additional configuration is needed and the waypoints are stored in local memory while the Navigation process is running, or `"mongodb"`, where data persists at the specified [MongoDB URI](https://www.mongodb.com/docs/manual/reference/connection-string) of your MongoDB deployment. |
 | `base` | string | **Required** | The `name` you have configured for the [base](/components/base/) you are operating with this service. |
 | `movement_sensor` | string | **Required** | The `name` of the [movement sensor](/components/movement-sensor/) you have configured for the base you are operating with this service. |
-| `motion_service` | string | Optional | The `name` of the [Motion Service](/services/motion/) you have configured for the base you are operating with this service.
-If you have not added a Motion Service to your robot, the default Motion Service will be used.
-Reference this default service by using the name `"builtin"`. |
+| `motion_service` | string | Optional | The `name` of the [Motion Service](/services/motion/) you have configured for the base you are operating with this service. If you have not added a Motion Service to your robot, the default Motion Service will be used. Reference this default service in your code with the name `"builtin"`. |
 | `degs_per_sec` | float | Optional | The default angular velocity for the [base](/components/base/) in degrees per second. <br> Default: `60` |
 | `meters_per_sec` | float | Optional | The default linear velocity for the [base](/components/base/) in meters per second. <br> Default: `0.3` |
 | `obstacles` | obj | Optional | Any obstacles you wish to add to the robot's path. See the [Motion Service](/services/motion/) for more information. |


### PR DESCRIPTION
A newline in the row caused this table to appear a little funky in production, this pr fixes that newline