### PR TITLE
DOCS-1109: Clarify difference between `max_rotation_deg` and `max` attribute configuration for a `pi` servo

### DIFF
--- a/docs/components/servo/pi.md
+++ b/docs/components/servo/pi.md
@@ -90,7 +90,7 @@ The following attributes are available for `pi` servos:
 | `max` | float | Optional | Sets a software limit on the maximum angle in degrees your servo can rotate to. <br> Default = `180.0` <br> Range = [`0.0`, `180.0`] |
 | `starting_position_degs` | float | Optional | Starting position of the servo in degrees. <br> Default = `0.0` <br> Range = [`0.0`, `180.0`] |
 | `hold_position` | boolean | Optional | If `false`, power down a servo if it has tried and failed to go to a position for a duration of 500 milliseconds. <br> Default = `true` |
-| `max_rotation_deg` | int | Optional | The maximum angle that you know your servo can possibly rotate to, according to its hardware. Refer to your servo's data sheet for clarification. Must be in between the values you choose for `min` and `max`. <br> Default = `180` |
+| `max_rotation_deg` | int | Optional | The maximum angle that you know your servo can possibly rotate to, according to its hardware. Refer to your servo's data sheet for clarification. Must be greater than or equal to the value you set for `max`. <br> Default = `180` |
 
 {{% alert title="Tip" color="tip" %}}
 

--- a/docs/components/servo/pi.md
+++ b/docs/components/servo/pi.md
@@ -86,11 +86,11 @@ The following attributes are available for `pi` servos:
 | ---- | ---- | --------- | ----------- |
 | `pin` | string | **Required** | The {{< glossary_tooltip term_id="pin-number" text="pin number" >}} of the pin the servo's control wire is wired to on the [board](/components/board/). |
 | `board` | string | **Required** | `name` of the [board](/components/board/) the servo is wired to. |
-| `min` | float | Optional | The minimum angle in degrees that the servo can reach. <br> Default = `0.0` <br> Range = [`0.0`, `180.0`] |
-| `max` | float | Optional | The maximum angle in degrees that the servo can reach. <br> Default = `180.0` <br> Range = [`0.0`, `180.0`] |
+| `min` | float | Optional | The minimum angle in degrees you want your servo to reach while rotating. <br> Default = `0.0` <br> Range = [`0.0`, `180.0`] |
+| `max` | float | Optional | The maximum angle in degrees you want your servo to reach while rotating. <br> Default = `180.0` <br> Range = [`0.0`, `180.0`] |
 | `starting_position_degs` | float | Optional | Starting position of the servo in degrees. <br> Default = `0.0` <br> Range = [`0.0`, `180.0`] |
 | `hold_position` | boolean | Optional | If `false`, power down a servo if it has tried and failed to go to a position for a duration of 500 milliseconds. <br> Default = `true` |
-| `max_rotation_deg` | int | Optional | The maximum angle the servo can rotate. Must be in between `min` and `max`. <br> Default = `180` |
+| `max_rotation_deg` | int | Optional | The maximum angle that you know your servo can possibly rotate to, according to its hardware. Refer to your servo's data sheet for clarification. Must be in between the values you choose for `min` and `max`. <br> Default = `180` |
 
 {{% alert title="Tip" color="tip" %}}
 

--- a/docs/components/servo/pi.md
+++ b/docs/components/servo/pi.md
@@ -86,8 +86,8 @@ The following attributes are available for `pi` servos:
 | ---- | ---- | --------- | ----------- |
 | `pin` | string | **Required** | The {{< glossary_tooltip term_id="pin-number" text="pin number" >}} of the pin the servo's control wire is wired to on the [board](/components/board/). |
 | `board` | string | **Required** | `name` of the [board](/components/board/) the servo is wired to. |
-| `min` | float | Optional | The minimum angle in degrees you want your servo to reach while rotating. <br> Default = `0.0` <br> Range = [`0.0`, `180.0`] |
-| `max` | float | Optional | The maximum angle in degrees you want your servo to reach while rotating. <br> Default = `180.0` <br> Range = [`0.0`, `180.0`] |
+| `min` | float | Optional | Sets a software limit on the minimum angle in degrees your servo can rotate to. <br> Default = `0.0` <br> Range = [`0.0`, `180.0`] |
+| `max` | float | Optional | Sets a software limit on the maximum angle in degrees your servo can rotate to. <br> Default = `180.0` <br> Range = [`0.0`, `180.0`] |
 | `starting_position_degs` | float | Optional | Starting position of the servo in degrees. <br> Default = `0.0` <br> Range = [`0.0`, `180.0`] |
 | `hold_position` | boolean | Optional | If `false`, power down a servo if it has tried and failed to go to a position for a duration of 500 milliseconds. <br> Default = `true` |
 | `max_rotation_deg` | int | Optional | The maximum angle that you know your servo can possibly rotate to, according to its hardware. Refer to your servo's data sheet for clarification. Must be in between the values you choose for `min` and `max`. <br> Default = `180` |

--- a/docs/program/run.md
+++ b/docs/program/run.md
@@ -10,13 +10,27 @@ tags: ["client", "sdk", "application", "sdk", "fleet", "program"]
 
 After saving your [code sample](/program/#hello-world-the-code-sample-tab) and adding control logic with [Viam's SDKs](/program/apis/), run your program to control your Viam-connected robot.
 
+### Authentication
+
+You must reference a robot's location secret to authenticate yourself to the robot.
+However, the app hides the robot location secret from the sample by default for your security.
+
+To copy the robot location secret, select **Include Secret** on the **Code sample** tab of your robot's page on the [Viam app](https://app.viam.com).
+Paste it into your SDK code as directed by the code sample.
+
+You must also include the robot's remote address, like `12345.somerobot-main.viam.cloud`, as an external or public address to connect to your robot.
+The code sample should include this address at default.
+You can find it at the top of the robot's **Control** tab.
+
+{{% snippet "secret-share.md" %}}
+
 ## Run Code Remotely
 
-As long as you are connecting to your robot through an external signaling address, you can remotely control your robot without editing the app-generated connection code in your SDK program beyond including the necessary [authentication credentials](#authentication).
+Most of the time, as long as both you and your robot are connected to the internet, you will want to upload code to your robot remotely.
+The advantage of this method is that your robot and your computer do not even have to connected to the same WAN/LAN to issue control commands, as your robot receives operation requests from your client program over the cloud.
 
-Do this by running a command to execute the program in the terminal of a machine with the appropriate programming language and Viam SDK installed.
-
-For example:
+As long as you are connecting to your robot through an external signaling address, you can remotely control your robot from anywhere in the world.
+After editing your code to include your robot's [authentication credentials](#authentication), run a command to execute the program in the terminal of a machine with the appropriate programming language and Viam SDK installed:
 
 {{< tabs >}}
 {{% tab name="Python" %}}
@@ -53,20 +67,6 @@ flutter run <DART_FILE>
 {{< /tabs >}}
 
 This is useful because as long as that computer is able to establish a network connection with the robot's computer, your control logic will be executed on the robot.
-
-### Authentication
-
-You must reference a robot's location secret to authenticate yourself to the robot.
-However, the app hides the robot location secret from the sample by default for your security.
-
-To copy the robot location secret, select **Include Secret** on the **Code sample** tab of your robot's page on the [Viam app](https://app.viam.com).
-Paste it into your SDK code as directed by the code sample.
-
-You must also include the robot's remote address, like `12345.somerobot-main.viam.cloud`, as an external or public address to connect to your robot.
-The code sample should include this address at default.
-You can find it at the top of the robot's **Control** tab.
-
-{{% snippet "secret-share.md" %}}
 
 ## Run Code On-Robot
 

--- a/docs/program/run.md
+++ b/docs/program/run.md
@@ -10,27 +10,13 @@ tags: ["client", "sdk", "application", "sdk", "fleet", "program"]
 
 After saving your [code sample](/program/#hello-world-the-code-sample-tab) and adding control logic with [Viam's SDKs](/program/apis/), run your program to control your Viam-connected robot.
 
-### Authentication
-
-You must reference a robot's location secret to authenticate yourself to the robot.
-However, the app hides the robot location secret from the sample by default for your security.
-
-To copy the robot location secret, select **Include Secret** on the **Code sample** tab of your robot's page on the [Viam app](https://app.viam.com).
-Paste it into your SDK code as directed by the code sample.
-
-You must also include the robot's remote address, like `12345.somerobot-main.viam.cloud`, as an external or public address to connect to your robot.
-The code sample should include this address at default.
-You can find it at the top of the robot's **Control** tab.
-
-{{% snippet "secret-share.md" %}}
-
 ## Run Code Remotely
 
-Most of the time, as long as both you and your robot are connected to the internet, you will want to upload code to your robot remotely.
-The advantage of this method is that your robot and your computer do not even have to connected to the same WAN/LAN to issue control commands, as your robot receives operation requests from your client program over the cloud.
+As long as you are connecting to your robot through an external signaling address, you can remotely control your robot without editing the app-generated connection code in your SDK program beyond including the necessary [authentication credentials](#authentication).
 
-As long as you are connecting to your robot through an external signaling address, you can remotely control your robot from anywhere in the world.
-After editing your code to include your robot's [authentication credentials](#authentication), run a command to execute the program in the terminal of a machine with the appropriate programming language and Viam SDK installed:
+Do this by running a command to execute the program in the terminal of a machine with the appropriate programming language and Viam SDK installed.
+
+For example:
 
 {{< tabs >}}
 {{% tab name="Python" %}}
@@ -67,6 +53,20 @@ flutter run <DART_FILE>
 {{< /tabs >}}
 
 This is useful because as long as that computer is able to establish a network connection with the robot's computer, your control logic will be executed on the robot.
+
+### Authentication
+
+You must reference a robot's location secret to authenticate yourself to the robot.
+However, the app hides the robot location secret from the sample by default for your security.
+
+To copy the robot location secret, select **Include Secret** on the **Code sample** tab of your robot's page on the [Viam app](https://app.viam.com).
+Paste it into your SDK code as directed by the code sample.
+
+You must also include the robot's remote address, like `12345.somerobot-main.viam.cloud`, as an external or public address to connect to your robot.
+The code sample should include this address at default.
+You can find it at the top of the robot's **Control** tab.
+
+{{% snippet "secret-share.md" %}}
 
 ## Run Code On-Robot
 


### PR DESCRIPTION
* Add clarification here that `max` is user's choice for maximum rotation (along with `min`) and `max_rotation_deg` should be based off of what your hardware can possibly support, for PWM safety protection 