### PR TITLE
DOCS-1044, DOCS-1050: Provide model implementation guidance

### DIFF
--- a/docs/extend/modular-resources/configure.md
+++ b/docs/extend/modular-resources/configure.md
@@ -74,15 +74,15 @@ Add these properties to your module's configuration:
 
 ### Configure your modular resource
 
-Once you have configured a module as part of your robot configuration, you can add any number of the resources that module makes available to your robot by adding new components or services configured with your modular resources' new subtype or [model](/extend/modular-resources/key-concepts/#models).
+Once you have configured a module as part of your robot configuration, you can add any number of the resources that module makes available to your robot by adding new components or services configured with your modular resources' new [model](/extend/modular-resources/key-concepts/#models).
 
 The following properties are available for modular resources:
 
 | Name | Type | Inclusion | Description |
 | ---- | ---- | --------- | ----------- |
-| `namespace` | string | **Required** | The namespace of the [API](/extend/modular-resources/key-concepts/#apis) (the first part of the {{< glossary_tooltip term_id="api-namespace-triplet" text="API namespace triplet">}}). |
-| `type` | string | **Required** | The {{< glossary_tooltip term_id="subtype" text="subtype">}} of the [API](/extend/modular-resources/key-concepts/#apis) (the third part of the {{< glossary_tooltip term_id="api-namespace-triplet" text="API namespace triplet">}}). |
-| `name` | string | **Required** | What you want to name this instance of your modular resource. |
+| `namespace` | string | **Required** | The namespace of the API (the first part of the {{< glossary_tooltip term_id="api-namespace-triplet" text="API namespace triplet">}}). See [Valid APIs to implement in your model](/extend/modular-resources/key-concepts/#valid-apis-to-implement-in-your-model). |
+| `type` | string | **Required** | The {{< glossary_tooltip term_id="subtype" text="subtype">}} of the API (the third part of the {{< glossary_tooltip term_id="api-namespace-triplet" text="API namespace triplet">}}). See [Valid APIs to implement in your model](/extend/modular-resources/key-concepts/#valid-apis-to-implement-in-your-model). |
+| `name` | string | **Required** | A custom name for this instance of your modular resource. |
 | `model` | string | **Required** | The full {{< glossary_tooltip term_id="model-namespace-triplet" text="model namespace triplet">}} of the modular resource's [model](/extend/modular-resources/key-concepts/#models). |
 | `depends_on` | array | Optional | The `name` of components you want to confirm are available on your robot alongside your modular resource. Often a [board](/components/board/). Unnecessary if you coded [implicit dependencies](/extend/modular-resources/key-concepts/#dependency-management). |
 

--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -43,7 +43,8 @@ Provide this as a file inside of your module, <file>my_modular_resource.go</file
    View the appropriate `viam-server` client interface to see what your resource's responses from `viam-server` will look like when your model is utilizing the subtype's API.
    This way, you can make the client interface you code return the type of response `viam-server` expects to receive.
 
-   - Find the relevant `viam-server` client interface as `<resource-name>/client.go` or `<resource-name>/client.py` on [Viam's GitHub](https://github.com/viamrobotics/rdk/blob/main/). See [Valid APIs to implement in your model](/extend/modular-resources/key-concepts/#valid-apis-to-implement-in-your-model) for more information.
+   - Find the relevant `viam-server` client interface as `<resource-name>/client.go` or `<resource-name>/client.py` on [Viam's GitHub](https://github.com/viamrobotics/rdk/blob/main/).
+     See [Valid APIs to implement in your model](/extend/modular-resources/key-concepts/#valid-apis-to-implement-in-your-model) for more information.
    - For example, the base client is defined in [<file>rdk/components/base/client.go</file>](https://github.com/viamrobotics/rdk/blob/main/components/base/client.go).
    - Base your edits to <file>my_modular_resource.go</file> or <file>my_modular_resource.py</file> on this first file.
    - Name your model according to the namespace of the built-in API you are implementing.

--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -38,7 +38,7 @@ Provide this as a file inside of your module, <file>my_modular_resource.go</file
    - For example, the base client is defined in [<file>rdk/components/base/client.go</file>](https://github.com/viamrobotics/rdk/blob/main/components/base/client.go).
    - Base your edits to <file>my_modular_resource.go</file> or <file>my_modular_resource.py</file> on this first file.
    - Name your model according to the namespace of the built-in API you are implementing.
-     For more information see [Model Namespace](/extend/modular-resources/key-concepts/#naming-your-model).
+     For more information see [Naming your model](/extend/modular-resources/key-concepts/#naming-your-model).
 
     <br> **To prepare to import your custom model and your chosen resource subtype's API into your main program and register them with your chosen SDK:**
 

--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -34,35 +34,7 @@ Define a new model of a built-in resource subtype:
 1. [Code a new resource model](#code-a-new-resource-model) server implementing all methods the Viam RDK requires in `viam-server`'s built-in API client of its subtype (ex. `rdk:component:base`).
 Provide this as a file inside of your module, <file>my_modular_resource.go</file> or <file>my_modular_resource.py</file>.
 
-   Follow these instructions to gather the information you will need before starting the process.
-
-   **To choose a name for a new custom resource model**:
-
-   Model names are uniquely namespaced as colon-delimited-triplets in the form of `namespace:family:name`, and are named according to the Viam RDK API that your model implements.
-
-   - If your module provides a single model, the `family` should match `subtype` of whichever API your model implements.
-     For example, the Intel Realsense module `realsense`, available from [the Viam Registry](https://app.viam.com/module/viam/realsense), implements the `camera` component API, so is named as follows:
-
-     ```json {class="line-numbers linkable-line-numbers"}
-     {
-       "api": "rdk:component:camera",
-       "model": "viam:camera:realsense"
-     }
-     ```
-
-   - If your module provides multiple models, the `family` should describe the common functionality provided across all the models of that module.
-     For example, the ODrive module `odrive`, available from [the Viam Registry](https://app.viam.com/module/viam/odrive), implements the several `motor` component API, so is named as follows:
-
-     ```json {class="line-numbers linkable-line-numbers"}
-     {
-       "api": "rdk:component:motor",
-       "model": "viam:odrive:serial"
-     },
-     {
-       "api": "rdk:component:motor",
-       "model": "viam:odrive:canbus"
-     }
-     ```
+   Follow these instructions to find the appropriate source code before you start the process.
 
    **To prepare to code a new custom resource model**:
 
@@ -74,12 +46,13 @@ Provide this as a file inside of your module, <file>my_modular_resource.go</file
    - Find the relevant `viam-server` client interface as `<resource-name>/client.go` or `<resource-name>/client.py` on [Viam's GitHub](https://github.com/viamrobotics/rdk/blob/main/).
    - For example, the base client is defined in [<file>rdk/components/base/client.go</file>](https://github.com/viamrobotics/rdk/blob/main/components/base/client.go).
    - Base your edits to <file>my_modular_resource.go</file> or <file>my_modular_resource.py</file> on this first file.
+   - Name your model according to the namespace of the built-in API you are implementing. For more information see [Model namespace](/extend/modular-resources/key-concepts/#namespace-1).
 
     <br> **To prepare to import your custom model and your chosen resource subtype's API into your main program and register them with your chosen SDK:**
 
    - Find the subtype API as defined in the relevant `<resource-name>/<resource-name>.go` file in the RDK on Viam's GitHub.
    - For example, the base subtype is defined in [<file>rdk/components/base/base.go</file>](https://github.com/viamrobotics/rdk/blob/fdff22e90b8976061c318b2d1ca3b1034edc19c9/components/base/base.go#L37).
-   - Base your edits to <file>main.go</file> or <file>main.py</file> on this second file. <br>
+   - Base your edits to <file>main.go</file> or <file>main.py</file> on this second file.<br>
 
 2. [Code a main program](#code-a-main-entry-point-program), <file>main.go</file> or <file>main.py</file>, that starts the module after adding your desired resources from the registry.
 Import your custom model and API into the main program and register them with your chosen SDK.
@@ -108,7 +81,7 @@ This main program is the "entry point" to your module.
 
 ### Code a new resource model
 
-The following example module registers a modular resource implementing Viam's built-in [Base API](/components/base/#api) [(rdk:service:base)](/extend/modular-resources/key-concepts/#models) as a new model, `"mybase"`:
+The following example module registers a modular resource implementing Viam's built-in [Base API](/components/base/#api) [(rdk:service:base)](/extend/modular-resources/key-concepts/#models) as a new model, `"mybase"`, using the model family `acme:demo:mybase`. For more information on model naming see [Model namespace](/extend/modular-resources/key-concepts/#namespace-1).
 
 The Go code for the custom model (<file>mybase.go</file>) and module entry point file (<file>main.go</file>) is adapted from the full demo modules available on the [Viam GitHub](https://github.com/viamrobotics/rdk/blob/main/examples/customresources).
 

--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -8,28 +8,18 @@ description: "Use the Viam module system to implement custom resources that can 
 no_list: true
 ---
 
-The Viam module system allows you to integrate custom {{< glossary_tooltip term_id="resource" text="resources" >}} ([components](/components/) and [services](/services/)) into any robot running on Viam.
+You can extend Viam by creating a custom [module](/extend/modular-resources/key-concepts/#modules) that provides one or more modular {{< glossary_tooltip term_id="resource" text="resources" >}} ([components](/components/) and [services](/services/)), and can be added to any robot running on Viam.
 
 A common use case for modular resources is to create a new model that implements an existing Viam API.
-However, you can also create and expose new APIs with modular resources.
-
-{{% alert title="Modules vs. modular resources" color="tip" %}}
-
-A configured *module* can make one or more *modular resources* available for configuration.
-
-{{% /alert %}}
 
 Once you have created your custom resource, you can use the [Viam CLI](/manage/cli/) to [upload your custom resource](/extend/modular-resources/upload/) to the Viam Registry, to share it with other Viam users or just to other users in your organization.
 
 Alternatively, you can add your module locally to your robot without uploading to the Viam Registry.
 
-## Create a custom modular resource
+## Create a custom module
 
-To create your own modular resource, code a module in Go or Python using the module support libraries provided by [Viam's SDKs](/program/apis/) that implements at least one new {{< glossary_tooltip term_id="model" text="model" >}} or {{< glossary_tooltip term_id="subtype" text="subtype" >}} of {{< glossary_tooltip term_id="resource" text="resource" >}}:
-
-{{< tabs >}}
-{{% tab name="New Model" %}}
-Define a new model of a built-in resource subtype:
+To create a custom module, follow the steps below.
+A custom module can implement one or more [models](/extend/modular-resources/key-concepts/#models).
 
 1. [Code a new resource model](#code-a-new-resource-model) server implementing all methods the Viam RDK requires in `viam-server`'s built-in API client of its subtype (ex. `rdk:component:base`).
 Provide this as a file inside of your module, <file>my_modular_resource.go</file> or <file>my_modular_resource.py</file>.
@@ -61,25 +51,6 @@ Import your custom model and API into the main program and register them with yo
 This main program is the "entry point" to your module.
 
 3. [Compile or package](#compile-the-module-into-an-executable) the module into a single executable that can receive a socket argument from Viam, open the socket, and start the module at the entry point.
-
-{{% /tab %}}
-{{% tab name="New Type" %}}
-Define a new {{< glossary_tooltip term_id="api-namespace-triplet" text="type or subtype" >}} of resource:
-
-1. Define the methods and messages of the new API in [protobuf](https://github.com/protocolbuffers/protobuf) and in Python or Go, then use a protobuf compiler to [generate the rest of the required protobuf files](https://grpc.io/docs/languages/python/generated-code/) based on that Python or Go code.
-Find detailed instructions in [Define a New Resource Subtype](create-subtype/).
-
-1. [Code at least one model](#code-a-new-resource-model) of this new resource.
-Make sure to implement every method required in your API definition.
-Import your custom models and APIs into the main program and register them with your chosen SDK.
-
-1. [Code a main program](#code-a-main-entry-point-program) that starts the module after adding your desired resources from the registry.
-This main program is the "entry point" to your module.
-
-1. [Compile or package](#compile-the-module-into-an-executable) the module into a single executable that can receive a socket argument from Viam, open the socket, and start the module at the entry point.
-
-{{% /tab %}}
-{{% /tabs %}}
 
 ### Code a new resource model
 

--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -46,7 +46,8 @@ Provide this as a file inside of your module, <file>my_modular_resource.go</file
    - Find the relevant `viam-server` client interface as `<resource-name>/client.go` or `<resource-name>/client.py` on [Viam's GitHub](https://github.com/viamrobotics/rdk/blob/main/).
    - For example, the base client is defined in [<file>rdk/components/base/client.go</file>](https://github.com/viamrobotics/rdk/blob/main/components/base/client.go).
    - Base your edits to <file>my_modular_resource.go</file> or <file>my_modular_resource.py</file> on this first file.
-   - Name your model according to the namespace of the built-in API you are implementing. For more information see [Model namespace](/extend/modular-resources/key-concepts/#namespace-1).
+   - Name your model according to the namespace of the built-in API you are implementing.
+     For more information see [Model Namespace](/extend/modular-resources/key-concepts/#namespace-1).
 
     <br> **To prepare to import your custom model and your chosen resource subtype's API into your main program and register them with your chosen SDK:**
 
@@ -81,7 +82,8 @@ This main program is the "entry point" to your module.
 
 ### Code a new resource model
 
-The following example module registers a modular resource implementing Viam's built-in [Base API](/components/base/#api) [(rdk:service:base)](/extend/modular-resources/key-concepts/#models) as a new model, `"mybase"`, using the model family `acme:demo:mybase`. For more information on model naming see [Model namespace](/extend/modular-resources/key-concepts/#namespace-1).
+The following example module registers a modular resource implementing Viam's built-in [Base API](/components/base/#api) [(rdk:service:base)](/extend/modular-resources/key-concepts/#models) as a new model, `"mybase"`, using the model family `acme:demo:mybase`.
+For more information on model naming see [Model Namespace](/extend/modular-resources/key-concepts/#namespace-1).
 
 The Go code for the custom model (<file>mybase.go</file>) and module entry point file (<file>main.go</file>) is adapted from the full demo modules available on the [Viam GitHub](https://github.com/viamrobotics/rdk/blob/main/examples/customresources).
 

--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -31,7 +31,7 @@ To create your own modular resource, code a module in Go or Python using the mod
 {{% tab name="New Model" %}}
 Define a new model of a built-in resource subtype:
 
-1. [Code a new resource model](#code-a-new-resource-model) server implementing all methods the Viam RDK requires in `viam-servers`'s built-in API client of its subtype (ex. `rdk:component:base`).
+1. [Code a new resource model](#code-a-new-resource-model) server implementing all methods the Viam RDK requires in `viam-server`'s built-in API client of its subtype (ex. `rdk:component:base`).
 Provide this as a file inside of your module, <file>my_modular_resource.go</file> or <file>my_modular_resource.py</file>.
 
    Follow these instructions to gather the information you will need before starting the process.

--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -55,7 +55,7 @@ This main program is the "entry point" to your module.
 ### Code a new resource model
 
 The following example module registers a modular resource implementing Viam's built-in [Base API](/components/base/#api) [(rdk:service:base)](/extend/modular-resources/key-concepts/#models) as a new model, `"mybase"`, using the model family `acme:demo:mybase`.
-For more information on model naming see [Model Namespace](/extend/modular-resources/key-concepts/#namespace-1).
+For more information see [Naming your model](/extend/modular-resources/key-concepts/#naming-your-model).
 
 The Go code for the custom model (<file>mybase.go</file>) and module entry point file (<file>main.go</file>) is adapted from the full demo modules available on the [Viam GitHub](https://github.com/viamrobotics/rdk/blob/main/examples/customresources).
 

--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -43,11 +43,11 @@ Provide this as a file inside of your module, <file>my_modular_resource.go</file
    View the appropriate `viam-server` client interface to see what your resource's responses from `viam-server` will look like when your model is utilizing the subtype's API.
    This way, you can make the client interface you code return the type of response `viam-server` expects to receive.
 
-   - Find the relevant `viam-server` client interface as `<resource-name>/client.go` or `<resource-name>/client.py` on [Viam's GitHub](https://github.com/viamrobotics/rdk/blob/main/).
+   - Find the relevant `viam-server` client interface as `<resource-name>/client.go` or `<resource-name>/client.py` on [Viam's GitHub](https://github.com/viamrobotics/rdk/blob/main/). See [Valid APIs to implement in your model](/extend/modular-resources/key-concepts/#valid-apis-to-implement-in-your-model) for more information.
    - For example, the base client is defined in [<file>rdk/components/base/client.go</file>](https://github.com/viamrobotics/rdk/blob/main/components/base/client.go).
    - Base your edits to <file>my_modular_resource.go</file> or <file>my_modular_resource.py</file> on this first file.
    - Name your model according to the namespace of the built-in API you are implementing.
-     For more information see [Model Namespace](/extend/modular-resources/key-concepts/#namespace-1).
+     For more information see [Model Namespace](/extend/modular-resources/key-concepts/#naming-your-model).
 
     <br> **To prepare to import your custom model and your chosen resource subtype's API into your main program and register them with your chosen SDK:**
 

--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -36,7 +36,7 @@ Provide this as a file inside of your module, <file>my_modular_resource.go</file
 
    Follow these instructions to find the appropriate source code before you start the process.
 
-   **To prepare to code a new custom resource model**:
+   **To prepare to code a new resource model**:
 
    The methods you will code in <file>my_modular_resource.go</file> or <file>my_modular_resource.py</file> are your model's "**client** interface", or how your model's server will respond when `viam-server` asks your resource for something through the API.
 

--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -34,9 +34,37 @@ Define a new model of a built-in resource subtype:
 1. [Code a new resource model](#code-a-new-resource-model) server implementing all methods the Viam RDK requires in `viam-servers`'s built-in API client of its subtype (ex. `rdk:component:base`).
 Provide this as a file inside of your module, <file>my_modular_resource.go</file> or <file>my_modular_resource.py</file>.
 
-   Follow these instructions to find the appropriate source code before you start the process.
+   Follow these instructions to gather the information you will need before starting the process.
 
-   **To prepare to code a new resource model**:
+   **To choose a name for a new custom resource model**:
+
+   Model names are uniquely namespaced as colon-delimited-triplets in the form of `namespace:family:name`, and are named according to the Viam RDK API that your model implements.
+
+   - If your module provides a single model, the `family` should match `subtype` of whichever API your model implements.
+     For example, the Intel Realsense module `realsense`, available from [the Viam Registry](https://app.viam.com/module/viam/realsense), implements the `camera` component API, so is named as follows:
+
+     ```json {class="line-numbers linkable-line-numbers"}
+     {
+       "api": "rdk:component:camera",
+       "model": "viam:camera:realsense"
+     }
+     ```
+
+   - If your module provides multiple models, the `family` should describe the common functionality provided across all the models of that module.
+     For example, the ODrive module `odrive`, available from [the Viam Registry](https://app.viam.com/module/viam/odrive), implements the several `motor` component API, so is named as follows:
+
+     ```json {class="line-numbers linkable-line-numbers"}
+     {
+       "api": "rdk:component:motor",
+       "model": "viam:odrive:serial"
+     },
+     {
+       "api": "rdk:component:motor",
+       "model": "viam:odrive:canbus"
+     }
+     ```
+
+   **To prepare to code a new custom resource model**:
 
    The methods you will code in <file>my_modular_resource.go</file> or <file>my_modular_resource.py</file> are your model's "**client** interface", or how your model's server will respond when `viam-server` asks your resource for something through the API.
 
@@ -383,7 +411,7 @@ func init() {
 {{% tab name="Python"%}}
 
 <file>main.py</file> is the Python module's entry point file.
-When executed, it registers the mybase custom model and API helper functions with the Python SDK and creates and starts the new module.
+When executed, it registers the `mybase` custom model and API helper functions with the Python SDK and creates and starts the new module.
 
 <details>
   <summary>Click to view sample code from <file>main.py</file></summary>

--- a/docs/extend/modular-resources/key-concepts.md
+++ b/docs/extend/modular-resources/key-concepts.md
@@ -31,7 +31,7 @@ Each component or service is typed by a proto API, such as the [component proto 
 Any resource on your robot needs to implement either one of these [existing Viam APIs](#valid-apis-to-implement-in-your-model), or a custom interface.
 
 A *modular resource* is a resource that is provided by a [module](#modules), and not built-in to the RDK.
-A modular resource runs in the module process. This differs from built in resources, which run as part of `viam-server`.
+A modular resource runs in the module process. This differs from built-in resources, which run as part of `viam-server`.
 
 ## Models
 
@@ -41,7 +41,8 @@ Models allow you to control different instances of resource with a consistent in
 For example, some DC motors communicate using [GPIO](/components/board/), while other DC motors use serial protocols like the [SPI bus](/components/board/#spis).
 Regardless, you can power any motor model that implements the `rdk:component:motor` API with the `SetPower()` method.
 
-Models are uniquely namespaced as colon-delimited-triplets in the form `namespace:family:name`, and are named according to the Viam API that your model implements.
+Models are uniquely namespaced as colon-delimited-triplets in the form `namespace:family:name`.
+See [Naming your model](/extend/modular-resources/key-concepts/#naming-your-model) for more information.
 
 Models are either:
 

--- a/docs/extend/modular-resources/key-concepts.md
+++ b/docs/extend/modular-resources/key-concepts.md
@@ -73,7 +73,15 @@ For example:
 
 The [Viam Registry](https://app.viam.com/module) makes available both Viam-provided and community-written modules for download and use on your robot.
 Each module provides one or more models.
-Guidance for naming your models for upload to the Viam Registry depends on whether your module will be implementing a single model, or multiple models:
+
+If you are [creating a custom module](/extend/modular-resources/create/) and [uploading that module](/extend/modular-resources/upload/) to the Viam Registry, ensure your model name meets the following requirements:
+
+- The namespace of your model **must** match the [namespace of your organization](/manage/fleet/organizations/#create-a-namespace-for-your-organization).
+  For example, if your organization uses the `acme` namespace, your models must all begin with `acme`, like `acme:demo:mybase`.
+- Your model triplet must be all-lowercase.
+- Your model triplet may only use alphanumeric (`a-z` and `0-9`), hyphen (`-`), and underscore (`_`) characters.
+
+In addition, you should chose a name for the `family` of your model based on the whether your module implements a single model, or multiple models:
 
 - If your module provides a single model, the `family` should match the `subtype` of whichever API your model implements.
   For example, the Intel Realsense module `realsense`, available from [the Viam Registry](https://app.viam.com/module/viam/realsense), implements the `camera` component API, so it is named as follows:
@@ -98,13 +106,6 @@ Guidance for naming your models for upload to the Viam Registry depends on wheth
     "model": "viam:odrive:canbus"
   }
   ```
-
-If you are [creating a custom module](/extend/modular-resources/create/) and [uploading that module](/extend/modular-resources/upload/) to the Viam Registry, ensure your model name meets the following requirements:
-
-- The namespace of your model **must** match the [namespace of your organization](/manage/fleet/organizations/#create-a-namespace-for-your-organization).
-  For example, if your organization uses the `acme` namespace, your models must all begin with `acme`, like `acme:demo:mybase`.
-- Your entire model triplet must be all-lowercase.
-- Your model triplet may only use alphanumeric (`a-z` and `0-9`), hyphen (`-`), and underscore (`_`) characters.
 
 A model with the `viam` namespace is always Viam-provided.
 

--- a/docs/extend/modular-resources/key-concepts.md
+++ b/docs/extend/modular-resources/key-concepts.md
@@ -55,7 +55,7 @@ Models are uniquely namespaced as colon-delimited-triplets in the form `namespac
 
 Models are either:
 
-- Built-in to the RDK, and included when you [install `viam-server`](/installation/) or when you use one of the [Viam SDKs](/program/apis/).
+- Built into the RDK, and included when you [install `viam-server`](/installation/) or when you use one of the [Viam SDKs](/program/apis/).
 - Provided in custom modules available for download from [the Viam Registry](https://app.viam.com/module), and are written by either Viam or community users.
 
 A model with the `viam` namespace is always Viam-provided.
@@ -76,7 +76,7 @@ Each module provides one or more models.
 Guidance for naming your models for upload to the Viam Registry depends on whether your module will be implementing a single model, or multiple models:
 
 - If your module provides a single model, the `family` should match the `subtype` of whichever API your model implements.
-  For example, the Intel Realsense module `realsense`, available from [the Viam Registry](https://app.viam.com/module/viam/realsense), implements the `camera` component API, so is named as follows:
+  For example, the Intel Realsense module `realsense`, available from [the Viam Registry](https://app.viam.com/module/viam/realsense), implements the `camera` component API, so it is named as follows:
 
   ```json {class="line-numbers linkable-line-numbers"}
   {
@@ -86,7 +86,7 @@ Guidance for naming your models for upload to the Viam Registry depends on wheth
   ```
 
 - If your module provides multiple models, the `family` should describe the common functionality provided across all the models of that module.
-  For example, the ODrive module `odrive`, available from [the Viam Registry](https://app.viam.com/module/viam/odrive), implements several `motor` component APIs, so is named as follows:
+  For example, the ODrive module `odrive`, available from [the Viam Registry](https://app.viam.com/module/viam/odrive), implements several `motor` component APIs, so it is named as follows:
 
   ```json {class="line-numbers linkable-line-numbers"}
   {

--- a/docs/extend/modular-resources/key-concepts.md
+++ b/docs/extend/modular-resources/key-concepts.md
@@ -84,7 +84,7 @@ Guidance for naming your models for upload to the Viam Registry depends on wheth
   ```
 
 - If your module provides multiple models, the `family` should describe the common functionality provided across all the models of that module.
-  For example, the ODrive module `odrive`, available from [the Viam Registry](https://app.viam.com/module/viam/odrive), implements several `motor` component API, so is named as follows:
+  For example, the ODrive module `odrive`, available from [the Viam Registry](https://app.viam.com/module/viam/odrive), implements several `motor` component APIs, so is named as follows:
 
   ```json {class="line-numbers linkable-line-numbers"}
   {
@@ -98,6 +98,8 @@ Guidance for naming your models for upload to the Viam Registry depends on wheth
   ```
 
 If you are [creating a custom module](/extend/modular-resources/create/) and [uploading that module](/extend/modular-resources/upload/) to the Viam Registry, the namespace of your model **must** match the [namespace of your organization](docs/manage/fleet/organizations/#create-a-namespace-for-your-organization).
+For example, if your organization uses the `acme` namespace, your models must all begin with `acme`, like `acme:demo:mybase`.
+A model that begins with the `viam` namespace is always Viam-provided.
 
 ## Management
 

--- a/docs/extend/modular-resources/key-concepts.md
+++ b/docs/extend/modular-resources/key-concepts.md
@@ -51,12 +51,16 @@ Regardless, you can power any motor model that implements the `rdk:component:mot
 
 ### Namespace
 
-Models are also uniquely namespaced as colon-delimited-triplets in the form of `namespace:family:name`.
+Models are uniquely namespaced as colon-delimited-triplets in the form of `namespace:family:name`.
 
 For example:
 
 - The `rdk:builtin:gpio` model of the `rdk:component:motor` API provides RDK support for [GPIO-controlled DC motors](/components/motor/gpio/).
 - The `rdk:builtin:DMC4000` model of the same `rdk:component:motor` API provides RDK support for the [DMC4000](/components/motor/dmc4000/) motor.
+
+{{% alert title="Important" color="note" %}}
+If you are creating a custom module and uploading that module to the Viam Registry, the namespace of your model **must** match the namespace of your organization.
+{{% /alert %}}
 
 ## Management
 

--- a/docs/extend/modular-resources/key-concepts.md
+++ b/docs/extend/modular-resources/key-concepts.md
@@ -56,7 +56,7 @@ Models are uniquely namespaced as colon-delimited-triplets in the form `namespac
 Models are either:
 
 - Built-in to the RDK, and included when you [install `viam-server`](/installation/) or when you use one of the [Viam SDKs](/program/apis/).
-- Available for download from [the Viam Registry](https://app.viam.com/module), and are written by either Viam or community users.
+- Provided in custom modules available for download from [the Viam Registry](https://app.viam.com/module), and are written by either Viam or community users.
 
 A model with the `viam` namespace is always Viam-provided.
 

--- a/docs/extend/modular-resources/key-concepts.md
+++ b/docs/extend/modular-resources/key-concepts.md
@@ -99,8 +99,13 @@ Guidance for naming your models for upload to the Viam Registry depends on wheth
   }
   ```
 
-If you are [creating a custom module](/extend/modular-resources/create/) and [uploading that module](/extend/modular-resources/upload/) to the Viam Registry, the namespace of your model **must** match the [namespace of your organization](/manage/fleet/organizations/#create-a-namespace-for-your-organization).
-For example, if your organization uses the `acme` namespace, your models must all begin with `acme`, like `acme:demo:mybase`.
+If you are [creating a custom module](/extend/modular-resources/create/) and [uploading that module](/extend/modular-resources/upload/) to the Viam Registry, ensure your model name meets the following requirements:
+
+- The namespace of your model **must** match the [namespace of your organization](/manage/fleet/organizations/#create-a-namespace-for-your-organization).
+  For example, if your organization uses the `acme` namespace, your models must all begin with `acme`, like `acme:demo:mybase`.
+- Your entire model triplet must be all-lowercase.
+- Your model triplet may only use alphanumeric (`a-z` and `0-9`), hyphen (`-`), and underscore (`_`) characters.
+
 A model with the `viam` namespace is always Viam-provided.
 
 ## Management

--- a/docs/extend/modular-resources/key-concepts.md
+++ b/docs/extend/modular-resources/key-concepts.md
@@ -13,25 +13,32 @@ A custom module can provide one or more modular resource models.
 
 ## Modules
 
-A *module* provides one or more *modular resources* ([components](/components/) and [services](/services/)), and is a flexible way to extend the functionality of your Viam robot.
-
-A module provides at least one [model](#models) that implements an [existing API](#valid-apis-to-implement-in-your-model).
+A *module* provides one or more [*modular resources*](#resources), and is a flexible way to extend the functionality of your Viam robot.
+Modules run alongside `viam-server` as a separate process, communicating with `viam-server` over a UNIX socket.
+A module provides definitions for one or more pairs of [APIs](#valid-apis-to-implement-in-your-model) and [model](#models).
+When the module initialized, it registered those pairs on your robot, making the functionality defined by that pair available for use.
 
 You can [upload your own modules to the Viam Registry](/extend/modular-resources/upload/) or can [add existing modules from the Registry](/extend/modular-resources/configure).
 
 See [Creating a custom module](/extend/modular-resources/create/) for more information.
 
+## Resources
+
+A resource is a [component](/components/) or [service](/services/).
+Each component or service is typed by a proto API, suhc as the [component proto definitions](https://github.com/viamrobotics/api/tree/main/proto/viam/component).
+
+Any resource on your robot needs to implement either one of these [existing Viam APIs](#valid-apis-to-implement-in-your-model), or a custom interface.
+
+A *modular resource* is a resource that is provided by a [module](#modules), and not built-in to the RDK.
+A modular resource runs in the module process. This differs from built in resources, which run as part of `viam-server`.
+
 ## Models
 
-A *model* describes a specific implementation of a resource that implements (speaks) its API.
-Models allow you to control different instances of resource {{< glossary_tooltip term_id="api-namespace-triplet" text="subtypes" >}} with a consistent interface.
+A *model* describes a specific implementation of a [resource](#resources) that implements (speaks) its API.
+Models allow you to control different instances of resource with a consistent interface, even if the underlying implementation differs.
 
-For example:
-
-Some DC motors use just [GPIO](/components/board/), while other DC motors use serial protocols like [SPI bus](/components/board/#spis).
+For example, some DC motors communicate using [GPIO](/components/board/), while other DC motors use serial protocols like the [SPI bus](/components/board/#spis).
 Regardless, you can power any motor model that implements the `rdk:component:motor` API with the `SetPower()` method.
-
-### Namespace
 
 Models are uniquely namespaced as colon-delimited-triplets in the form `namespace:family:name`, and are named according to the Viam API that your model implements.
 
@@ -40,7 +47,7 @@ Models are either:
 - Built into the RDK, and included when you [install `viam-server`](/installation/) or when you use one of the [Viam SDKs](/program/apis/).
 - Provided in custom modules available for download from [the Viam Registry](https://app.viam.com/module), and are written by either Viam or community users.
 
-#### Built-in models
+### Built-in models
 
 Viam provides many built-in models that implement API capabilities, each using `rdk` as the `namespace`, and `builtin` as the `family`.
 
@@ -49,12 +56,12 @@ For example:
 - The `rdk:builtin:gpio` model of the `rdk:component:motor` API provides RDK support for [GPIO-controlled DC motors](/components/motor/gpio/).
 - The `rdk:builtin:DMC4000` model of the same `rdk:component:motor` API provides RDK support for the [DMC4000](/components/motor/dmc4000/) motor.
 
-#### Custom models
+### Custom models
 
 The [Viam Registry](https://app.viam.com/registry) makes available both Viam-provided and community-written modules for download and use on your robot.
 Each module provides one or more models.
 
-##### Valid APIs to implement in your model
+#### Valid APIs to implement in your model
 
 When implementing a custom model of an existing [component](/components/), valid [APIs](/program/apis/) are always:
 
@@ -68,7 +75,7 @@ When implementing a custom model of an existing [service](/services/), valid [AP
 - `type`: `service`
 - `subtype`: any one of [these service proto files](https://github.com/viamrobotics/api/tree/main/proto/viam/service).
 
-##### Naming your model
+#### Naming your model
 
 If you are [creating a custom module](/extend/modular-resources/create/) and [uploading that module](/extend/modular-resources/upload/) to the Viam Registry, ensure your model name meets the following requirements:
 

--- a/docs/extend/modular-resources/key-concepts.md
+++ b/docs/extend/modular-resources/key-concepts.md
@@ -58,8 +58,6 @@ Models are either:
 - Built into the RDK, and included when you [install `viam-server`](/installation/) or when you use one of the [Viam SDKs](/program/apis/).
 - Provided in custom modules available for download from [the Viam Registry](https://app.viam.com/module), and are written by either Viam or community users.
 
-A model with the `viam` namespace is always Viam-provided.
-
 #### Built-in models
 
 Viam provides many built-in models that implement API capabilities, each using `rdk` as the `namespace`, and `builtin` as the `family`.

--- a/docs/extend/modular-resources/key-concepts.md
+++ b/docs/extend/modular-resources/key-concepts.md
@@ -8,36 +8,18 @@ description: "The key concepts behind how Viam's resource APIs and models are un
 no_list: true
 ---
 
-`viam-server` [manages](#management) modular {{< glossary_tooltip term_id="resource" text="resources" >}} configured on your robot the same way it manages resources that are already built into the Robot Development Kit [(RDK)](/internals/rdk/).
-Two key concepts exist across all Viam resources, both built-in and modular, that make this flexible management possible: uniquely namespaced resource [*APIs*](#apis) and [*models*](#models).
+You can extend the features of an existing {{< glossary_tooltip term_id="resource" text="resource" >}} API by [creating a custom module](/extend/modular-resources/create/) to define a new [model](#models) that implements that API.
+A custom module can provide one or more modular resource models.
 
-If you create your [own module](/extend/modular-resources/create/), you must register any new APIs and models you define in your model with Viam's model registry in the appropriate namespaces to [configure](/extend/modular-resources/configure/) the modular resource on your robot.
+## Modules
 
-## APIs
+A *module* provides one or more *modular resources* ([components](/components/) and [services](/services/)), and is a flexible way to extend the functionality of your Viam robot.
 
-{{% alert title="Modules vs. modular resources" color="tip" %}}
+A module provides at least one [model](#models) that implements an [existing API](#valid-apis-to-implement-in-your-model).
 
-A configured *module* can make one or more *modular resources* available for configuration.
+You can [upload your own modules to the Viam Registry](/extend/modular-resources/upload/) or can [add existing modules from the Registry](/extend/modular-resources/configure).
 
-{{% /alert %}}
-
-Every Viam {{< glossary_tooltip term_id="resource" text="resource" >}} subtype exposes an [application programming interface (API)](https://en.wikipedia.org/wiki/API).
-This can be understood as a description of how you can interact with that resource.
-Each API is described through [protocol buffers](https://developers.google.com/protocol-buffers).
-Viam SDKs [expose these APIs](/internals/robot-to-robot-comms/).
-
-### Namespace
-
-Each Viam resource's API is uniquely namespaced as a colon-delimited-triplet in the form `namespace:type:subtype`.
-
-For example:
-
-- The API of built-in component [camera](/components/camera/) is `rdk:component:camera`, which exposes methods such as `GetImage()`.
-- The API of built-in service [vision](/services/vision/) is `rdk:service:vision`, which exposes methods such as `GetDetectionsFromCamera()`.
-
-{{% alert title="Tip" color="tip" %}}
-You can see built-in Viam resource APIs in the [Viam GitHub](https://github.com/viamrobotics/api).
-{{% /alert %}}
+See [Creating a custom module](/extend/modular-resources/create/) for more information.
 
 ## Models
 
@@ -69,7 +51,7 @@ For example:
 
 #### Custom models
 
-The [Viam Registry](https://app.viam.com/module) makes available both Viam-provided and community-written modules for download and use on your robot.
+The [Viam Registry](https://app.viam.com/registry) makes available both Viam-provided and community-written modules for download and use on your robot.
 Each module provides one or more models.
 
 ##### Valid APIs to implement in your model

--- a/docs/extend/modular-resources/key-concepts.md
+++ b/docs/extend/modular-resources/key-concepts.md
@@ -19,7 +19,7 @@ A module provides definitions for one or more pairs of [APIs](#valid-apis-to-imp
 
 When the module initializes, it registers those pairs on your robot, making the functionality defined by that pair available for use.
 
-You can [upload your own modules to the Viam Registry](/extend/modular-resources/upload/) or can [add existing modules from the Registry](/extend/modular-resources/configure).
+You can [upload your own modules to the Viam Registry](/extend/modular-resources/upload/) or can [add existing modules from the Registry](/extend/modular-resources/configure/).
 
 See [Creating a custom module](/extend/modular-resources/create/) for more information.
 

--- a/docs/extend/modular-resources/key-concepts.md
+++ b/docs/extend/modular-resources/key-concepts.md
@@ -99,7 +99,7 @@ Guidance for naming your models for upload to the Viam Registry depends on wheth
   }
   ```
 
-If you are [creating a custom module](/extend/modular-resources/create/) and [uploading that module](/extend/modular-resources/upload/) to the Viam Registry, the namespace of your model **must** match the [namespace of your organization](docs/manage/fleet/organizations/#create-a-namespace-for-your-organization).
+If you are [creating a custom module](/extend/modular-resources/create/) and [uploading that module](/extend/modular-resources/upload/) to the Viam Registry, the namespace of your model **must** match the [namespace of your organization](/manage/fleet/organizations/#create-a-namespace-for-your-organization).
 For example, if your organization uses the `acme` namespace, your models must all begin with `acme`, like `acme:demo:mybase`.
 A model with the `viam` namespace is always Viam-provided.
 

--- a/docs/extend/modular-resources/key-concepts.md
+++ b/docs/extend/modular-resources/key-concepts.md
@@ -60,7 +60,7 @@ Models are either:
 
 A model with the `viam` namespace is always Viam-provided.
 
-#### Built-in namespaces
+#### Built-in models
 
 Viam provides many built-in models that implement API capabilities, each using `rdk` as the `namespace`, and `builtin` as the `family`.
 
@@ -69,10 +69,26 @@ For example:
 - The `rdk:builtin:gpio` model of the `rdk:component:motor` API provides RDK support for [GPIO-controlled DC motors](/components/motor/gpio/).
 - The `rdk:builtin:DMC4000` model of the same `rdk:component:motor` API provides RDK support for the [DMC4000](/components/motor/dmc4000/) motor.
 
-#### Viam Registry namespaces
+#### Custom models
 
 The [Viam Registry](https://app.viam.com/module) makes available both Viam-provided and community-written modules for download and use on your robot.
 Each module provides one or more models.
+
+##### Valid APIs to implement in your model
+
+When implementing a custom model of an existing [component](/components/), valid [APIs](/program/apis/) are always:
+
+- `namespace`: `rdk`
+- `type`: `component`
+- `subtype`: any one of [these component proto files](https://github.com/viamrobotics/api/tree/main/proto/viam/component).
+
+When implementing a custom model of an existing [service](/services/), valid [APIs](/program/apis/) are always
+
+- `namespace`: `rdk`
+- `type`: `service`
+- `subtype`: any one of [these service proto files](https://github.com/viamrobotics/api/tree/main/proto/viam/service).
+
+##### Naming your model
 
 If you are [creating a custom module](/extend/modular-resources/create/) and [uploading that module](/extend/modular-resources/upload/) to the Viam Registry, ensure your model name meets the following requirements:
 

--- a/docs/extend/modular-resources/key-concepts.md
+++ b/docs/extend/modular-resources/key-concepts.md
@@ -28,7 +28,7 @@ Viam SDKs [expose these APIs](/internals/robot-to-robot-comms/).
 
 ### Namespace
 
-Each Viam resource's API is uniquely namespaced as a colon-delimited-triplet in the form of `namespace:type:subtype`.
+Each Viam resource's API is uniquely namespaced as a colon-delimited-triplet in the form `namespace:type:subtype`.
 
 For example:
 
@@ -51,16 +51,53 @@ Regardless, you can power any motor model that implements the `rdk:component:mot
 
 ### Namespace
 
-Models are uniquely namespaced as colon-delimited-triplets in the form of `namespace:family:name`.
+Models are uniquely namespaced as colon-delimited-triplets in the form `namespace:family:name`, and are named according to the Viam API that your model implements.
+
+Models are either:
+
+- Built-in to the RDK, and included when you [install `viam-server`](/installation/) or when you use one of the [Viam SDKs](/program/apis/)
+- Written by community users, and available from [the Viam Registry](https://app.viam.com/module).
+
+#### Built-in namespaces
+
+Viam provides many built-in models that implement API capabilities, each using `rdk` as the `namespace`, and `builtin` as the `family`.
 
 For example:
 
 - The `rdk:builtin:gpio` model of the `rdk:component:motor` API provides RDK support for [GPIO-controlled DC motors](/components/motor/gpio/).
 - The `rdk:builtin:DMC4000` model of the same `rdk:component:motor` API provides RDK support for the [DMC4000](/components/motor/dmc4000/) motor.
 
-{{% alert title="Important" color="note" %}}
-If you are creating a custom module and uploading that module to the Viam Registry, the namespace of your model **must** match the namespace of your organization.
-{{% /alert %}}
+#### Community namespaces
+
+The [Viam Registry](https://app.viam.com/module) makes available both Viam-provided and community-written modules for download and use on your robot.
+Each module provides one or more models.
+Guidance for naming your models for upload to the Viam Registry depends on whether your module will be implementing a single model, or multiple models:
+
+- If your module provides a single model, the `family` should match `subtype` of whichever API your model implements.
+  For example, the Intel Realsense module `realsense`, available from [the Viam Registry](https://app.viam.com/module/viam/realsense), implements the `camera` component API, so is named as follows:
+
+  ```json {class="line-numbers linkable-line-numbers"}
+  {
+    "api": "rdk:component:camera",
+    "model": "viam:camera:realsense"
+  }
+  ```
+
+- If your module provides multiple models, the `family` should describe the common functionality provided across all the models of that module.
+  For example, the ODrive module `odrive`, available from [the Viam Registry](https://app.viam.com/module/viam/odrive), implements several `motor` component API, so is named as follows:
+
+  ```json {class="line-numbers linkable-line-numbers"}
+  {
+    "api": "rdk:component:motor",
+    "model": "viam:odrive:serial"
+  },
+  {
+    "api": "rdk:component:motor",
+    "model": "viam:odrive:canbus"
+  }
+  ```
+
+If you are [creating a custom module](/extend/modular-resources/create/) and [uploading that module](/extend/modular-resources/upload/) to the Viam Registry, the namespace of your model **must** match the [namespace of your organization](docs/manage/fleet/organizations/#create-a-namespace-for-your-organization).
 
 ## Management
 

--- a/docs/extend/modular-resources/key-concepts.md
+++ b/docs/extend/modular-resources/key-concepts.md
@@ -15,8 +15,9 @@ A custom module can provide one or more modular resource models.
 
 A *module* provides one or more [*modular resources*](#resources), and is a flexible way to extend the functionality of your Viam robot.
 Modules run alongside `viam-server` as a separate process, communicating with `viam-server` over a UNIX socket.
-A module provides definitions for one or more pairs of [APIs](#valid-apis-to-implement-in-your-model) and [model](#models).
-When the module initialized, it registered those pairs on your robot, making the functionality defined by that pair available for use.
+A module provides definitions for one or more pairs of [APIs](#valid-apis-to-implement-in-your-model) and [models](#models).
+
+When the module initializes, it registers those pairs on your robot, making the functionality defined by that pair available for use.
 
 You can [upload your own modules to the Viam Registry](/extend/modular-resources/upload/) or can [add existing modules from the Registry](/extend/modular-resources/configure).
 
@@ -25,7 +26,7 @@ See [Creating a custom module](/extend/modular-resources/create/) for more infor
 ## Resources
 
 A resource is a [component](/components/) or [service](/services/).
-Each component or service is typed by a proto API, suhc as the [component proto definitions](https://github.com/viamrobotics/api/tree/main/proto/viam/component).
+Each component or service is typed by a proto API, such as the [component proto definitions](https://github.com/viamrobotics/api/tree/main/proto/viam/component).
 
 Any resource on your robot needs to implement either one of these [existing Viam APIs](#valid-apis-to-implement-in-your-model), or a custom interface.
 
@@ -50,6 +51,7 @@ Models are either:
 ### Built-in models
 
 Viam provides many built-in models that implement API capabilities, each using `rdk` as the `namespace`, and `builtin` as the `family`.
+These models run within `viam-server`.
 
 For example:
 
@@ -59,7 +61,7 @@ For example:
 ### Custom models
 
 The [Viam Registry](https://app.viam.com/registry) makes available both Viam-provided and community-written modules for download and use on your robot.
-Each module provides one or more models.
+These models run outside `viam-server` as a separate process.
 
 #### Valid APIs to implement in your model
 

--- a/docs/extend/modular-resources/key-concepts.md
+++ b/docs/extend/modular-resources/key-concepts.md
@@ -55,8 +55,10 @@ Models are uniquely namespaced as colon-delimited-triplets in the form `namespac
 
 Models are either:
 
-- Built-in to the RDK, and included when you [install `viam-server`](/installation/) or when you use one of the [Viam SDKs](/program/apis/)
-- Written by community users, and available from [the Viam Registry](https://app.viam.com/module).
+- Built-in to the RDK, and included when you [install `viam-server`](/installation/) or when you use one of the [Viam SDKs](/program/apis/).
+- Available for download from [the Viam Registry](https://app.viam.com/module), and are written by either Viam or community users.
+
+A model with the `viam` namespace is always Viam-provided.
 
 #### Built-in namespaces
 
@@ -67,13 +69,13 @@ For example:
 - The `rdk:builtin:gpio` model of the `rdk:component:motor` API provides RDK support for [GPIO-controlled DC motors](/components/motor/gpio/).
 - The `rdk:builtin:DMC4000` model of the same `rdk:component:motor` API provides RDK support for the [DMC4000](/components/motor/dmc4000/) motor.
 
-#### Community namespaces
+#### Viam Registry namespaces
 
 The [Viam Registry](https://app.viam.com/module) makes available both Viam-provided and community-written modules for download and use on your robot.
 Each module provides one or more models.
 Guidance for naming your models for upload to the Viam Registry depends on whether your module will be implementing a single model, or multiple models:
 
-- If your module provides a single model, the `family` should match `subtype` of whichever API your model implements.
+- If your module provides a single model, the `family` should match the `subtype` of whichever API your model implements.
   For example, the Intel Realsense module `realsense`, available from [the Viam Registry](https://app.viam.com/module/viam/realsense), implements the `camera` component API, so is named as follows:
 
   ```json {class="line-numbers linkable-line-numbers"}
@@ -99,7 +101,7 @@ Guidance for naming your models for upload to the Viam Registry depends on wheth
 
 If you are [creating a custom module](/extend/modular-resources/create/) and [uploading that module](/extend/modular-resources/upload/) to the Viam Registry, the namespace of your model **must** match the [namespace of your organization](docs/manage/fleet/organizations/#create-a-namespace-for-your-organization).
 For example, if your organization uses the `acme` namespace, your models must all begin with `acme`, like `acme:demo:mybase`.
-A model that begins with the `viam` namespace is always Viam-provided.
+A model with the `viam` namespace is always Viam-provided.
 
 ## Management
 

--- a/docs/extend/modular-resources/upload/_index.md
+++ b/docs/extend/modular-resources/upload/_index.md
@@ -106,7 +106,7 @@ To upload your custom module to the Viam Registry, either as a public or private
    ```
 
    {{% alert title="Important" color="note" %}}
-   If you are publishing a public module (`visibility: "public"`), the [namespace of your model](/extend/modular-resources/key-concepts/#namespace-1) must match the [namespace of your organization](/manage/fleet/organizations/#create-a-namespace-for-your-organization).
+   If you are publishing a public module (`visibility: "public"`), the [namespace of your model](/extend/modular-resources/key-concepts/#naming-your-model) must match the [namespace of your organization](/manage/fleet/organizations/#create-a-namespace-for-your-organization).
    In the example above, the model namespace is set to `acme` to match the owning organization's namespace.
    If the two namespaces do not match, the command will return an error.
    {{% /alert %}}

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -404,7 +404,7 @@ For example, the following represents the configuration of an example `my-module
 ```
 
 {{% alert title="Important" color="note" %}}
-If you are publishing a public module (`visibility: "public"`), the [namespace of your model](/extend/modular-resources/key-concepts/#namespace-1) must match the [namespace of your organization](/manage/fleet/organizations/#create-a-namespace-for-your-organization).
+If you are publishing a public module (`visibility: "public"`), the [namespace of your model](/extend/modular-resources/key-concepts/#naming-your-model) must match the [namespace of your organization](/manage/fleet/organizations/#create-a-namespace-for-your-organization).
 In the example above, the model namespace is set to `acme` to match the owning organization's namespace.
 If the two namespaces do not match, the command will return an error.
 {{% /alert %}}

--- a/docs/tutorials/custom/controlling-an-intermode-rover-canbus.md
+++ b/docs/tutorials/custom/controlling-an-intermode-rover-canbus.md
@@ -108,7 +108,7 @@ The [base](/components/base/) component exposes an API for controlling a mobile 
 To use it for the Intermode rover, you must create a new [model](/extend/modular-resources/key-concepts/#models) with its own implementation of each method.
 
 Both the **API** and **model** of any Viam resource are represented as colon-separated triplets where the first element is a namespace.
-Since you will conform to an existing Viam API for [base](/components/base/), the [API](/extend/modular-resources/key-concepts/#apis) you will use is:
+Since you will conform to an existing Viam API for [base](/components/base/), the [API](/extend/modular-resources/key-concepts/#valid-apis-to-implement-in-your-model) you will use is:
 **rdk:component:base**
 
 This base model is being created for tutorial purposes only, and will implement only partial functionality for demonstration purposes.
@@ -232,7 +232,7 @@ Now the intermode base can receive and execute *SetPower* commands using the sam
 
 ### Leaving some methods unimplemented
 
-In some cases, you may not want to implement specific methods provided by the resource type's [API](/extend/modular-resources/key-concepts/#apis).
+In some cases, you may not want to implement specific methods provided by the resource type's [API](/extend/modular-resources/key-concepts/#valid-apis-to-implement-in-your-model).
 For example, some hardware may not support specific functionality.
 When you want to leave a method unimplemented you must still create that method, but return an appropriate error message.
 


### PR DESCRIPTION
Add guidance to selecting a model name to the Modular Resources Key Concepts page
- Add links to this guidance from two places on existing `create` workflow page.
- Folded in separate guidance from DOCS-1035 as well (`to_lower()` pls!)
- Folded in additional guidance from DOCS-1050 as well (valid APIs to implement as custom models)
- Removing subtype content and API naming details per EH & FA feedback. Dedicated "New API subtype" page will move elsewhere in a separate PR.
	- Updated links elsewhere to use new headers.

## Staging

- [Modular Resources: Key Concepts](https://docs-test.viam.dev/0d6b450bee3620c3a98b715595977b9ca222723f/public/extend/modular-resources/key-concepts/#namespace-1)