### PR TITLE
DOCS-1049: Change gamepad link on scuttle tutorial to fix failing test 

### DIFF
--- a/docs/tutorials/control/scuttle-gamepad.md
+++ b/docs/tutorials/control/scuttle-gamepad.md
@@ -37,7 +37,7 @@ You will need the following hardware to complete this tutorial:
 - A wheeled rover, configured with a [base component](/components/base/) on the [Viam app](https://app.viam.com/).
   This tutorial uses a [SCUTTLE rover](https://www.scuttlerobot.org/shop/) as an example but you can complete this tutorial using a different rover.
   - Regardless of the type of base you are using, [Setting up a SCUTTLE with Viam](/tutorials/configure/scuttlebot/) is a good place to start if you haven't already configured your base.
-- [EasySMX ESM-9101 Wireless Controller](https://droix.net/product/easysmx-esm-9101/) or a similar gamepad and dongle.
+- [EasySMX ESM-9101 Wireless Controller](https://www.amazon.com/Wireless-Controller-EasySMX-ESM-9101-Gamepad/dp/B07F1NLGW2?th=1) or a similar gamepad and dongle.
   This is the controller that comes with the SCUTTLE rover.
 
 {{<video webm_src="/tutorials/videos/scuttledemos_gamepad.webm" mp4_src="/tutorials/videos/scuttledemos_gamepad.mp4" alt="Controlling a Scuttle robot using a Bluetooth gamepad" poster="/tutorials/scuttlebot/scuttledemos_gamepad.jpg">}}


### PR DESCRIPTION
* Change to amazon link that is less likely to be removed 