### PR TITLE
Change base stop link

### DIFF
--- a/docs/components/base/_index.md
+++ b/docs/components/base/_index.md
@@ -382,7 +382,7 @@ await my_base.stop()
 
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
-For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/base#Base).
+For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Actuator).
 
 ```go {class="line-numbers linkable-line-numbers"}
 myBase, err := base.FromRobot(robot, "my_base")


### PR DESCRIPTION
Since this method is provided through actuator, may make more sense to link to the page that actually shows the stop method
