### PR TITLE
Make AI Companion left nav title case

### DIFF
--- a/docs/tutorials/projects/integrating-viam-with-openai.md
+++ b/docs/tutorials/projects/integrating-viam-with-openai.md
@@ -1,6 +1,6 @@
 ---
 title: "Integrate Viam with ChatGPT to create a companion robot"
-linkTitle: "AI companion robot"
+linkTitle: "AI Companion Robot"
 weight: 60
 type: "docs"
 tags: ["base", "AI", "OpenAI", "ChatGPT", "ElevenLabs", "servo", "vision", "computer vision", "camera", "viam rover", "python"]


### PR DESCRIPTION
Make AI Companion tutorial's left-nav entry title case, to be consistent with other tutorials.