### PR TITLE
DOCS-953: Clarify serial_path

### DIFF
--- a/docs/components/base/agilex-limo.md
+++ b/docs/components/base/agilex-limo.md
@@ -53,4 +53,4 @@ The following attributes are available for `agilex-limo` bases:
 | Name | Type | Inclusion | Description |
 | ---- | ---- | --------- | ----------- |
 | `drive_mode` | string | **Required** | LIMO [steering mode](https://docs.trossenrobotics.com/agilex_limo_docs/operation/steering_modes.html#switching-steering-modes). Options: `differential`, `ackermann`, `omni` (mecanum). |
-| `serial_path` | string | **Required** | Your serial port connection to your LIMO's [board](../../board/). Determine during setup and start of your LIMO. <br> Default: `/dev/ttyTHS1` |
+| `serial_path` | string | **Required** | The full filesystem path to the serial device, starting with <file>/dev/</file>. With your serial device connected, you can run `sudo dmesg | grep tty` to show relevant device connection log messages, and then match the returned device name, such as `ttyTHS1` , to its device file, such as <file>/dev/ttyTHS1</file>.<br>Default: `/dev/ttyTHS1` |

--- a/docs/components/motor/dmc4000.md
+++ b/docs/components/motor/dmc4000.md
@@ -92,7 +92,7 @@ The following attributes are available for `DMC4000` motors:
 |`amplifier_gain` | int | **Required** | Set the [per phase current](https://www.galil.com/download/comref/com4103/index.html#amplifier_gain.html) (when using stepper amp). |
 | `low_current` | int | **Required** | Reduce the [hold current](https://www.galil.com/download/comref/com4103/index.html#low_current_stepper_mode.html). |
 | `ticks_per_rotation` | int | **Required** | Number of full steps in a rotation. 200 (equivalent to 1.8 degrees per step) is very common. If your data sheet specifies this in terms of degrees per step, divide 360 by that number to get ticks per rotation. |
-| `serial_path` | string | **Required** | Path to <file>/dev/ttyXXXX</file> file. You can find the `XXXX` by running `dmesg` on the computer plugged into the DMC-40x0. If you leave this empty, Viam will attempt to automatically detect the path. |
+| `serial_path` | string | **Required** | The full filesystem path to the serial device, starting with <file>/dev/</file>. With your serial device connected, you can run `sudo dmesg | grep tty` to show relevant device connection log messages, and then match the returned device name, such as `ttyAMA0`, to its device file, such as <file>/dev/ttyAMA0</file>.  If you omit this attribute, Viam will attempt to automatically detect the path. |
 | `controller_axis` | string | **Required** | Physical port label (A-H); select which "axis" the motor is wired to on the controller. |
 | `home_rpm` | int | **Required** | Set speed in revolutions per minute (RPM) that the motor will turn when executing a Home() command (using  DoCommand()). |
 | `dir_flip` | bool | Optional | Flip the direction of the signal sent if there is a DIR pin. |

--- a/docs/components/motor/roboclaw.md
+++ b/docs/components/motor/roboclaw.md
@@ -85,7 +85,7 @@ The following attributes are available for `roboclaw` motors:
 
 | Name | Type | Inclusion | Description |
 | ---- | ---- | --------- | ----------- |
-| `serial_path` | string | **Required** | Serial path of the `roboclaw` controller's USB connection to your robot's filesystem. Run `ls /dev/serial/by-path` in your terminal to find USB serial ports on a Raspberry Pi. <br> Example: `"/dev/serial/by-path/usb-0:1.1:1.0"` |
+| `serial_path` | string | **Required** | The full filesystem path to the serial device, starting with <file>/dev/</file>. With your serial device connected, you can run `sudo dmesg | grep tty` to show relevant device connection log messages, and then match the returned device name, such as `ttyAMA0` , to its device file, such as <file>/dev/ttyAMA0</file>. On a Raspberry Pi, you can also run `ls /dev/serial/by-path` to list USB serial ports. If you omit this attribute, Viam will attempt to automatically detect the path.<br>Example: `"/dev/serial/by-path/usb-0:1.1:1.0"` |
 | `serial_baud_rate` | int | Optional | [Rate to send data](https://learn.sparkfun.com/tutorials/serial-communication) over the serial line. This must match the baudrate you have set up using basicmicro's setup program. You cannot have multiple `roboclaw` motors with different baud rates. <br> Default: `38400` |
 | `motor_channel` | int | **Required** | Channel the motor is connected to on the controller. Must be `1` or `2`. |
 | `address` | int | Optional | Serial address of the controller. <br> Default: `128`  |

--- a/docs/components/movement-sensor/imu/imu-wit.md
+++ b/docs/components/movement-sensor/imu/imu-wit.md
@@ -83,5 +83,5 @@ Edit and fill in the attributes as applicable.
 
 Name | Type | Inclusion | Description
 ---- | ---- | --------- | -----------
-`serial_path` | string | **Required** | The name of the port through which the sensor communicates with the computer.
-`serial_baud_rate` | int | Optional | The rate at which data is sent from the sensor, between `9600` and `115200`. The default rate will work for all models. *Only the HWT901B can have a different serial baud rate.* Refer to your model's data sheet. <br> Default: `115200`
+`serial_path` | string | **Required** | The full filesystem path to the serial device, starting with <file>/dev/</file>. With your serial device connected, you can run `sudo dmesg | grep tty` to show relevant device connection log messages, and then match the returned device name, such as `ttyAMA0` , to its device file, such as <file>/dev/ttyAMA0</file>. On a Raspberry Pi, you can also run `ls /dev/serial/by-path` to list USB serial ports. If you omit this attribute, Viam will attempt to automatically detect the path.<br>Example: `"/dev/serial/by-path/usb-0:1.1:1.0"`
+`serial_baud_rate` | int | Optional | The rate at which data is sent from the sensor over the serial connection. Valid rates are `9600` and `115200`. The default rate will work for all models. *Only the HWT901B can have a different serial baud rate.* Refer to your model's data sheet. <br>Default: `115200`

--- a/docs/components/sensor/renogy.md
+++ b/docs/components/sensor/renogy.md
@@ -74,6 +74,6 @@ The following attributes are available for `renogy` sensors:
 
 | Attribute | Type | Inclusion | Description |
 | --------- | ---- | --------- | ----------- |
-| `serial_path` | string | **Required** | The serial port your controller is connected to. <br> Default: `/dev/serial/0` |
+| `serial_path` | string | **Required** | The full filesystem path to the serial device, starting with <file>/dev/</file>. With your serial device connected, you can run `sudo dmesg | grep tty` to show relevant device connection log messages, and then match the returned device name, such as `ttyAMA0` , to its device file, such as <file>/dev/ttyAMA0</file>. If you omit this attribute, Viam will attempt to automatically detect the path.<br>Default: `/dev/serial0` |
 | `serial_baud_rate` | int | **Required** | The baud rate to use for serial communications. <br> Default: `9600` |
 | `modbus_id`  | int | **Required** | Controller MODBUS address. <br> Default: `1` |

--- a/static/include/components/movement-sensor/connection.md
+++ b/static/include/components/movement-sensor/connection.md
@@ -13,7 +13,7 @@ For a movement sensor communicating over serial, you'll need to include a `seria
 
 Name | Type | Inclusion | Description
 ---- | ---- | --------- | -----------
-`serial_path` | string | **Required** | The name of the port through which the sensor communicates with the computer.
+`serial_path` | string | **Required** | The full filesystem path to the serial device, starting with <file>/dev/</file>. With your serial device connected, you can run `sudo dmesg | grep tty` to show relevant device connection log messages, and then match the returned device name, such as `ttyAMA0` , to its device file, such as <file>/dev/ttyAMA0</file>. If you omit this attribute, Viam will attempt to automatically detect the path.
 `serial_baud_rate` | int | Optional | The rate at which data is sent from the sensor. <br> Default: `38400`
 ---
 


### PR DESCRIPTION
Standardize guidance on determining `serial_path` for all motors and bases that require the attribute.

- Some minor corrections