### PR TITLE
DOCS-928: Move API overviews into includes

### DIFF
--- a/docs/components/arm/_index.md
+++ b/docs/components/arm/_index.md
@@ -104,6 +104,8 @@ import (
 
 ## API
 
+The arm component supports the following methods:
+
 {{< readfile "/static/include/components/apis/arm.md" >}}
 
 ### GetEndPosition

--- a/docs/components/arm/_index.md
+++ b/docs/components/arm/_index.md
@@ -104,18 +104,7 @@ import (
 
 ## API
 
-The arm component supports the following methods:
-
-| Method Name | Description |
-| ----------- | ----------- |
-| [GetEndPosition](#getendposition) | Get the current position of the arm as a Pose. |
-| [MoveToPosition](#movetoposition) | Move the end of the arm to the desired Pose. |
-| [MoveToJointPositions](#movetojointpositions) | Move each joint on the arm to the desired position. |
-| [JointPositions](#jointpositions) | Get the current position of each joint on the arm. |
-| [Stop](#stop) | Stop the arm from moving. |
-| [IsMoving](#ismoving) | Get if the arm is currently moving. |
-| [Kinematics](#kinematics) | Get the kinematics information associated with the arm. |
-| [DoCommand](#docommand) | Send or receive model-specific commands. |
+{{< readfile "/static/include/components/apis/arm.md" >}}
 
 ### GetEndPosition
 

--- a/docs/components/base/_index.md
+++ b/docs/components/base/_index.md
@@ -73,15 +73,7 @@ import (
 
 The base component supports the following methods:
 
-| Method Name | Description |
-| ----------- | ----------- |
-| [MoveStraight](#movestraight)  | Move the base in a straight line across the given distance at the given velocity. |
-| [Spin](#spin) | Move the base to the given angle at the given angular velocity. |
-| [SetPower](#setpower) | Set the relative power (out of max power) for linear and angular propulsion of the base. |
-| [SetVelocity](#setvelocity) | Set the linear and angular velocity of the base. |
-| [Stop](#stop) | Stop the base. |
-| [GetProperties](#getproperties) | Get the width and turning radius of the base in meters. |
-| [DoCommand](#docommand) | Send or receive model-specific commands. |
+{{< readfile "/static/include/components/apis/base.md" >}}
 
 ### MoveStraight
 

--- a/docs/components/board/_index.md
+++ b/docs/components/board/_index.md
@@ -367,33 +367,19 @@ Additionally, the nested `GPIOPin`, `AnalogReader`, and `DigitalInterrupt` inter
 
 [`GPIOPin`](#gpiopin-api) API:
 
-| Method Name | Description |
-| ----------- | ----------- |
-| [Set](#set) | Set the output of this pin to high/low. |
-| [Get](#get) | Get if this pin is active (high). |
-| [PWM](#pwm) | Get the pin’s pulse-width modulation duty cycle. |
-| [SetPWM](#pwmfreq) | Set the pin’s pulse-width modulation duty cycle. |
-| [PWMFreq](#pwmfreq) | Get the pulse-width modulation frequency of this pin. |
-| [SetPWMFreq](#setpwmfreq) | Set the pulse-width modulation frequency of this pin. |
+{{< readfile "/static/include/components/apis/gpiopin.md" >}}
 
 <br>
 
 [`AnalogReader`](#analogreader-api) API:
 
-| Method Name | Description |
-| ----------- | ----------- |
-| [Read](#read) | Read the current integer value of the digital signal output by the ADC. |
+{{< readfile "/static/include/components/apis/analogreader.md" >}}
 
 <br>
 
 [`DigitalInterrupt`](#digitalinterrupt-api) API:
 
-| Method Name | Description |
-| ----------- | ----------- |
-| [Value](#value) | Get the current value of this interrupt. |
-| [Tick](#tick) | Record an interrupt. |
-| [AddCallback](#addcallback) | Add a channel as a callback for [Tick()](#tick). |
-| [AddPostProcessor](#addpostprocessor) | Add a PostProcessor function for [Value()](#value). |
+{{< readfile "/static/include/components/apis/digitalinterrupt.md" >}}
 
 ### AnalogReaderByName
 

--- a/docs/components/board/_index.md
+++ b/docs/components/board/_index.md
@@ -361,16 +361,7 @@ import (
 
 The board component supports the following methods:
 
-| Method Name | Description |
-| ----------- | ----------- |
-| [AnalogReaderByName](#analogreaderbyname) | Get an [`AnalogReader`](#analogs) by `name`. |
-| [DigitalInterruptByName](#digitalinterruptbyname) | Get a [`DigitalInterrupt`](#digital_interrupts) by `name`. |
-| [GPIOPinByName](#gpiopinbyname) | Get a `GPIOPin` by its {{< glossary_tooltip term_id="pin-number" text="pin number" >}}. |
-| [AnalogReaderNames](#analogreadernames) | Get the `name` of every [`AnalogReader`](#analogs). |
-| [DigitalInterruptNames](#digitalinterruptnames) | Get the `name` of every [`DigitalInterrupt`](#digital_interrupts). |
-| [Status](#status) | Get the current status of this board. |
-| [ModelAttributes](#modelattributes) | Get the attributes related to the model of this board. |
-| [SetPowerMode](#setpowermode) | Set the board to the indicated power mode. |
+{{< readfile "/static/include/components/apis/board.md" >}}
 
 Additionally, the nested `GPIOPin`, `AnalogReader`, and `DigitalInterrupt` interfaces support the following methods:
 

--- a/docs/components/camera/_index.md
+++ b/docs/components/camera/_index.md
@@ -88,12 +88,7 @@ import (
 
 The camera component supports the following methods:
 
-| Method Name | Description |
-| ----------- | ----------- |
-| [GetImage](#getimage) | Return an image from the camera. |
-| [GetPointCloud](#getpointcloud) | Return a point cloud from the camera. |
-| [GetProperties](#getproperties) | Return the camera intrinsic and camera distortion parameters, as well as whether the camera supports returning point clouds. |
-| [DoCommand](#docommand) | Send or receive model-specific commands. |
+{{< readfile "/static/include/components/apis/camera.md" >}}
 
 ### GetImage
 

--- a/docs/components/component/_index.md
+++ b/docs/components/component/_index.md
@@ -78,11 +78,9 @@ import (
 The COMPONENT component supports the following methods:
 
 *Writing Instructions: Use the method names in the protobuf, not the Python or Go-specific method names.*
+*Use an included snippet so you can add it to <file>/program/apis/</file>.*
 
-Method Name | Description
------------ | -----------
-[GetReadings](#getreadings) | Do the thing the method does.
-[MethodName2](#methodname2) | Do the thing this method does.
+{{< readfile "/static/include/components/apis/component.md" >}}
 
 ### GetReadings
 

--- a/docs/components/encoder/_index.md
+++ b/docs/components/encoder/_index.md
@@ -83,12 +83,7 @@ import (
 
 The encoder component supports the following methods:
 
-Method Name | Description
------------ | -----------
-[Position](#position) | Get the current position of the encoder.
-[ResetPosition](#resetposition) | Reset the position to zero.
-[GetProperties](#getproperties) | Get the supported properties of this encoder.
-[DoCommand](#docommand) | Send or receive model-specific commands.
+{{< readfile "/static/include/components/apis/encoder.md" >}}
 
 ### Position
 

--- a/docs/components/gantry/_index.md
+++ b/docs/components/gantry/_index.md
@@ -81,15 +81,7 @@ import (
 
 The gantry component supports the following methods:
 
-| Method Name | Description |
-| ----------- | ----------- |
-| [Position](#position) | Get the current positions of the axes of the gantry in mm. |
-| [MoveToPosition](#movetoposition) | Move the axes of the gantry to the desired positions at the requested speeds. |
-| [Home](#home) | Run the homing sequence of the gantry to re-calibrate the axes with respect to the limit switches. |
-| [Lengths](#lengths) | Get the lengths of the axes of the gantry in mm. |
-| [Stop](#stop) | Stop the gantry from moving. |
-| [IsMoving](#ismoving) | Get if the gantry is currently moving. |
-| [DoCommand](#docommand) | Send or receive model-specific commands. |
+{{< readfile "/static/include/components/apis/gantry.md" >}}
 
 ### Position
 

--- a/docs/components/gripper/_index.md
+++ b/docs/components/gripper/_index.md
@@ -60,13 +60,9 @@ import (
 
 ## API
 
-Method Name | Description
------------ | -----------
-[`Open`](#open) | Open the gripper.
-[`Grab`](#grab) | Close the gripper until it grabs something or closes completely.
-[`Stop`](#stop) | Stop the gripper's movement.
-[`IsMoving`](#ismoving) | Report whether the gripper is currently moving.
-[`DoCommand`](#docommand) | Send or receive model-specific commands.
+The gripper component supports the following methods:
+
+{{< readfile "/static/include/components/apis/gripper.md" >}}
 
 ### Open
 

--- a/docs/components/input-controller/_index.md
+++ b/docs/components/input-controller/_index.md
@@ -79,12 +79,7 @@ import (
 
 The input controller component supports the following methods:
 
-| Method Name | Description |
-| ----------- | ----------- |
-| [Controls](#controls) | Get a list of input `Controls` that this Controller provides. |
-| [Events](#events) | Get the current state of the Controller as a map of the most recent [Event](#event-object) for each [Control](#control-field). |
-| [RegisterControlCallback](#registercontrolcallback) | Define a callback function to execute whenever one of the [`EventTypes`](#eventtype-field) selected occurs on the given [Control](#control-field). |
-| [DoCommand](#docommand) | Send or receive model-specific commands. |
+{{< readfile "/static/include/components/apis/input-controller.md" >}}
 
 ### RegisterControlCallback
 

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -76,21 +76,9 @@ import (
 
 ## API
 
-Method Name | Description
------------ | -----------
-[SetPower](#setpower) | Set the power to send to the motor as a portion of max power.
-[GoFor](#gofor) | Spin the motor the specified number of revolutions at specified RPM.
-[GoTo](#goto) | Send the motor to a specified position (in terms of revolutions from home) at a specified speed.
-[ResetZeroPosition](#resetzeroposition) | Set the current position to be the new zero (home) position.
-[GetPosition](#getposition) | Report the position of the motor based on its encoder. Not supported on all motors.
-[GetProperties](#getproperties) | Return whether or not the motor supports certain optional features.
-[Stop](#stop) | Cut power to the motor off immediately, without any gradual step down.
-[IsPowered](#ispowered) | Return whether or not the motor is currently on, and the amount of power to it.
-[IsMoving](#ismoving) | Return whether the motor is moving or not.
-[DoCommand](#docommand) | Send or receive model-specific commands.
+The motor component supports the following methods:
 
-In addition to the information below, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor)
-or [Python SDK docs](https://python.viam.dev/autoapi/viam/components/motor/index.html#).
+{{< readfile "/static/include/components/apis/motor.md" >}}
 
 ### SetPower
 

--- a/docs/components/movement-sensor/_index.md
+++ b/docs/components/movement-sensor/_index.md
@@ -81,20 +81,7 @@ Different movement sensors provide different data, so be aware that not all of t
 You can run `GetProperties` on your sensor for a list of its supported methods.
 {{< /alert >}}
 
-Method Name | Description | Models That Support This Method
------------ | ----------- | -------------------------------
-[GetPosition](#getposition) | Get the current latitude, longitude and altitude. | GPS models
-[GetLinearVelocity](#getlinearvelocity) | Get the current linear velocity as a 3D vector. | GPS models
-[GetAngularVelocity](#getangularvelocity) | Get the current angular velocity as a 3D vector. | IMU models and `gyro-mpu6050`
-[GetLinearAcceleration](#getlinearacceleration) | Get the current linear acceleration as a 3D vector. | IMU models,  `accel-adxl345`, and `gyro-mpu6050`
-[GetCompassHeading](#getcompassheading) | Get the current compass heading in degrees. | GPS models and `imu-vectornav`
-[GetOrientation](#getorientation) | Get the current orientation. | IMU models
-[GetProperties](#getproperties) | Get the supported properties of this sensor. | all models
-[GetAccuracy](#getaccuracy) | Get the accuracy of the various sensors. | GPS models
-[GetReadings](#getreadings) | Obtain the measurements/data specific to this sensor. | all models
-[DoCommand](#docommand) | Send or receive model-specific commands. | all models
-
-In addition to the information below, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/movementsensor#MovementSensor) or [Python SDK docs](https://python.viam.dev/autoapi/viam/components/movement_sensor/index.html#).
+{{< readfile "/static/include/components/apis/movement-sensor.md" >}}
 
 ### GetPosition
 

--- a/docs/components/sensor/_index.md
+++ b/docs/components/sensor/_index.md
@@ -85,9 +85,7 @@ import (
 
 The sensor component supports the following methods:
 
-| Method Name | Description |
-| ----------- | ----------- |
-| [Readings](#readings) | Get the measurements or readings that this sensor provides. |
+{{< readfile "/static/include/components/apis/sensor.md" >}}
 
 ### Readings
 

--- a/docs/components/servo/_index.md
+++ b/docs/components/servo/_index.md
@@ -87,12 +87,7 @@ import (
 
 The servo component supports the following methods:
 
-| Method Name | Description |
-| ----------- | ----------- |
-| [Move](#move) | Move the servo to the desired angle. |
-| [Position](#position) | Get the current angle of the servo. |
-| [Stop](#stop) | Stop the servo. |
-| [DoCommand](#docommand) | Send or receive model-specific commands. |
+{{< readfile "/static/include/components/apis/servo.md" >}}
 
 ### Move
 

--- a/docs/program/apis/_index.md
+++ b/docs/program/apis/_index.md
@@ -229,72 +229,44 @@ The [encoder component](/components/encoder/) supports the following methods:
 
 The [gantry component](/components/gantry/) supports the following methods:
 
-| Method Name | Description |
-| ----------- | ----------- |
-[Position](/components/gantry/#position) | Get the current positions of the axes of the gantry in mm. |
-[MoveToPosition](/components/gantry/#movetoposition) | Move the axes of the gantry to the desired positions. |
-[Lengths](/components/gantry/#lengths) | Get the lengths of the axes of the gantry in mm. |
-[Stop](/components/gantry/#stop) | Stop the gantry from moving. |
-[IsMoving](/components/gantry/#ismoving) | Get if the gantry is currently moving. |
+{{< readfile "/static/include/components/apis/gantry.md" >}}
 
 ### Gripper
 
-Method Name | Description
------------ | -----------
-[`Open`](/components/gripper/#open) | Open the gripper.
-[`Grab`](/components/gripper/#grab) | Close the gripper until it grabs something or closes completely.
-[`Stop`](/components/gripper/#stop) | Stop the gripper's movement.
-[`IsMoving`](/components/gripper/#ismoving) | Report whether the gripper is currently moving.
+The [gripper component](/components/gripper/) supports the following methods:
+
+{{< readfile "/static/include/components/apis/gripper.md" >}}
 
 ### Input Controller
 
-| Method Name | Description |
-| ----------- | ----------- |
-| [Controls](/components/input-controller/#controls) | Get a list of input `Controls` that this Controller provides. |
-| [Events](/components/input-controller/#events) | Get the current state of the Controller as a map of the most recent [Event](/components/input-controller/#event-object) for each [Control](/components/input-controller/#control-field). |
-| [RegisterControlCallback](/components/input-controller/#registercontrolcallback) | Define a callback function to execute whenever one of the [`EventTypes`](/components/input-controller/#eventtype-field) selected occurs on the given [Control](/components/input-controller/#control-field). |
+The [input controller component](/components/input-controller/) supports the following methods:
+
+{{< readfile "/static/include/components/apis/input-controller.md" >}}
 
 ### Motor
 
-Method Name | Description
------------ | -----------
-[SetPower](/components/motor/#setpower) | Set the power to send to the motor as a portion of max power.
-[GoFor](/components/motor/#gofor) | Spin the motor the specified number of revolutions at specified RPM.
-[GoTo](/components/motor/#goto) | Send the motor to a specified position (in terms of revolutions from home) at a specified speed.
-[ResetZeroPosition](/components/motor/#resetzeroposition) | Set the current position to be the new zero (home) position.
-[GetPosition](/components/motor/#getposition) | Report the position of the motor based on its encoder. Not supported on all motors.
-[GetProperties](/components/motor/#getproperties) | Return whether or not the motor supports certain optional features.
-[Stop](/components/motor/#stop) | Cut power to the motor off immediately, without any gradual step down.
-[IsPowered](/components/motor/#ispowered) | Return whether or not the motor is currently on, and the amount of power to it.
-[IsMoving](/components/motor/#ismoving) | Return whether the motor is moving or not.
+The [motor component](/components/motor/) supports the following methods:
+
+{{< readfile "/static/include/components/apis/motor.md" >}}
 
 ### Movement Sensor
 
-Method Name | Description |
------------ | ----------- |
-[GetPosition](/components/movement-sensor/#getposition) | Get the current latitude, longitude and altitude. |
-[GetLinearVelocity](/components/movement-sensor/#getlinearvelocity) | Get the current linear velocity as a 3D vector. |
-[GetAngularVelocity](/components/movement-sensor/#getangularvelocity) | Get the current angular velocity as a 3D vector. |
-[GetLinearAcceleration](/components/movement-sensor/#getlinearacceleration) | Get the current linear acceleration as a 3D vector. |
-[GetCompassHeading](/components/movement-sensor/#getcompassheading) | Get the current compass heading in degrees. |
-[GetOrientation](/components/movement-sensor/#getorientation) | Get the current orientation. |
-[GetProperties](/components/movement-sensor/#getproperties) | Get the supported properties of this sensor. |
-[GetAccuracy](/components/movement-sensor/#getaccuracy) | Get the accuracy of the various sensors. |
-[GetReadings](/components/movement-sensor/#getreadings) | Obtain the measurements/data specific to this sensor. |
+The [movement sensor component](/components/movement-sensor/) supports the following methods.
+Some methods are only supported by certain models:
+
+{{< readfile "/static/include/components/apis/movement-sensor.md" >}}
 
 ### Sensor
 
-| Method Name | Description |
-| ----------- | ----------- |
-| [Readings](/components/sensor/#readings) | Get the measurements or readings that this sensor provides. |
+The [sensor component](/components/sensor/) supports the following methods:
+
+{{< readfile "/static/include/components/apis/sensor.md" >}}
 
 ### Servo
 
-| Method Name | Description |
-| ----------- | ----------- |
-| [Move](/components/servo/#move) | Move the servo to the desired angle. |
-| [Position](/components/servo/#position) | Get the current angle of the servo. |
-| [Stop](/components/servo/#stop) | Stop the servo. |
+The [servo component](/components/servo/) supports the following methods:
+
+{{< readfile "/static/include/components/apis/servo.md" >}}
 
 ## Service APIs
 

--- a/docs/program/apis/_index.md
+++ b/docs/program/apis/_index.md
@@ -18,7 +18,7 @@ The API methods provided by the SDKs for each of these resource APIs wrap gRPC c
 
 ## ResourceBase Methods
 
-In the Python SDK, [the `ResourceBase` class](https://python.viam.dev/autoapi/viam/resource/base/index.html) defines a basic set of API methods that all child resources should provide for users.
+In the Python SDK, the [`ResourceBase`](https://python.viam.dev/autoapi/viam/resource/base/index.html) class defines a basic set of API methods that all child resources should provide for users.
 In the other SDKs, resource APIs implement but do not inherit these base requirements.
 
 `ResourceBase` methods include:
@@ -197,54 +197,37 @@ Documentation on using these methods in your SDK code is found on each [componen
 
 ### Arm
 
+The [arm component](/components/arm/) supports the following methods:
+
 {{< readfile "/static/include/components/apis/arm.md" >}}
 
 ### Base
 
-The base component supports the following methods:
+The [base component](/components/base/) supports the following methods:
 
-| Method Name | Description |
-| ----------- | ----------- |
-| [MoveStraight](/components/base/#movestraight)  | Move the base in a straight line across the given distance at the given velocity. |
-| [Spin](/components/base/#spin) | Move the base to the given angle at the given angular velocity. |
-| [SetPower](/components/base/#setpower) | Set the relative power (out of max power) for linear and angular propulsion of the base. |
-| [SetVelocity](/components/base/#setvelocity) | Set the linear velocity and angular velocity of the base. |
-| [Stop](/components/base/#stop) | Stop the base. |
-| [GetProperties](/components/base/#getproperties) | Get the width and turning radius of the base in meters. |
-| [DoCommand](/components/base/#docommand) | Send or receive model-specific commands. |
+{{< readfile "/static/include/components/apis/base.md" >}}
 
 ### Board
 
-The board component supports the following methods:
+The [board component](/components/board/) supports the following methods:
 
-| Method Name | Description |
-| ----------- | ----------- |
-| [AnalogReaderByName](/components/board/#analogreaderbyname) | Get an [`AnalogReader`](/components/board/#analogs) by `name`. |
-| [DigitalInterruptByName](/components/board/#digitalinterruptbyname) | Get a [`DigitalInterrupt`](/components/board/#digital_interrupts) by `name`. |
-| [GPIOPinByName](/components/board/#gpiopinbyname) | Get a `GPIOPin` by its {{< glossary_tooltip term_id="pin-number" text="pin number" >}}. |
-| [AnalogReaderNames](/components/board/#analogreadernames) | Get the `name` of every [`AnalogReader`](/components/board/#analogs). |
-| [DigitalInterruptNames](/components/board/#digitalinterruptnames) | Get the `name` of every [`DigitalInterrupt`](/components/board/#digital_interrupts). |
-| [Status](/components/board/#status) | Get the current status of this board. |
-| [ModelAttributes](/components/board/#modelattributes) | Get the attributes related to the model of this board. |
-| [SetPowerMode](/components/board/#setpowermode) | Set the board to the indicated power mode. |
+{{< readfile "/static/include/components/apis/board.md" >}}
 
 ### Camera
 
-| Method Name | Description |
-| ----------- | ----------- |
-| [GetImage](/components/camera/#getimage) | Return an image from the camera. |
-| [GetPointCloud](/components/camera/#getpointcloud) | Return a point cloud from the camera. |
-| [GetProperties](/components/camera/#getproperties) | Return the camera intrinsic and camera distortion parameters, as well as whether the camera supports returning point clouds. |
+The [camera component](/components/camera/) supports the following methods:
+
+{{< readfile "/static/include/components/apis/camera.md" >}}
 
 ### Encoder
 
-Method Name | Description
------------ | -----------
-[Position](/components/encoder/#position) | Get the current position of the encoder.
-[ResetPosition](/components/encoder/#resetposition) | Reset the position to zero.
-[GetProperties](/components/encoder/#getproperties) | Get the supported properties of this encoder.
+The [encoder component](/components/encoder/) supports the following methods:
+
+{{< readfile "/static/include/components/apis/encoder.md" >}}
 
 ### Gantry
+
+The [gantry component](/components/gantry/) supports the following methods:
 
 | Method Name | Description |
 | ----------- | ----------- |

--- a/docs/program/apis/_index.md
+++ b/docs/program/apis/_index.md
@@ -306,10 +306,9 @@ The [Navigation Service](/services/navigation/) supports the following methods:
 
 ### Sensors
 
-Method Name | Description
------------ | -----------
-[`Sensors`](/services/sensors/#sensors) | Returns a list of names of the available sensors.
-[`Readings`](/services/sensors/#readings) | Returns a list of readings from a given list of sensors.
+The [Sensors Service](/services/sensors/) supports the following methods:
+
+{{< readfile "/static/include/services/apis/sensors.md" >}}
 
 ### SLAM
 
@@ -327,35 +326,21 @@ Different [Vision Service](/services/vision/) models support different methods:
 
 ### GPIO Pins
 
-In addition to the [Board API](#board), the [board component](/components/board/) supports the following methods for interfacing with GPIO Pins on a board:
+In addition to the [board API](#board), the [board component](/components/board/) supports the following methods for interfacing with GPIO pins on a board:
 
-| Method Name | Description |
-| ----------- | ----------- |
-| [Set](/components/board/#set) | Set the output of this pin to high/low. |
-| [Get](/components/board/#get) | Get if this pin is active (high). |
-| [PWM](/components/board/#pwm) | Get the pin’s pulse-width modulation duty cycle. |
-| [SetPWM](/components/board/#pwmfreq) | Set the pin’s pulse-width modulation duty cycle. |
-| [PWMFreq](/components/board/#pwmfreq) | Get the pulse-width modulation frequency of this pin. |
-| [SetPWMFreq](/components/board/#setpwmfreq) | Set the pulse-width modulation frequency of this pin. |
+{{< readfile "/static/include/components/apis/gpiopin.md" >}}
 
 ### Analog-to-Digital Converters (ADCs)
 
-In addition to the [Board API](#board), the [board component](/components/board/) supports the following methods for interfacing with [ADCs](/components/board/#analogs) on a board:
+In addition to the [board API](#board), the [board component](/components/board/) supports the following methods for interfacing with [ADCs](/components/board/#analogs) on a board:
 
-| Method Name | Description |
-| ----------- | ----------- |
-| [Read](/components/board/#read) | Read the current integer value of the digital signal output by the ADC. |
+{{< readfile "/static/include/components/apis/analogreader.md" >}}
 
 ### Digital Interrupts
 
-In addition to the [Board API](#board), the [board component](/components/board/) supports the following methods for interfacing with [digital interrupts](/components/board/#digital_interrupts)  on a board:
+In addition to the [board API](#board), the [board component](/components/board/) supports the following methods for interfacing with [digital interrupts](/components/board/#digital_interrupts) on a board:
 
-| Method Name | Description |
-| ----------- | ----------- |
-| [Value](/components/board/#value) | Get the current value of this interrupt. |
-| [Tick](/components/board/#tick) | Record an interrupt. |
-| [AddCallback](/components/board/#addcallback) | Add a channel as a callback for [Tick()](/components/board/#tick). |
-| [AddPostProcessor](/components/board/#addpostprocessor) | Add a PostProcessor function for [Value()](/components/board/#value). |
+{{< readfile "/static/include/components/apis/digitalinterrupt.md" >}}
 
 ## Robot API
 

--- a/docs/program/apis/_index.md
+++ b/docs/program/apis/_index.md
@@ -197,18 +197,7 @@ Documentation on using these methods in your SDK code is found on each [componen
 
 ### Arm
 
-The arm component supports the following methods:
-
-| Method Name | Description |
-| ----------- | ----------- |
-| [GetEndPosition](/components/arm/#getendposition) | Get the current position of the arm as a Pose. |
-| [MoveToPosition](/components/arm/#movetoposition) | Move the end of the arm to the desired Pose. |
-| [MoveToJointPositions](/components/arm/#movetojointpositions) | Move each joint on the arm to the desired position. |
-| [JointPositions](/components/arm/#jointpositions) | Get the current position of each joint on the arm. |
-| [Stop](/components/arm/#stop) | Stop the arm from moving. |
-| [IsMoving](/components/arm/#ismoving) | Get if the arm is currently moving. |
-| [Kinematics](/components/arm/#kinematics) | Get the kinematics information associated with the arm. |
-| [DoCommand](/components/arm/#docommand) | Send or receive model-specific commands. |
+{{< readfile "/static/include/components/apis/arm.md" >}}
 
 ### Base
 

--- a/docs/program/apis/_index.md
+++ b/docs/program/apis/_index.md
@@ -276,28 +276,33 @@ Documentation on using these methods in your SDK code is found on [service pages
 
 ### Base Remote Control
 
-Method Name | Description
------------ | -----------
-[`Close`](/services/base-rc/#close) | Close out of all remote control related systems.
-[`ControllerInputs`](/services/base-rc/#controllerinputs) | Get a list of inputs from the controller that is being monitored for that control mode.
+The [Base Remote Control Service](/services/base-rc/) supports the following methods:
 
-### Data Manager
+{{< readfile "/static/include/services/apis/base-rc.md" >}}
 
-Method Name | Description
------------ | -----------
-[`Sync`](/services/data/#sync) | Sync data stored on the robot to the cloud.
+### Data Management
+
+The [Data Management Service](/services/data/) supports the following methods:
+
+{{< readfile "/static/include/services/apis/data.md" >}}
+
+### MLModel
+
+The [ML Model Service](/services/ml/) supports the following methods:
+
+{{< readfile "/static/include/services/apis/ml.md" >}}
+
+### Motion
+
+The [Motion Service](/services/motion/) supports the following methods:
+
+{{< readfile "/static/include/services/apis/motion.md" >}}
 
 ### Navigation
 
-Method Name | Description
------------ | -----------
-[`Mode`](/services/navigation/#mode) | Get the mode the service is operating in.
-[`SetMode`](/services/navigation/#setmode) | Set the mode the service is operating in.
-[`Location`](/services/navigation/#location) | Get the current location of the robot.
-[`Waypoints`](/services/navigation/#waypoints) | Get the waypoints currently in the service's data storage.
-[`AddWaypoint`](/services/navigation/#addwaypoint) | Add a waypoint to the service's data storage.
-[`RemoveWaypoint`](/services/navigation/#removewaypoint) | Remove a waypoint from the service's data storage.
-[`GetObstacles`](/services/navigation/#getobstacles) | Get the obstacles currently in the service's data storage.
+The [Navigation Service](/services/navigation/) supports the following methods:
+
+{{< readfile "/static/include/services/apis/navigation.md" >}}
 
 ### Sensors
 
@@ -306,41 +311,17 @@ Method Name | Description
 [`Sensors`](/services/sensors/#sensors) | Returns a list of names of the available sensors.
 [`Readings`](/services/sensors/#readings) | Returns a list of readings from a given list of sensors.
 
-### Motion
-
-Method Name | Description
------------ | -----------
-[`Move`](/services/motion/#move) | Move multiple components in a coordinated way to achieve a desired motion.
-[`MoveSingleComponent`](/services/motion/#movesinglecomponent) | Move a single component "manually."
-[`GetPose`](/services/motion/#getpose) | Get the current location and orientation of a component.
-[`MoveOnMap`](/services/motion/#moveonmap) | Move a [base](/components/base/) component to a `Pose` in respect to the origin of a [SLAM](/services/slam/) map.
-[`MoveOnGlobe`](/services/motion/#moveonglobe) | Move a [base](/components/base/) component to a destination GPS point. Use a [Movement Sensor](/components/movement-sensor/) to measure the robot's GPS coordinates.
-
 ### SLAM
 
-Method Name | Description
------------ | -----------
-[`GetPosition`](/services/slam/#getposition) | Get the current position of the specified source component in the point cloud SLAM map.
-[`GetPointCloudMap`](/services/slam/#getpointcloudmap) | Get the point cloud SLAM map.
-[`GetInternalState`](/services/slam/#getinternalstate) | Get the internal state of the SLAM algorithm required to continue mapping/localization.
-[`GetLatestMapInfo`](/services/slam/#getlatestmapinfo) | Get the timestamp of the last update to the point cloud SLAM map.
+The [SLAM Service](/services/slam/) supports the following methods:
 
-### MLModel
-
-Method Name | Description
------------ | -----------
-`Infer` | Take an already ordered input tensor as an array, make an inference on the model, and return an output tensor map.
-`Metadata`| Get the metadata (such as name, type, expected tensor/array shape, inputs, and outputs) associated with the ML model.
+{{< readfile "/static/include/services/apis/slam.md" >}}
 
 ### Vision
 
-Method Name | Description |
------------ | ----------- |
-`DetectionsFromCamera` | Get a list of detections in the next image given a camera and a detector. |
-`Detections`| Get a list of detections in the given image using the specified detector. |
-`ClassificationsFromCamera` | Get a list of classifications in the next image given a camera and a classifier. |
-`Classifications` | Get a list of detections in the given image using the specified detector. |
-`ObjectPointClouds`| Returns a list of the 3D point cloud objects and associated metadata in the latest picture obtained from the specified 3D camera (using the specified segmenter). |
+Different [Vision Service](/services/vision/) models support different methods:
+
+{{< readfile "/static/include/services/apis/vision.md" >}}
 
 ## Signaling APIs
 

--- a/docs/services/base-rc/_index.md
+++ b/docs/services/base-rc/_index.md
@@ -87,10 +87,7 @@ The following attributes are available for Base Remote Control services:
 
 The Base Remote Control Service supports the following methods:
 
-Method Name | Description
------------ | -----------
-[`Close`](#close) | Close out of all remote control related systems.
-[`ControllerInputs`](#controllerinputs) | Get a list of inputs from the controller that is being monitored for that control mode.
+{{< readfile "/static/include/services/apis/base-rc.md" >}}
 
 {{% alert title="Tip" color="tip" %}}
 

--- a/docs/services/data/_index.md
+++ b/docs/services/data/_index.md
@@ -98,9 +98,7 @@ Currently, Viam does not safeguard against this.
 
 The Data Management Service supports the following methods:
 
-Method Name | Description
------------ | -----------
-[`Sync`](#sync) | Sync data stored on the robot to the cloud.
+{{< readfile "/static/include/services/apis/data.md" >}}
 
 {{% alert title="Tip" color="tip" %}}
 

--- a/docs/services/motion/_index.md
+++ b/docs/services/motion/_index.md
@@ -39,13 +39,7 @@ Use the name `"builtin"` to access the built-in Motion Service in your code with
 
 The Motion Service supports the following methods:
 
-Method Name | Description
------------ | -----------
-[`Move`](#move) | Move multiple components in a coordinated way to achieve a desired motion.
-[`MoveSingleComponent`](#movesinglecomponent) | Move a single component "manually."
-[`GetPose`](#getpose) | Get the current location and orientation of a component as a `Pose`.
-[`MoveOnMap`](#moveonmap) | Move a [base](/components/base/) component to a `Pose` in respect to the origin of a [SLAM](/services/slam/) map.
-[`MoveOnGlobe`](#moveonglobe) | Move a [base](/components/base/) component to a destination GPS point. Use a [Movement Sensor](/components/movement-sensor/) to measure the robot's GPS coordinates.
+{{< readfile "/static/include/services/apis/motion.md" >}}
 
 {{% alert title="Tip" color="tip" %}}
 

--- a/docs/services/navigation/_index.md
+++ b/docs/services/navigation/_index.md
@@ -173,15 +173,7 @@ Then, to calibrate your frame system for the most accurate autonomous GPS naviga
 
 The Navigation Service supports the following methods:
 
-Method Name | Description
------------ | -----------
-[`Mode`](#mode) | Get the mode the service is operating in.
-[`SetMode`](#setmode) | Set the mode the service is operating in.
-[`Location`](#location) | Get the current location of the robot.
-[`Waypoints`](#waypoints) | Get the waypoints currently in the service's data storage.
-[`AddWaypoint`](#addwaypoint) | Add a waypoint to the service's data storage.
-[`RemoveWaypoint`](#removewaypoint) | Remove a waypoint from the service's data storage.
-[`GetObstacles`](#getobstacles) | Get the obstacles currently in the service's data storage.
+{{< readfile "/static/include/services/apis/navigation.md" >}}
 
 {{% alert title="Tip" color="tip" %}}
 

--- a/docs/services/sensors.md
+++ b/docs/services/sensors.md
@@ -17,10 +17,7 @@ With it you can obtain readings from multiple sensors on your robot at once.
 
 The Sensors Service supports the following methods:
 
-Method Name | Description
------------ | -----------
-[`Sensors`](#sensors) | Returns a list of names of the available sensors.
-[`Readings`](#readings) | Returns a list of readings from a given list of sensors.
+{{< readfile "/static/include/services/apis/sensors.md" >}}
 
 {{% alert title="Tip" color="tip" %}}
 
@@ -29,7 +26,7 @@ Go to your robot's **Code sample** tab on the [Viam app](https://app.viam.com) f
 
 {{% /alert %}}
 
-### Sensors
+### GetSensors
 
 Returns a list containing the `name` of each available sensor.
 
@@ -84,7 +81,7 @@ sensor_names, err := sensorsService.Sensors(context.Background(), nil)
 {{% /tab %}}
 {{< /tabs >}}
 
-### Readings
+### GetReadings
 
 Returns a list of sensor readings from a given list of sensors.
 

--- a/docs/services/slam/_index.md
+++ b/docs/services/slam/_index.md
@@ -37,12 +37,7 @@ Click the model name for configuration instructions.
 
 The SLAM Service supports the following methods:
 
-Method Name | Description
------------ | -----------
-[`GetPosition`](#getposition) | Get the current position of the specified source component in the point cloud SLAM map.
-[`GetPointCloudMap`](#getpointcloudmap) | Get the point cloud SLAM map.
-[`GetInternalState`](#getinternalstate) | Get the internal state of the SLAM algorithm required to continue mapping/localization.
-[`GetLatestMapInfo`](#getlatestmapinfo) | Get the timestamp of the last update to the point cloud SLAM map.
+{{< readfile "/static/include/services/apis/slam.md" >}}
 
 {{% alert title="Tip" color="tip" %}}
 

--- a/docs/services/vision/_index.md
+++ b/docs/services/vision/_index.md
@@ -26,13 +26,7 @@ Currently, the Vision Service supports the following models:
 
 Different Vision Service models support different methods:
 
-Method Name | Description | Models That Support This Method
------------ | ----------- | -------------------------------
-[`GetDetections`](#getdetections) | Get detections from an image. | [detectors](./detection/)
-[`GetDetectionsFromCamera`](#getdetectionsfromcamera) | Get detections from the next image from a camera. | [detectors](./detection/)
-[`GetClassifications`](#getclassifications) | Get classifications from an image. | [classifiers](./classification/)
-[`GetClassificationsFromCamera`](#getclassificationsfromcamera) | Get classifications from the next image from a camera. | [classifiers](./classification/)
-[`GetObjectPointClouds`](#getobjectpointclouds) | Get a list of point cloud objects from a 3D camera. | [segmenters](./segmentation/)
+{{< readfile "/static/include/services/apis/vision.md" >}}
 
 {{% alert title="Tip" color="tip" %}}
 

--- a/static/include/components/apis/analogreader.md
+++ b/static/include/components/apis/analogreader.md
@@ -1,3 +1,3 @@
 Method Name | Description
 ----------- | -----------
-[Read](/components/board/#read) | Read the current integer value of the digital signal output by the ADC.
+[`Read`](/components/board/#read) | Read the current integer value of the digital signal output by the ADC.

--- a/static/include/components/apis/analogreader.md
+++ b/static/include/components/apis/analogreader.md
@@ -1,0 +1,3 @@
+Method Name | Description
+----------- | -----------
+[Read](/components/board/#read) | Read the current integer value of the digital signal output by the ADC.

--- a/static/include/components/apis/arm.md
+++ b/static/include/components/apis/arm.md
@@ -1,10 +1,10 @@
-| Method Name | Description |
-| ----------- | ----------- |
-| [GetEndPosition](/components/arm/#getendposition) | Get the current position of the arm as a Pose. |
-| [MoveToPosition](/components/arm/#movetoposition) | Move the end of the arm to the desired Pose. |
-| [MoveToJointPositions](/components/arm/#movetojointpositions) | Move each joint on the arm to the desired position. |
-| [JointPositions](/components/arm/#jointpositions) | Get the current position of each joint on the arm. |
-| [Stop](/components/arm/#stop) | Stop the arm from moving. |
-| [IsMoving](/components/arm/#ismoving) | Get if the arm is currently moving. |
-| [Kinematics](/components/arm/#kinematics) | Get the kinematics information associated with the arm. |
-| [DoCommand](/components/arm/#docommand) | Send or receive model-specific commands. |
+Method Name | Description
+----------- | -----------
+[GetEndPosition](/components/arm/#getendposition) | Get the current position of the arm as a Pose.
+[MoveToPosition](/components/arm/#movetoposition) | Move the end of the arm to the desired Pose.
+[MoveToJointPositions](/components/arm/#movetojointpositions) | Move each joint on the arm to the desired position.
+[JointPositions](/components/arm/#jointpositions) | Get the current position of each joint on the arm.
+[Stop](/components/arm/#stop) | Stop the arm from moving.
+[IsMoving](/components/arm/#ismoving) | Get if the arm is currently moving.
+[Kinematics](/components/arm/#kinematics) | Get the kinematics information associated with the arm.
+[DoCommand](/components/arm/#docommand) | Send or receive model-specific commands.

--- a/static/include/components/apis/arm.md
+++ b/static/include/components/apis/arm.md
@@ -1,20 +1,10 @@
-
-The arm component supports the following methods:
-
 | Method Name | Description |
 | ----------- | ----------- |
-| [GetEndPosition](#getendposition) | Get the current position of the arm as a Pose. |
-| [MoveToPosition](#movetoposition) | Move the end of the arm to the desired Pose. |
-| [MoveToJointPositions](#movetojointpositions) | Move each joint on the arm to the desired position. |
-| [JointPositions](#jointpositions) | Get the current position of each joint on the arm. |
-| [Stop](#stop) | Stop the arm from moving. |
-| [IsMoving](#ismoving) | Get if the arm is currently moving. |
-| [Kinematics](#kinematics) | Get the kinematics information associated with the arm. |
-| [DoCommand](#docommand) | Send or receive model-specific commands. |
-
-{{% alert title="Note" color="note" %}}
-Test note.
-Line 2.
-{{% /alert %}}
-
-<code>testing html tags</code>
+| [GetEndPosition](/components/arm/#getendposition) | Get the current position of the arm as a Pose. |
+| [MoveToPosition](/components/arm/#movetoposition) | Move the end of the arm to the desired Pose. |
+| [MoveToJointPositions](/components/arm/#movetojointpositions) | Move each joint on the arm to the desired position. |
+| [JointPositions](/components/arm/#jointpositions) | Get the current position of each joint on the arm. |
+| [Stop](/components/arm/#stop) | Stop the arm from moving. |
+| [IsMoving](/components/arm/#ismoving) | Get if the arm is currently moving. |
+| [Kinematics](/components/arm/#kinematics) | Get the kinematics information associated with the arm. |
+| [DoCommand](/components/arm/#docommand) | Send or receive model-specific commands. |

--- a/static/include/components/apis/arm.md
+++ b/static/include/components/apis/arm.md
@@ -1,0 +1,20 @@
+
+The arm component supports the following methods:
+
+| Method Name | Description |
+| ----------- | ----------- |
+| [GetEndPosition](#getendposition) | Get the current position of the arm as a Pose. |
+| [MoveToPosition](#movetoposition) | Move the end of the arm to the desired Pose. |
+| [MoveToJointPositions](#movetojointpositions) | Move each joint on the arm to the desired position. |
+| [JointPositions](#jointpositions) | Get the current position of each joint on the arm. |
+| [Stop](#stop) | Stop the arm from moving. |
+| [IsMoving](#ismoving) | Get if the arm is currently moving. |
+| [Kinematics](#kinematics) | Get the kinematics information associated with the arm. |
+| [DoCommand](#docommand) | Send or receive model-specific commands. |
+
+{{% alert title="Note" color="note" %}}
+Test note.
+Line 2.
+{{% /alert %}}
+
+<code>testing html tags</code>

--- a/static/include/components/apis/arm.md
+++ b/static/include/components/apis/arm.md
@@ -1,10 +1,10 @@
 Method Name | Description
 ----------- | -----------
-[GetEndPosition](/components/arm/#getendposition) | Get the current position of the arm as a Pose.
-[MoveToPosition](/components/arm/#movetoposition) | Move the end of the arm to the desired Pose.
-[MoveToJointPositions](/components/arm/#movetojointpositions) | Move each joint on the arm to the desired position.
-[JointPositions](/components/arm/#jointpositions) | Get the current position of each joint on the arm.
-[Stop](/components/arm/#stop) | Stop the arm from moving.
-[IsMoving](/components/arm/#ismoving) | Get if the arm is currently moving.
-[Kinematics](/components/arm/#kinematics) | Get the kinematics information associated with the arm.
-[DoCommand](/components/arm/#docommand) | Send or receive model-specific commands.
+[`GetEndPosition`](/components/arm/#getendposition) | Get the current position of the arm as a Pose.
+[`MoveToPosition`](/components/arm/#movetoposition) | Move the end of the arm to the desired Pose.
+[`MoveToJointPositions`](/components/arm/#movetojointpositions) | Move each joint on the arm to the desired position.
+[`JointPositions`](/components/arm/#jointpositions) | Get the current position of each joint on the arm.
+[`Stop`](/components/arm/#stop) | Stop the arm from moving.
+[`IsMoving`](/components/arm/#ismoving) | Get if the arm is currently moving.
+[`Kinematics`](/components/arm/#kinematics) | Get the kinematics information associated with the arm.
+[`DoCommand`](/components/arm/#docommand) | Send or receive model-specific commands.

--- a/static/include/components/apis/base.md
+++ b/static/include/components/apis/base.md
@@ -1,9 +1,9 @@
-| Method Name | Description |
-| ----------- | ----------- |
-| [MoveStraight](/components/base/#movestraight)  | Move the base in a straight line across the given distance at the given velocity. |
-| [Spin](/components/base/#spin) | Move the base to the given angle at the given angular velocity. |
-| [SetPower](/components/base/#setpower) | Set the relative power (out of max power) for linear and angular propulsion of the base. |
-| [SetVelocity](/components/base/#setvelocity) | Set the linear velocity and angular velocity of the base. |
-| [Stop](/components/base/#stop) | Stop the base. |
-| [GetProperties](/components/base/#getproperties) | Get the width and turning radius of the base in meters. |
-| [DoCommand](/components/base/#docommand) | Send or receive model-specific commands. |
+Method Name | Description
+----------- | -----------
+[MoveStraight](/components/base/#movestraight)  | Move the base in a straight line across the given distance at the given velocity.
+[Spin](/components/base/#spin) | Move the base to the given angle at the given angular velocity.
+[SetPower](/components/base/#setpower) | Set the relative power (out of max power) for linear and angular propulsion of the base.
+[SetVelocity](/components/base/#setvelocity) | Set the linear velocity and angular velocity of the base.
+[Stop](/components/base/#stop) | Stop the base.
+[GetProperties](/components/base/#getproperties) | Get the width and turning radius of the base in meters.
+[DoCommand](/components/base/#docommand) | Send or receive model-specific commands.

--- a/static/include/components/apis/base.md
+++ b/static/include/components/apis/base.md
@@ -1,9 +1,9 @@
 Method Name | Description
 ----------- | -----------
-[MoveStraight](/components/base/#movestraight)  | Move the base in a straight line across the given distance at the given velocity.
-[Spin](/components/base/#spin) | Move the base to the given angle at the given angular velocity.
-[SetPower](/components/base/#setpower) | Set the relative power (out of max power) for linear and angular propulsion of the base.
-[SetVelocity](/components/base/#setvelocity) | Set the linear velocity and angular velocity of the base.
-[Stop](/components/base/#stop) | Stop the base.
-[GetProperties](/components/base/#getproperties) | Get the width and turning radius of the base in meters.
-[DoCommand](/components/base/#docommand) | Send or receive model-specific commands.
+[`MoveStraight`](/components/base/#movestraight)  | Move the base in a straight line across the given distance at the given velocity.
+[`Spin`](/components/base/#spin) | Move the base to the given angle at the given angular velocity.
+[`SetPower`](/components/base/#setpower) | Set the relative power (out of max power) for linear and angular propulsion of the base.
+[`SetVelocity`](/components/base/#setvelocity) | Set the linear velocity and angular velocity of the base.
+[`Stop`](/components/base/#stop) | Stop the base.
+[`GetProperties`](/components/base/#getproperties) | Get the width and turning radius of the base in meters.
+[`DoCommand`](/components/base/#docommand) | Send or receive model-specific commands.

--- a/static/include/components/apis/base.md
+++ b/static/include/components/apis/base.md
@@ -1,0 +1,9 @@
+| Method Name | Description |
+| ----------- | ----------- |
+| [MoveStraight](/components/base/#movestraight)  | Move the base in a straight line across the given distance at the given velocity. |
+| [Spin](/components/base/#spin) | Move the base to the given angle at the given angular velocity. |
+| [SetPower](/components/base/#setpower) | Set the relative power (out of max power) for linear and angular propulsion of the base. |
+| [SetVelocity](/components/base/#setvelocity) | Set the linear velocity and angular velocity of the base. |
+| [Stop](/components/base/#stop) | Stop the base. |
+| [GetProperties](/components/base/#getproperties) | Get the width and turning radius of the base in meters. |
+| [DoCommand](/components/base/#docommand) | Send or receive model-specific commands. |

--- a/static/include/components/apis/board.md
+++ b/static/include/components/apis/board.md
@@ -1,10 +1,10 @@
-| Method Name | Description |
-| ----------- | ----------- |
-| [AnalogReaderByName](/components/board/#analogreaderbyname) | Get an [`AnalogReader`](/components/board/#analogs) by `name`. |
-| [DigitalInterruptByName](/components/board/#digitalinterruptbyname) | Get a [`DigitalInterrupt`](/components/board/#digital_interrupts) by `name`. |
-| [GPIOPinByName](/components/board/#gpiopinbyname) | Get a `GPIOPin` by its {{< glossary_tooltip term_id="pin-number" text="pin number" >}}. |
-| [AnalogReaderNames](/components/board/#analogreadernames) | Get the `name` of every [`AnalogReader`](/components/board/#analogs). |
-| [DigitalInterruptNames](/components/board/#digitalinterruptnames) | Get the `name` of every [`DigitalInterrupt`](/components/board/#digital_interrupts). |
-| [Status](/components/board/#status) | Get the current status of this board. |
-| [ModelAttributes](/components/board/#modelattributes) | Get the attributes related to the model of this board. |
-| [SetPowerMode](/components/board/#setpowermode) | Set the board to the indicated power mode. |
+Method Name | Description
+----------- | -----------
+[AnalogReaderByName](/components/board/#analogreaderbyname) | Get an [`AnalogReader`](/components/board/#analogs) by `name`.
+[DigitalInterruptByName](/components/board/#digitalinterruptbyname) | Get a [`DigitalInterrupt`](/components/board/#digital_interrupts) by `name`.
+[GPIOPinByName](/components/board/#gpiopinbyname) | Get a `GPIOPin` by its {{< glossary_tooltip term_id="pin-number" text="pin number" >}}.
+[AnalogReaderNames](/components/board/#analogreadernames) | Get the `name` of every [`AnalogReader`](/components/board/#analogs).
+[DigitalInterruptNames](/components/board/#digitalinterruptnames) | Get the `name` of every [`DigitalInterrupt`](/components/board/#digital_interrupts).
+[Status](/components/board/#status) | Get the current status of this board.
+[ModelAttributes](/components/board/#modelattributes) | Get the attributes related to the model of this board.
+[SetPowerMode](/components/board/#setpowermode) | Set the board to the indicated power mode.

--- a/static/include/components/apis/board.md
+++ b/static/include/components/apis/board.md
@@ -1,0 +1,10 @@
+| Method Name | Description |
+| ----------- | ----------- |
+| [AnalogReaderByName](/components/board/#analogreaderbyname) | Get an [`AnalogReader`](/components/board/#analogs) by `name`. |
+| [DigitalInterruptByName](/components/board/#digitalinterruptbyname) | Get a [`DigitalInterrupt`](/components/board/#digital_interrupts) by `name`. |
+| [GPIOPinByName](/components/board/#gpiopinbyname) | Get a `GPIOPin` by its {{< glossary_tooltip term_id="pin-number" text="pin number" >}}. |
+| [AnalogReaderNames](/components/board/#analogreadernames) | Get the `name` of every [`AnalogReader`](/components/board/#analogs). |
+| [DigitalInterruptNames](/components/board/#digitalinterruptnames) | Get the `name` of every [`DigitalInterrupt`](/components/board/#digital_interrupts). |
+| [Status](/components/board/#status) | Get the current status of this board. |
+| [ModelAttributes](/components/board/#modelattributes) | Get the attributes related to the model of this board. |
+| [SetPowerMode](/components/board/#setpowermode) | Set the board to the indicated power mode. |

--- a/static/include/components/apis/board.md
+++ b/static/include/components/apis/board.md
@@ -1,10 +1,10 @@
 Method Name | Description
 ----------- | -----------
-[AnalogReaderByName](/components/board/#analogreaderbyname) | Get an [`AnalogReader`](/components/board/#analogs) by `name`.
-[DigitalInterruptByName](/components/board/#digitalinterruptbyname) | Get a [`DigitalInterrupt`](/components/board/#digital_interrupts) by `name`.
-[GPIOPinByName](/components/board/#gpiopinbyname) | Get a `GPIOPin` by its {{< glossary_tooltip term_id="pin-number" text="pin number" >}}.
-[AnalogReaderNames](/components/board/#analogreadernames) | Get the `name` of every [`AnalogReader`](/components/board/#analogs).
-[DigitalInterruptNames](/components/board/#digitalinterruptnames) | Get the `name` of every [`DigitalInterrupt`](/components/board/#digital_interrupts).
-[Status](/components/board/#status) | Get the current status of this board.
-[ModelAttributes](/components/board/#modelattributes) | Get the attributes related to the model of this board.
-[SetPowerMode](/components/board/#setpowermode) | Set the board to the indicated power mode.
+[`AnalogReaderByName`](/components/board/#analogreaderbyname) | Get an [`AnalogReader`](/components/board/#analogs) by `name`.
+[`DigitalInterruptByName`](/components/board/#digitalinterruptbyname) | Get a [`DigitalInterrupt`](/components/board/#digital_interrupts) by `name`.
+[`GPIOPinByName`](/components/board/#gpiopinbyname) | Get a `GPIOPin` by its {{< glossary_tooltip term_id="pin-number" text="pin number" >}}.
+[`AnalogReaderNames`](/components/board/#analogreadernames) | Get the `name` of every [`AnalogReader`](/components/board/#analogs).
+[`DigitalInterruptNames`](/components/board/#digitalinterruptnames) | Get the `name` of every [`DigitalInterrupt`](/components/board/#digital_interrupts).
+[`Status`](/components/board/#status) | Get the current status of this board.
+[`ModelAttributes`](/components/board/#modelattributes) | Get the attributes related to the model of this board.
+[`SetPowerMode`](/components/board/#setpowermode) | Set the board to the indicated power mode.

--- a/static/include/components/apis/camera.md
+++ b/static/include/components/apis/camera.md
@@ -1,0 +1,6 @@
+| Method Name | Description |
+| ----------- | ----------- |
+| [GetImage](/components/camera/#getimage) | Return an image from the camera. |
+| [GetPointCloud](/components/camera/#getpointcloud) | Return a point cloud from the camera. |
+| [GetProperties](/components/camera/#getproperties) | Return the camera intrinsic and camera distortion parameters, as well as whether the camera supports returning point clouds. |
+| [DoCommand](/components/camera/#docommand) | Send or receive model-specific commands. |

--- a/static/include/components/apis/camera.md
+++ b/static/include/components/apis/camera.md
@@ -1,6 +1,6 @@
 Method Name | Description
 ----------- | -----------
-[GetImage](/components/camera/#getimage) | Return an image from the camera.
-[GetPointCloud](/components/camera/#getpointcloud) | Return a point cloud from the camera.
-[GetProperties](/components/camera/#getproperties) | Return the camera intrinsic and camera distortion parameters, as well as whether the camera supports returning point clouds.
-[DoCommand](/components/camera/#docommand) | Send or receive model-specific commands.
+[`GetImage`](/components/camera/#getimage) | Return an image from the camera.
+[`GetPointCloud`](/components/camera/#getpointcloud) | Return a point cloud from the camera.
+[`GetProperties`](/components/camera/#getproperties) | Return the camera intrinsic and camera distortion parameters, as well as whether the camera supports returning point clouds.
+[`DoCommand`](/components/camera/#docommand) | Send or receive model-specific commands.

--- a/static/include/components/apis/camera.md
+++ b/static/include/components/apis/camera.md
@@ -1,6 +1,6 @@
-| Method Name | Description |
-| ----------- | ----------- |
-| [GetImage](/components/camera/#getimage) | Return an image from the camera. |
-| [GetPointCloud](/components/camera/#getpointcloud) | Return a point cloud from the camera. |
-| [GetProperties](/components/camera/#getproperties) | Return the camera intrinsic and camera distortion parameters, as well as whether the camera supports returning point clouds. |
-| [DoCommand](/components/camera/#docommand) | Send or receive model-specific commands. |
+Method Name | Description
+----------- | -----------
+[GetImage](/components/camera/#getimage) | Return an image from the camera.
+[GetPointCloud](/components/camera/#getpointcloud) | Return a point cloud from the camera.
+[GetProperties](/components/camera/#getproperties) | Return the camera intrinsic and camera distortion parameters, as well as whether the camera supports returning point clouds.
+[DoCommand](/components/camera/#docommand) | Send or receive model-specific commands.

--- a/static/include/components/apis/component.md
+++ b/static/include/components/apis/component.md
@@ -1,5 +1,5 @@
 Method Name | Description
 ----------- | -----------
-[GetReadings](#getreadings) | Do the thing the method does.
-[MethodName2](#methodname2) | Do the thing this method does.
-[DoCommand](/components/encoder/#docommand) | Send or receive model-specific commands.
+[`GetReadings`](#getreadings) | Do the thing the method does.
+[`MethodName2`](#methodname2) | Do the thing this method does.
+[`DoCommand`](/components/encoder/#docommand) | Send or receive model-specific commands.

--- a/static/include/components/apis/component.md
+++ b/static/include/components/apis/component.md
@@ -1,0 +1,5 @@
+Method Name | Description
+----------- | -----------
+[GetReadings](#getreadings) | Do the thing the method does.
+[MethodName2](#methodname2) | Do the thing this method does.
+[DoCommand](/components/encoder/#docommand) | Send or receive model-specific commands.

--- a/static/include/components/apis/digitalinterrupt.md
+++ b/static/include/components/apis/digitalinterrupt.md
@@ -1,6 +1,6 @@
 Method Name | Description
 ----------- | -----------
-[Value](/components/board/#value) | Get the current value of this interrupt.
-[Tick](/components/board/#tick) | Record an interrupt.
-[AddCallback](/components/board/#addcallback) | Add a channel as a callback for [Tick()](/components/board/#tick).
-[AddPostProcessor](/components/board/#addpostprocessor) | Add a PostProcessor function for [Value()](/components/board/#value).
+[`Value`](/components/board/#value) | Get the current value of this interrupt.
+[`Tick`](/components/board/#tick) | Record an interrupt.
+[`AddCallback`](/components/board/#addcallback) | Add a channel as a callback for [Tick()](/components/board/#tick).
+[`AddPostProcessor`](/components/board/#addpostprocessor) | Add a PostProcessor function for [Value()](/components/board/#value).

--- a/static/include/components/apis/digitalinterrupt.md
+++ b/static/include/components/apis/digitalinterrupt.md
@@ -1,0 +1,6 @@
+Method Name | Description
+----------- | -----------
+[Value](/components/board/#value) | Get the current value of this interrupt.
+[Tick](/components/board/#tick) | Record an interrupt.
+[AddCallback](/components/board/#addcallback) | Add a channel as a callback for [Tick()](/components/board/#tick).
+[AddPostProcessor](/components/board/#addpostprocessor) | Add a PostProcessor function for [Value()](/components/board/#value).

--- a/static/include/components/apis/encoder.md
+++ b/static/include/components/apis/encoder.md
@@ -1,6 +1,6 @@
 Method Name | Description
 ----------- | -----------
-[Position](/components/encoder/#position) | Get the current position of the encoder.
-[ResetPosition](/components/encoder/#resetposition) | Reset the position to zero.
-[GetProperties](/components/encoder/#getproperties) | Get the supported properties of this encoder.
-[DoCommand](/components/encoder/#docommand) | Send or receive model-specific commands.
+[`Position`](/components/encoder/#position) | Get the current position of the encoder.
+[`ResetPosition`](/components/encoder/#resetposition) | Reset the position to zero.
+[`GetProperties`](/components/encoder/#getproperties) | Get the supported properties of this encoder.
+[`DoCommand`](/components/encoder/#docommand) | Send or receive model-specific commands.

--- a/static/include/components/apis/encoder.md
+++ b/static/include/components/apis/encoder.md
@@ -1,0 +1,6 @@
+Method Name | Description
+----------- | -----------
+[Position](/components/encoder/#position) | Get the current position of the encoder.
+[ResetPosition](/components/encoder/#resetposition) | Reset the position to zero.
+[GetProperties](/components/encoder/#getproperties) | Get the supported properties of this encoder.
+[DoCommand](/components/encoder/#docommand) | Send or receive model-specific commands.

--- a/static/include/components/apis/gantry.md
+++ b/static/include/components/apis/gantry.md
@@ -1,8 +1,8 @@
 Method Name | Description
 ----------- | -----------
-[Position](/components/gantry/#position) | Get the current positions of the axes of the gantry in mm.
-[MoveToPosition](/components/gantry/#movetoposition) | Move the axes of the gantry to the desired positions.
-[Lengths](/components/gantry/#lengths) | Get the lengths of the axes of the gantry in mm.
-[Stop](/components/gantry/#stop) | Stop the gantry from moving.
-[IsMoving](/components/gantry/#ismoving) | Get if the gantry is currently moving.
-[DoCommand](/components/gantry/#docommand) | Send or receive model-specific commands.
+[`Position`](/components/gantry/#position) | Get the current positions of the axes of the gantry in mm.
+[`MoveToPosition`](/components/gantry/#movetoposition) | Move the axes of the gantry to the desired positions.
+[`Lengths`](/components/gantry/#lengths) | Get the lengths of the axes of the gantry in mm.
+[`Stop`](/components/gantry/#stop) | Stop the gantry from moving.
+[`IsMoving`](/components/gantry/#ismoving) | Get if the gantry is currently moving.
+[`DoCommand`](/components/gantry/#docommand) | Send or receive model-specific commands.

--- a/static/include/components/apis/gantry.md
+++ b/static/include/components/apis/gantry.md
@@ -1,0 +1,8 @@
+Method Name | Description
+----------- | -----------
+[Position](/components/gantry/#position) | Get the current positions of the axes of the gantry in mm.
+[MoveToPosition](/components/gantry/#movetoposition) | Move the axes of the gantry to the desired positions.
+[Lengths](/components/gantry/#lengths) | Get the lengths of the axes of the gantry in mm.
+[Stop](/components/gantry/#stop) | Stop the gantry from moving.
+[IsMoving](/components/gantry/#ismoving) | Get if the gantry is currently moving.
+[DoCommand](/components/gantry/#docommand) | Send or receive model-specific commands.

--- a/static/include/components/apis/gpiopin.md
+++ b/static/include/components/apis/gpiopin.md
@@ -1,8 +1,8 @@
 Method Name | Description
 ----------- | -----------
-[Set](/components/board/#set) | Set the output of this pin to high/low.
-[Get](/components/board/#get) | Get if this pin is active (high).
-[PWM](/components/board/#pwm) | Get the pin’s pulse-width modulation duty cycle.
-[SetPWM](/components/board/#pwmfreq) | Set the pin’s pulse-width modulation duty cycle.
-[PWMFreq](/components/board/#pwmfreq) | Get the pulse-width modulation frequency of this pin.
-[SetPWMFreq](/components/board/#setpwmfreq) | Set the pulse-width modulation frequency of this pin.
+[`Set`](/components/board/#set) | Set the output of this pin to high/low.
+[`Get`](/components/board/#get) | Get if this pin is active (high).
+[`PWM`](/components/board/#pwm) | Get the pin’s pulse-width modulation duty cycle.
+[`SetPWM`](/components/board/#pwmfreq) | Set the pin’s pulse-width modulation duty cycle.
+[`PWMFreq`](/components/board/#pwmfreq) | Get the pulse-width modulation frequency of this pin.
+[`SetPWMFreq`](/components/board/#setpwmfreq) | Set the pulse-width modulation frequency of this pin.

--- a/static/include/components/apis/gpiopin.md
+++ b/static/include/components/apis/gpiopin.md
@@ -1,0 +1,8 @@
+Method Name | Description
+----------- | -----------
+[Set](/components/board/#set) | Set the output of this pin to high/low.
+[Get](/components/board/#get) | Get if this pin is active (high).
+[PWM](/components/board/#pwm) | Get the pin’s pulse-width modulation duty cycle.
+[SetPWM](/components/board/#pwmfreq) | Set the pin’s pulse-width modulation duty cycle.
+[PWMFreq](/components/board/#pwmfreq) | Get the pulse-width modulation frequency of this pin.
+[SetPWMFreq](/components/board/#setpwmfreq) | Set the pulse-width modulation frequency of this pin.

--- a/static/include/components/apis/gripper.md
+++ b/static/include/components/apis/gripper.md
@@ -1,0 +1,7 @@
+Method Name | Description
+----------- | -----------
+[`Open`](/components/gripper/#open) | Open the gripper.
+[`Grab`](/components/gripper/#grab) | Close the gripper until it grabs something or closes completely.
+[`Stop`](/components/gripper/#stop) | Stop the gripper's movement.
+[`IsMoving`](/components/gripper/#ismoving) | Report whether the gripper is currently moving.
+[DoCommand](/components/gripper/#docommand) | Send or receive model-specific commands.

--- a/static/include/components/apis/input-controller.md
+++ b/static/include/components/apis/input-controller.md
@@ -1,6 +1,6 @@
 Method Name | Description
 ----------- | -----------
-[Controls](/components/input-controller/#controls) | Get a list of input `Controls` that this Controller provides.
-[Events](/components/input-controller/#events) | Get the current state of the Controller as a map of the most recent [Event](/components/input-controller/#event-object) for each [Control](/components/input-controller/#control-field).
-[RegisterControlCallback](/components/input-controller/#registercontrolcallback) | Define a callback function to execute whenever one of the [`EventTypes`](/components/input-controller/#eventtype-field) selected occurs on the given [Control](/components/input-controller/#control-field).
-[DoCommand](/components/input-controller/#docommand) | Send or receive model-specific commands.
+[`Controls`](/components/input-controller/#controls) | Get a list of input `Controls` that this Controller provides.
+[`Events`](/components/input-controller/#events) | Get the current state of the Controller as a map of the most recent [Event](/components/input-controller/#event-object) for each [Control](/components/input-controller/#control-field).
+[`RegisterControlCallback`](/components/input-controller/#registercontrolcallback) | Define a callback function to execute whenever one of the [`EventTypes`](/components/input-controller/#eventtype-field) selected occurs on the given [Control](/components/input-controller/#control-field).
+[`DoCommand`](/components/input-controller/#docommand) | Send or receive model-specific commands.

--- a/static/include/components/apis/input-controller.md
+++ b/static/include/components/apis/input-controller.md
@@ -1,0 +1,6 @@
+Method Name | Description
+----------- | -----------
+[Controls](/components/input-controller/#controls) | Get a list of input `Controls` that this Controller provides.
+[Events](/components/input-controller/#events) | Get the current state of the Controller as a map of the most recent [Event](/components/input-controller/#event-object) for each [Control](/components/input-controller/#control-field).
+[RegisterControlCallback](/components/input-controller/#registercontrolcallback) | Define a callback function to execute whenever one of the [`EventTypes`](/components/input-controller/#eventtype-field) selected occurs on the given [Control](/components/input-controller/#control-field).
+[DoCommand](/components/input-controller/#docommand) | Send or receive model-specific commands.

--- a/static/include/components/apis/motor.md
+++ b/static/include/components/apis/motor.md
@@ -1,0 +1,12 @@
+Method Name | Description
+----------- | -----------
+[SetPower](/components/motor/#setpower) | Set the power to send to the motor as a portion of max power.
+[GoFor](/components/motor/#gofor) | Spin the motor the specified number of revolutions at specified RPM.
+[GoTo](/components/motor/#goto) | Send the motor to a specified position (in terms of revolutions from home) at a specified speed.
+[ResetZeroPosition](/components/motor/#resetzeroposition) | Set the current position to be the new zero (home) position.
+[GetPosition](/components/motor/#getposition) | Report the position of the motor based on its encoder. Not supported on all motors.
+[GetProperties](/components/motor/#getproperties) | Return whether or not the motor supports certain optional features.
+[Stop](/components/motor/#stop) | Cut power to the motor off immediately, without any gradual step down.
+[IsPowered](/components/motor/#ispowered) | Return whether or not the motor is currently on, and the amount of power to it.
+[IsMoving](/components/motor/#ismoving) | Return whether the motor is moving or not.
+[DoCommand](/components/motor/#docommand) | Send or receive model-specific commands.

--- a/static/include/components/apis/motor.md
+++ b/static/include/components/apis/motor.md
@@ -1,12 +1,12 @@
 Method Name | Description
 ----------- | -----------
-[SetPower](/components/motor/#setpower) | Set the power to send to the motor as a portion of max power.
-[GoFor](/components/motor/#gofor) | Spin the motor the specified number of revolutions at specified RPM.
-[GoTo](/components/motor/#goto) | Send the motor to a specified position (in terms of revolutions from home) at a specified speed.
-[ResetZeroPosition](/components/motor/#resetzeroposition) | Set the current position to be the new zero (home) position.
-[GetPosition](/components/motor/#getposition) | Report the position of the motor based on its encoder. Not supported on all motors.
-[GetProperties](/components/motor/#getproperties) | Return whether or not the motor supports certain optional features.
-[Stop](/components/motor/#stop) | Cut power to the motor off immediately, without any gradual step down.
-[IsPowered](/components/motor/#ispowered) | Return whether or not the motor is currently on, and the amount of power to it.
-[IsMoving](/components/motor/#ismoving) | Return whether the motor is moving or not.
-[DoCommand](/components/motor/#docommand) | Send or receive model-specific commands.
+[`SetPower`](/components/motor/#setpower) | Set the power to send to the motor as a portion of max power.
+[`GoFor`](/components/motor/#gofor) | Spin the motor the specified number of revolutions at specified RPM.
+[`GoTo`](/components/motor/#goto) | Send the motor to a specified position (in terms of revolutions from home) at a specified speed.
+[`ResetZeroPosition`](/components/motor/#resetzeroposition) | Set the current position to be the new zero (home) position.
+[`GetPosition`](/components/motor/#getposition) | Report the position of the motor based on its encoder. Not supported on all motors.
+[`GetProperties`](/components/motor/#getproperties) | Return whether or not the motor supports certain optional features.
+[`Stop`](/components/motor/#stop) | Cut power to the motor off immediately, without any gradual step down.
+[`IsPowered`](/components/motor/#ispowered) | Return whether or not the motor is currently on, and the amount of power to it.
+[`IsMoving`](/components/motor/#ismoving) | Return whether the motor is moving or not.
+[`DoCommand`](/components/motor/#docommand) | Send or receive model-specific commands.

--- a/static/include/components/apis/movement-sensor.md
+++ b/static/include/components/apis/movement-sensor.md
@@ -1,12 +1,12 @@
 Method Name | Description | Models That Support This Method
 ----------- | ----------- | -------------------------------
-[GetPosition](/components/movement-sensor/#getposition) | Get the current latitude, longitude and altitude. | GPS models
-[GetLinearVelocity](/components/movement-sensor/#getlinearvelocity) | Get the current linear velocity as a 3D vector. | GPS models
-[GetAngularVelocity](/components/movement-sensor/#getangularvelocity) | Get the current angular velocity as a 3D vector. | IMU models and `gyro-mpu6050`
-[GetLinearAcceleration](/components/movement-sensor/#getlinearacceleration) | Get the current linear acceleration as a 3D vector. | IMU models,  `accel-adxl345`, and `gyro-mpu6050`
-[GetCompassHeading](/components/movement-sensor/#getcompassheading) | Get the current compass heading in degrees. | GPS models and `imu-vectornav`
-[GetOrientation](/components/movement-sensor/#getorientation) | Get the current orientation. | IMU models
-[GetProperties](/components/movement-sensor/#getproperties) | Get the supported properties of this sensor. | all models
-[GetAccuracy](/components/movement-sensor/#getaccuracy) | Get the accuracy of the various sensors. | GPS models
-[GetReadings](/components/movement-sensor/#getreadings) | Obtain the measurements/data specific to this sensor. | all models
-[DoCommand](/components/movement-sensor/#docommand) | Send or receive model-specific commands. | all models
+[`GetPosition`](/components/movement-sensor/#getposition) | Get the current latitude, longitude and altitude. | GPS models
+[`GetLinearVelocity`](/components/movement-sensor/#getlinearvelocity) | Get the current linear velocity as a 3D vector. | GPS models
+[`GetAngularVelocity`](/components/movement-sensor/#getangularvelocity) | Get the current angular velocity as a 3D vector. | IMU models and `gyro-mpu6050`
+[`GetLinearAcceleration`](/components/movement-sensor/#getlinearacceleration) | Get the current linear acceleration as a 3D vector. | IMU models,  `accel-adxl345`, and `gyro-mpu6050`
+[`GetCompassHeading`](/components/movement-sensor/#getcompassheading) | Get the current compass heading in degrees. | GPS models and `imu-vectornav`
+[`GetOrientation`](/components/movement-sensor/#getorientation) | Get the current orientation. | IMU models
+[`GetProperties`](/components/movement-sensor/#getproperties) | Get the supported properties of this sensor. | all models
+[`GetAccuracy`](/components/movement-sensor/#getaccuracy) | Get the accuracy of the various sensors. | GPS models
+[`GetReadings`](/components/movement-sensor/#getreadings) | Obtain the measurements/data specific to this sensor. | all models
+[`DoCommand`](/components/movement-sensor/#docommand) | Send or receive model-specific commands. | all models

--- a/static/include/components/apis/movement-sensor.md
+++ b/static/include/components/apis/movement-sensor.md
@@ -1,0 +1,12 @@
+Method Name | Description | Models That Support This Method
+----------- | ----------- | -------------------------------
+[GetPosition](/components/movement-sensor/#getposition) | Get the current latitude, longitude and altitude. | GPS models
+[GetLinearVelocity](/components/movement-sensor/#getlinearvelocity) | Get the current linear velocity as a 3D vector. | GPS models
+[GetAngularVelocity](/components/movement-sensor/#getangularvelocity) | Get the current angular velocity as a 3D vector. | IMU models and `gyro-mpu6050`
+[GetLinearAcceleration](/components/movement-sensor/#getlinearacceleration) | Get the current linear acceleration as a 3D vector. | IMU models,  `accel-adxl345`, and `gyro-mpu6050`
+[GetCompassHeading](/components/movement-sensor/#getcompassheading) | Get the current compass heading in degrees. | GPS models and `imu-vectornav`
+[GetOrientation](/components/movement-sensor/#getorientation) | Get the current orientation. | IMU models
+[GetProperties](/components/movement-sensor/#getproperties) | Get the supported properties of this sensor. | all models
+[GetAccuracy](/components/movement-sensor/#getaccuracy) | Get the accuracy of the various sensors. | GPS models
+[GetReadings](/components/movement-sensor/#getreadings) | Obtain the measurements/data specific to this sensor. | all models
+[DoCommand](/components/movement-sensor/#docommand) | Send or receive model-specific commands. | all models

--- a/static/include/components/apis/sensor.md
+++ b/static/include/components/apis/sensor.md
@@ -1,0 +1,3 @@
+Method Name | Description
+----------- | -----------
+[Readings](/components/sensor/#readings) | Get the measurements or readings that this sensor provides.

--- a/static/include/components/apis/sensor.md
+++ b/static/include/components/apis/sensor.md
@@ -1,3 +1,3 @@
 Method Name | Description
 ----------- | -----------
-[Readings](/components/sensor/#readings) | Get the measurements or readings that this sensor provides.
+[`Readings`](/components/sensor/#readings) | Get the measurements or readings that this sensor provides.

--- a/static/include/components/apis/servo.md
+++ b/static/include/components/apis/servo.md
@@ -1,0 +1,6 @@
+Method Name | Description
+----------- | -----------
+[Move](/components/servo/#move) | Move the servo to the desired angle.
+[Position](/components/servo/#position) | Get the current angle of the servo.
+[Stop](/components/servo/#stop) | Stop the servo.
+[DoCommand](/components/servo/#docommand) | Send or receive model-specific commands.

--- a/static/include/components/apis/servo.md
+++ b/static/include/components/apis/servo.md
@@ -1,6 +1,6 @@
 Method Name | Description
 ----------- | -----------
-[Move](/components/servo/#move) | Move the servo to the desired angle.
-[Position](/components/servo/#position) | Get the current angle of the servo.
-[Stop](/components/servo/#stop) | Stop the servo.
-[DoCommand](/components/servo/#docommand) | Send or receive model-specific commands.
+[`Move`](/components/servo/#move) | Move the servo to the desired angle.
+[`Position`](/components/servo/#position) | Get the current angle of the servo.
+[`Stop`](/components/servo/#stop) | Stop the servo.
+[`DoCommand`](/components/servo/#docommand) | Send or receive model-specific commands.

--- a/static/include/services/apis/base-rc.md
+++ b/static/include/services/apis/base-rc.md
@@ -1,0 +1,4 @@
+Method Name | Description
+----------- | -----------
+[`Close`](/services/base-rc/#close) | Close out of all remote control related systems.
+[`ControllerInputs`](/services/base-rc/#controllerinputs) | Get a list of inputs from the controller that is being monitored for that control mode.

--- a/static/include/services/apis/data.md
+++ b/static/include/services/apis/data.md
@@ -1,0 +1,3 @@
+Method Name | Description
+----------- | -----------
+[`Sync`](/services/data/#sync) | Sync data stored on the robot to the cloud.

--- a/static/include/services/apis/ml.md
+++ b/static/include/services/apis/ml.md
@@ -1,0 +1,4 @@
+Method Name | Description
+----------- | -----------
+`Infer` | Take an already ordered input tensor as an array, make an inference on the model, and return an output tensor map.
+`Metadata`| Get the metadata (such as name, type, expected tensor/array shape, inputs, and outputs) associated with the ML model.

--- a/static/include/services/apis/motion.md
+++ b/static/include/services/apis/motion.md
@@ -1,0 +1,7 @@
+Method Name | Description
+----------- | -----------
+[`Move`](/services/motion/#move) | Move multiple components in a coordinated way to achieve a desired motion.
+[`MoveSingleComponent`](/services/motion/#movesinglecomponent) | Move a single component "manually."
+[`GetPose`](/services/motion/#getpose) | Get the current location and orientation of a component as a `Pose`.
+[`MoveOnMap`](/services/motion/#moveonmap) | Move a [base](/components/base/) component to a `Pose` in respect to the origin of a [SLAM](/services/slam/) map.
+[`MoveOnGlobe`](/services/motion/#moveonglobe) | Move a [base](/components/base/) component to a destination GPS point. Use a [Movement Sensor](/components/movement-sensor/) to measure the robot's GPS coordinates.

--- a/static/include/services/apis/navigation.md
+++ b/static/include/services/apis/navigation.md
@@ -1,0 +1,9 @@
+Method Name | Description
+----------- | -----------
+[`Mode`](/services/navigation/#mode) | Get the mode the service is operating in.
+[`SetMode`](/services/navigation/#setmode) | Set the mode the service is operating in.
+[`Location`](/services/navigation/#location) | Get the current location of the robot.
+[`Waypoints`](/services/navigation/#waypoints) | Get the waypoints currently in the service's data storage.
+[`AddWaypoint`](/services/navigation/#addwaypoint) | Add a waypoint to the service's data storage.
+[`RemoveWaypoint`](/services/navigation/#removewaypoint) | Remove a waypoint from the service's data storage.
+[`GetObstacles`](/services/navigation/#getobstacles) | Get the obstacles currently in the service's data storage.

--- a/static/include/services/apis/sensors.md
+++ b/static/include/services/apis/sensors.md
@@ -1,0 +1,4 @@
+Method Name | Description
+----------- | -----------
+[`GetSensors`](/services/sensors/#getsensors) | Returns a list of names of the available sensors.
+[`GetReadings`](/services/sensors/#getreadings) | Returns a list of readings from a given list of sensors.

--- a/static/include/services/apis/slam.md
+++ b/static/include/services/apis/slam.md
@@ -1,0 +1,6 @@
+Method Name | Description
+----------- | -----------
+[`GetPosition`](/services/slam/#getposition) | Get the current position of the specified source component in the point cloud SLAM map.
+[`GetPointCloudMap`](/services/slam/#getpointcloudmap) | Get the point cloud SLAM map.
+[`GetInternalState`](/services/slam/#getinternalstate) | Get the internal state of the SLAM algorithm required to continue mapping/localization.
+[`GetLatestMapInfo`](/services/slam/#getlatestmapinfo) | Get the timestamp of the last update to the point cloud SLAM map.

--- a/static/include/services/apis/vision.md
+++ b/static/include/services/apis/vision.md
@@ -1,0 +1,7 @@
+Method Name | Description | Models That Support This Method
+----------- | ----------- | -------------------------------
+[`GetDetections`](/services/vision/#getdetections) | Get detections from an image. | [detectors](/services/vision/detection/)
+[`GetDetectionsFromCamera`](/services/vision/#getdetectionsfromcamera) | Get detections from the next image from a camera. | [detectors](/services/vision/detection/)
+[`GetClassifications`](/services/vision/#getclassifications) | Get classifications from an image. | [classifiers](/services/vision/classification/)
+[`GetClassificationsFromCamera`](/services/vision#getclassificationsfromcamera) | Get classifications from the next image from a camera. | [classifiers](/services/vision/classification/)
+[`GetObjectPointClouds`](/services/vision#getobjectpointclouds) | Get a list of point cloud objects from a 3D camera. | [segmenters](/services/vision/segmentation/)

--- a/static/include/services/apis/vision.md
+++ b/static/include/services/apis/vision.md
@@ -3,5 +3,5 @@ Method Name | Description | Models That Support This Method
 [`GetDetections`](/services/vision/#getdetections) | Get detections from an image. | [detectors](/services/vision/detection/)
 [`GetDetectionsFromCamera`](/services/vision/#getdetectionsfromcamera) | Get detections from the next image from a camera. | [detectors](/services/vision/detection/)
 [`GetClassifications`](/services/vision/#getclassifications) | Get classifications from an image. | [classifiers](/services/vision/classification/)
-[`GetClassificationsFromCamera`](/services/vision#getclassificationsfromcamera) | Get classifications from the next image from a camera. | [classifiers](/services/vision/classification/)
-[`GetObjectPointClouds`](/services/vision#getobjectpointclouds) | Get a list of point cloud objects from a 3D camera. | [segmenters](/services/vision/segmentation/)
+[`GetClassificationsFromCamera`](/services/vision/#getclassificationsfromcamera) | Get classifications from the next image from a camera. | [classifiers](/services/vision/classification/)
+[`GetObjectPointClouds`](/services/vision/#getobjectpointclouds) | Get a list of point cloud objects from a 3D camera. | [segmenters](/services/vision/segmentation/)


### PR DESCRIPTION
This does change the API page in some ways:
- Adds links to each component doc in the text under the heading
- Adds movement sensor model specifications (which were on the movement sensor page but not the APIs page)
  - This isn't necessarily a good or bad thing, was just out of necessity, and I'm just calling out since with includes it's harder to see in the diff, in case anyone has opinions about this change
- Adds DoCommand to the tables for every component on the API page (except sensor and board because there's nothing to link for them yet; made https://viam.atlassian.net/browse/DOCS-964). As above, this isn't necessarily an improvement, just a change because it's needed on the component pages so it's in the included files.
- Shortens vision service descriptions (makes sense with recent addition of vision service API documentation update)