### PR TITLE
Fix caps nit on fleet management

### DIFF
--- a/docs/manage/fleet/_index.md
+++ b/docs/manage/fleet/_index.md
@@ -85,7 +85,7 @@ You can also revert to an earlier configuration from the History tab.
 For some configuration aspects you may require physical access to the robot so you can see how components are connected.
 {{< /alert >}}
 
-### Package Deployment
+### Package deployment
 
 _Coming soon._
 


### PR DESCRIPTION
The only title case heading on the page