### PR TITLE
DOCS-1051: Add guidance on requirements.txt

### DIFF
--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -498,11 +498,10 @@ Make sure that you set up a Python virtual environment in the directory your mod
 See the [Python virtual environment documentation](https://docs.python-guide.org/dev/virtualenvs/) for more information.
 
 You will also need to create a `requirements.txt` file containing a list of all the dependencies your module relies on.
-For example, a `requirements.txt` file with the following contents ensures that version `4.23.4` of `protobuf` and version `0.4.6` or later of the Viam Python SDK (`viam-sdk`) is installed:
+For example, a `requirements.txt` file with the following contents ensures that the Viam Python SDK (`viam-sdk`) is installed. You may also add additional dependencies as needed:
 
 ``` sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-protobuf == 4.23.4 ; python_version >= "3.9"
-viam-sdk >= 0.4.6 ; python_version >= "3.9"
+viam-sdk
 ```
 
 See the [pip `requirements.txt` file documentation](https://pip.pypa.io/en/stable/reference/requirements-file-format/) for more information.

--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -495,9 +495,19 @@ Your options for completing this step are flexible, as this file does not need t
 One option is to create and save a new shell script (<file>.sh</file>) that runs your module at your entry point (main program) file.
 
 Make sure that you set up a Python virtual environment in the directory your module is in to compile your resource properly at execution.
-See the [Python Documentation](https://docs.python-guide.org/dev/virtualenvs/) for help with this.
+See the [Python virtual environment documentation](https://docs.python-guide.org/dev/virtualenvs/) for more information.
 
-Include `venv` set-up and manage dependencies in your script as in the following template:
+You will also need to create a `requirements.txt` file containing a list of all the dependencies your module relies on.
+For example, a `requirements.txt` file with the following contents ensures that version `4.23.4` of `protobuf` and version `0.4.6` or later of the Viam Python SDK (`viam-sdk`) is installed:
+
+``` sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+protobuf == 4.23.4 ; python_version >= "3.9"
+viam-sdk >= 0.4.6 ; python_version >= "3.9"
+```
+
+See the [pip `requirements.txt` file documentation](https://pip.pypa.io/en/stable/reference/requirements-file-format/) for more information.
+
+The following template sets up a new virtual enviroment (`venv`), installs the dependencies listed in `requirements.txt`, and runs the module entry point file `main.py`:
 
 ``` sh {id="terminal-prompt" class="command-line" data-prompt="$"}
 #!/bin/sh

--- a/docs/extend/modular-resources/upload/_index.md
+++ b/docs/extend/modular-resources/upload/_index.md
@@ -141,7 +141,7 @@ To upload your custom module to the Viam Registry, either as a public or private
      tar -czf module.tar.gz run.sh requirements.txt src
      ```
 
-     Where `run.sh` is your [entrypoint file](/extend/modular-resources/create/#compile-the-module-into-an-executable), `requirements.txt` is your Python dependency list, and `src` is the source directory of your module.
+     Where `run.sh` is your [entrypoint file](/extend/modular-resources/create/#compile-the-module-into-an-executable), `requirements.txt` is your [pip dependency list file](/extend/modular-resources/create/#compile-the-module-into-an-executable), and `src` is the source directory of your module.
 
 1. Run `viam module upload` to upload the updated custom module to the Viam Registry:
 
@@ -211,7 +211,7 @@ You can also use the [Viam CLI](/manage/cli/) to update an existing custom modul
      tar -czf module.tar.gz run.sh requirements.txt src
      ```
 
-     Where `run.sh` is your [entrypoint file](/extend/modular-resources/create/#compile-the-module-into-an-executable), `requirements.txt` is your Python dependency list, and `src` is the source directory of your module.
+     Where `run.sh` is your [entrypoint file](/extend/modular-resources/create/#compile-the-module-into-an-executable), `requirements.txt` is your [pip dependency list file](/extend/modular-resources/create/#compile-the-module-into-an-executable), and `src` is the source directory of your module.
 
 1. Run `viam module upload` to upload the updated custom module to the Viam Registry:
 


### PR DESCRIPTION
Add guidance on the required form of the `requirements.txt` file when building custom modules (for upload to the Registry).
- Link to this new guidance from `import` steps, for Python example.

Note that this appears to be under consideration for re-evaluation with engineering: See RSDK - 3941.

## Staging
[Compile the module into an executable](https://docs-test.viam.dev/41b8d4046aa6ff21884a331f5e26fc7d3fc6a790/public/extend/modular-resources/create/#compile-the-module-into-an-executable)