### PR TITLE
DOCS-1058: Add --force flag to CLI

### DIFF
--- a/docs/extend/modular-resources/upload/_index.md
+++ b/docs/extend/modular-resources/upload/_index.md
@@ -173,6 +173,8 @@ To upload your custom module to the Viam Registry, either as a public or private
    viam module upload --version 1.0.0 --platform darwin/arm64 module.tar.gz
    ```
 
+   When you `upload` a module, the command performs basic [validation](/manage/CLI/#upload-validation) of your packaged module to ensure it is compatible with the Viam Registry.
+
 For more information, see the [`viam module` command](/manage/cli/#module)
 
 ## Update an existing module

--- a/docs/extend/modular-resources/upload/_index.md
+++ b/docs/extend/modular-resources/upload/_index.md
@@ -173,7 +173,7 @@ To upload your custom module to the Viam Registry, either as a public or private
    viam module upload --version 1.0.0 --platform darwin/arm64 module.tar.gz
    ```
 
-   When you `upload` a module, the command performs basic [validation](/manage/CLI/#upload-validation) of your packaged module to ensure it is compatible with the Viam Registry.
+   When you `upload` a module, the command performs basic [validation](/manage/cli/#upload-validation) of your packaged module to ensure it is compatible with the Viam Registry.
 
 For more information, see the [`viam module` command](/manage/cli/#module)
 
@@ -227,5 +227,7 @@ You can also use the [Viam CLI](/manage/cli/) to update an existing custom modul
    ``` sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    viam module upload --version 1.0.1 --platform darwin/arm64 my-module.tar.gz
    ```
+
+   When you `upload` a module, the command performs basic [validation](/manage/cli/#upload-validation) of your packaged module to ensure it is compatible with the Viam Registry.
 
 For more information, see the [`viam module` command](/manage/cli/#module)

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -291,6 +291,7 @@ See [Upload a custom module](/extend/modular-resources/upload/#upload-a-custom-m
 
 |        argument     |       description | applicable commands | required
 | ----------- | ----------- | ----------- | ----------- |
+| `--force`    | skip local validation of the packaged module, which may result in an unusable module if the contents of the packaged module are not correct | `upload` | false
 | `--module`     |  the path to the [`meta.json` file](#the-metajson-file) for the custom module, if not in the current directory | `update`, `upload` | false |
 | `--name`     |  the name of the custom module to be created | `create` | true |
 | `--org-id`      | the organization ID to associate the module to. See [Using the `--org-id` argument](#using-the---org-id-and---public-namespace-arguments) | `create`, `update`, `upload` | true |

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -284,7 +284,7 @@ See [Upload a custom module](/extend/modular-resources/upload/#upload-a-custom-m
 | ----------- | ----------- | ----------- |
 | `create`    | generate new metadata for a custom module on your local filesystem  | - |
 | `update`    | update an existing custom module on your local filesystem with recent changes to the [`meta.json` file](#the-metajson-file) | - |
-| `upload`    | upload a new or existing custom module on your local filesystem to the Viam Registry |
+| `upload`    | validate and upload a new or existing custom module on your local filesystem to the Viam Registry. See [Upload validation](#upload-validation) for more information |
 | `--help`      | return help      | - |
 
 ##### Named arguments
@@ -331,6 +331,16 @@ Users can choose to pin to a specific patch version, permit upgrades within majo
 
 When you `update` a module configuration and then `upload` it, the `entrypoint` for that module defined in the [`meta.json` file](#the-metajson-file) is associated with the specific `--version` for that `upload`.
 Therefore, you are able to change the `entrypoint` file from version to version, if desired.
+
+##### Upload validation
+
+When you `upload` a module, the command validates your local packaged module to ensure that it meets the requirements to successfully upload to the Viam Registry.
+The following criteria are checked for every `upload`:
+
+* The packaged module must exist on the filesystem at the path provided to the `upload` command.
+* The packaged module must use the `.tar.gz` extension.
+* The entry point file specified in the [`meta.json` file](#the-metajson-file) must exist on the filesystem at the path specified.
+* The entry point file must be executable.
 
 ##### The `meta.json` file
 

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -291,7 +291,7 @@ See [Upload a custom module](/extend/modular-resources/upload/#upload-a-custom-m
 
 |        argument     |       description | applicable commands | required
 | ----------- | ----------- | ----------- | ----------- |
-| `--force`    | skip local validation of the packaged module, which may result in an unusable module if the contents of the packaged module are not correct | `upload` | false
+| `--force`    | skip local validation of the packaged module, which may result in an unusable module if the contents of the packaged module are not correct | `upload` | false |
 | `--module`     |  the path to the [`meta.json` file](#the-metajson-file) for the custom module, if not in the current directory | `update`, `upload` | false |
 | `--name`     |  the name of the custom module to be created | `create` | true |
 | `--org-id`      | the organization ID to associate the module to. See [Using the `--org-id` argument](#using-the---org-id-and---public-namespace-arguments) | `create`, `update`, `upload` | true |


### PR DESCRIPTION
Add `--force` flag to CLI reference docs. Not mentioning on `upload` workflow procedural. LMK if you'd like a mention there (we wish to discourage its use, yes?)

## Staging

[`viam module` Named Arguments](https://docs-test.viam.dev/7372e15f303e7516a92d82a576913a716754ce62/public/manage/cli/#named-arguments-1)