### PR TITLE
Fixup for session management disabling in go

### DIFF
--- a/docs/program/apis/sessions.md
+++ b/docs/program/apis/sessions.md
@@ -109,7 +109,7 @@ async def main():
 {{% tab name="Go" %}}
 
 ```go {class="line-numbers linkable-line-numbers"}
-robot, err := client.New(ctx, "my-robot-address", logger, client.WithDisableSessions(), ...)
+robot, err := client.New(ctx, "my-robot-address", logger, client.WithDisableSessions("true"), ...)
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
set disable = `true` like in all the other code examples-- this one was copied/pasted and doesn't explicitly say `true` but the other copy/pasted ones do, so i figure if they all match that's better 