### PR TITLE
Removing medium.com for now

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -24,6 +24,7 @@ IgnoreURLs:
 - "universal-robots.com"
 - "digikey.com"
 - "ufactory.cc"
+- "medium.com"
 IgnoreDirs:
 - "lib"
 CacheExpires: "6h"


### PR DESCRIPTION
- Temporarily removing `medium.com` from `htmltest` tests.