### PR TITLE
remove config builder tab from rplidar docs

### DIFF
--- a/docs/extend/modular-resources/examples/rplidar.md
+++ b/docs/extend/modular-resources/examples/rplidar.md
@@ -55,62 +55,6 @@ For example, if you are using the [RPlidar A1](https://www.slamtec.com/en/Lidar/
 Then, go to your robot's page on the [Viam app](https://app.viam.com/).
 
 {{< tabs name="Add the RPlidar component">}}
-{{% tab name="Config Builder" %}}
-Navigate to the **Config** tab on your robot's page, and click on the **Components** subtab.
-
-Add a component with type `camera`, model `viam:lidar:rplidar`, and a name of your choice:
-
-![adding rplidar component](/extend/modular-resources/add-rplidar/add-rplidar-component-ui.png)
-
-Paste the following into the **Attributes** field of your new component according to your machine's architecture (none needed for Linux).
-
-{{< tabs name="Add RPlidar Configs">}}
-{{% tab name="macOS x86_64" %}}
-
-```json
-{
-  "device_path": "/dev/tty.SLAB_USBtoUART"
-}
-```
-
-{{% /tab %}}
-
-{{% tab name="macOS ARM64 (M1 & M2)" %}}
-
-If you are on an M1 or M2 Macbook, determine the device path by running the following command:
-
-```sh {class="command-line" data-prompt="$"}
-ls /dev/ | grep tty.usbserial
-```
-
-For example, you may see `tty.usbserial-130`, in which case your device path would be `/dev/tty.usbserial-130`.
-Use the device path in your configuration:
-
-```json
-{
-  "device_path": "/dev/tty.usbserial-XXX"
-}
-```
-
-{{% /tab %}}
-{{< /tabs >}}
-
-Click on the **Modules** subtab. Add the rplidar module with a name of your choice and an executable path that points to the location of your installed `rplidar-module` binary:
-
-{{< tabs name="Add RPlidar Component Module">}}
-{{% tab name="Linux/macOS x86_64" %}}
-
-![adding rplidar module linux](/extend/modular-resources/add-rplidar/add-rplidar-module-ui-linux.png)
-
-{{% /tab %}}
-
-{{% tab name="macOS ARM64 (M1 & M2)" %}}
-
-![adding rplidar module M1 M2](/extend/modular-resources/add-rplidar/add-rplidar-module-ui-M1-M2.png)
-
-{{% /tab %}}
-{{< /tabs >}}
-{{% /tab %}}
 {{% tab name="JSON Template" %}}
 
 Navigate to the **Config** tab.


### PR DESCRIPTION
Per this thread (https://viaminc.slack.com/archives/C02KFSY4H89/p1693405628296269), we're going to remove the Config Builder tab so that the docs don't have non-working instructions. The docs should be updated again once rplidar-module is uploaded to the modular registry.