### PR TITLE
DOCS-1098: Add link to modular resource examples in relevant resource pages

### DIFF
--- a/docs/components/arm/_index.md
+++ b/docs/components/arm/_index.md
@@ -60,6 +60,8 @@ Supported arm models include:
 | [`yahboom-dofbot`](yahboom-dofbot/) | [Yahboom DOFBOT](https://category.yahboom.net/collections/r-robotics-arm) |
 | [`ur5e`](ur5e/) | [Universal Robots UR5e](https://www.universal-robots.com/products/ur5-robot) |
 
+Follow [this guide](/extend/modular-resources/examples/custom-arm/) to implement your custom arm as a [modular resource](/extend/modular-resources/).
+
 ## Control your arm with Viam's client SDK libraries
 
 To get started using Viam's SDKs to connect to and control your robot, go to your robot's page on [the Viam app](https://app.viam.com), navigate to the **Code sample** tab, select your preferred programming language, and copy the sample code generated.

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -48,7 +48,7 @@ Viam also provides the following motor models as [modular resources](/extend/mod
  [`viam:odrive:canbus`](/extend/modular-resources/examples/odrive/) | An [ODrive S1](https://odriverobotics.com/shop/odrive-s1) motor driver with CANbus communication
  [`viam:odrive:serial`](/extend/modular-resources/examples/odrive/) | An [ODrive S1](https://odriverobotics.com/shop/odrive-s1) motor driver with serial communication
 
-These modules can be [added to your robot from the Viam registry](https://docs.viam.com/extend/modular-resources/configure/#add-a-module-from-the-viam-registry)
+These modules can be [added to your robot from the Viam registry](/extend/modular-resources/configure/#add-a-module-from-the-viam-registry)
 
 ## Control your motor with Viam's client SDK libraries
 

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -48,7 +48,8 @@ Viam also provides the following motor models as [modular resources](/extend/mod
  [`viam:odrive:canbus`](/extend/modular-resources/examples/odrive/) | An [ODrive S1](https://odriverobotics.com/shop/odrive-s1) motor driver with CANbus communication
  [`viam:odrive:serial`](/extend/modular-resources/examples/odrive/) | An [ODrive S1](https://odriverobotics.com/shop/odrive-s1) motor driver with serial communication
 
-These modules can be [added to your robot from the Viam registry](/extend/modular-resources/configure/#add-a-module-from-the-viam-registry)
+These modules can be [added to your robot from the Viam registry](/extend/modular-resources/configure/#add-a-module-from-the-viam-registry).
+
 
 ## Control your motor with Viam's client SDK libraries
 

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -48,6 +48,7 @@ Viam also provides the following motor models as [modular resources](/extend/mod
  [`viam:odrive:canbus`](/extend/modular-resources/examples/odrive/) | An [ODrive S1](https://odriverobotics.com/shop/odrive-s1) motor driver with CANbus communication
  [`viam:odrive:serial`](/extend/modular-resources/examples/odrive/) | An [ODrive S1](https://odriverobotics.com/shop/odrive-s1) motor driver with serial communication
 
+These modules can be [added to your robot from the Viam registry](https://docs.viam.com/extend/modular-resources/configure/#add-a-module-from-the-viam-registry)
 ## Control your motor with Viam's client SDK libraries
 
 To get started using Viam's SDKs to connect to and control your robot, go to your robot's page on [the Viam app](https://app.viam.com), navigate to the **Code sample** tab, select your preferred programming language, and copy the sample code generated.

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -49,6 +49,7 @@ Viam also provides the following motor models as [modular resources](/extend/mod
  [`viam:odrive:serial`](/extend/modular-resources/examples/odrive/) | An [ODrive S1](https://odriverobotics.com/shop/odrive-s1) motor driver with serial communication
 
 These modules can be [added to your robot from the Viam registry](https://docs.viam.com/extend/modular-resources/configure/#add-a-module-from-the-viam-registry)
+
 ## Control your motor with Viam's client SDK libraries
 
 To get started using Viam's SDKs to connect to and control your robot, go to your robot's page on [the Viam app](https://app.viam.com), navigate to the **Code sample** tab, select your preferred programming language, and copy the sample code generated.

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -41,6 +41,13 @@ Model | Description <a name="model-table"></a>
 [`roboclaw`](./roboclaw/) | [Standard brushed DC motor](https://en.wikipedia.org/wiki/DC_motor) driven by [Basicmicro's](https://www.basicmicro.com/) [RoboClaw](https://www.basicmicro.com/RoboClaw-2x30A-Motor-Controller_p_9.html) motor controller
 [`fake`](./fake/) | Used to test code without hardware
 
+Viam also provides the following motor models as [modular resources](/extend/modular-resources/):
+
+ Model | Description
+ ----- | -----------
+ [`viam:odrive:canbus`](/extend/modular-resources/examples/odrive/) | An [ODrive S1](https://odriverobotics.com/shop/odrive-s1) motor driver with CANbus communication
+ [`viam:odrive:serial`](/extend/modular-resources/examples/odrive/) | An [ODrive S1](https://odriverobotics.com/shop/odrive-s1) motor driver with serial communication
+
 ## Control your motor with Viam's client SDK libraries
 
 To get started using Viam's SDKs to connect to and control your robot, go to your robot's page on [the Viam app](https://app.viam.com), navigate to the **Code sample** tab, select your preferred programming language, and copy the sample code generated.

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -50,7 +50,6 @@ Viam also provides the following motor models as [modular resources](/extend/mod
 
 These modules can be [added to your robot from the Viam registry](/extend/modular-resources/configure/#add-a-module-from-the-viam-registry).
 
-
 ## Control your motor with Viam's client SDK libraries
 
 To get started using Viam's SDKs to connect to and control your robot, go to your robot's page on [the Viam app](https://app.viam.com), navigate to the **Code sample** tab, select your preferred programming language, and copy the sample code generated.

--- a/docs/components/sensor/_index.md
+++ b/docs/components/sensor/_index.md
@@ -48,6 +48,12 @@ This allows you to have the same access and control of the sensor through Viam a
 
 For an example of creating a custom component, see a [WiFi strength sensor built with the Viam Go SDK](https://github.com/viam-labs/wifi-sensor/blob/main/linuxwifi/linuxwifi.go) or [custom resource types implemented with the Viam Python SDK](https://github.com/viamrobotics/viam-python-sdk/tree/main/examples/).
 
+Viam also provides the following sensor models as [modular resources](/extend/modular-resources/):
+
+ Model | Description
+ ----- | -----------
+ [`viam:visual_odometry:opencv_orb`](/extend/modular-resources/examples/odrive/) | A resource which uses monocular [visual odometry](https://en.wikipedia.org/wiki/Visual_odometry) to enable any [calibrated cameras](/components/camera/calibrate/) to function as a movement sensor
+
 ## Control your sensor with Viam's client SDK libraries
 
 To get started using Viam's SDKs to connect to and control your robot, go to your robot's page on [the Viam app](https://app.viam.com), navigate to the **Code sample** tab, select your preferred programming language, and copy the sample code generated.

--- a/docs/components/sensor/_index.md
+++ b/docs/components/sensor/_index.md
@@ -54,7 +54,7 @@ Viam also provides the following sensor model as a [modular resource](/extend/mo
  ----- | -----------
  [`viam:visual_odometry:opencv_orb`](/extend/modular-resources/examples/odrive/) | A resource which uses monocular [visual odometry](https://en.wikipedia.org/wiki/Visual_odometry) to enable any [calibrated cameras](/components/camera/calibrate/) to function as a movement sensor
 
-This module can be [added to your robot from the Viam registry](/extend/modular-resources/configure/#add-a-module-from-the-viam-registry).
+This module can be [added to your robot from the Viam registry.](/extend/modular-resources/configure/#add-a-module-from-the-viam-registry).
 
 ## Control your sensor with Viam's client SDK libraries
 

--- a/docs/components/sensor/_index.md
+++ b/docs/components/sensor/_index.md
@@ -48,12 +48,13 @@ This allows you to have the same access and control of the sensor through Viam a
 
 For an example of creating a custom component, see a [WiFi strength sensor built with the Viam Go SDK](https://github.com/viam-labs/wifi-sensor/blob/main/linuxwifi/linuxwifi.go) or [custom resource types implemented with the Viam Python SDK](https://github.com/viamrobotics/viam-python-sdk/tree/main/examples/).
 
-Viam also provides the following sensor models as [modular resources](/extend/modular-resources/):
+Viam also provides the following sensor model as a [modular resource](/extend/modular-resources/):
 
  Model | Description
  ----- | -----------
  [`viam:visual_odometry:opencv_orb`](/extend/modular-resources/examples/odrive/) | A resource which uses monocular [visual odometry](https://en.wikipedia.org/wiki/Visual_odometry) to enable any [calibrated cameras](/components/camera/calibrate/) to function as a movement sensor
 
+This module can be [added to your robot from the Viam registry](https://docs.viam.com/extend/modular-resources/configure/#add-a-module-from-the-viam-registry).
 ## Control your sensor with Viam's client SDK libraries
 
 To get started using Viam's SDKs to connect to and control your robot, go to your robot's page on [the Viam app](https://app.viam.com), navigate to the **Code sample** tab, select your preferred programming language, and copy the sample code generated.

--- a/docs/components/sensor/_index.md
+++ b/docs/components/sensor/_index.md
@@ -55,6 +55,7 @@ Viam also provides the following sensor model as a [modular resource](/extend/mo
  [`viam:visual_odometry:opencv_orb`](/extend/modular-resources/examples/odrive/) | A resource which uses monocular [visual odometry](https://en.wikipedia.org/wiki/Visual_odometry) to enable any [calibrated cameras](/components/camera/calibrate/) to function as a movement sensor
 
 This module can be [added to your robot from the Viam registry](https://docs.viam.com/extend/modular-resources/configure/#add-a-module-from-the-viam-registry).
+
 ## Control your sensor with Viam's client SDK libraries
 
 To get started using Viam's SDKs to connect to and control your robot, go to your robot's page on [the Viam app](https://app.viam.com), navigate to the **Code sample** tab, select your preferred programming language, and copy the sample code generated.

--- a/docs/components/sensor/_index.md
+++ b/docs/components/sensor/_index.md
@@ -54,7 +54,7 @@ Viam also provides the following sensor model as a [modular resource](/extend/mo
  ----- | -----------
  [`viam:visual_odometry:opencv_orb`](/extend/modular-resources/examples/odrive/) | A resource which uses monocular [visual odometry](https://en.wikipedia.org/wiki/Visual_odometry) to enable any [calibrated cameras](/components/camera/calibrate/) to function as a movement sensor
 
-This module can be [added to your robot from the Viam registry](https://docs.viam.com/extend/modular-resources/configure/#add-a-module-from-the-viam-registry).
+This module can be [added to your robot from the Viam registry](/extend/modular-resources/configure/#add-a-module-from-the-viam-registry).
 
 ## Control your sensor with Viam's client SDK libraries
 

--- a/docs/components/sensor/_index.md
+++ b/docs/components/sensor/_index.md
@@ -54,7 +54,7 @@ Viam also provides the following sensor model as a [modular resource](/extend/mo
  ----- | -----------
  [`viam:visual_odometry:opencv_orb`](/extend/modular-resources/examples/odrive/) | A resource which uses monocular [visual odometry](https://en.wikipedia.org/wiki/Visual_odometry) to enable any [calibrated cameras](/components/camera/calibrate/) to function as a movement sensor
 
-This module can be [added to your robot from the Viam registry.](/extend/modular-resources/configure/#add-a-module-from-the-viam-registry).
+This module can be [added to your robot from the Viam registry](/extend/modular-resources/configure/#add-a-module-from-the-viam-registry).
 
 ## Control your sensor with Viam's client SDK libraries
 


### PR DESCRIPTION
First five examples are now covered-- last three are a little ambigious and unsure whether/where to add (tensorflow-lite for what the model name is and how to add it to docs, last two are old custom base tutorials) 