### PR TITLE
DOCS-1018: Add duplicate component button

### DIFF
--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -174,11 +174,10 @@ Components of the same model are supported using the same low-level code.
   Many built-in components have convenient implicit dependencies, in which case `depends_on` can be left blank.
   For example, a [`gpio` motor](/components/motor/gpio/) depends on the `board` to which it is wired, but it has a dedicated `board` attribute and `viam-server` will automatically initialize that board before it looks for the motor.
 
-If you are configuring several similar components, you can use the **Duplicate component** button in the upper-right of a component's configuration pane to duplicate the existing configuration for that component.
-A new component with identical configuration settings will be created beneath your existing one, named `<existing-component>-copy`.
+If you are configuring several similar components, you can use the **Duplicate component** button in the upper-right of a component's configuration pane to create a new identical component beneath your existing one.
 Be sure to edit the duplicated component to change any parameters that are unique to the new component, such as its name.
 
-To delete a component, click the **trash** icon in the upper-right of the component configuration pane.
+To delete a component, click the trash can icon in the upper-right of the component configuration pane.
 
 For specific information on how to configure each supported component type, see the [components documentation](/components/).
 

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -176,6 +176,7 @@ Components of the same model are supported using the same low-level code.
 
 If you are configuring several similar components, you can use the **Duplicate component** button in the upper-right of a component's configuration pane to duplicate the existing configuration for that component.
 A new component with identical configuration settings will be created beneath your existing one, named `<existing-component>-copy`.
+Be sure to edit the duplicated component to change any parameters that are unique to the new component, such as its name.
 This is useful when configuring several components together that have similar configurations, such as left and right [motors](/component/motor/).
 
 To delete a component, click the **trash** icon in the upper-right of the component configuration pane.

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -163,16 +163,22 @@ Components of the same model are supported using the same low-level code.
 - `attributes`: A struct to define things like how the component is wired to the robot, its dimensions, and other specifications; attributes vary widely between models.
   See the [component documentation](/components/) for a given component type and model for more details.
 
-{{% alert title="Tip" color="tip" %}}
+   {{% alert title="Tip" color="tip" %}}
 
-Some optional attributes have default values.
-If you omit these attributes from your config, or if you include them but leave their values empty, `viam-server` will apply these default values at runtime, even though they are not reflected in the configuration file.
+   Some optional attributes have default values.
+   If you omit these attributes from your config, or if you include them but leave their values empty, `viam-server` will apply these default values at runtime, even though they are not reflected in the configuration file.
 
-{{% /alert %}}
+   {{% /alert %}}
 
 - `depends_on`: Any components that a given component relies upon, and that must be initialized on boot before this component is initialized.
   Many built-in components have convenient implicit dependencies, in which case `depends_on` can be left blank.
   For example, a [`gpio` motor](/components/motor/gpio/) depends on the `board` to which it is wired, but it has a dedicated `board` attribute and `viam-server` will automatically initialize that board before it looks for the motor.
+
+If you are configuring several similar components, you can use the **Duplicate component** button in the upper-right of a component's configuration pane to duplicate the existing configuration for that component.
+A new component with identical configuration settings will be created beneath your existing one, named `<existing-component>-copy`.
+This is useful when configuring several components together that have similar configurations, e.g., left and right [motors](/component/motor/).
+
+To delete a component, click the **trash** icon in the upper-right of the component configuration pane.
 
 For specific information on how to configure each supported component type, see the [components documentation](/components/).
 

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -176,7 +176,7 @@ Components of the same model are supported using the same low-level code.
 
 If you are configuring several similar components, you can use the **Duplicate component** button in the upper-right of a component's configuration pane to duplicate the existing configuration for that component.
 A new component with identical configuration settings will be created beneath your existing one, named `<existing-component>-copy`.
-This is useful when configuring several components together that have similar configurations, e.g., left and right [motors](/component/motor/).
+This is useful when configuring several components together that have similar configurations, such as left and right [motors](/component/motor/).
 
 To delete a component, click the **trash** icon in the upper-right of the component configuration pane.
 

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -177,7 +177,6 @@ Components of the same model are supported using the same low-level code.
 If you are configuring several similar components, you can use the **Duplicate component** button in the upper-right of a component's configuration pane to duplicate the existing configuration for that component.
 A new component with identical configuration settings will be created beneath your existing one, named `<existing-component>-copy`.
 Be sure to edit the duplicated component to change any parameters that are unique to the new component, such as its name.
-This is useful when configuring several components together that have similar configurations, such as left and right [motors](/component/motor/).
 
 To delete a component, click the **trash** icon in the upper-right of the component configuration pane.
 


### PR DESCRIPTION
Adds brief notice of **Duplicate component** and **Trash** buttons in Viam app > Config > Components UI.

- Seems too simple. Is there anywhere else in the docs we talk about configuring components in the app that could use this notice?
- Drive-by alert indentation fix while in here.