### PR TITLE
DOCS-763: Update Go SDK module code sample for the addition of `Properties` to base API

### DIFF
--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -301,6 +301,11 @@ func (base *MyBase) SetVelocity(ctx context.Context, linear, angular r3.Vector, 
     return errUnimplemented
 }
 
+// Properties: unimplemented
+func (base *MyBase) Spin(ctx context.Context, extra map[string]interface{}) error {
+    return errUnimplemented
+}
+
 // SetPower: sets the linear and angular velocity of the left and right motors on the base
 func (base *MyBase) SetPower(ctx context.Context, linear, angular r3.Vector, extra map[string]interface{}) error {
     // stop the base if absolute value of linear and angular velocity is less than .01


### PR DESCRIPTION
From feedback from Michael Lee and Abe -- this error is fairly easy to catch but annoying 

* Update Golang module code sample to raise an unimplemented error for `Properties` so that the sample doesn't error out when the module starts because `Properties` was added to the base API