### PR TITLE
Update confetti-bot.md code for correct board name

### DIFF
--- a/docs/tutorials/get-started/confetti-bot.md
+++ b/docs/tutorials/get-started/confetti-bot.md
@@ -181,10 +181,10 @@ On the [**Raw JSON** tab](/manage/configuration/#the-config-tab), replace the co
           "b": "15",
           "pwm": "11"
         },
-        "board": "local",
+        "board": "party",
         "max_rpm": 1000
       },
-      "depends_on": ["local"]
+      "depends_on": ["party"]
     }
   ]
 }


### PR DESCRIPTION
* Noticed that raw JSON template was using `local` after naming board `party`