### PR TITLE
DOCS-948: Add PulseAudio troubleshooting

### DIFF
--- a/docs/appendix/troubleshooting.md
+++ b/docs/appendix/troubleshooting.md
@@ -81,7 +81,7 @@ For example, if you are using `jackd` and `PulseAudio` on a Raspberry Pi, you ca
 sudo apt install jackd qjackctl libpulse-dev pulseaudio
 ```
 
-This error can be safely ignored if your do not intend to use audio on your robot.
+This error can be safely ignored if you do not intend to use audio on your robot.
 
 ## Common Viam App Errors
 

--- a/docs/appendix/troubleshooting.md
+++ b/docs/appendix/troubleshooting.md
@@ -81,6 +81,8 @@ For example, if you are using `jackd` and `PulseAudio` on a Raspberry Pi, you ca
 sudo apt install jackd qjackctl libpulse-dev pulseaudio
 ```
 
+This error can be safely ignored if your do not intend to use audio on your robot.
+
 ## Common Viam App Errors
 
 ### Failed to connect; retrying

--- a/docs/appendix/troubleshooting.md
+++ b/docs/appendix/troubleshooting.md
@@ -68,6 +68,19 @@ In addition, if you are installing `viam-server` within a Docker container, you 
 
 **Solution:** See [I get some errors related to something called "FUSE" - AppImage documentation](https://docs.appimage.org/user-guide/troubleshooting/fuse.html) for assistance in resolving FUSE errors on Linux or in Docker.
 
+### PulseAudio: Unable to connect: Connection refused
+
+**Additional Error:** `jack server is not running or cannot be started`
+
+**Description**: When configuring a Linux {{< glossary_tooltip term_id="board" text="board" >}}, Linux installations with broken or misconfigured sound libraries may experience one or both of these errors, even if not using audio components in the robot configuration.
+
+**Solution:** Consult the documentation for your Linux OS and chosen sound library for guidance on installing any missing software dependencies.
+For example, if you are using `jackd` and `PulseAudio` on a Raspberry Pi, you can run the following to install any missing dependencies:
+
+```sh
+sudo apt install jackd qjackctl libpulse-dev pulseaudio
+```
+
 ## Common Viam App Errors
 
 ### Failed to connect; retrying


### PR DESCRIPTION
Add brief troubleshooting item addressing `PulseAudio` / `jackd` errors with best effort fix:
- Fix is specific to Linux OS / sound library combo, but included RPI example command to install missing deps for that specific platform / sound library combo.