### PR TITLE
[RSDK-4743] Add warning for connecting jetson pins to signals over 3.3V

### DIFF
--- a/docs/components/board/jetson.md
+++ b/docs/components/board/jetson.md
@@ -17,7 +17,7 @@ Follow one of our Jetson [setup guides](/installation/) to prepare your board fo
 
 {{% alert title="CAUTION: Use 3.3V inputs and outputs" color="warning" %}}
 
-The jetson's gpio pins are rated for inputs and outputs at 3.3V. Signals from encoders and sensors at even 5V can cause damage to a pin. We recommend connecting hardware that can operate and send signals at 3.3V or lower. [Jetson Nano Developer Kit 40-Pin Expansion Header GPIO Usage Considerations Applications Note](https://developer.nvidia.com/jetson-nano-developer-kit-40-pin-expansion-header-gpio-usage-considerations-applications-note)
+The jetson's GPIO pins are rated for inputs and outputs at 3.3V. Signals from encoders and sensors at even 5V can cause damage to a pin. We recommend connecting hardware that can operate and send signals at 3.3V or lower. For details, see pages 1-3 of the [Jetson Nano Developer Kit 40-Pin Expansion Header GPIO Usage Considerations Applications Note](https://developer.nvidia.com/jetson-nano-developer-kit-40-pin-expansion-header-gpio-usage-considerations-applications-note)
 
 {{% /alert %}}
 

--- a/docs/components/board/jetson.md
+++ b/docs/components/board/jetson.md
@@ -15,7 +15,7 @@ Follow one of our Jetson [setup guides](/installation/) to prepare your board fo
 
 {{% /alert %}}
 
-{{% alert title="REQUIREMENTS" color="warning" %}}
+{{% alert title="CAUTION: Use 3.3V inputs and outputs" color="warning" %}}
 
 The jetson's gpio pins are rated for inputs and outputs at 3.3V. Signals from encoders and sensors at even 5V can cause damage to a pin. We recommend connecting hardware that can operate and send signals at 3.3V or lower. [Jetson Nano Developer Kit 40-Pin Expansion Header GPIO Usage Considerations Applications Note](https://developer.nvidia.com/jetson-nano-developer-kit-40-pin-expansion-header-gpio-usage-considerations-applications-note)
 

--- a/docs/components/board/jetson.md
+++ b/docs/components/board/jetson.md
@@ -15,6 +15,12 @@ Follow one of our Jetson [setup guides](/installation/) to prepare your board fo
 
 {{% /alert %}}
 
+{{% alert title="REQUIREMENTS" color="warning" %}}
+
+The jetson's gpio pins are rated for inputs and outputs at 3.3V. Signals from encoders and sensors at even 5V can cause damage to a pin. We recommend connecting hardware that can operate and send signals at 3.3V or lower. [Jetson Nano Developer Kit 40-Pin Expansion Header GPIO Usage Considerations Applications Note](https://developer.nvidia.com/jetson-nano-developer-kit-40-pin-expansion-header-gpio-usage-considerations-applications-note)
+
+{{% /alert %}}
+
 Configure a `jetson` board to integrate a [NVIDIA Jetson Orin Module and Developer Kit](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/), [NVIDIA Jetson Xavier NX](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-agx-xavier/), or [NVIDIA Jetson Nano](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-nano/) into your robot:
 
 {{< tabs name="Configure an jetson Board" >}}


### PR DESCRIPTION
Hidden deep within jetson documentation is a spec that says the pins "all operate on 3.3v signals". This means that you can harm them by attaching signals over 3.3v, such as from an encoder powered by 5v. Here is my attempt at a warning to users so they don't fry their pins.


