### PR TITLE
DOCS-1110: Clarify visibility private by default

### DIFF
--- a/docs/extend/modular-resources/_index.md
+++ b/docs/extend/modular-resources/_index.md
@@ -35,7 +35,7 @@ Once the module has been uploaded to the Registry, you can [deploy the module](/
 ### Uploading to Viam Registry
 
 After you finish programming your module, you can [upload your module to the Viam registry](/extend/modular-resources/upload/) to make it available for deployment to robots.
-As part of the upload process, you decide whether your module is *public* (visible to all users) or *private* (visible only to other members of your [organization](/manage/fleet/organizations/)).
+As part of the upload process, you decide whether your module is *private* (visible only to other members of your [organization](/manage/fleet/organizations/)), or *public* (visible to all Viam users).
 
 You can see details about each module in the [Viam registry](https://app.viam.com/registry) on its module details page.
 See the [Odrive module](https://app.viam.com/module/viam/odrive) for an example.
@@ -48,8 +48,7 @@ When you make changes to your module, you can [uploaded the newer version](/exte
 Once you [upload a module to the Viam registry](/extend/modular-resources/upload/), you can [deploy the module](/extend/modular-resources/configure/) to any robot in your organization from [the Viam app](https://app.viam.com/).
 Navigate to your robot's **Configuration** tab, click the **+ Create component** button, then start typing the name of the module you would like to deploy.
 
-By default, a newly-created module is *private*, meaning that the module will only appear for users within your [organization](/manage/fleet/organizations/).
-When you [upload your module](/extend/modular-resources/upload/#upload-a-custom-module) to the registry, or later [update your module](/extend/modular-resources/upload/#update-an-existing-module) with new changes, you can set your module to be *public*, which makes your module available to all Viam users.
+By default, a newly-created module is *private*, meaning that the module will only appear for users within your [organization](/manage/fleet/organizations/), but you can later [update your module](/extend/modular-resources/upload/#update-an-existing-module) to set it to be *public*, which makes your module available to all Viam users.
 
 When you deploy a module to your robot, you can [choose how to update that module](/extend/modular-resources/configure/#configure-version-update-management-for-a-registry-module) when new versions become available.
 

--- a/docs/extend/modular-resources/_index.md
+++ b/docs/extend/modular-resources/_index.md
@@ -47,7 +47,9 @@ When you make changes to your module, you can [uploaded the newer version](/exte
 
 Once you [upload a module to the Viam registry](/extend/modular-resources/upload/), you can [deploy the module](/extend/modular-resources/configure/) to any robot in your organization from [the Viam app](https://app.viam.com/).
 Navigate to your robot's **Configuration** tab, click the **+ Create component** button, then start typing the name of the module you would like to deploy.
-If you uploaded your module and set its visibility to private, the module will only appear for users within your [organization](/manage/fleet/organizations/).
+
+By default, a newly-created module is *private*, meaning that the module will only appear for users within your [organization](/manage/fleet/organizations/).
+You can change this to *public*, which makes your module available to all Viam users.
 
 When you deploy a module to your robot, you can [choose how to update that module](/extend/modular-resources/configure/#configure-version-update-management-for-a-registry-module) when new versions become available.
 

--- a/docs/extend/modular-resources/_index.md
+++ b/docs/extend/modular-resources/_index.md
@@ -49,7 +49,7 @@ Once you [upload a module to the Viam registry](/extend/modular-resources/upload
 Navigate to your robot's **Configuration** tab, click the **+ Create component** button, then start typing the name of the module you would like to deploy.
 
 By default, a newly-created module is *private*, meaning that the module will only appear for users within your [organization](/manage/fleet/organizations/).
-You can change this to *public*, which makes your module available to all Viam users.
+When you [upload your module](/extend/modular-resources/upload/#upload-a-custom-module) to the registry, or later [update your module](/extend/modular-resources/upload/#update-an-existing-module) with new changes, you can set your module to be *public*, which makes your module available to all Viam users.
 
 When you deploy a module to your robot, you can [choose how to update that module](/extend/modular-resources/configure/#configure-version-update-management-for-a-registry-module) when new versions become available.
 

--- a/docs/extend/modular-resources/upload/_index.md
+++ b/docs/extend/modular-resources/upload/_index.md
@@ -55,7 +55,7 @@ To upload your custom module to the [Viam registry](https://app.viam.com/registr
        <td><code>visibility</code></td>
        <td>string</td>
        <td><strong>Required</strong></td>
-       <td>Whether the module is visible to all Viam users (<code>public</code>), or accessible only to members of your <a href="/manage/fleet/organizations/">organization</a> (<code>private</code>). You can change this setting later using the <code>viam module update</code> command.<br><br>Default: <code>private</code></td>
+       <td>Whether the module is accessible only to members of your <a href="/manage/fleet/organizations/">organization</a> (<code>private</code>), or visible to all Viam users (<code>public</code>). You can change this setting later using the <code>viam module update</code> command.<br><br>Default: <code>private</code></td>
      </tr>
      <tr>
        <td><code>url</code></td>
@@ -102,7 +102,7 @@ To upload your custom module to the [Viam registry](https://app.viam.com/registr
    ```
 
    {{% alert title="Important" color="note" %}}
-   If you are publishing a public module (`visibility: "public"`), the [namespace of your model](/extend/modular-resources/key-concepts/#naming-your-model) must match the [namespace of your organization](/manage/fleet/organizations/#create-a-namespace-for-your-organization).
+   If you are publishing a public module (`"visibility": "public"`), the [namespace of your model](/extend/modular-resources/key-concepts/#naming-your-model) must match the [namespace of your organization](/manage/fleet/organizations/#create-a-namespace-for-your-organization).
    In the example above, the model namespace is set to `acme` to match the owning organization's namespace.
    If the two namespaces do not match, the command will return an error.
    {{% /alert %}}

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -356,7 +356,7 @@ All of the `module` commands accept either the `--org-id` or `--public-namespace
 * Use the `--public-namespace` argument to supply the [namespace](/manage/fleet/organizations/#create-a-namespace-for-your-organization) of your organization, suitable for uploading your module to the Viam registry and sharing with other users.
 * Use the `--org-id` to provide your organization ID instead, suitable for sharing your module privately within your organization.
 
-You may use either argument for the `viam module create` command, but must use `--public-namespace` for the `update` and `upload` commands when uploading as a public module (`visibility: "public"`) to the Viam registry.
+You may use either argument for the `viam module create` command, but must use `--public-namespace` for the `update` and `upload` commands when uploading as a public module (`"visibility": "public"`) to the Viam registry.
 
 ##### Using the `--platform` argument
 
@@ -420,7 +420,7 @@ The `meta.json` file includes the following configuration options:
     <td><code>visibility</code></td>
     <td>string</td>
     <td><strong>Required</strong></td>
-    <td>Whether the module is visible to all Viam users (<code>public</code>), or accessible only to members of your <a href="/manage/fleet/organizations/">organization</a> (<code>private</code>). You can change this setting later using the <code>viam module update</code> command.<br><br>Default: <code>private</code></td>
+    <td>Whether the module is accessible only to members of your <a href="/manage/fleet/organizations/">organization</a> (<code>private</code>), or visible to all Viam users (<code>public</code>). You can change this setting later using the <code>viam module update</code> command.<br><br>Default: <code>private</code></td>
   </tr>
   <tr>
     <td><code>url</code></td>
@@ -467,7 +467,7 @@ For example, the following represents the configuration of an example `my-module
 ```
 
 {{% alert title="Important" color="note" %}}
-If you are publishing a public module (`visibility: "public"`), the [namespace of your model](/extend/modular-resources/key-concepts/#naming-your-model) must match the [namespace of your organization](/manage/fleet/organizations/#create-a-namespace-for-your-organization).
+If you are publishing a public module (`"visibility": "public"`), the [namespace of your model](/extend/modular-resources/key-concepts/#naming-your-model) must match the [namespace of your organization](/manage/fleet/organizations/#create-a-namespace-for-your-organization).
 In the example above, the model namespace is set to `acme` to match the owning organization's namespace.
 If the two namespaces do not match, the command will return an error.
 {{% /alert %}}


### PR DESCRIPTION
Clarified mentions of `visibility` field in `meta.json`. We already indicated that it was `private` by default (maybe I intuited the change, or saw an eng ticket somewhere coming down the pipe? Don't remember), so this is mostly to unify language.