### PR TITLE
Add link to Viam App

### DIFF
--- a/docs/manage/fleet/organizations.md
+++ b/docs/manage/fleet/organizations.md
@@ -25,7 +25,7 @@ For example, you may have an account with one organization for your personal rob
 
 {{<youtube embed_url="https://www.youtube-nocookie.com/embed/eb7v6dabCGQ">}}
 
-You organization is shown in the upper right corner of the Viam app.
+You organization is shown in the upper right corner of [the Viam app](https://app.viam.com).
 If you click on the organization drop down, the app displays your name, email, and a list of organizations you belong to.
 
 {{< imgproc alt="The org drop down showing an example user's name, email, Sign out button, list of organizations, and org settings button." src="/manage/app-usage/my-org.png" resize="400x" declaredimensions=true >}}


### PR DESCRIPTION
Add link to Viam App from Fleet > Organizations page, based on Friday's workshop feedback.