### PR TITLE
DOCS-986: Update Viam CLI installation

### DIFF
--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -34,9 +34,9 @@ You can use the `uname -m` command to determine your system architecture.
 {{% /alert %}}
 
 {{< tabs >}}
-{{% tab name="Linux arm64" %}}
+{{% tab name="Linux aarch64" %}}
 
-To download the Viam CLI on a Linux computer with the `arm64` architecture, run the following commands:
+To download the Viam CLI on a Linux computer with the `aarch64` architecture, run the following commands:
 
 ```{class="command-line" data-prompt="$"}
 sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-linux-arm64

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -74,9 +74,9 @@ sudo chmod a+rx /usr/local/bin/viam
 ```
 
 {{% /tab %}}
-{{% tab name="Build" %}}
+{{% tab name="Source" %}}
 
-If you have [Go installed](https://go.dev/doc/install), you can build the Viam CLI directly using the `go install` command:
+If you have [Go installed](https://go.dev/doc/install), you can build the Viam CLI directly from source using the `go install` command:
 
 ```sh {class="command-line" data-prompt="$"}
 go install go.viam.com/rdk/cli/viam@latest

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -36,7 +36,7 @@ You can use the `uname -m` command to determine your system architecture.
 {{< tabs >}}
 {{% tab name="Linux arm64" %}}
 
-To download the Viam CLI on a Linux computer with the `arm64` architecture:
+To download the Viam CLI on a Linux computer with the `arm64` architecture, run the following commands:
 
 ```{class="command-line" data-prompt="$"}
 sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-linux-arm64
@@ -46,7 +46,7 @@ sudo chmod a+rx /usr/local/bin/viam
 {{% /tab %}}
 {{% tab name="Linux x86_64" %}}
 
-To download the Viam CLI on a Linux computer with the `amd64` (Intel `x86_64`) architecture:
+To download the Viam CLI on a Linux computer with the `amd64` (Intel `x86_64`) architecture, run the following commands:
 
 ```{class="command-line" data-prompt="$"}
 sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-linux-amd64
@@ -56,7 +56,7 @@ sudo chmod a+rx /usr/local/bin/viam
 {{% /tab %}}
 {{% tab name="macOS arm64" %}}
 
-To download the Viam CLI on a macOS computer with the `arm64` (Apple Silicon) architecture:
+To download the Viam CLI on a macOS computer with the `arm64` (Apple Silicon) architecture, run the following commands:
 
 ```{class="command-line" data-prompt="$"}
 sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-darwin-arm64
@@ -66,7 +66,7 @@ sudo chmod a+rx /usr/local/bin/viam
 {{% /tab %}}
 {{% tab name="macOS x86_64" %}}
 
-To download the Viam CLI on a macOS computer with the `amd64` (Intel `x86_64`) architecture:
+To download the Viam CLI on a macOS computer with the `amd64` (Intel `x86_64`) architecture, run the following commands:
 
 ```{class="command-line" data-prompt="$"}
 sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-darwin-amd64
@@ -94,7 +94,7 @@ echo 'export PATH="$HOME/go/bin:$PATH"' >> ~/.bashrc
 {{% /tab %}}
 {{< /tabs >}}
 
-To update the Viam CLI tool, reinstall using the steps above.
+To later update the Viam CLI tool, you can use the steps above to reinstall the latest version.
 
 ## Authenticate
 

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -44,7 +44,7 @@ sudo chmod a+rx /usr/local/bin/viam
 ```
 
 {{% /tab %}}
-{{% tab name="Linux x86_64" %}}
+{{% tab name="Linux amd64 (x86_64)" %}}
 
 To download the Viam CLI on a Linux computer with the `amd64` (Intel `x86_64`) architecture:
 
@@ -64,7 +64,7 @@ sudo chmod a+rx /usr/local/bin/viam
 ```
 
 {{% /tab %}}
-{{% tab name="macOS Intel" %}}
+{{% tab name="macOS Intel (x86_64)" %}}
 
 To download the Viam CLI on a macOS computer with the `amd64` (Intel `x86_64`) architecture:
 

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -26,7 +26,53 @@ viam.component.servo.v1.ServoService.MoveRequest
 
 ## Install
 
-If you have [Go installed](https://go.dev/doc/install), you can install the Viam CLI with the 'go install' command:
+You can download the Viam CLI executable using one of the options below.
+Select the tab for your platform and architecture:
+
+{{< tabs >}}
+{{% tab name="Linux aarch64" %}}
+
+To download the Viam CLI on a Linux computer with the `arm64` (Apple Silicon, Raspberry Pi) architecture:
+
+```{class="command-line" data-prompt="$"}
+sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-linux-arm64
+sudo chmod a+rx /usr/local/bin/viam
+```
+
+{{% /tab %}}
+{{% tab name="Linux x86_64" %}}
+
+To download the Viam CLI on a Linux computer with the `amd64` (Intel `x86_64`) architecture:
+
+```{class="command-line" data-prompt="$"}
+sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-linux-amd64
+sudo chmod a+rx /usr/local/bin/viam
+```
+
+{{% /tab %}}
+{{% tab name="macOS Apple Silicon" %}}
+
+To download the Viam CLI on a macOS computer with the `arm64` (Apple Silicon, Raspberry Pi) architecture:
+
+```{class="command-line" data-prompt="$"}
+sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-darwin-arm64
+sudo chmod a+rx /usr/local/bin/viam
+```
+
+{{% /tab %}}
+{{% tab name="macOS x86_64" %}}
+
+To download the Viam CLI on a macOS computer with the `amd64` (Intel `x86_64`) architecture:
+
+```{class="command-line" data-prompt="$"}
+sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-darwin-amd64
+sudo chmod a+rx /usr/local/bin/viam
+```
+
+{{% /tab %}}
+{{% tab name="Build from Source" %}}
+
+Alternatively, if you have [Go installed](https://go.dev/doc/install), you can build the Viam CLI directly using the `go install` command:
 
 ```sh {class="command-line" data-prompt="$"}
 go install go.viam.com/rdk/cli/viam@latest
@@ -41,9 +87,10 @@ If you use `bash` as your shell, you can use the following command:
 echo 'export PATH="$HOME/go/bin:$PATH"' >> ~/.bashrc
 ```
 
-{{% alert title="Tip" color="tip" %}}
-If you are using a shell other than bash, you may need to modify the above command.
-{{% /alert %}}
+{{% /tab %}}
+{{< /tabs >}}
+
+To update the Viam CLI tool, reinstall using the steps above.
 
 ## Authenticate
 

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -44,7 +44,7 @@ sudo chmod a+rx /usr/local/bin/viam
 ```
 
 {{% /tab %}}
-{{% tab name="Linux amd64 (x86_64)" %}}
+{{% tab name="Linux x86_64" %}}
 
 To download the Viam CLI on a Linux computer with the `amd64` (Intel `x86_64`) architecture:
 
@@ -54,7 +54,7 @@ sudo chmod a+rx /usr/local/bin/viam
 ```
 
 {{% /tab %}}
-{{% tab name="macOS Apple Silicon" %}}
+{{% tab name="macOS arm64" %}}
 
 To download the Viam CLI on a macOS computer with the `arm64` (Apple Silicon) architecture:
 
@@ -64,7 +64,7 @@ sudo chmod a+rx /usr/local/bin/viam
 ```
 
 {{% /tab %}}
-{{% tab name="macOS Intel (x86_64)" %}}
+{{% tab name="macOS x86_64" %}}
 
 To download the Viam CLI on a macOS computer with the `amd64` (Intel `x86_64`) architecture:
 
@@ -74,9 +74,9 @@ sudo chmod a+rx /usr/local/bin/viam
 ```
 
 {{% /tab %}}
-{{% tab name="Build from Source" %}}
+{{% tab name="Build" %}}
 
-Alternatively, if you have [Go installed](https://go.dev/doc/install), you can build the Viam CLI directly using the `go install` command:
+If you have [Go installed](https://go.dev/doc/install), you can build the Viam CLI directly using the `go install` command:
 
 ```sh {class="command-line" data-prompt="$"}
 go install go.viam.com/rdk/cli/viam@latest

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -27,12 +27,16 @@ viam.component.servo.v1.ServoService.MoveRequest
 ## Install
 
 You can download the Viam CLI executable using one of the options below.
-Select the tab for your platform and architecture:
+Select the tab for your platform and architecture.
+
+{{% alert title="Tip" color="tip" %}}
+You can use the `uname -m` command to determine your system architecture.
+{{% /alert %}}
 
 {{< tabs >}}
-{{% tab name="Linux aarch64" %}}
+{{% tab name="Linux arm64" %}}
 
-To download the Viam CLI on a Linux computer with the `arm64` (Apple Silicon, Raspberry Pi) architecture:
+To download the Viam CLI on a Linux computer with the `arm64` architecture:
 
 ```{class="command-line" data-prompt="$"}
 sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-linux-arm64
@@ -52,7 +56,7 @@ sudo chmod a+rx /usr/local/bin/viam
 {{% /tab %}}
 {{% tab name="macOS Apple Silicon" %}}
 
-To download the Viam CLI on a macOS computer with the `arm64` (Apple Silicon, Raspberry Pi) architecture:
+To download the Viam CLI on a macOS computer with the `arm64` (Apple Silicon) architecture:
 
 ```{class="command-line" data-prompt="$"}
 sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-darwin-arm64
@@ -60,7 +64,7 @@ sudo chmod a+rx /usr/local/bin/viam
 ```
 
 {{% /tab %}}
-{{% tab name="macOS x86_64" %}}
+{{% tab name="macOS Intel" %}}
 
 To download the Viam CLI on a macOS computer with the `amd64` (Intel `x86_64`) architecture:
 

--- a/docs/manage/data/export.md
+++ b/docs/manage/data/export.md
@@ -8,14 +8,9 @@ tags: ["data management", "cloud", "sync"]
 # SME: Aaron Casas
 ---
 
-First, install the [Viam CLI](/manage/cli/) and [authenticate](/manage/cli/#authenticate).
+First, [install the Viam CLI](/manage/cli/#install) and [authenticate](/manage/cli/#authenticate) to Viam.
 
-```sh {class="command-line" data-prompt="$"}
-go install go.viam.com/rdk/cli/viam@latest
-viam login
-```
-
-To export data from the data management service in the cloud:
+Then, to export data from the data management service in the cloud:
 
 1. Navigate to the [**DATA** page in the Viam app](https://app.viam.com/data/view).
 2. Below the **SEARCH** button in the **Filtering** panel, click **Copy Export Command** to copy the export command to the clipboard.
@@ -25,7 +20,7 @@ To export data from the data management service in the cloud:
 3. Run the copied command in a terminal:
 
    ```sh {class="command-line" data-prompt="$"}
-   go run go.viam.com/rdk/cli/viam data export --org-ids=<org-id> --data-type=binary --mime-types=<mime types> --destination=.
+   viam data export --org-ids=<org-id> --data-type=binary --mime-types=image/jpeg,image/png --destination=.
    ```
 
    This command uses the Viam CLI to download the data locally onto your computer based on the search criteria you select in the Viam app.

--- a/docs/manage/data/export.md
+++ b/docs/manage/data/export.md
@@ -20,7 +20,7 @@ Then, to export data from the data management service in the cloud:
 3. Run the copied command in a terminal:
 
    ```sh {class="command-line" data-prompt="$"}
-   viam data export --org-ids=<org-id> --data-type=binary --mime-types=image/jpeg,image/png --destination=.
+   viam data export --org-ids=<org-id> --data-type=binary --mime-types=<mime types> --destination=.
    ```
 
    This command uses the Viam CLI to download the data locally onto your computer based on the search criteria you select in the Viam app.

--- a/docs/tutorials/services/data-management-tutorial.md
+++ b/docs/tutorials/services/data-management-tutorial.md
@@ -145,21 +145,16 @@ For more detailed information see [View and Filter Data](/manage/data/view/).
 You've successfully saved data from your robot in the cloud.
 Now, let's export that image data from the Viam app onto your local computer.
 
-To export data from Viam:
+First, [install the Viam CLI](/manage/cli/#install) and [authenticate](/manage/cli/#authenticate) to Viam.
 
-1. First, install the [Viam CLI](/manage/cli/) and [authenticate](/manage/cli/#authenticate):
+Then, to export data from the data management service in the cloud:
 
-   ```sh {class="command-line" data-prompt="$"}
-   go install go.viam.com/rdk/cli/viam@latest
-   viam login
-   ```
-
-2. Head back to the [**DATA** page in the Viam app](https://app.viam.com/data/view).
-3. Below the **SEARCH** button in the **Filtering** panel, click **Copy Export Command** to copy the export command to the clipboard.
+1. Navigate to the [**DATA** page in the Viam app](https://app.viam.com/data/view).
+2. Below the **SEARCH** button in the **Filtering** panel, click **Copy Export Command** to copy the export command to the clipboard.
 
    ![The "copy export command" button from the Viam app.](/tutorials/data-management/image4.png)
 
-4. Run the copied command in a terminal:
+3. Run the copied command in a terminal:
 
    ```sh {class="command-line" data-prompt="$"}
    viam data export --org_ids=<org_id> --data_type=binary --mime_types=<mime_types> --destination=.


### PR DESCRIPTION
Update Viam CLI tool installations instructions to use new compiled binary executable downloads.
- Retained "Build from Source" as fifth tab: build in Go for any supported platform.
- Using `stable` in place of `latest` in the URL links per discussion.

Question:
- Sending the downloaded binary to `/usr/local/bin/viam`, so requiring `sudo` twice. Same way we have users [download our pre-built modules](https://docs.viam.com/extend/modular-resources/examples/rplidar/#requirements). Look good?