### PR TITLE
Add linuxbrew install instructions

### DIFF
--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -51,13 +51,6 @@ sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.co
 sudo chmod a+rx /usr/local/bin/viam
 ```
 
-You can also install the Viam CLI using [brew](https://brew.sh/):
-
-```{class="command-line" data-prompt="$"}
-brew tap viamrobotics/brews
-brew install viam
-```
-
 {{% /tab %}}
 {{% tab name="Linux x86_64" %}}
 

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -61,7 +61,7 @@ sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.co
 sudo chmod a+rx /usr/local/bin/viam
 ```
 
-You can also install the Viam CLI using [brew](https://brew.sh/):
+You can also install the Viam CLI using [brew](https://brew.sh/) on Linux `amd64` (Intel `x86_64`):
 
 ```{class="command-line" data-prompt="$"}
 brew tap viamrobotics/brews

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -62,6 +62,16 @@ sudo chmod a+rx /usr/local/bin/viam
 ```
 
 {{% /tab %}}
+{{% tab name="Linux x86_64 (brew)" %}}
+
+To download the Viam CLI on a Linux computer with the `amd64` (Intel `x86_64`) architecture, install [brew](https://brew.sh/) and then run the following commands:
+
+```{class="command-line" data-prompt="$"}
+brew tap viamrobotics/brews
+brew install viam
+```
+
+{{% /tab %}}
 {{% tab name="Source" %}}
 
 If you have [Go installed](https://go.dev/doc/install), you can build the Viam CLI directly from source using the `go install` command:

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -51,6 +51,13 @@ sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.co
 sudo chmod a+rx /usr/local/bin/viam
 ```
 
+You can also install the Viam CLI using [brew](https://brew.sh/):
+
+```{class="command-line" data-prompt="$"}
+brew tap viamrobotics/brews
+brew install viam
+```
+
 {{% /tab %}}
 {{% tab name="Linux x86_64" %}}
 
@@ -61,10 +68,7 @@ sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.co
 sudo chmod a+rx /usr/local/bin/viam
 ```
 
-{{% /tab %}}
-{{% tab name="Linux x86_64 (brew)" %}}
-
-To download the Viam CLI on a Linux computer with the `amd64` (Intel `x86_64`) architecture, install [brew](https://brew.sh/) and then run the following commands:
+You can also install the Viam CLI using [brew](https://brew.sh/):
 
 ```{class="command-line" data-prompt="$"}
 brew tap viamrobotics/brews


### PR DESCRIPTION
# Description

tested on linux x86_64.

Might as well include instructions so that people get updates.


@abe-winter Is there a reason we didn't include instructions for linuxbrew?