### PR TITLE
Fix update go package step

### DIFF
--- a/docs/extend/modular-resources/upload/_index.md
+++ b/docs/extend/modular-resources/upload/_index.md
@@ -197,13 +197,14 @@ You can also use the [Viam CLI](/manage/cli/) to update an existing custom modul
    Currently, the Registry only supports `tar.gz` or `tar.xz` format.
    Use the command below specific for the language of your module:
 
-   - To package a module written in Go, run the following command from the same directory as your `meta.json` file:
+   - To package a module written in Go, run the following commands from the same directory as your `meta.json` file:
 
      ``` sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-     tar -czf module.tar.gz module.go
+     go build -o bin/module ./module/main.go
+     tar -cxf module.tar.gz bin/module
      ```
 
-     Where `module.go` is your [compiled entrypoint file](/extend/modular-resources/create/#compile-the-module-into-an-executable).
+     For more information, see [Compile a module into an executable](/extend/modular-resources/create/#compile-the-module-into-an-executable).
 
    - To package a module written in Python, run the following command from the same directory as your `meta.json` file:
 


### PR DESCRIPTION
- Replace erroneous build step in `update` with fixed step from `create`.