### PR TITLE
DOCS-1118: Add tgz support to registry

### DIFF
--- a/docs/extend/custom-components-remotes.md
+++ b/docs/extend/custom-components-remotes.md
@@ -15,7 +15,7 @@ description: "Implement custom components and register them on a server configur
 [Modular resources](/extend/modular-resources/key-concepts/) are the preferred method of creating custom resource implementations for SDKs with module support unless you are hosting `viam-server` on a non-Linux system or have another issue with compilation.
 {{% /alert %}}
 
-If a type or model of [component](/components/) you are working with is not [built-in to the Viam RDK](/internals/rdk/), or [available from the Viam Registry as a module](/extend/modular-resources/key-concepts/), you can use a [Viam SDK](/program/apis/) to code a custom resource implementation, host it on a server, and add it as a [remote](/manage/parts-and-remotes/) of your robot.
+If a type or model of [component](/components/) you are working with is not [built-in to the Viam RDK](/internals/rdk/), or [available from the Viam registry as a module](/extend/modular-resources/key-concepts/), you can use a [Viam SDK](/program/apis/) to code a custom resource implementation, host it on a server, and add it as a [remote](/manage/parts-and-remotes/) of your robot.
 
 Once you have coded your custom component and configured the remote servers, you can control and monitor your component with the Viam SDKs, like any other component.
 

--- a/docs/extend/modular-resources/_index.md
+++ b/docs/extend/modular-resources/_index.md
@@ -24,15 +24,15 @@ For example, you can:
 These custom implementations are called *modular resources*, and are made available for use on a robot through {{< glossary_tooltip term_id="module" text="modules" >}}.
 A module can provide one or more modular resources, and can be added to your robot from the Viam registry.
 
-## The Viam Registry
+## The Viam registry
 
 The [Viam registry](https://app.viam.com/registry) allows hardware and software engineers to collaborate on their robotics projects by writing and sharing custom modules with each other.
 You can add a module from the Viam registry directly from your robot's **Configuration** tab in [the Viam app](https://app.viam.com/), using the **+ Create component** button.
 
 The code behind any modular resource can be packaged as a {{< glossary_tooltip term_id="module" text="module" >}} and uploaded to the Viam registry.
-Once the module has been uploaded to the Registry, you can [deploy the module](/extend/modular-resources/configure/) to any robot in your organization from [the Viam app](https://app.viam.com/).
+Once the module has been uploaded to the registry, you can [deploy the module](/extend/modular-resources/configure/) to any robot in your organization from [the Viam app](https://app.viam.com/).
 
-### Uploading to Viam Registry
+### Uploading to Viam registry
 
 After you finish programming your module, you can [upload your module to the Viam registry](/extend/modular-resources/upload/) to make it available for deployment to robots.
 As part of the upload process, you decide whether your module is *public* (visible to all users) or *private* (visible only to other members of your [organization](/manage/fleet/organizations/)).
@@ -63,7 +63,7 @@ To get started working with modular resources:
 
 - Browse the [Viam registry](https://app.viam.com/registry) to see modules uploaded by other users.
 
-- [Deploy a module](/extend/modular-resources/configure/) to your robot from the Registry.
+- [Deploy a module](/extend/modular-resources/configure/) to your robot from the registry.
 
 - Browse the [modular resources tutorials](/extend/modular-resources/examples/) for examples of deploying and using custom modular resources on your robot.
 

--- a/docs/extend/modular-resources/configure.md
+++ b/docs/extend/modular-resources/configure.md
@@ -95,7 +95,7 @@ This pane lists the models provided by the module, any [components](/components/
 
 {{<imgproc src="extend/modular-resources/configure/deployed-module-with-component.png" resize="1000x" declaredimensions=true alt="The module subtab of the config tab showing the realsense custom module configuration pane includes the update management section showing version update management options version type, set to Patch (X.Y.Z) and version set to 0.0.3">}}
 
-### Configure version update management for a Registry module
+### Configure version update management for a registry module
 
 When you add a module to your robot, you can also configure how that module updates itself when a newer version becomes available from the Viam registry.
 By default, a newly-added module is set to pin to the specific patch release (**Patch (X.Y.Z)**) of the version you added, meaning that the module will *never automatically update itself*.
@@ -123,7 +123,7 @@ For any version type other than **Patch (X.Y.Z)**, the module will upgrade as so
 If, for example, the module provides a motor component, and the motor is running, it will stop while the module upgrades.
 {{% /alert %}}
 
-### Create a new modular resource from a Registry module
+### Create a new modular resource from a registry module
 
 Once you have [added a module](#add-a-module-from-the-viam-registry) from the Viam registry, you can add any number of the modular resources it provides to your robot by adding new components or services configured with your modular resources' [model](/extend/modular-resources/key-concepts/#models).
 

--- a/docs/extend/modular-resources/key-concepts.md
+++ b/docs/extend/modular-resources/key-concepts.md
@@ -19,7 +19,7 @@ A module provides definitions for one or more pairs of [APIs](#valid-apis-to-imp
 
 When the module initializes, it registers those pairs on your robot, making the functionality defined by that pair available for use.
 
-You can [upload your own modules to the Viam registry](/extend/modular-resources/upload/) or can [add existing modules from the Registry](/extend/modular-resources/configure/).
+You can [upload your own modules to the Viam registry](/extend/modular-resources/upload/) or can [add existing modules from the registry](/extend/modular-resources/configure/).
 
 See [Creating a custom module](/extend/modular-resources/create/) for more information.
 

--- a/docs/extend/modular-resources/upload/_index.md
+++ b/docs/extend/modular-resources/upload/_index.md
@@ -119,7 +119,7 @@ To upload your custom module to the [Viam registry](https://app.viam.com/registr
    On a successful update, the command will return a link to the updated module in the Viam registry.
 
 1. Package your custom module to get it ready to upload to the Viam registry.
-   Currently, the Registry only supports `tar.gz` or `tar.xz` format.
+   Your packaged module must use the `.tar.gz` or `.tgz` extension.
    Use the command below specific for the language of your module:
 
    - To package a module written in Go, run the following commands from the same directory as your `meta.json` file:
@@ -155,7 +155,8 @@ To upload your custom module to the [Viam registry](https://app.viam.com/registr
       - `darwin/amd64` - macOS computers running the Intel `x86_64` architecture.
       - `linux/arm64` - Linux computers or {{< glossary_tooltip term_id="board" text="boards" >}} running the `arm64` (`aarch64`) architecture, such as the Raspberry Pi.
       - `linux/amd64` - Linux computers or {{< glossary_tooltip term_id="board" text="boards" >}} running the Intel `x86_64` architecture.
-   - `path` - provide the path to the compressed archive, in `tar.gz` or `tar.xz` format, that contains your custom module code.
+   - `path` - provide the path to the compressed archive that contains your custom module code.
+      Your archive must use the `.tar.gz` or `.tgz` extension.
 
    {{% alert title="Important" color="note" %}}
    The `viam module upload` command only supports one `platform` argument at a time.
@@ -203,7 +204,7 @@ To update an existing module in the [Viam registry](https://app.viam.com/registr
    On a successful update, the command will return a link to the updated module in the Viam registry.
 
 1. Package your custom module to get it ready to upload to the Viam registry.
-   Currently, the Registry only supports `tar.gz` or `tar.xz` format.
+   Your packaged module must use the `.tar.gz` or `.tgz` extension.
    Use the command below specific for the language of your module:
 
    - To package a module written in Go, run the following commands from the same directory as your `meta.json` file:

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -390,7 +390,7 @@ When you `upload` a module, the command validates your local packaged module to 
 The following criteria are checked for every `upload`:
 
 * The packaged module must exist on the filesystem at the path provided to the `upload` command.
-* The packaged module must use the `.tar.gz` extension.
+* The packaged module must use the `.tar.gz` or `.tgz` extension.
 * The entry point file specified in the [`meta.json` file](#the-metajson-file) must exist on the filesystem at the path specified.
 * The entry point file must be executable.
 


### PR DESCRIPTION
Add mention to packaging steps, requirements, and CLI reference that `.tgz` extension is also supported alongside existing `.tar.gz`.
- Also lowercasing a bunch of instances of `Registry` while in here, missed these earlier.