### PR TITLE
DOCS-1071: Add CLI org API key commands

### DIFF
--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -141,14 +141,15 @@ To use an organization API key to authenticate your CLI session, you must first 
 
    Where:
 
-   * `org-id` is your organization ID. You can find your organization ID by running `viam organizations list` or by visiting your organization's **Settings** page in [the Viam App](https://app.viam.com/).
+   * `org-id` is your organization ID. You can find your organization ID by running `viam organizations list` or by visiting your organization's **Settings** page in [the Viam app](https://app.viam.com/).
    * `key-name` is an optional name for your API key. If omitted, a name will be auto-generated based on your login info and the current time.
 
-The command will return a `key id` and a `key value`; you will need both to authenticate using `viam login api-key`
+The command will return a `key id` and a `key value`.
+You will need both to authenticate using `viam login api-key`.
 
 {{% alert title="Important" color="note" %}}
 Secure these key values safely.
-Authenticating using an organization API key gives full write access to your organization, including to all robots within it.
+Authenticating using an organization API key gives the authenticated CLI session full read and write access to all robots within your organization.
 {{% /alert %}}
 
 Once created, you can then use the organization API key to authenticate future CLI sessions.
@@ -496,7 +497,7 @@ See [create an organization API key](#create-an-organization-api-key) for more i
 |        argument     |       description | applicable commands | required
 | ----------- | ----------- | ----------- | ----------- |
 | `--org-id`      | your organization ID      |`api-key`|true |
-| `--name`     |  optional name for the organization API key. If omitted, a name will be auto-generated based on your login info and the current time    |`api-key`|false |
+| `--name` |  optional name for the organization API key. If omitted, a name will be auto-generated based on your login info and the current time |`api-key`| false |
 
 ### organizations
 

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -144,11 +144,11 @@ To use your organization API key to authenticate your CLI session, you must firs
    * `org-id` is your organization ID. You can find your organization ID on your organization's **Settings** page in [the Viam App](https://app.viam.com/).
    * `key-name` is an optional name for your API key. If omitted, a name will be auto-generated based on your login info and the current time.
 
-The command will return both a `key id` and a `key value`; you will need both to authenticate using `viam login api-key`
+The command will return a `key id` and a `key value`; you will need both to authenticate using `viam login api-key`
 
 {{% alert title="Important" color="note" %}}
 Secure these key values safely.
-Authenticating using your organization API key gives full write access to your organization, including to all robots within it.
+Authenticating using an organization API key gives full write access to your organization, including to all robots within it.
 {{% /alert %}}
 
 Once created, you can then use the organization API key to authenticate future CLI sessions.
@@ -264,7 +264,7 @@ The `login` command helps you authorize your device for CLI usage. See [Authenti
 
 ```sh {class="command-line" data-prompt="$"}
 viam login
-viam login api-key --key-id <api-key-uuid> --key <api-key>
+viam login api-key --key-id <api-key-uuid> --key <api-key-value>
 viam login print-access-token
 ```
 
@@ -283,8 +283,8 @@ If you haven't already, you must [create an organization API key](#create-an-org
 
 |        argument     |       description | applicable commands | required
 | ----------- | ----------- | ----------- | ----------- |
-| `--key-id`    | the UUID of your organization's API key | `api-key` | true |
-| `--key`    | the name of your organization's API key | `api-key` | true |
+| `--key-id`    | the `key id` (UUID) of your organization's API key | `api-key` | true |
+| `--key`    | the `key value` of your organization's API key | `api-key` | true |
 
 ### `logout`
 
@@ -474,8 +474,7 @@ See [Upload a custom module](/extend/modular-resources/upload/#upload-a-custom-m
 
 ### organization
 
-The *organization* (singular) command allows you to create a new organization API key.
-See [organizations](#organizations) instead to list organizations your sessions belongs to.
+The *organization* command allows you to create a new organization API key.
 
 ```sh {class="command-line" data-prompt="$"}
 viam organization api-key create --org-id <org-id> [--name <key-name>]
@@ -500,7 +499,6 @@ See [create an organization API key](#create-an-organization-api-key) for more i
 ### organizations
 
 The *organizations* command lists all organizations that the authenticated session belongs to, and can be used to create a new organization API key to use when authenticating your CLI session to Viam.
-See [organization](#organization) instead to create a new organization API key.
 
 ```sh {class="command-line" data-prompt="$"}
 viam organizations list

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -99,22 +99,53 @@ To later update the Viam CLI tool, you can use the steps above to reinstall the 
 
 ## Authenticate
 
-Once you have successfully installed the Viam CLI, you need to authenticate your device for CLI usage with your Viam app account before you can control your robots with the CLI.
-Do this by issuing the command:
+Once you have [installed the Viam CLI](#install), you must authenticate your CLI session with Viam in order to run CLI commands.
 
-```sh {class="command-line" data-prompt="$"}
-viam login
-```
+You can authenticate your CLI session using either a personal access token or your organization's API key.
+To use your organization API key to authenticate, you must first [create an organization API key](#create-an-organization-api-key).
 
-This will open a new browser window with a prompt to start the authentication process.
-If a browser window does not open, the CLI will present a URL for you to manually open in your browser.
-Follow the instructions to complete the authentication process.
+* To authenticate your CLI session using a personal access token:
 
-{{% alert title="Info" color="info" %}}
+   ```sh {class="command-line" data-prompt="$"}
+   viam login
+   ```
+
+   This will open a new browser window with a prompt to start the authentication process.
+   If a browser window does not open, the CLI will present a URL for you to manually open in your browser.
+   Follow the instructions to complete the authentication process.
+
+* To authenticate your CLI session using your organization API key:
+
+   ```sh {class="command-line" data-prompt="$"}
+   viam login api-key --key-id <api-key-uuid> --key <api-key>
+   ```
+
+   If you haven't already, [create an organization API key](#create-an-organization-api-key) to use this authentication method.
+
 An authenticated session is valid for 24 hours, unless you explicitly [log out](#logout).
 
 After the session expires or you log out, you must re-authenticate to use the CLI again.
-{{% /alert %}}
+
+### Create an organization API key
+
+To use your organization API key to authenticate your CLI session, you must first create a organization API key:
+
+1. First, [authenticate](#authenticate) your CLI session.
+   You must authenticate using a personal access token in order to be able to create an organization API key.
+
+1. Then, run the following command to create a new organization API key:
+
+   ```sh {class="command-line" data-prompt="$"}
+   viam organization api-key create --org-id <org-id> --name <key-name>
+   ```
+
+   Where:
+
+   * `org-id` is your organization ID. You can find your organization ID on your organization's **Settings** page in [the Viam App](https://app.viam.com/).
+   * `key-name` is an optional name for your API key.
+
+Once created, you can then use the organization API key to authenticate future CLI sessions.
+To switch to using your organization API key for authentication right away, [logout](#logout) then log back in using `viam login api-key`.
 
 ## Manage your robots with the Viam CLI
 
@@ -226,19 +257,31 @@ The `login` command helps you authorize your device for CLI usage. See [Authenti
 
 ```sh {class="command-line" data-prompt="$"}
 viam login
+viam login api-key --key-id <api-key-uuid> --key <api-key>
 viam login print-access-token
 ```
+
+Use `viam login` to authenticate using a personal access token, or `viam login api-key` to authenticate using your organization's API key.
+If you haven't already, you must [create an organization API key](create-an-organization-api-key) first in order to authenticate using one.
 
 #### Command options
 
 |        command option     |       description      | positional arguments
 | ----------- | ----------- | ----------- |
-| `print-access-token`      | prints the access token the CLI uses during an authenticated CLI session      | - |
-| `help`      | return help      | - |
+| `api-key`      | authenticate to Viam using your organization's API key      | - |
+| `print-access-token`      | prints the access token used to authenticate the current CLI session      | - |
+| `--help`      | return help      | - |
+
+##### Named arguments
+
+|        argument     |       description | applicable commands | required
+| ----------- | ----------- | ----------- | ----------- |
+| `--key-id`    | the UUID of your organization's API key | `api-key` | true |
+| `--key`    | the name (value) of your organization's API key | `api-key` | true |
 
 ### `logout`
 
-The `logout` command ends an authenticated CLI session
+The `logout` command ends an authenticated CLI session.
 
 ```sh {class="command-line" data-prompt="$"}
 viam logout
@@ -422,9 +465,35 @@ If the two namespaces do not match, the command will return an error.
 
 See [Upload a custom module](/extend/modular-resources/upload/#upload-a-custom-module) and [Update an existing module](/extend/modular-resources/upload/#update-an-existing-module) for a detailed walkthrough of the `viam module` commands.
 
+### organization
+
+The *organization* (singular) command allows you to create a new organization API key.
+See [organizations](#organizations) instead to list organizations your sessions belongs to.
+
+```sh {class="command-line" data-prompt="$"}
+viam organization api-key create --org-id <organization ID> [--name <string>]
+```
+
+See [create an organization API key](#create-an-organization-api-key) for more information.
+
+#### Command options
+
+|        command option     |       description      | positional arguments
+| ----------- | ----------- | ----------- |
+| `api-key`      | create a new organization API key    | - |
+| `--help`      | return help      | - |
+
+##### Named arguments
+
+|        argument     |       description | applicable commands | required
+| ----------- | ----------- | ----------- | ----------- |
+| `--org-id`      | your organization ID      |`api-key`|true |
+| `--name`     |  optional name for your organization API key    |`api-key`|false |
+
 ### organizations
 
-The *organizations* command lists all organizations that the authenticated session belongs to.
+The *organizations* command lists all organizations that the authenticated session belongs to, and can be used to create a new organization API key to use when authenticating your CLI session to Viam.
+See [organization](#organization) instead to create a new organization API key.
 
 ```sh {class="command-line" data-prompt="$"}
 viam organizations list

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -117,7 +117,7 @@ To use your organization API key to authenticate, you must first [create an orga
 * To authenticate your CLI session using your organization API key:
 
    ```sh {class="command-line" data-prompt="$"}
-   viam login api-key --key-id <api-key-uuid> --key <api-key>
+   viam login api-key --key-id <api-key-uuid> --key <api-key-name>
    ```
 
    If you haven't already, [create an organization API key](#create-an-organization-api-key) to use this authentication method.
@@ -142,7 +142,14 @@ To use your organization API key to authenticate your CLI session, you must firs
    Where:
 
    * `org-id` is your organization ID. You can find your organization ID on your organization's **Settings** page in [the Viam App](https://app.viam.com/).
-   * `key-name` is an optional name for your API key.
+   * `key-name` is an optional name for your API key. If omitted, a name will be auto-generated based on your login info and the current time.
+
+The command will return both a `key id` and a `key value`; you will need both to authenticate using `viam login api-key`
+
+{{% alert title="Important" color="note" %}}
+Secure these key values safely.
+Authenticating using your organization API key gives full write access to your organization, including to all robots within it.
+{{% /alert %}}
 
 Once created, you can then use the organization API key to authenticate future CLI sessions.
 To switch to using your organization API key for authentication right away, [logout](#logout) then log back in using `viam login api-key`.
@@ -262,7 +269,7 @@ viam login print-access-token
 ```
 
 Use `viam login` to authenticate using a personal access token, or `viam login api-key` to authenticate using your organization's API key.
-If you haven't already, you must [create an organization API key](create-an-organization-api-key) first in order to authenticate using one.
+If you haven't already, you must [create an organization API key](#create-an-organization-api-key) first in order to authenticate using one.
 
 #### Command options
 
@@ -277,7 +284,7 @@ If you haven't already, you must [create an organization API key](create-an-orga
 |        argument     |       description | applicable commands | required
 | ----------- | ----------- | ----------- | ----------- |
 | `--key-id`    | the UUID of your organization's API key | `api-key` | true |
-| `--key`    | the name (value) of your organization's API key | `api-key` | true |
+| `--key`    | the name of your organization's API key | `api-key` | true |
 
 ### `logout`
 
@@ -471,7 +478,7 @@ The *organization* (singular) command allows you to create a new organization AP
 See [organizations](#organizations) instead to list organizations your sessions belongs to.
 
 ```sh {class="command-line" data-prompt="$"}
-viam organization api-key create --org-id <organization ID> [--name <string>]
+viam organization api-key create --org-id <org-id> [--name <key-name>]
 ```
 
 See [create an organization API key](#create-an-organization-api-key) for more information.
@@ -488,7 +495,7 @@ See [create an organization API key](#create-an-organization-api-key) for more i
 |        argument     |       description | applicable commands | required
 | ----------- | ----------- | ----------- | ----------- |
 | `--org-id`      | your organization ID      |`api-key`|true |
-| `--name`     |  optional name for your organization API key    |`api-key`|false |
+| `--name`     |  optional name for your organization API key. If omitted, a name will be auto-generated based on your login info and the current time    |`api-key`|false |
 
 ### organizations
 

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -101,8 +101,8 @@ To later update the Viam CLI tool, you can use the steps above to reinstall the 
 
 Once you have [installed the Viam CLI](#install), you must authenticate your CLI session with Viam in order to run CLI commands.
 
-You can authenticate your CLI session using either a personal access token or your organization's API key.
-To use your organization API key to authenticate, you must first [create an organization API key](#create-an-organization-api-key).
+You can authenticate your CLI session using either a personal access token or an organization API key.
+To use an organization API key to authenticate, you must first [create an organization API key](#create-an-organization-api-key).
 
 * To authenticate your CLI session using a personal access token:
 
@@ -114,10 +114,10 @@ To use your organization API key to authenticate, you must first [create an orga
    If a browser window does not open, the CLI will present a URL for you to manually open in your browser.
    Follow the instructions to complete the authentication process.
 
-* To authenticate your CLI session using your organization API key:
+* To authenticate your CLI session using an organization API key:
 
    ```sh {class="command-line" data-prompt="$"}
-   viam login api-key --key-id <api-key-uuid> --key <api-key-name>
+   viam login api-key --key-id <api-key-uuid> --key <api-key-secret-value>
    ```
 
    If you haven't already, [create an organization API key](#create-an-organization-api-key) to use this authentication method.
@@ -128,10 +128,10 @@ After the session expires or you log out, you must re-authenticate to use the CL
 
 ### Create an organization API key
 
-To use your organization API key to authenticate your CLI session, you must first create a organization API key:
+To use an organization API key to authenticate your CLI session, you must first create one:
 
 1. First, [authenticate](#authenticate) your CLI session.
-   You must authenticate using a personal access token in order to be able to create an organization API key.
+   If your organization does not already have an organization API key created, authenticate using a personal access token.
 
 1. Then, run the following command to create a new organization API key:
 
@@ -141,7 +141,7 @@ To use your organization API key to authenticate your CLI session, you must firs
 
    Where:
 
-   * `org-id` is your organization ID. You can find your organization ID on your organization's **Settings** page in [the Viam App](https://app.viam.com/).
+   * `org-id` is your organization ID. You can find your organization ID by running `viam organizations list` or by visiting your organization's **Settings** page in [the Viam App](https://app.viam.com/).
    * `key-name` is an optional name for your API key. If omitted, a name will be auto-generated based on your login info and the current time.
 
 The command will return a `key id` and a `key value`; you will need both to authenticate using `viam login api-key`
@@ -152,7 +152,9 @@ Authenticating using an organization API key gives full write access to your org
 {{% /alert %}}
 
 Once created, you can then use the organization API key to authenticate future CLI sessions.
-To switch to using your organization API key for authentication right away, [logout](#logout) then log back in using `viam login api-key`.
+To switch to using an organization API key for authentication right away, [logout](#logout) then log back in using `viam login api-key`.
+
+An organization can have multiple API keys.
 
 ## Manage your robots with the Viam CLI
 
@@ -264,18 +266,18 @@ The `login` command helps you authorize your device for CLI usage. See [Authenti
 
 ```sh {class="command-line" data-prompt="$"}
 viam login
-viam login api-key --key-id <api-key-uuid> --key <api-key-value>
+viam login api-key --key-id <api-key-uuid> --key <api-key-secret-value>
 viam login print-access-token
 ```
 
-Use `viam login` to authenticate using a personal access token, or `viam login api-key` to authenticate using your organization's API key.
+Use `viam login` to authenticate using a personal access token, or `viam login api-key` to authenticate using an organization API key.
 If you haven't already, you must [create an organization API key](#create-an-organization-api-key) first in order to authenticate using one.
 
 #### Command options
 
 |        command option     |       description      | positional arguments
 | ----------- | ----------- | ----------- |
-| `api-key`      | authenticate to Viam using your organization's API key      | - |
+| `api-key`      | authenticate to Viam using an organization API key      | - |
 | `print-access-token`      | prints the access token used to authenticate the current CLI session      | - |
 | `--help`      | return help      | - |
 
@@ -283,8 +285,8 @@ If you haven't already, you must [create an organization API key](#create-an-org
 
 |        argument     |       description | applicable commands | required
 | ----------- | ----------- | ----------- | ----------- |
-| `--key-id`    | the `key id` (UUID) of your organization's API key | `api-key` | true |
-| `--key`    | the `key value` of your organization's API key | `api-key` | true |
+| `--key-id`    | the `key id` (UUID) of the organization API key | `api-key` | true |
+| `--key`    | the `key value` of the organization API key | `api-key` | true |
 
 ### `logout`
 
@@ -494,7 +496,7 @@ See [create an organization API key](#create-an-organization-api-key) for more i
 |        argument     |       description | applicable commands | required
 | ----------- | ----------- | ----------- | ----------- |
 | `--org-id`      | your organization ID      |`api-key`|true |
-| `--name`     |  optional name for your organization API key. If omitted, a name will be auto-generated based on your login info and the current time    |`api-key`|false |
+| `--name`     |  optional name for the organization API key. If omitted, a name will be auto-generated based on your login info and the current time    |`api-key`|false |
 
 ### organizations
 

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -498,7 +498,7 @@ See [create an organization API key](#create-an-organization-api-key) for more i
 
 ### organizations
 
-The *organizations* command lists all organizations that the authenticated session belongs to, and can be used to create a new organization API key to use when authenticating your CLI session to Viam.
+The *organizations* command lists all organizations that the authenticated session belongs to.
 
 ```sh {class="command-line" data-prompt="$"}
 viam organizations list


### PR DESCRIPTION
- Add `viam login --api-key` and `viam organization api-key create` reference documentation, with usage instructions.

## Staging

- [/manage/cli/#authenticate](https://docs-test.viam.dev/91609eb01c0541117f13ec11ef0aaf2ab4004b2f/public/manage/cli/#authenticate)