### PR TITLE
[DOCS-1047][DOCS-DOCS-1053]Odrive Renaming and Movement sensor units

### DIFF
--- a/docs/components/movement-sensor/_index.md
+++ b/docs/components/movement-sensor/_index.md
@@ -189,7 +189,7 @@ linVel, err := myMovementSensor.LinearVelocity(context.Background(), nil)
 
 ### GetAngularVelocity
 
-Report the current angular velocity about the x, y and z axes (as a 3D vector) in radians per second.
+Report the current angular velocity about the x, y and z axes (as a 3D vector) in degrees per second.
 
 Supported by IMU models and by `gyro-mpu6050`.
 
@@ -202,7 +202,7 @@ Supported by IMU models and by `gyro-mpu6050`.
 
 **Returns:**
 
-- [(Vector3)](https://python.viam.dev/autoapi/viam/components/movement_sensor/index.html#viam.components.movement_sensor.Vector3): A 3D vector containing three floats representing the angular velocity about the x, y and z axes in radians per second.
+- [(Vector3)](https://python.viam.dev/autoapi/viam/components/movement_sensor/index.html#viam.components.movement_sensor.Vector3): A 3D vector containing three floats representing the angular velocity about the x, y and z axes in degrees per second.
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/movement_sensor/index.html#viam.components.movement_sensor.MovementSensor.get_angular_velocity).
 
@@ -226,7 +226,7 @@ y_ang_vel = ang_vel.y
 
 **Returns:**
 
-- [(r3.Vector)](https://pkg.go.dev/github.com/golang/geo/r3#Vector): A 3D vector containing three floats representing the angular velocity about the x, y and z axes in radians per second.
+- [(r3.Vector)](https://pkg.go.dev/github.com/golang/geo/r3#Vector): A 3D vector containing three floats representing the angular velocity about the x, y and z axes in degrees per second.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/movementsensor#MovementSensor).

--- a/docs/components/movement-sensor/_index.md
+++ b/docs/components/movement-sensor/_index.md
@@ -367,7 +367,7 @@ Supported by IMU models.
 
 **Returns:**
 
-- [(Orientation)](https://python.viam.dev/autoapi/viam/components/movement_sensor/index.html#viam.components.movement_sensor.Orientation): Abstract base class for protocol messages, containing `o_x`, `o_y`, `o_z`, and `theta`, which together represent a vector pointing in the direction that the sensor is pointing, and the angle (`theta`) of the sensor's rotation about that axis.
+- [(Orientation)](https://python.viam.dev/autoapi/viam/components/movement_sensor/index.html#viam.components.movement_sensor.Orientation): Abstract base class for protocol messages, containing `o_x`, `o_y`, `o_z`, and `theta`, which together represent a vector pointing in the direction that the sensor is pointing, and the angle (`theta`) in degrees of the sensor's rotation about that axis.
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/movement_sensor/index.html#viam.components.movement_sensor.MovementSensor.get_orientation).
 
@@ -406,7 +406,7 @@ orientation := sensorOrientation.OrientationVectorDegrees()
 logger.Info("The x component of the orientation vector: ", orientation.OX)
 logger.Info("The y component of the orientation vector: ", orientation.OY)
 logger.Info("The z component of the orientation vector: ", orientation.OZ)
-logger.Info("The number of degrees that the movement sensor is rotated about the vector: ", orientation.OX)
+logger.Info("The number of degrees that the movement sensor is rotated about the vector: ", orientation.Theta)
 ```
 
 {{% /tab %}}

--- a/docs/extend/modular-resources/examples/odrive.md
+++ b/docs/extend/modular-resources/examples/odrive.md
@@ -10,7 +10,7 @@ tags: ["motor", "odrive", "canbus", "serial", "module", "modular resources", "Py
 
 The [Viam GitHub](https://github.com/viamrobotics/odrive) provides an implementation of ODrive Robotics' [ODrive S1](https://odriverobotics.com/shop/odrive-s1) motor driver as module defining two modular resources [extending](/extend/modular-resources/) the [motor API](/components/motor/#api) as new motor types.
 
-[Install requirements](#requirements), [prepare](#prepare-your-odrive) your ODrive, and [configure](#configuration) the module to configure an `odrive-serial` or `odrive-canbus` [motor](/components/motor/) {{< glossary_tooltip term_id="resource" text="resource" >}} on your robot.
+[Install requirements](#requirements), [prepare](#prepare-your-odrive) your ODrive, and [configure](#configuration) the module to configure an `serial` or `canbus` [motor](/components/motor/) {{< glossary_tooltip term_id="resource" text="resource" >}} on your robot.
 
 {{% alert title="Note" color="note" %}}
 
@@ -60,7 +60,7 @@ If you wish to set the native configuration dynamically, use `odrivetool` to fin
 Provide this in configuration as the optional attribute `odrive_config_file`.
 See [add an `odrive_config_file`](#add-an-odrive_config_file) for more information.
 
-This option is not recommend for the `odrive-canbus` model.
+This option is not recommend for the `canbus` model.
 
 {{% /alert %}}
 
@@ -82,19 +82,19 @@ Additionally, make sure you have [enabled SPI communication on your Pi](/install
 4. Make sure your ODrive is connected to your [board](/components/board/) as follows, depending on your preferred connection method:
 
 {{< tabs name="Connect your ODrive">}}
-{{% tab name="odrive-serial" %}}
+{{% tab name="serial" %}}
 
 Plug the [USB Isolator for Odrive](https://odriverobotics.com/shop/usb-c-to-usb-a-cable-and-usb-isolator) into a USB port on your board.
 Plug a USB-C to USB-A cable from the isolator to the ODrive.
 
 {{% /tab %}}
-{{% tab name="odrive-canbus" %}}
+{{% tab name="canbus" %}}
 
 Wire the CANH and CANL pins from your board to your ODrive.
 Refer to your board and the [ODrive's pinout](https://docs.odriverobotics.com/v/latest/pinout.html) diagrams for the location of these pins.
 
 You must make a serial connection to set up your ODrive. If CAN chains together multiple ODrives, only one at a time must have this serial connection for reconfiguration
-After setting up the ODrive, if you wish to use the `odrive-canbus` model, you can either leave the serial connection plugged in or remove it and leave only the CANH and CANL pins wired.
+After setting up the ODrive, if you wish to use the `canbus` model, you can either leave the serial connection plugged in or remove it and leave only the CANH and CANL pins wired.
 
 Note that if you want to only use the CAN pins, you cannot specify an `"odrive_config_file"` in your Viam configuration.
 The ODrive would not be able to make the serial connection it needs to perform reconfiguration.
@@ -102,7 +102,7 @@ The ODrive would not be able to make the serial connection it needs to perform r
 {{% /tab %}}
 {{< /tabs >}}
 
-After preparing your ODrive, configure the module to configure `odrive-serial` or `odrive-canbus` model motors on your robot.
+After preparing your ODrive, configure the module to configure `serial` or `canbus` model motors on your robot.
 
 ## Configuration
 
@@ -142,14 +142,14 @@ Select **Raw JSON** mode.
 Copy and paste the following JSON along with your module JSON depending on your preferred communication type:
 
 {{< tabs name="Add an ODrive motor">}}
-{{% tab name="odrive-serial" %}}
+{{% tab name="serial" %}}
 
 ```json {class="line-numbers linkable-line-numbers"}
 {
   // "modules": [ {"name": "odrive" ...  } ] MODULE JSON
   "components": [
     {
-      "model": "viam:motor:odrive-serial",
+      "model": "viam:odrive:serial",
       "namespace": "rdk",
       "attributes": {
       },
@@ -162,14 +162,14 @@ Copy and paste the following JSON along with your module JSON depending on your 
 ```
 
 {{% /tab %}}
-{{% tab name="odrive-canbus" %}}
+{{% tab name="canbus" %}}
 
 ```json {class="line-numbers linkable-line-numbers"}
 {
   // "modules": [ {"name": "odrive" ...  } ] MODULE JSON
   "components": [
     {
-      "model": "viam:motor:odrive-canbus",
+      "model": "viam:odrive:canbus",
       "namespace": "rdk",
       "attributes": {
         "canbus_node_id": <int>,
@@ -195,7 +195,7 @@ Copy and paste the following JSON along with your module JSON depending on your 
   ],
   "components": [
     {
-      "model": "viam:motor:odrive-canbus",
+      "model": "viam:odrive:canbus",
       "namespace": "rdk",
       "attributes": {
         "canbus_node_id": 0,
@@ -207,7 +207,7 @@ Copy and paste the following JSON along with your module JSON depending on your 
       "name": "odrive-motor"
     },
     {
-      "model": "viam:motor:odrive-canbus",
+      "model": "viam:odrive:canbus",
       "namespace": "rdk",
       "attributes": {
         "canbus_node_id": 2,
@@ -231,17 +231,17 @@ The following attributes are available for the motor resources available in the 
 
 | Name | Type | Inclusion | Description |
 | ---- | ---- | --------- | ----------- |
-| `canbus_node_id` | int | Optional | Required for successful initialization of the `"odrive-canbus"` type. <br> Node ID of the CAN node you would like to use. You configured this when [setting up your ODrive](https://docs.odriverobotics.com/v/latest/can-guide.html#setting-up-the-odrive). <br> Example: `0` |
+| `canbus_node_id` | int | Optional | Required for successful initialization of the `"canbus"` type. <br> Node ID of the CAN node you would like to use. You configured this when [setting up your ODrive](https://docs.odriverobotics.com/v/latest/can-guide.html#setting-up-the-odrive). <br> Example: `0` |
 | `odrive_config_file` | string | Optional | Filepath of a separate JSON file containing your ODrive's native configuration. See [add an `odrive_config_file`](#add-an-odrive_config_file) for instructions if you add this attribute. </br> See the [Odrive S1 Modular Component repository](https://github.com/viamrobotics/odrive/tree/main/sample-configs) for an example of this file. |
 | `serial_number` | string | Optional | The serial number of the ODrive. Note that this is not necessary if you only have one ODrive connected. See "[Troubleshooting](#troubleshooting): [Hanging](https://github.com/viamrobotics/odrive#hanging)" for help finding this value. |
-| `canbus_baud_rate` | string | Optional | [Baud rate](https://docs.odriverobotics.com/v/latest/can-guide.html#setting-up-the-odrive) of the ODrive CAN protocol. This attribute is only available for `"odrive-canbus"` connections. </br> Use [`odrivetool`](https://docs.odriverobotics.com/v/latest/odrivetool.html) to obtain this value with `<odrv>.can.config.baud_rate`. Format the string as a multiple of 1000 (k). <br> Example: `"250k"` |
+| `canbus_baud_rate` | string | Optional | [Baud rate](https://docs.odriverobotics.com/v/latest/can-guide.html#setting-up-the-odrive) of the ODrive CAN protocol. This attribute is only available for `"canbus"` connections. </br> Use [`odrivetool`](https://docs.odriverobotics.com/v/latest/odrivetool.html) to obtain this value with `<odrv>.can.config.baud_rate`. Format the string as a multiple of 1000 (k). <br> Example: `"250k"` |
 
 Save the config.
 Check the [**Logs** tab](/program/debug/) of your robot in the Viam app to make sure your ODrive motor has connected and no errors are being raised.
 
 {{% alert title="Tip" color="tip" %}}
 
-The `"odrive-canbus"` type allows you to connect multiple ODrives without providing a `serial_number` as long as you have not defined any `odrive_config_file` once the drive has been configured with `odrivetool`.
+The `"canbus"` type allows you to connect multiple ODrives without providing a `serial_number` as long as you have not defined any `odrive_config_file` once the drive has been configured with `odrivetool`.
 
 {{% /alert %}}
 
@@ -253,7 +253,7 @@ To add an `odrive_config_file` and reconfigure your ODrive natively each time th
 See the [ODrive documentation](https://docs.odriverobotics.com/v/latest/odrivetool.html#configuration-backup) for more info.
 2. `iq_msg_rate_ms` in the config defaults to `0`.
 You must set this to or around `100` to use the [motor API's `SetPower` method](https://docs.viam.com/components/motor/#setpower).
-3. If you add an `odrive_config_file` to an `odrive-canbus` motor, you will have to leave the serial connection established with your ODrive plugged in to the USB port, in addition to wiring the CANH and CANL pins.
+3. If you add an `odrive_config_file` to an `canbus` motor, you will have to leave the serial connection established with your ODrive plugged in to the USB port, in addition to wiring the CANH and CANL pins.
 
 An alternative to adding an `odrive_config_file` is running the command `odrivetool restore-config /path/to/config.json` in your terminal.
 


### PR DESCRIPTION
# Description

Sorry if this is a bit out of order, but wanted to get these changes in since they were simple and the readmes were updated:
- Our API contract for angular velocity of movement sensors is degrees/second
- The odrive naming triplet has changed.

cc @jeremyrhyde because I couldn't find your docs ticket.
