### PR TITLE
DOCS-1009: Remove `camera_mono` movement sensor experimental model

### DIFF
--- a/docs/components/movement-sensor/_index.md
+++ b/docs/components/movement-sensor/_index.md
@@ -36,7 +36,6 @@ Model | Description <a name="model-table"></a>
 [`imu-wit`](./imu/imu-wit/) | IMUs manufactured by [WitMotion](https://witmotion-sensor.com/)
 [`imu-vectornav`](./imu/imu-wit/) | IMUs manufactured by [VectorNav](https://www.vectornav.com/products)
 [`accel-adxl345`](./adxl345/) | The [Analog Devices ADXL345](https://www.analog.com/en/products/adxl345.html) digital accelerometer
-[`camera_mono`](./cameramono/) | A model that derives movement data from a [camera](/components/camera/) stream (**experimental**)
 [`gyro-mpu6050`](./mpu6050/) | A gyroscope/accelerometer manufactured by TDK InvenSense
 [`merged`](./merged/) | A model that allows you to aggregate the API methods supported by multiple sensors into a singular sensor client, effectively merging the models of the individual resources
 [`fake`](./fake/) | Used to test code without hardware

--- a/docs/components/movement-sensor/cameramono.md
+++ b/docs/components/movement-sensor/cameramono.md
@@ -5,6 +5,7 @@ weight: 40
 type: "docs"
 description: "Configure camera_mono, an experimental visual odometry model."
 images: ["/icons/components/imu.svg"]
+draft: true
 # SMEs: Rand
 ---
 


### PR DESCRIPTION
* Taking this model out of RDK as it is being removed 

keeping page with `draft: true` for now in case we want that info in the future for `mono-camera` module? can remove