### PR TITLE
DOCS-1015: Add IsMoving to base

### DIFF
--- a/docs/components/base/_index.md
+++ b/docs/components/base/_index.md
@@ -397,6 +397,58 @@ myBase.Stop(context.Background(), nil)
 {{% /tab %}}
 {{< /tabs >}}
 
+### IsMoving
+
+Returns whether the base is actively moving (or attempting to move) under its own power.
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- None
+
+**Returns:**
+
+- [(bool)](https://docs.python.org/3/library/functions.html#bool): True if the base is currently moving; false if not.
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/base/index.html#viam.components.base.Base.is_moving).
+
+```python
+my_base = Base.from_robot(robot=robot, name="my_base")
+
+# Check whether the base is currently moving.
+moving = await my_base.is_moving()
+print('Moving: ', moving)
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+**Parameters:**
+
+- `ctx` [(Context)](https://pkg.go.dev/context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
+
+**Returns:**
+
+- [(bool)](https://pkg.go.dev/builtin#bool): True if the base is currently moving.
+- [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
+
+For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#MovingCheckable).
+
+```go
+myBase, err := base.FromRobot(robot, "my_base")
+
+// Check whether the base is currently moving.
+moving, err := myBase.IsMoving(context.Background())
+
+logger.Info("Is moving?")
+logger.Info(moving)
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ### GetProperties
 
 Get the width and turning radius of the {{< glossary_tooltip term_id="model" text="model" >}} of base in meters.

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -397,54 +397,6 @@ logger.Info(properties)
 {{% /tab %}}
 {{< /tabs >}}
 
-### Stop
-
-Cut the power to the motor immediately, without any gradual step down.
-
-{{< tabs >}}
-{{% tab name="Python" %}}
-
-**Parameters:**
-
-- None
-
-**Returns:**
-
-- None
-
-For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/motor/index.html#viam.components.motor.Motor.stop).
-
-```python
-my_motor = Motor.from_robot(robot=robot, name="my_motor")
-
-# Stop the motor.
-await my_motor.stop()
-```
-
-{{% /tab %}}
-{{% tab name="Go" %}}
-
-**Parameters:**
-
-- `ctx` [(Context)](https://pkg.go.dev/context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
-- `extra` [(map\[string\]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
-
-**Returns:**
-
-- [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
-
-For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
-
-```go
-myMotor, err := motor.FromRobot(robot, "my_motor")
-
-// Stop the motor.
-myMotor.Stop(context.Background(), nil)
-```
-
-{{% /tab %}}
-{{< /tabs >}}
-
 ### IsPowered
 
 Returns whether or not the motor is currently running, and the portion of max power (between 0 and 1; if the motor is off the power will be 0).
@@ -551,6 +503,54 @@ moving, err := myMotor.IsMoving(context.Background())
 
 logger.Info("Is moving?")
 logger.Info(moving)
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### Stop
+
+Cut the power to the motor immediately, without any gradual step down.
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- None
+
+**Returns:**
+
+- None
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/motor/index.html#viam.components.motor.Motor.stop).
+
+```python
+my_motor = Motor.from_robot(robot=robot, name="my_motor")
+
+# Stop the motor.
+await my_motor.stop()
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+**Parameters:**
+
+- `ctx` [(Context)](https://pkg.go.dev/context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
+- `extra` [(map\[string\]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
+
+**Returns:**
+
+- [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
+
+For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
+
+```go
+myMotor, err := motor.FromRobot(robot, "my_motor")
+
+// Stop the motor.
+myMotor.Stop(context.Background(), nil)
 ```
 
 {{% /tab %}}

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -471,7 +471,7 @@ Returns whether the motor is actively moving (or attempting to move) under its o
 
 - [(bool)](https://docs.python.org/3/library/functions.html#bool): True if the motor is currently moving; false if not.
 
-For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/motor/index.html#viam.components.motor.Motor.is_moving).
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/motor/motor/index.html#viam.components.motor.motor.Motor.is_moving).
 
 ```python
 my_motor = Motor.from_robot(robot=robot, name="my_motor")
@@ -493,7 +493,7 @@ print('Moving: ', moving)
 - [(bool)](https://pkg.go.dev/builtin#bool): True if the motor is currently moving.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
-For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#MovingCheckable).
+For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/resource#MovingCheckable).
 
 ```go
 myMotor, err := motor.FromRobot(robot, "my_motor")
@@ -523,7 +523,7 @@ Cut the power to the motor immediately, without any gradual step down.
 
 - None
 
-For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/motor/index.html#viam.components.motor.Motor.stop).
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/motor/motor/index.html#viam.components.motor.motor.Motor.stop).
 
 ```python
 my_motor = Motor.from_robot(robot=robot, name="my_motor")

--- a/static/include/components/apis/base.md
+++ b/static/include/components/apis/base.md
@@ -4,6 +4,7 @@ Method Name | Description
 [`Spin`](/components/base/#spin) | Move the base to the given angle at the given angular velocity.
 [`SetPower`](/components/base/#setpower) | Set the relative power (out of max power) for linear and angular propulsion of the base.
 [`SetVelocity`](/components/base/#setvelocity) | Set the linear velocity and angular velocity of the base.
+[`IsMoving`](/components/base/#ismoving) | Return whether the base is moving or not.
 [`Stop`](/components/base/#stop) | Stop the base.
 [`GetProperties`](/components/base/#getproperties) | Get the width and turning radius of the base in meters.
 [`DoCommand`](/components/base/#docommand) | Send or receive model-specific commands.

--- a/static/include/components/apis/motor.md
+++ b/static/include/components/apis/motor.md
@@ -6,7 +6,7 @@ Method Name | Description
 [`ResetZeroPosition`](/components/motor/#resetzeroposition) | Set the current position to be the new zero (home) position.
 [`GetPosition`](/components/motor/#getposition) | Report the position of the motor based on its encoder. Not supported on all motors.
 [`GetProperties`](/components/motor/#getproperties) | Return whether or not the motor supports certain optional features.
-[`Stop`](/components/motor/#stop) | Cut power to the motor off immediately, without any gradual step down.
 [`IsPowered`](/components/motor/#ispowered) | Return whether or not the motor is currently on, and the amount of power to it.
 [`IsMoving`](/components/motor/#ismoving) | Return whether the motor is moving or not.
+[`Stop`](/components/motor/#stop) | Cut power to the motor off immediately, without any gradual step down.
 [`DoCommand`](/components/motor/#docommand) | Send or receive model-specific commands.


### PR DESCRIPTION
- Add the IsMoving method to the base API documentation
- Change the order of the API for motor so that Stop (which is part of the actuator API) is grouped more logically next to the other actuator API method (IsMoving)

Note to reviewers: The motor index file isn't changing meaningfully; it's just a copy paste order change.