### PR TITLE
DOCS-1113: Add clarification for running code remotely to client SDK Run Code page

### DIFF
--- a/docs/program/run.md
+++ b/docs/program/run.md
@@ -28,7 +28,7 @@ You can find it at the top of the robot's **Control** tab.
 
 Most of the time, as long as both you and your robot are connected to the internet, you will want to upload code to your robot remotely.
 The advantage of this method is that your robot and your computer do not have to be connected to the same WAN/LAN to issue control commands.
-You can remotely control your robot from anywhere in the world.
+You can remotely control your robot with any application you implement from anywhere in the world.
 After editing your code to include your robot's [authentication credentials](#authentication), run a command to execute the program in the terminal of a machine with the appropriate programming language and Viam SDK installed:
 
 {{< tabs >}}

--- a/docs/program/run.md
+++ b/docs/program/run.md
@@ -10,13 +10,27 @@ tags: ["client", "sdk", "application", "sdk", "fleet", "program"]
 
 After saving your [code sample](/program/#hello-world-the-code-sample-tab) and adding control logic with [Viam's SDKs](/program/apis/), run your program to control your Viam-connected robot.
 
+### Authentication
+
+You must reference a robot's location secret to authenticate yourself to the robot.
+However, the app hides the robot location secret from the sample by default for your security.
+
+To copy the robot location secret, select **Include Secret** on the **Code sample** tab of your robot's page on the [Viam app](https://app.viam.com).
+Paste it into your SDK code as directed by the code sample.
+
+You must also include the robot's remote address, like `12345.somerobot-main.viam.cloud`, as an external or public address to connect to your robot.
+The code sample should include this address at default.
+You can find it at the top of the robot's **Control** tab.
+
+{{% snippet "secret-share.md" %}}
+
 ## Run Code Remotely
 
-As long as you are connecting to your robot through an external signaling address, you can remotely control your robot without editing the app-generated connection code in your SDK program beyond including the necessary [authentication credentials](#authentication).
+Most of the time, as long as both you and your robot are connected to the internet, you will want to upload code to your robot remotely.
+The advantage of this method is that your robot and your computer do not even have to connected to the same WAN/LAN to issue control commands, as your robot receives operation requests from your client program over the cloud.
 
-Do this by running a command to execute the program in the terminal of a machine with the appropriate programming language and Viam SDK installed.
-
-For example:
+As long as you are connecting to your robot through an external signaling address, you can remotely control your robot from anywhere in the world.
+After editing your code to include your robot's [authentication credentials](#authentication), run a command to execute the program in the terminal of a machine with the appropriate programming language and Viam SDK installed:
 
 {{< tabs >}}
 {{% tab name="Python" %}}
@@ -53,20 +67,6 @@ flutter run <DART_FILE>
 {{< /tabs >}}
 
 This is useful because as long as that computer is able to establish a network connection with the robot's computer, your control logic will be executed on the robot.
-
-### Authentication
-
-You must reference a robot's location secret to authenticate yourself to the robot.
-However, the app hides the robot location secret from the sample by default for your security.
-
-To copy the robot location secret, select **Include Secret** on the **Code sample** tab of your robot's page on the [Viam app](https://app.viam.com).
-Paste it into your SDK code as directed by the code sample.
-
-You must also include the robot's remote address, like `12345.somerobot-main.viam.cloud`, as an external or public address to connect to your robot.
-The code sample should include this address at default.
-You can find it at the top of the robot's **Control** tab.
-
-{{% snippet "secret-share.md" %}}
 
 ## Run Code On-Robot
 

--- a/docs/program/run.md
+++ b/docs/program/run.md
@@ -29,7 +29,7 @@ You can find it at the top of the robot's **Control** tab.
 Most of the time, as long as both you and your robot are connected to the internet, you will want to run code to control your robot remotely.
 The advantage of this method is that your robot and your computer do not have to be connected to the same WAN/LAN to issue control commands.
 You can remotely control your robot with any application you implement from anywhere in the world.
-For example, you can run code on your personal computer, creating a client [session](/program/apis/sessions/), where the code running on that computer sends instructions to your robot's computer's `viam-server` instance over the internet.
+For example, you can run code on your personal computer, creating a client [session](/program/apis/sessions/), where the code running on that computer sends instructions to your robot's `viam-server` instance over the internet.
 
 After editing your code to include your robot's [authentication credentials](#authentication), run a command to execute the program in the terminal of a machine with the appropriate programming language and Viam SDK installed:
 

--- a/docs/program/run.md
+++ b/docs/program/run.md
@@ -19,7 +19,7 @@ To copy the robot location secret, select **Include Secret** on the **Code sampl
 Paste it into your SDK code as directed by the code sample.
 
 You must also include the robot's remote address, like `12345.somerobot-main.viam.cloud`, as an external or public address to connect to your robot.
-The code sample should include this address at default.
+The code sample includes this address at default.
 You can find it at the top of the robot's **Control** tab.
 
 {{% snippet "secret-share.md" %}}

--- a/docs/program/run.md
+++ b/docs/program/run.md
@@ -28,7 +28,6 @@ You can find it at the top of the robot's **Control** tab.
 
 Most of the time, as long as both you and your robot are connected to the internet, you will want to upload code to your robot remotely.
 The advantage of this method is that your robot and your computer do not have to be connected to the same WAN/LAN to issue control commands.
-
 As long as you are connecting to your robot through an external signaling address, you can remotely control your robot from anywhere in the world.
 After editing your code to include your robot's [authentication credentials](#authentication), run a command to execute the program in the terminal of a machine with the appropriate programming language and Viam SDK installed:
 

--- a/docs/program/run.md
+++ b/docs/program/run.md
@@ -26,7 +26,7 @@ You can find it at the top of the robot's **Control** tab.
 
 ## Run Code Remotely
 
-Most of the time, as long as both you and your robot are connected to the internet, you will want to run code on your robot remotely.
+Most of the time, as long as both you and your robot are connected to the internet, you will want to run code to control your robot remotely.
 The advantage of this method is that your robot and your computer do not have to be connected to the same WAN/LAN to issue control commands.
 You can remotely control your robot with any application you implement from anywhere in the world.
 For example, you can run code on your personal computer, creating a client [session](/program/apis/sessions/), where the code running on that computer sends instructions to your robot's computer's `viam-server` instance over the internet.

--- a/docs/program/run.md
+++ b/docs/program/run.md
@@ -26,7 +26,7 @@ You can find it at the top of the robot's **Control** tab.
 
 ## Run Code Remotely
 
-Most of the time, as long as both you and your robot are connected to the internet, you will want to upload code to your robot remotely.
+Most of the time, as long as both you and your robot are connected to the internet, you will want to run code on your robot remotely.
 The advantage of this method is that your robot and your computer do not have to be connected to the same WAN/LAN to issue control commands.
 You can remotely control your robot with any application you implement from anywhere in the world.
 After editing your code to include your robot's [authentication credentials](#authentication), run a command to execute the program in the terminal of a machine with the appropriate programming language and Viam SDK installed:

--- a/docs/program/run.md
+++ b/docs/program/run.md
@@ -27,7 +27,7 @@ You can find it at the top of the robot's **Control** tab.
 ## Run Code Remotely
 
 Most of the time, as long as both you and your robot are connected to the internet, you will want to upload code to your robot remotely.
-The advantage of this method is that your robot and your computer do not have to be connected to the same WAN/LAN to issue control commands, as your robot receives operation requests from your client program over the cloud.
+The advantage of this method is that your robot and your computer do not have to be connected to the same WAN/LAN to issue control commands.
 
 As long as you are connecting to your robot through an external signaling address, you can remotely control your robot from anywhere in the world.
 After editing your code to include your robot's [authentication credentials](#authentication), run a command to execute the program in the terminal of a machine with the appropriate programming language and Viam SDK installed:

--- a/docs/program/run.md
+++ b/docs/program/run.md
@@ -28,7 +28,7 @@ You can find it at the top of the robot's **Control** tab.
 
 Most of the time, as long as both you and your robot are connected to the internet, you will want to upload code to your robot remotely.
 The advantage of this method is that your robot and your computer do not have to be connected to the same WAN/LAN to issue control commands.
-As long as you are connecting to your robot through an external signaling address, you can remotely control your robot from anywhere in the world.
+You can remotely control your robot from anywhere in the world.
 After editing your code to include your robot's [authentication credentials](#authentication), run a command to execute the program in the terminal of a machine with the appropriate programming language and Viam SDK installed:
 
 {{< tabs >}}

--- a/docs/program/run.md
+++ b/docs/program/run.md
@@ -29,6 +29,8 @@ You can find it at the top of the robot's **Control** tab.
 Most of the time, as long as both you and your robot are connected to the internet, you will want to run code on your robot remotely.
 The advantage of this method is that your robot and your computer do not have to be connected to the same WAN/LAN to issue control commands.
 You can remotely control your robot with any application you implement from anywhere in the world.
+For example, you can run code on your personal computer, creating a client [session](/program/apis/sessions/), where the code running on that computer sends instructions to your robot's computer's `viam-server` instance over the internet.
+
 After editing your code to include your robot's [authentication credentials](#authentication), run a command to execute the program in the terminal of a machine with the appropriate programming language and Viam SDK installed:
 
 {{< tabs >}}

--- a/docs/program/run.md
+++ b/docs/program/run.md
@@ -27,7 +27,7 @@ You can find it at the top of the robot's **Control** tab.
 ## Run Code Remotely
 
 Most of the time, as long as both you and your robot are connected to the internet, you will want to upload code to your robot remotely.
-The advantage of this method is that your robot and your computer do not even have to connected to the same WAN/LAN to issue control commands, as your robot receives operation requests from your client program over the cloud.
+The advantage of this method is that your robot and your computer do not have to be connected to the same WAN/LAN to issue control commands, as your robot receives operation requests from your client program over the cloud.
 
 As long as you are connecting to your robot through an external signaling address, you can remotely control your robot from anywhere in the world.
 After editing your code to include your robot's [authentication credentials](#authentication), run a command to execute the program in the terminal of a machine with the appropriate programming language and Viam SDK installed:


### PR DESCRIPTION
* Trying to explain the "why" of this use case-- internal docs feedback from @mcvella and team 