### PR TITLE
DOCS-941: Fix table rendering in includes

### DIFF
--- a/docs/note.md
+++ b/docs/note.md
@@ -123,7 +123,7 @@ This is **some markdown.**
 
 ### Alerts Shortcodes
 
-{{< alert title="Note" color="note" >}}
+{{< alert title="Important" color="note" >}}
 It can even contain shortcodes.
 {{< /alert >}}
 
@@ -416,7 +416,7 @@ If you add an MP4 file, test it on an iPhone with the deployed link on the PR.
 
 {{< /alert >}}
 
-{{< alert title="Note" color="note" >}}
+{{< alert title="Important" color="note" >}}
 The gif can and should be used only in the frontmater `images` variable and only if close in size to 1MB.
 The `images` variable sets it to be the preview image on social platforms (for example it will be the preview when you share a link on slack).
 Link previews do not support `webm` and `mp4` but they do support gifs.
@@ -508,7 +508,7 @@ ffmpeg -ss 00:00:05 -i ${vdirname}/${vfname}mp4 -frames:v 1 ${vdirname}/${vfname
 }
 ```
 
-{{< alert title="Note" color="note" >}}
+{{< alert title="Important" color="note" >}}
 The `2gif` commands only turn the first 5 seconds of a video into a low res gif.
 {{< /alert >}}
 
@@ -520,7 +520,7 @@ If the image is supposed to take up the full width of the page use the regular m
 
 If the image is smaller use the `imgproc` shortcode with an appropriate resize value.
 
-{{< alert title="Note" color="note" >}}
+{{< alert title="Important" color="note" >}}
 
 You cannot directly use the `<img>` html tag for images in the assets folder because the images, once built, are renamed.
 If you really need to use html directly, place the image in the static folder.

--- a/docs/note.md
+++ b/docs/note.md
@@ -267,7 +267,7 @@ Figure styles the Attribution text as body text.
 
 {{< readfile "/static/include/sample.md" >}}
 
-Section content before this line is contained in an included file: /static/include/sample.md
+Section content before this line is contained in an included file: <file>/static/include/sample.md</file>
 
 ## Videos
 

--- a/layouts/shortcodes/readfile.html
+++ b/layouts/shortcodes/readfile.html
@@ -32,10 +32,8 @@ if the file is not found */}}
     {{- highlight ($.Scratch.Get "filepath" | readFile | htmlUnescape |
     safeHTML ) (.Get "lang") "" -}}
   {{ else }}
-<div>
-  {{- $.Scratch.Get "filepath" | os.ReadFile | .Page.RenderString | safeHTML -}}
-</div>
+    {{- $.Scratch.Get "filepath" | os.ReadFile | .Page.RenderString | safeHTML -}}
   {{ end }}
 {{ else }}
-{{ errorf "The file %s was not found" ($.Scratch.Get "filepath") }}
+  {{ errorf "The file %s was not found" ($.Scratch.Get "filepath") }}
 {{ end }}

--- a/static/include/sample.md
+++ b/static/include/sample.md
@@ -3,7 +3,8 @@
 This entire section was added to the current topic using the `readfile` shortcode.
 
 {{% alert="Note" color="note" %}}
-Changes to included files do not appear in local mode (`hugo server -D`). You'll need to halt and restart the server to view the changes.
+Changes to included files do not appear in local mode (`hugo server -D`).
+You'll need to halt and restart the server to view the changes.
 {{% /alert %}}
 
 ## Heading 2

--- a/static/include/sample.md
+++ b/static/include/sample.md
@@ -1,24 +1,94 @@
-
 ### This is a Heading in the Sample File
-This entire section was added to the current topic using the readfile shortcode.
+
+This entire section was added to the current topic using the `readfile` shortcode.
 
 {{% alert="Note" color="note" %}}
-Changes to included files do not appear in local mode (hugo server -D). You'll need to halt and restart the server to view the changes.
+Changes to included files do not appear in local mode (`hugo server -D`). You'll need to halt and restart the server to view the changes.
 {{% /alert %}}
 
-
 ## Heading 2
+
 * bullet 1
 * bullet 2
 
 ### Heading 3
 
-**Markdown Table**
+This Markdown code:
+
+``` sh
+Markdown Table
 | id | name    |
 |----|---------|
 | 1  | Roberta |
 | 2  | Oliver  |
 | 3  | Shayna  |
 | 4  | Fechin  |
+```
+
+Renders like so:
+
+Markdown Table
+| id | name    |
+|----|---------|
+| 1  | Roberta |
+| 2  | Oliver  |
+| 3  | Shayna  |
+| 4  | Fechin  |
+
+This HTML code:
+
+``` html
+<h3>HTML Table</h3>
+
+<table>
+  <tr>
+    <th>id</th>
+    <th>name</th>
+  </tr>
+  <tr>
+    <td>1</td>
+    <td>Roberta</td>
+  </tr>
+  <tr>
+    <td>2</td>
+    <td>Oliver</td>
+  </tr>
+  <tr>
+    <td>3</td>
+    <td>Shayna</td>
+  </tr>
+  <tr>
+    <td>4</td>
+    <td>Fechin</td>
+  </tr>
+</table>
+```
+
+Renders like so:
+
+<h3>HTML Table</h3>
+
+<table>
+  <tr>
+    <th>id</th>
+    <th>name</th>
+  </tr>
+  <tr>
+    <td>1</td>
+    <td>Roberta</td>
+  </tr>
+  <tr>
+    <td>2</td>
+    <td>Oliver</td>
+  </tr>
+  <tr>
+    <td>3</td>
+    <td>Shayna</td>
+  </tr>
+  <tr>
+    <td>4</td>
+    <td>Fechin</td>
+  </tr>
+</table>
 
 **This is the last line of the included file.**


### PR DESCRIPTION
Fix table rendering in includes by removing wrapping `<div>` elements from `readfile.html`.

- Also using opportunity to expand `note.md` to showcase HTML and MD tables in includes, useful for testing this.