### PR TITLE
Docs 923: Document `csi` camera module for the Jetson Orin Nano's embedded camera

### DIFF
--- a/docs/components/board/jetson.md
+++ b/docs/components/board/jetson.md
@@ -13,6 +13,9 @@ tags: ["board", "components"]
 
 Follow one of our Jetson [setup guides](/installation/) to prepare your board for running `viam-server` before configuring a `jetson` board.
 
+If after configuring a `jetson` board you want to add your Orin Nano's CSI camera to your robot, you can with Viam's `csi` module.
+Follow [these instructions](/extend/modular-resources/examples/csi) to do so.
+
 {{% /alert %}}
 
 Configure a `jetson` board to integrate a [NVIDIA Jetson Orin Module and Developer Kit](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/), [NVIDIA Jetson Xavier NX](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-agx-xavier/), or [NVIDIA Jetson Nano](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-nano/) into your robot:

--- a/docs/extend/modular-resources/examples/csi.md
+++ b/docs/extend/modular-resources/examples/csi.md
@@ -1,0 +1,91 @@
+---
+title: "Add an ODrive motor as a Modular Resource"
+linkTitle: "ODrive"
+weight: 40
+type: "docs"
+description: "How to add an ODrive motor with serial or CANbus communication as a modular resource of your robot."
+tags: ["motor", "odrive", "canbus", "serial", "module", "modular resources", "Python", "python SDK", "CAN"]
+# SMEs: Kim, Martha, Rand
+---
+
+The [Viam GitHub](https://github.com/viamrobotics/odrive) provides an implementation of ODrive Robotics' [ODrive S1](https://odriverobotics.com/shop/odrive-s1) motor driver as module defining two modular resources [extending](/extend/modular-resources/) the [motor API](/components/motor/#api) as new motor types.
+
+[Install requirements](#requirements) and [configure](#configuration) the module to configure an `serial` or `canbus` [motor](/components/motor/) {{< glossary_tooltip term_id="resource" text="resource" >}} on your robot.
+
+## Requirements
+
+On your robot's computer, download [the Viam `csi` appimage](https://github.com/viamrobotics/odrive) and make it executable:
+
+``` {class="command-line" data-prompt="$"}
+sudo wget https://github.com/seanavery/viam-csi/releases/download/v0.0.2/viam-csi-0.0.2-aarch64.AppImage -O /usr/local/bin/viam-csi
+sudo chmod 755 /usr/local/bin/viam-csi
+```
+
+## Configuration
+
+### Module
+
+{{< tabs name="Add the ODrive module">}}
+{{% tab name="Config Builder" %}}
+
+Go to your robot's page on the [Viam app](https://app.viam.com/).
+Navigate to the **Config** tab on your robot's page, and click on the **Modules** subtab.
+
+Copy and  the csi module with a name of your choice.
+
+![The ODrive module with the name 'odrive' and executable path '~/desktop/odrive/odrive-motor/run.sh' added to a robot in the Viam app config builder](/extend/modular-resources/add-odrive/add-odrive-module-ui.png)
+
+{{% /tab %}}
+{{% tab name="JSON Template" %}}
+
+Go to your robot's page on the [Viam app](https://app.viam.com/).
+Navigate to the **Config** tab on your robot's page and select **Raw JSON** mode.
+Copy and paste the following raw JSON to add a `csi` [camera](/components/camera) component with the name `my_test_csicam`:
+
+```json {class="line-numbers linkable-line-numbers"}
+{
+    "modules": [
+      {
+        "executable_path": "/usr/bin/csi-mr",
+        "name": "csi_cam_module"
+      }
+    ],
+    "components": [
+      {
+        "model": "viam:camera:csi",
+        "attributes": {
+          "width_px": 1920,
+          "height_px": 1080,
+          "frame_rate": 30,
+          "debug": true
+        },
+        "depends_on": [],
+        "name": "my_test_csicam",
+        "namespace": "rdk",
+        "type": "camera"
+      }
+    ]
+}
+```
+
+Save the config.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+Edit and fill in the attributes as applicable to your `csi` camera.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+The following attributes are available for the `csi` camera resource made programmatically available in the `viam:camera:csi` module:
+
+| Name | Type | Inclusion | Description |
+| ---- | ---- | --------- | ----------- |
+| `width_px` | int | Optional | . <br> Example: `0` |
+| `height_px` | string | Optional | . |
+| `frame__rate` | string | Optional | . |
+| `debug` | string | Optional | . <br> Example: `"250k"` |
+
+Save the config.
+Check the [**Logs** tab](/program/debug/) of your robot in the Viam app to make sure your `csi` camera has connected and no errors are being raised.

--- a/docs/extend/modular-resources/examples/csi.md
+++ b/docs/extend/modular-resources/examples/csi.md
@@ -1,20 +1,25 @@
 ---
-title: "Add an ODrive motor as a Modular Resource"
-linkTitle: "ODrive"
+title: "Add a CSI Camera as a Modular Resource"
+linkTitle: "CSI Camera"
 weight: 40
 type: "docs"
-description: "How to add an ODrive motor with serial or CANbus communication as a modular resource of your robot."
-tags: ["motor", "odrive", "canbus", "serial", "module", "modular resources", "Python", "python SDK", "CAN"]
+description: "How to add a CSI Camera as a modular resource of your robot."
+tags: ["board", "csi", "jetson", "serial", "module", "modular resources", "Python", "python SDK", "nvidia", "jetson orin", "jetson orin nano", "nano", "camera"]
 # SMEs: Kim, Martha, Rand
 ---
 
-The [Viam GitHub](https://github.com/viamrobotics/odrive) provides an implementation of ODrive Robotics' [ODrive S1](https://odriverobotics.com/shop/odrive-s1) motor driver as module defining two modular resources [extending](/extend/modular-resources/) the [motor API](/components/motor/#api) as new motor types.
 
-[Install requirements](#requirements) and [configure](#configuration) the module to configure an `serial` or `canbus` [motor](/components/motor/) {{< glossary_tooltip term_id="resource" text="resource" >}} on your robot.
+Viam provides a modular resource [extending](/extend/modular-resources/) the [camera API](/components/camera/#api) as a new `viam:camera:csi` model of [camera](/components/camera/).
+
+This module includes a simple wrapper around `GStreamer` and a control interface for the **control** tab of the [Viam app](https://app.viam.com) so you can utilize the hardware accelerated GST plugins and use the embedded CSI cameras on your `jetson` boards with Viam.
+
+The module is open-sourced and available on [GitHub](https://github.com/seanavery/viam-csi).
+
+[Install requirements](#requirements) and [configure](#configuration) the module to add an `viam:camera:csi` [camera](/components/camera/) {{< glossary_tooltip term_id="resource" text="resource" >}} to your robot.
 
 ## Requirements
 
-On your robot's computer, download [the Viam `csi` appimage](https://github.com/viamrobotics/odrive) and make it executable:
+On your robot's computer, download [the `viam:camera:csi` appimage](https://github.com/viamrobotics/odrive) and make it executable:
 
 ``` {class="command-line" data-prompt="$"}
 sudo wget https://github.com/seanavery/viam-csi/releases/download/v0.0.2/viam-csi-0.0.2-aarch64.AppImage -O /usr/local/bin/viam-csi
@@ -25,22 +30,12 @@ sudo chmod 755 /usr/local/bin/viam-csi
 
 ### Module
 
-{{< tabs name="Add the ODrive module">}}
-{{% tab name="Config Builder" %}}
-
-Go to your robot's page on the [Viam app](https://app.viam.com/).
-Navigate to the **Config** tab on your robot's page, and click on the **Modules** subtab.
-
-Copy and  the csi module with a name of your choice.
-
-![The ODrive module with the name 'odrive' and executable path '~/desktop/odrive/odrive-motor/run.sh' added to a robot in the Viam app config builder](/extend/modular-resources/add-odrive/add-odrive-module-ui.png)
-
-{{% /tab %}}
+{{< tabs name="Add the csi module">}}
 {{% tab name="JSON Template" %}}
 
 Go to your robot's page on the [Viam app](https://app.viam.com/).
 Navigate to the **Config** tab on your robot's page and select **Raw JSON** mode.
-Copy and paste the following raw JSON to add a `csi` [camera](/components/camera) component with the name `my_test_csicam`:
+Copy and paste the following raw JSON to add a `csi` [camera](/components/camera) component with the name `my_test_csi_cam`:
 
 ```json {class="line-numbers linkable-line-numbers"}
 {
@@ -60,7 +55,7 @@ Copy and paste the following raw JSON to add a `csi` [camera](/components/camera
           "debug": true
         },
         "depends_on": [],
-        "name": "my_test_csicam",
+        "name": "my_test_csi_cam",
         "namespace": "rdk",
         "type": "camera"
       }
@@ -69,23 +64,19 @@ Copy and paste the following raw JSON to add a `csi` [camera](/components/camera
 ```
 
 Save the config.
+Edit and fill in the attributes as applicable.
+
+Check the [**Logs** tab](/program/debug/) of your robot in the Viam app to make sure your camera has connected and no errors are being raised.
 
 {{% /tab %}}
 {{< /tabs >}}
 
-Edit and fill in the attributes as applicable to your `csi` camera.
-
-{{% /tab %}}
-{{< /tabs >}}
-
-The following attributes are available for the `csi` camera resource made programmatically available in the `viam:camera:csi` module:
+The following attributes are available for the `viam:camera:csi` model:
 
 | Name | Type | Inclusion | Description |
 | ---- | ---- | --------- | ----------- |
-| `width_px` | int | Optional | . <br> Example: `0` |
-| `height_px` | string | Optional | . |
-| `frame__rate` | string | Optional | . |
-| `debug` | string | Optional | . <br> Example: `"250k"` |
-
-Save the config.
-Check the [**Logs** tab](/program/debug/) of your robot in the Viam app to make sure your `csi` camera has connected and no errors are being raised.
+| `width_px` | int | Optional | Width of the image this camera captures in pixels. <br> Default: `1920` |
+| `height_px` | int | Optional | Height of the image this camera captures in pixels. <br> Default: `1080` |
+| `frame_rate` | int | Optional | The image capture frame rate this camera should use. <br> Default: `30` |
+| `video_path` | string | Optional | The filepath to the input sensor of this camera on your board. If none is given, your robot will attempt to detect the video path automatically. <br> Default: `"0"` |
+| `debug` | boolean | Optional | Whether or not you want debug input from this camera in your robot's logs. <br> Example: `true` |


### PR DESCRIPTION
Is not just for the `jetson`, is meant for the `pi` as well in the future

SME: @seanavery 