### PR TITLE
Fix classification typo

### DIFF
--- a/docs/appendix/release-notes.md
+++ b/docs/appendix/release-notes.md
@@ -132,7 +132,7 @@ You can replace existing color detectors by [configuring new ones in the UI](/se
 
 #### TFLite Detector configurations
 
-You can replace existing TFLite detectors by [configuring new ones in the UI](/services/vision/detection/#configure-a-mlmodel-detector) or you can update the [Raw JSON configuration of your robots](/manage/configuration/#the-config-tab):
+You can replace existing TFLite detectors by [configuring new ones in the UI](/services/vision/detection/#configure-an-mlmodel-detector) or you can update the [Raw JSON configuration of your robots](/manage/configuration/#the-config-tab):
 
 {{< tabs >}}
 {{% tab name="New Way" %}}
@@ -192,7 +192,7 @@ You can replace existing TFLite detectors by [configuring new ones in the UI](/s
 
 #### TFLite Classifier configurations
 
-You can replace existing TFLite classifiers by [configuring new ones in the UI](/services/vision/classification/#configure-a-mlmodel-classifier) or you can update the [Raw JSON configuration of your robots](/manage/configuration/#the-config-tab):
+You can replace existing TFLite classifiers by [configuring new ones in the UI](/services/vision/classification/#configure-an-mlmodel-classifier) or you can update the [Raw JSON configuration of your robots](/manage/configuration/#the-config-tab):
 
 {{< tabs >}}
 {{% tab name="New Way" %}}

--- a/docs/extend/modular-resources/examples/tflite-module.md
+++ b/docs/extend/modular-resources/examples/tflite-module.md
@@ -3,7 +3,7 @@ title: "Add a TensorFlow Lite Modular Service"
 linkTitle: "TensorFlow Lite Modular Service"
 weight: 70
 type: "docs"
-description: "Add a ML model modular-resource-based service which uses TensorFlow Lite to classify audio samples."
+description: "Add an ML model modular-resource-based service which uses TensorFlow Lite to classify audio samples."
 tags: ["ml", "model training", "services"]
 # SMEs: Andrew Morrow
 ---

--- a/docs/manage/ml/_index.md
+++ b/docs/manage/ml/_index.md
@@ -21,7 +21,7 @@ To make use of ML models with your robot, you can use the built-in [ML model ser
 
 Once you have [deployed the ML model service](/services/ml/#create-an-ml-model-service) to your robot, you can then add another service to make use of the model.
 
-* For object detection and classification, you can use the [vision service](/services/vision/), which provides both [mlmodel detector](/services/vision/detection/#configure-a-mlmodel-detector) and [mlmodel classifier](/services/vision/classification/#configure-a-mlmodel-classifier) models.
+* For object detection and classification, you can use the [vision service](/services/vision/), which provides both [mlmodel detector](/services/vision/detection/#configure-an-mlmodel-detector) and [mlmodel classifier](/services/vision/classification/#configure-an-mlmodel-classifier) models.
 * For other usage, you can create a [modular resource](/extend/modular-resources/) to integrate it with your robot.
   For an example, see [this tutorial](/extend/modular-resources/examples/tflite-module/) which adds a modular-resource-based service that uses TensorFlow Lite to classify audio samples.
 

--- a/docs/services/ml/_index.md
+++ b/docs/services/ml/_index.md
@@ -136,5 +136,5 @@ You can use one of these architectures or build your own.
 
 To make use of your new model, follow the instructions to create:
 
-- a [`mlmodel` detector](../vision/detection/#configure-a-mlmodel-detector) or
-- a [`mlmodel` classifier](../vision/classification/#configure-a-mlmodel-classifier)
+- a [`mlmodel` detector](../vision/detection/#configure-an-mlmodel-detector) or
+- a [`mlmodel` classifier](../vision/classification/#configure-an-mlmodel-classifier)

--- a/docs/services/vision/classification.md
+++ b/docs/services/vision/classification.md
@@ -91,7 +91,7 @@ Add the vision service object to the services array in your raw JSON configurati
 {{% /tab %}}
 {{< /tabs >}}
 
-Click **Save config** and head to the **Components** tab.
+Click **Save config**.
 Proceed to [test your classifier](#test-your-classifier).
 
 ## Test your classifier

--- a/docs/services/vision/classification.md
+++ b/docs/services/vision/classification.md
@@ -25,7 +25,7 @@ The types of classifiers supported are:
 
 * **Object classification (`mlmodel`)**: a machine learning classifier that returns a class label and confidence score according to the specified `tensorflow-lite` model file available on the robot’s hard drive.
 
-## Configure a `mlmodel` classifier
+## Configure an `mlmodel` classifier
 
 To create a `mlmodel` classifier, you need an [ML model service with a suitable model](../../ml/).
 

--- a/docs/services/vision/classification.md
+++ b/docs/services/vision/classification.md
@@ -92,13 +92,13 @@ Add the vision service object to the services array in your raw JSON configurati
 {{< /tabs >}}
 
 Click **Save config** and head to the **Components** tab.
-Proceed to [Test your classifier](#test-your-classifier).
+Proceed to [test your classifier](#test-your-classifier).
 
 ## Test your classifier
 
 You can test your classifier with [live camera footage](#live-camera-footage) or [existing images](#existing-images).
 
-### Live Camera footage
+### Live camera footage
 
 If you intend to use the classifier with a camera that is part of your robot, you can test your classifier from the [**Control tab**](/manage/fleet/robots/#control) or with code:
 

--- a/docs/services/vision/detection.md
+++ b/docs/services/vision/detection.md
@@ -147,7 +147,7 @@ The optional **saturation_cutoff_pct** and **value_cutoff_pct** attributes speci
 Click **Save config**.
 Proceed to [test your detector](#test-your-detector).
 
-## Configure a `mlmodel` detector
+## Configure an `mlmodel` detector
 
 A machine learning detector that draws bounding boxes according to the specified tensorflow-lite model file available on the robot’s hard drive.
 To create a `mlmodel` classifier, you need an [ML model service with a suitable model](../../ml/).

--- a/docs/services/vision/detection.md
+++ b/docs/services/vision/detection.md
@@ -31,7 +31,7 @@ The returned detections consist of the bounding box around the identified object
 You can use the following types of detectors:
 
 - [**Color detection (`color_detector`)**](#configure-a-color_detector): A heuristic detector that draws boxes around objects according to their hue (does not detect black, gray, and white).
-- [**Object detection (`mlmodel`)**](#configure-a-mlmodel-detector): A detector that draws bounding boxes according to an [ML model](/services/ml/) available on the robot’s hard drive.
+- [**Object detection (`mlmodel`)**](#configure-an-mlmodel-detector): A detector that draws bounding boxes according to an [ML model](/services/ml/) available on the robot’s hard drive.
 
 ## Configure a `color_detector`
 

--- a/docs/tutorials/projects/guardian.md
+++ b/docs/tutorials/projects/guardian.md
@@ -258,7 +258,7 @@ scp labels.txt pi@guardian.local:/home/pi/labels.txt
 Next, navigate to the **Config** tab of your robot's page in [the Viam app](https://app.viam.com).
 Click on the **Services** subtab and navigate to the **Create service** menu.
 
-1. **Add a ML model service.**
+1. **Add an ML model service.**
 
    The [ML model service](/services/ml/) allows you to deploy the provided machine learning model to your robot.
    Create an ML model with the name `mlmodel`, the type `mlmodel` and the model `tflite_cpu`.

--- a/docs/tutorials/projects/send-security-photo.md
+++ b/docs/tutorials/projects/send-security-photo.md
@@ -115,7 +115,7 @@ Click on the **Services** subtab and navigate to the **Create service** menu.
     Select the **Path to Existing Model On Robot** for the **Deployment** field.
     Then specify the absolute **Model Path** as where your tflite file lives and any **Optional Settings** such as the absolute **Label Path** as where your labels.txt file lives and the **Number of threads** as 1.
 
-   1. **Configure a mlmodel detector**
+   1. **Configure an mlmodel detector**
 
     Add a [vision service](/services/vision/) with the name `myPeopleDetector`, type `vision` and model `mlmodel`.
     Click **Create service**.

--- a/docs/tutorials/projects/tipsy.md
+++ b/docs/tutorials/projects/tipsy.md
@@ -391,7 +391,7 @@ Click on the **Services** subtab and navigate to the **Create service** menu.
 
     ![mlmodel service panel, Deployment selected as Path to Existing Model On Robot, Model Path filled as /home/tipsy/effdet0.tflite and Label Path filled as /home/tipsy/labels.txt, Number of threads is 1.](/tutorials/tipsy/app-service-ml-after.png)
 
-1. **Configure a mlmodel detector**
+1. **Configure an mlmodel detector**
 
     Add a [vision service](/services/vision/) with the name `myPeopleDetector`, type `vision`, and model `mlmodel`.
     Click **Create service**.


### PR DESCRIPTION
Also noticed there's not a good reason to tell them to head to the components tab since they might test with existing images and not need to configure a transform camera.