### PR TITLE
DOCS-1107: Day-of MR tweaks

### DIFF
--- a/docs/appendix/glossary/module.md
+++ b/docs/appendix/glossary/module.md
@@ -2,10 +2,12 @@
 title: Module
 id: module
 full_link:
-short_description: Modular resources are a way to add resource types or models that are not built into Viam.
+short_description: A module provides one or more modular resources, which add resource types or models that are not built into Viam.
 aka:
 ---
 
-Modular resources are a way to add resource types or models that are not built into Viam.
+A module provides one or more [modular resources](/extend/modular-resources/) (such as [components](/components) or [services](/services)), which add resource types or models that are not built into Viam.
+
+You can extend the capabilities of Viam on your robot by [creating your own module](/extend/modular-resources/create/) or [adding an existing module from the Viam Registry](/extend/modular-resources/configure/).
 
 For more information see the [modular resource documentation](/extend/modular-resources/).

--- a/docs/appendix/glossary/module.md
+++ b/docs/appendix/glossary/module.md
@@ -6,7 +6,7 @@ short_description: A module provides one or more modular resources, which add re
 aka:
 ---
 
-A module provides one or more [modular resources](/extend/modular-resources/), which add resource types (such as [components](/components/) and [services](/services/)) or {{< glossary_tooltip term_id="model" text="models" >}} that are not built into Viam.
+A module provides one or more [modular resources](/extend/modular-resources/), which add resource types ([components](/components/) and [services](/services/)) or {{< glossary_tooltip term_id="model" text="models" >}} that are not built into Viam.
 
 You can extend the capabilities of Viam on your robot by [creating your own module](/extend/modular-resources/create/) or [adding an existing module from the Viam registry](/extend/modular-resources/configure/).
 

--- a/docs/appendix/glossary/module.md
+++ b/docs/appendix/glossary/module.md
@@ -6,8 +6,8 @@ short_description: A module provides one or more modular resources, which add re
 aka:
 ---
 
-A module provides one or more [modular resources](/extend/modular-resources/) (such as [components](/components) or [services](/services)), which add resource types or models that are not built into Viam.
+A module provides one or more [modular resources](/extend/modular-resources/), which add resource types (such as [components](/components/) or [services](/services/)) or {{< glossary_tooltip term_id="model" text="models" >}} that are not built into Viam.
 
-You can extend the capabilities of Viam on your robot by [creating your own module](/extend/modular-resources/create/) or [adding an existing module from the Viam Registry](/extend/modular-resources/configure/).
+You can extend the capabilities of Viam on your robot by [creating your own module](/extend/modular-resources/create/) or [adding an existing module from the Viam registry](/extend/modular-resources/configure/).
 
 For more information see the [modular resource documentation](/extend/modular-resources/).

--- a/docs/appendix/glossary/module.md
+++ b/docs/appendix/glossary/module.md
@@ -6,7 +6,7 @@ short_description: A module provides one or more modular resources, which add re
 aka:
 ---
 
-A module provides one or more [modular resources](/extend/modular-resources/), which add resource types (such as [components](/components/) or [services](/services/)) or {{< glossary_tooltip term_id="model" text="models" >}} that are not built into Viam.
+A module provides one or more [modular resources](/extend/modular-resources/), which add resource types (such as [components](/components/) and [services](/services/)) or {{< glossary_tooltip term_id="model" text="models" >}} that are not built into Viam.
 
 You can extend the capabilities of Viam on your robot by [creating your own module](/extend/modular-resources/create/) or [adding an existing module from the Viam registry](/extend/modular-resources/configure/).
 

--- a/docs/appendix/glossary/resource.md
+++ b/docs/appendix/glossary/resource.md
@@ -8,11 +8,11 @@ aka:
 
 Resources are individual, addressable elements of a robot.
 
-{{< glossary_tooltip term_id="part" text="Parts" >}} operate multiple types of resources:
+{{< glossary_tooltip term_id="part" text="Parts" >}} can operate multiple types of resources:
 
 - physical {{< glossary_tooltip term_id="component" text="components" >}}
 - software {{< glossary_tooltip term_id="service" text="services" >}}
-- {{< glossary_tooltip term_id="module" text="modules" >}}
+- [modular resources](/extend/modular-resources/) provided by {{< glossary_tooltip term_id="module" text="modules" >}}
 - {{< glossary_tooltip term_id="process" text="processes" >}}
 
 Each part has local resources and can also have resources from another {{< glossary_tooltip term_id="remote" text="remote">}} robot part.

--- a/docs/extend/_index.md
+++ b/docs/extend/_index.md
@@ -16,7 +16,7 @@ Viam's [Robot Development Kit (RDK)](/internals/rdk/) provides built-in support 
 - Various types of hardware [components](/components/).
 - High-level functionality exposed as [services](/services/).
 
-However, if you want to work with a new hardware component that is not already supported by Viam, or want to introduce a new software service or service model to support additional functionality on your robot, you can extend Viam by adding a {{< glossary_tooltip term_id="module" text="modular resource" >}} to your robot.
+However, if you want to work with a new hardware component that is not already supported by Viam, or want to introduce a new software service or service model to support additional functionality on your robot, you can extend Viam by adding a [modular resources](/extend/modular-resources/) to your robot.
 
 Click on the cards below for instructions on implementing modular resources through {{< glossary_tooltip term_id="module" text="modules" >}} or {{< glossary_tooltip term_id="remote" text="remotes" >}}:
 

--- a/docs/extend/_index.md
+++ b/docs/extend/_index.md
@@ -27,7 +27,7 @@ Click on the cards below for instructions on implementing modular resources thro
 
 {{% alert title="Tip" color="tip" %}}
 
-{{< glossary_tooltip term_id="module" text="Modular resources" >}} are the preferred method of creating custom resource implementations with the [Python and Go SDKs](/program/).
+[Modular resources](/extend/modular-resources/) are the preferred method of creating custom resource implementations with the [Python and Go SDKs](/program/).
 
 [Adding a custom component as a remote](/extend/custom-components-remotes/) is recommended if you are hosting `viam-server` on a non-Linux system or have another issue with compilation.
 

--- a/docs/extend/_index.md
+++ b/docs/extend/_index.md
@@ -16,7 +16,7 @@ Viam's [Robot Development Kit (RDK)](/internals/rdk/) provides built-in support 
 - Various types of hardware [components](/components/).
 - High-level functionality exposed as [services](/services/).
 
-However, if you want to work with a new hardware component that is not already supported by Viam, or want to introduce a new software service or service model to support additional functionality on your robot, you can extend Viam by adding a [modular resources](/extend/modular-resources/) to your robot.
+However, if you want to work with a new hardware component that is not already supported by Viam, or want to introduce a new software service or service model to support additional functionality on your robot, you can extend Viam by adding a [modular resource](/extend/modular-resources/) to your robot.
 
 Click on the cards below for instructions on implementing modular resources through {{< glossary_tooltip term_id="module" text="modules" >}} or {{< glossary_tooltip term_id="remote" text="remotes" >}}:
 
@@ -27,7 +27,7 @@ Click on the cards below for instructions on implementing modular resources thro
 
 {{% alert title="Tip" color="tip" %}}
 
-[Modular resources](/extend/modular-resources/) are the preferred method of creating custom resource implementations with the [Python and Go SDKs](/program/).
+[Modular resources](/extend/modular-resources/) provided by custom {{< glossary_tooltip term_id="module" text="modules" >}} are the preferred method of creating custom resource implementations.
 
 [Adding a custom component as a remote](/extend/custom-components-remotes/) is recommended if you are hosting `viam-server` on a non-Linux system or have another issue with compilation.
 

--- a/docs/extend/modular-resources/_index.md
+++ b/docs/extend/modular-resources/_index.md
@@ -21,7 +21,7 @@ For example, you can:
 
 - **Implement fully custom logic:** If your robot runs specialty or proprietary logic, and you want to use Viam to manage and control that logic, such as when managing a software development lifecyle, you can implement your own custom logic by wrapping the generic API.
 
-These custom implementations are called {{< glossary_tooltip term_id="module" text="modular resources" >}}, and are made available for use on a robot through [modules](/extend/modular-resources/key-concepts/#modules).
+These custom implementations are called *modular resources*, and are made available for use on a robot through {{< glossary_tooltip term_id="module" text="modules" >}}.
 A module can provide one or more modular resources, and can be added to your robot from the Viam registry.
 
 ## The Viam Registry
@@ -29,7 +29,7 @@ A module can provide one or more modular resources, and can be added to your rob
 The [Viam registry](https://app.viam.com/registry) allows hardware and software engineers to collaborate on their robotics projects by writing and sharing custom modules with each other.
 You can add a module from the Viam registry directly from your robot's **Configuration** tab in [the Viam app](https://app.viam.com/), using the **+ Create component** button.
 
-The code behind any modular resource can be packaged as a [module](/extend/modular-resources/key-concepts/#modules) and uploaded to the Viam registry.
+The code behind any modular resource can be packaged as a {{< glossary_tooltip term_id="module" text="module" >}} and uploaded to the Viam registry.
 Once the module has been uploaded to the Registry, you can [deploy the module](/extend/modular-resources/configure/) to any robot in your organization from [the Viam app](https://app.viam.com/).
 
 ### Uploading to Viam Registry

--- a/docs/extend/modular-resources/configure.md
+++ b/docs/extend/modular-resources/configure.md
@@ -42,6 +42,9 @@ To add a modular [component](/components/) from the Viam registry to your robot:
 
    {{<imgproc src="extend/modular-resources/configure/add-component-screen.png" resize="400x" declaredimensions=true alt="The add a component modal showing the intel realsense module pane, with the 'Add module' button shown">}}
 
+   Be sure the modular component you select supports the [platform](/manage/cli/#using-the---platform-argument) you intend to use it with, such as `linux arm64`.
+   You can see which platforms the module supports at bottom of the module information screen before you add it.
+
 When you add a module from the Viam registry, the custom modular component it provides appears under the **Components** subtab like any other component.
 You can also find [the module itself](#configure-a-module-from-the-viam-registry) listed as **Deployed** under the **Modules** subtab.
 
@@ -67,6 +70,9 @@ To add a modular [service](/services/) from the Viam registry to your robot:
 1. After selecting the modular service, click the **Add module** button, enter a name for your modular service, and click **Create** to add it to your robot.
 
    {{<imgproc src="extend/modular-resources/configure/add-service-screen.png" resize="400x" declaredimensions=true alt="The add a component modal showing the mlmodelservice triton module pane, with the 'Add module' button shown">}}
+
+   Be sure the modular service you select supports the [platform](/manage/cli/#using-the---platform-argument) you intend to use it with, such as `linux arm64`.
+   You can see which platforms the module supports at bottom of the module information screen before you add it.
 
 When you add a module from the Viam registry, the custom modular service it provides appears under the **Services** subtab like any other service.
 You can also find [the module itself](#configure-a-module-from-the-viam-registry) listed as **Deployed** under the **Modules** subtab.

--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -10,8 +10,6 @@ no_list: true
 
 You can extend Viam by creating a custom {{< glossary_tooltip term_id="module" text="module" >}} that provides one or more modular {{< glossary_tooltip term_id="resource" text="resources" >}} (such as [components](/components/) or [services](/services/)) or {{< glossary_tooltip term_id="model" text="models" >}}, and can be added to any robot running on Viam.
 
-(such as [components](/components/) or [services](/services/)) or {{< glossary_tooltip term_id="model" text="models" >}}
-
 A common use case for modular resources is to create a new [model](/extend/modular-resources/key-concepts/#models) that implements an existing Viam [API](/program/apis/).
 
 Once you have created your modular resource, you can use the [Viam CLI](/manage/cli/) to [upload your modular resource](/extend/modular-resources/upload/) to the [Viam registry](https://app.viam.com/registry), to share it with other Viam users or just to other users in your organization.

--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -8,7 +8,7 @@ description: "Use the Viam module system to implement modular resources that can
 no_list: true
 ---
 
-You can extend Viam by creating a custom {{< glossary_tooltip term_id="module" text="module" >}} that provides one or more modular {{< glossary_tooltip term_id="resource" text="resources" >}} (such as [components](/components/) or [services](/services/)) or {{< glossary_tooltip term_id="model" text="models" >}}, and can be added to any robot running on Viam.
+You can extend Viam by creating a custom {{< glossary_tooltip term_id="module" text="module" >}} that provides one or more modular {{< glossary_tooltip term_id="resource" text="resources" >}} ([components](/components/) or [services](/services/)) or {{< glossary_tooltip term_id="model" text="models" >}}, and can be added to any robot running on Viam.
 
 A common use case for modular resources is to create a new [model](/extend/modular-resources/key-concepts/#models) that implements an existing Viam [API](/program/apis/).
 

--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -13,7 +13,7 @@ You can extend Viam by creating a custom {{< glossary_tooltip term_id="module" t
 A common use case for modular resources is to create a new [model](/extend/modular-resources/key-concepts/#models) that implements an existing Viam [API](/program/apis/).
 
 Once you have created your modular resource, you can use the [Viam CLI](/manage/cli/) to [upload your modular resource](/extend/modular-resources/upload/) to the [Viam registry](https://app.viam.com/registry), to share it with other Viam users or just to other users in your organization.
-You can also configure [automatic upload of new versions of your module](/extend/modular-resources/upload/#update-an-existing-module-using-a-github-action) as part of a continuous integration (CI) workflow, using a GitHub Action.
+You can also configure [automatic uploads of new versions of your module](/extend/modular-resources/upload/#update-an-existing-module-using-a-github-action) as part of a continuous integration (CI) workflow, using a GitHub Action.
 
 Alternatively, you can add your module locally to your robot without uploading to the Viam registry.
 

--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -8,9 +8,9 @@ description: "Use the Viam module system to implement modular resources that can
 no_list: true
 ---
 
-You can extend Viam by creating a custom [module](/extend/modular-resources/key-concepts/#modules) that provides one or more modular {{< glossary_tooltip term_id="resource" text="resources" >}} ([components](/components/) and [services](/services/)), and can be added to any robot running on Viam.
+You can extend Viam by creating a custom {{< glossary_tooltip term_id="module" text="module" >}} that provides one or more modular {{< glossary_tooltip term_id="resource" text="resources" >}} ([components](/components/) and [services](/services/)), and can be added to any robot running on Viam.
 
-A common use case for modular resources is to create a new model that implements an existing Viam API.
+A common use case for modular resources is to create a new [model](/extend/modular-resources/key-concepts/#models) that implements an existing Viam [API](/program/apis/).
 
 Once you have created your modular resource, you can use the [Viam CLI](/manage/cli/) to [upload your modular resource](/extend/modular-resources/upload/) to the Viam registry, to share it with other Viam users or just to other users in your organization.
 

--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -12,7 +12,8 @@ You can extend Viam by creating a custom {{< glossary_tooltip term_id="module" t
 
 A common use case for modular resources is to create a new [model](/extend/modular-resources/key-concepts/#models) that implements an existing Viam [API](/program/apis/).
 
-Once you have created your modular resource, you can use the [Viam CLI](/manage/cli/) to [upload your modular resource](/extend/modular-resources/upload/) to the Viam registry, to share it with other Viam users or just to other users in your organization.
+Once you have created your modular resource, you can use the [Viam CLI](/manage/cli/) to [upload your modular resource](/extend/modular-resources/upload/) to the [Viam registry](https://app.viam.com/registry), to share it with other Viam users or just to other users in your organization.
+You can also configure [automatic upload of new versions of your module](/extend/modular-resources/upload/#update-an-existing-module-using-a-github-action) as part of a continuous integration (CI) workflow, using a GitHub Action.
 
 Alternatively, you can add your module locally to your robot without uploading to the Viam registry.
 

--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -8,7 +8,9 @@ description: "Use the Viam module system to implement modular resources that can
 no_list: true
 ---
 
-You can extend Viam by creating a custom {{< glossary_tooltip term_id="module" text="module" >}} that provides one or more modular {{< glossary_tooltip term_id="resource" text="resources" >}} ([components](/components/) and [services](/services/)), and can be added to any robot running on Viam.
+You can extend Viam by creating a custom {{< glossary_tooltip term_id="module" text="module" >}} that provides one or more modular {{< glossary_tooltip term_id="resource" text="resources" >}} (such as [components](/components/) or [services](/services/)) or {{< glossary_tooltip term_id="model" text="models" >}}, and can be added to any robot running on Viam.
+
+(such as [components](/components/) or [services](/services/)) or {{< glossary_tooltip term_id="model" text="models" >}}
 
 A common use case for modular resources is to create a new [model](/extend/modular-resources/key-concepts/#models) that implements an existing Viam [API](/program/apis/).
 

--- a/docs/extend/modular-resources/create/_index.md
+++ b/docs/extend/modular-resources/create/_index.md
@@ -8,7 +8,7 @@ description: "Use the Viam module system to implement modular resources that can
 no_list: true
 ---
 
-You can extend Viam by creating a custom {{< glossary_tooltip term_id="module" text="module" >}} that provides one or more modular {{< glossary_tooltip term_id="resource" text="resources" >}} ([components](/components/) or [services](/services/)) or {{< glossary_tooltip term_id="model" text="models" >}}, and can be added to any robot running on Viam.
+You can extend Viam by creating a custom {{< glossary_tooltip term_id="module" text="module" >}} that provides one or more modular {{< glossary_tooltip term_id="resource" text="resources" >}} ([components](/components/) and [services](/services/)) or {{< glossary_tooltip term_id="model" text="models" >}}, and can be added to any robot running on Viam.
 
 A common use case for modular resources is to create a new [model](/extend/modular-resources/key-concepts/#models) that implements an existing Viam [API](/program/apis/).
 

--- a/docs/extend/modular-resources/key-concepts.md
+++ b/docs/extend/modular-resources/key-concepts.md
@@ -8,7 +8,7 @@ description: "The key concepts behind how Viam's resource APIs and models are un
 no_list: true
 ---
 
-You can extend the features of an existing {{< glossary_tooltip term_id="resource" text="resource" >}} API by [creating a custom module](/extend/modular-resources/create/) to define a new [model](#models) that implements that API.
+You can extend the features of an existing {{< glossary_tooltip term_id="resource" text="resource" >}} API by [creating a module](/extend/modular-resources/create/) to define a new [model](#models) that implements that API.
 A custom module can provide one or more modular resource models.
 
 ## Modules
@@ -35,8 +35,8 @@ A modular resource runs in the module process. This differs from built-in resour
 
 ## Models
 
-A *model* describes a specific implementation of a [resource](#resources) that implements (speaks) its API.
-Models allow you to control different instances of resource with a consistent interface, even if the underlying implementation differs.
+A *model* describes a specific implementation of a [resource](#resources) that implements (speaks) its [API](/program/apis/).
+Models allow you to control different instances of a resource with a consistent interface, even if the underlying implementation differs.
 
 For example, some DC motors communicate using [GPIO](/components/board/), while other DC motors use serial protocols like the [SPI bus](/components/board/#spis).
 Regardless, you can power any motor model that implements the `rdk:component:motor` API with the `SetPower()` method.
@@ -47,7 +47,7 @@ See [Naming your model](/extend/modular-resources/key-concepts/#naming-your-mode
 Models are either:
 
 - Built into the RDK, and included when you [install `viam-server`](/installation/) or when you use one of the [Viam SDKs](/program/apis/).
-- Provided in custom modules available for download from the [Viam registry](https://app.viam.com/registry), and are written by either Viam or community users.
+- Provided in [custom modules](#modules) available for download from the [Viam registry](https://app.viam.com/registry), and are written by either Viam or community users.
 
 ### Built-in models
 
@@ -66,13 +66,13 @@ These models run outside `viam-server` as a separate process.
 
 #### Valid APIs to implement in your model
 
-When implementing a custom model of an existing [component](/components/), valid [APIs](/program/apis/) are always:
+When implementing a custom [model](#models) of an existing [component](/components/), valid [APIs](/program/apis/) are always:
 
 - `namespace`: `rdk`
 - `type`: `component`
 - `subtype`: any one of [these component proto files](https://github.com/viamrobotics/api/tree/main/proto/viam/component).
 
-When implementing a custom model of an existing [service](/services/), valid [APIs](/program/apis/) are always
+When implementing a custom [model](#models) of an existing [service](/services/), valid [APIs](/program/apis/) are always
 
 - `namespace`: `rdk`
 - `type`: `service`

--- a/docs/extend/modular-resources/key-concepts.md
+++ b/docs/extend/modular-resources/key-concepts.md
@@ -8,7 +8,7 @@ description: "The key concepts behind how Viam's resource APIs and models are un
 no_list: true
 ---
 
-You can extend the features of an existing {{< glossary_tooltip term_id="resource" text="resource" >}} API by [creating a module](/extend/modular-resources/create/) to define a new [model](#models) that implements that API.
+You can extend the features of an existing {{< glossary_tooltip term_id="resource" text="resource" >}} API by [creating a custom module](/extend/modular-resources/create/) to define a new [model](#models) that implements that API.
 A custom module can provide one or more modular resource models.
 
 ## Modules

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -299,11 +299,10 @@ viam logout
 
 ### module
 
-The `module` command allows to you to manage [custom modules](/extend/modular-resources/).
+The `module` command allows to you to manage [modular resources](/extend/modular-resources/).
 This includes:
 
 * Creating a new custom modular resource
-* Updating an existing module with new changes
 * Uploading a new module to the Viam registry
 * Updating an existing module in the Viam registry
 
@@ -479,6 +478,8 @@ If the two namespaces do not match, the command will return an error.
 {{% /alert %}}
 
 See [Upload a custom module](/extend/modular-resources/upload/#upload-a-custom-module) and [Update an existing module](/extend/modular-resources/upload/#update-an-existing-module) for a detailed walkthrough of the `viam module` commands.
+
+See [Modular resources](/extend/modular-resources/) for a conceptual overview of modules and the modular resource system at Viam.
 
 ### organization
 

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -299,11 +299,11 @@ viam logout
 
 ### module
 
-The `module` command allows to you to manage [modular resources](/extend/modular-resources/).
+The `module` command allows to you to manage custom {{< glossary_tooltip term_id="module" text="modules" >}}
 This includes:
 
-* Creating a new custom modular resource
-* Uploading a new module to the Viam registry
+* Creating a new custom {{< glossary_tooltip term_id="resource" text="modular resource" >}}
+* Uploading a new module to the [Viam registry](https://app.viam.com/registry)
 * Updating an existing module in the Viam registry
 
 ```sh {class="command-line" data-prompt="$"}

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -131,7 +131,7 @@ The **Config** tab has subtabs for each section of your robot's config:
 
 - [Components](#components): Components are the hardware of your robot.
 - [Services](#services): Services are the software that runs on your robot.
-- [Modules](#modules): Modular resources are a way to add resource types or models that are not built into Viam.
+- [Modules](#modules): {{< glossary_tooltip term_id="module" text="Modules" >}} provide [modular resources](/extend/modular-resources/), which are a way to add resource types or models that are not built into Viam.
 - [Remotes](#remotes): Remotes are a way to connect two separate robots so one can access the resources of the other.
 - [Processes](#processes): Processes automatically run specified scripts when the robot boots.
 - [Fragments](#fragments): Fragments are a way of sharing and managing identical configuration files (or parts of config files) across multiple robots.


### PR DESCRIPTION
Some quick updates to MR language and copy day-of release.
- Adding note to consider platform support when adding modules
- Updating uses of `module` glossary tooltip to consistenly use `module` as title text instead of `modular resource`. MR should link instead to `key-concepts`.
- Updated glossary entry itself for `module` to reflect the latest wisdom, and small tweak to `resource` glossary entry in like fashion.
- A few more opportunities for linking between reference and procedurals
- A few language fixes.