### PR TITLE
Update README link to Windows hugo install

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To be able to build the docs locally, you need to install the following:
 - [`npm`](https://nodejs.org/en/download/)
 - Hugo
   - macOS/Linux: `brew install hugo`
-  - Windows: [https://gohugo.io/getting-started/installing/](https://nodejs.org/en/download/)
+  - Windows: [https://gohugo.io/getting-started/installing/](https://gohugo.io/getting-started/installing/)
 
 You can build the docs for local development using the following command:
 


### PR DESCRIPTION
# Description

As I was setting up this project for the first time, I noticed the link to getting started with Hugo for Windows pointed to the Node.js download site. This PR updates the README to use the expected URL. 
