### PR TITLE
DOCS-1116: Update viam CLI brew install

### DIFF
--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -55,23 +55,13 @@ sudo chmod a+rx /usr/local/bin/viam
 ```
 
 {{% /tab %}}
-{{% tab name="macOS arm64" %}}
+{{% tab name="macOS" %}}
 
-To download the Viam CLI on a macOS computer with the `arm64` (Apple Silicon) architecture, run the following commands:
-
-```{class="command-line" data-prompt="$"}
-sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-darwin-arm64
-sudo chmod a+rx /usr/local/bin/viam
-```
-
-{{% /tab %}}
-{{% tab name="macOS x86_64" %}}
-
-To download the Viam CLI on a macOS computer with the `amd64` (Intel `x86_64`) architecture, run the following commands:
+To download the Viam CLI on a macOS computer, run the following commands:
 
 ```{class="command-line" data-prompt="$"}
-sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-darwin-amd64
-sudo chmod a+rx /usr/local/bin/viam
+brew tap viamrobotics/brews
+brew install viam
 ```
 
 {{% /tab %}}
@@ -95,7 +85,8 @@ echo 'export PATH="$HOME/go/bin:$PATH"' >> ~/.bashrc
 {{% /tab %}}
 {{< /tabs >}}
 
-To later update the Viam CLI tool, you can use the steps above to reinstall the latest version.
+To later update the Viam CLI tool on Linux, use the steps above to reinstall the latest version.
+to later update the Viam CLI tool on macOS, run `brew upgrade viamrobotics/brews/viam`.
 
 ## Authenticate
 

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -32,6 +32,16 @@ Select the tab for your platform and architecture.
 If you are on Linux, you can use the `uname -m` command to determine your system architecture.
 
 {{< tabs >}}
+{{% tab name="macOS" %}}
+
+To download the Viam CLI on a macOS computer, run the following commands:
+
+```{class="command-line" data-prompt="$"}
+brew tap viamrobotics/brews
+brew install viam
+```
+
+{{% /tab %}}
 {{% tab name="Linux aarch64" %}}
 
 To download the Viam CLI on a Linux computer with the `aarch64` architecture, run the following commands:
@@ -49,16 +59,6 @@ To download the Viam CLI on a Linux computer with the `amd64` (Intel `x86_64`) a
 ```{class="command-line" data-prompt="$"}
 sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-linux-amd64
 sudo chmod a+rx /usr/local/bin/viam
-```
-
-{{% /tab %}}
-{{% tab name="macOS" %}}
-
-To download the Viam CLI on a macOS computer, run the following commands:
-
-```{class="command-line" data-prompt="$"}
-brew tap viamrobotics/brews
-brew install viam
 ```
 
 {{% /tab %}}
@@ -83,7 +83,7 @@ echo 'export PATH="$HOME/go/bin:$PATH"' >> ~/.bashrc
 {{< /tabs >}}
 
 To later update the Viam CLI tool on Linux, use the steps above to reinstall the latest version.
-to later update the Viam CLI tool on macOS, run `brew upgrade viamrobotics/brews/viam`.
+to later update the Viam CLI tool on macOS, run `brew upgrade viam`.
 
 ## Authenticate
 

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -29,10 +29,7 @@ viam.component.servo.v1.ServoService.MoveRequest
 
 You can download the Viam CLI executable using one of the options below.
 Select the tab for your platform and architecture.
-
-{{% alert title="Tip" color="tip" %}}
-You can use the `uname -m` command to determine your system architecture.
-{{% /alert %}}
+If you are on Linux, you can use the `uname -m` command to determine your system architecture.
 
 {{< tabs >}}
 {{% tab name="Linux aarch64" %}}


### PR DESCRIPTION
Removed both macOS arch direct download steps in favor of new `brew` install.
- Also updated "To later update ..." sentence with macOS (brew)-specific instruction.
- Left Linux instructions as-are (but simplified `uname -m` tip, since it now only applies to a subset of installation paths)

## Staging
- [/manage/cli/#install](https://docs-test.viam.dev/08459e33eca493b9327147cabd30ee23e22262d8/public/manage/cli/#install)