### PR TITLE
DOCS-1090: Note platform visibility in registry

### DIFF
--- a/docs/extend/modular-resources/upload/_index.md
+++ b/docs/extend/modular-resources/upload/_index.md
@@ -165,6 +165,7 @@ To upload your custom module to the Viam Registry, either as a public or private
    The `viam module upload` command only supports one `platform` argument at a time.
    If you would like to upload your module with support for multiple platforms, you must run a separate `viam module upload` command for each platform.
    Use the *same version number* when running multiple `upload` commands of the same module code if only the `platform` support differs.
+   The Viam registry page for your module displays the platforms your module supports for each version you have uploaded.
    {{% /alert %}}
 
    For example, the following command uploads the compressed `module.tar.gz` archive to the Viam Registry when run in the same directory as the corresponding `meta.json` file:

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -374,6 +374,8 @@ The `viam module upload` command only supports one `platform` argument at a time
 If you would like to upload your module with support for multiple platforms, you must run a separate `viam module upload` command for each platform.
 Use the *same version number* when running multiple `upload` commands of the same module code if only the `platform` support differs.
 
+The Viam registry page for your module displays the platforms your module supports for each version you have uploaded.
+
 ##### Using the `--version` argument
 
 The `--version` argument accepts a valid [semver 2.0](https://semver.org/) version (example: `1.0.0`).


### PR DESCRIPTION
Add brief notice that a module's supported platforms can be viewed on that module's registry page.

- Will add additional related copy (selecting a platform) to the `configure` page for "add a module" steps as part of the DOCS - 1059 and DOCS - 1086 effort as soon as the eng tickets they are blocked on merge.