### PR TITLE
Change yahboom documentation to modular.

### DIFF
--- a/docs/components/arm/_index.md
+++ b/docs/components/arm/_index.md
@@ -58,7 +58,6 @@ For configuration information, click on one of the supported arm models:
 | [`xArm6`](xarm6/) | [UFACTORY xArm 6](https://www.ufactory.cc/product-page/ufactory-xarm-6) |
 | [`xArm7`](xarm7/) | [UFACTORY xArm 7](https://www.ufactory.cc/product-page/ufactory-xarm-7) |
 | [`xArmLite`](xarmlite/) | [UFACTORY Lite 6](https://www.ufactory.cc/product-page/ufactory-lite-6) |
-| [`yahboom-dofbot`](yahboom-dofbot/) | [Yahboom DOFBOT](https://category.yahboom.net/collections/r-robotics-arm) |
 | [`ur5e`](ur5e/) | [Universal Robots UR5e](https://www.universal-robots.com/products/ur5-robot) |
 
 Follow [this guide](/extend/modular-resources/examples/custom-arm/) to implement your custom arm as a [modular resource](/extend/modular-resources/).

--- a/docs/components/arm/yahboom-dofbot.md
+++ b/docs/components/arm/yahboom-dofbot.md
@@ -3,20 +3,22 @@ title: "Configure a yahboom-dofbot Arm"
 linkTitle: "yahboom-dofbot"
 weight: 50
 type: "docs"
-description: "Configure a yahboom-dofbot arm."
+draft: "true"
+description: "Configure a yahboom dofbot modular arm."
 images: ["/icons/components/arm.svg"]
 tags: ["arm", "components"]
 ---
 
-Configure a `yahboom-dofbot` arm to add a [Yahboom DOFBOT](https://category.yahboom.net/collections/r-robotics-arm) to your robot:
+Viam provides a `dofbot` arm from the manufacturer `yahboom` as a modular resource. To add a [Yahboom DOFBOT](https://category.yahboom.net/collections/r-robotics-arm) to your robot:
 
 {{< tabs >}}
 {{% tab name="Config Builder" %}}
 
 Navigate to the **Config** tab of your robot's page in [the Viam app](https://app.viam.com).
-Click on the **Components** subtab and click **Create component**.
-Select the `arm` type, then select the `yahboom-dofbot` model.
+Click on the **Components** subtab and find the **Create component** pane.
+Select the `arm` type, then select the `rand:yahboom:dofbot` modular resource.
 Enter a name for your arm and click **Create**.
+Note: There are not attributes for this modular arm.
 
 ![Web UI configuration panel for an arm of model yahboom-dofbot in the Viam app, with Attributes & Depends On drop-downs and the option to add a frame.](/components/arm/yahboom-dofbot-ui-config.png)
 
@@ -29,13 +31,10 @@ Edit and fill in the attributes as applicable.
 {
   "components": [
     {
-      "model": "yahboom-dofbot",
+      "model": "dofbot",
       "name": "<your-arm-name>",
       "type": "arm",
-      "attributes": {
-        "board": "<your-board-name>",
-        "i2c": "<your-i2c-name>"
-      },
+      "attributes": {},
       "depends_on": []
     }
   ]
@@ -49,28 +48,11 @@ Edit and fill in the attributes as applicable.
 {
   "components": [
     {
-      "depends_on": [],
-      "model": "pi",
-      "name": "local",
-      "type": "board",
-      "attributes": {
-        "i2cs": [
-          {
-            "name": "bus1",
-            "bus": "1"
-          }
-        ]
-      }
-    },
-    {
       "name": "myarm",
       "type": "arm",
       "model": "yahboom-dofbot",
-      "attributes": {
-        "board": "local",
-        "i2c": "bus1"
-      },
-      "depends_on": ["local"]
+      "attributes": {},
+      "depends_on": []
     }
   ]
 }
@@ -78,10 +60,3 @@ Edit and fill in the attributes as applicable.
 
 {{% /tab %}}
 {{< /tabs >}}
-
-The following attributes are available for `yahboom-dofbot` arms:
-
-<!-- prettier-ignore -->
-| Attribute | Type | Inclusion | Description |
-| --------- | ---- | ----------| ----------- |
-| `i2c`  | string | **Required** | The `name` of the Inter-Integrated Circuit (I<sup>2</sup>C) bus on your GPIO [board](/components/board/) where the connection to the `yahboom-dofbot` is made. See [configuration info](/components/board/#i2cs). |

--- a/docs/components/arm/yahboom-dofbot.md
+++ b/docs/components/arm/yahboom-dofbot.md
@@ -4,21 +4,23 @@ linkTitle: "yahboom-dofbot"
 weight: 50
 type: "docs"
 draft: "true"
-description: "Configure a yahboom dofbot modular arm."
+description: "Configure a Yahboom DOFBOT modular arm."
 images: ["/icons/components/arm.svg"]
 tags: ["arm", "components"]
 ---
 
-Viam provides a `dofbot` arm from the manufacturer `yahboom` as a modular resource. To add a [Yahboom DOFBOT](https://category.yahboom.net/collections/r-robotics-arm) to your robot:
+Viam supports the [Yahboom DOFBOT](https://category.yahboom.net/collections/r-robotics-arm) arm as a [modular resource](https://github.com/viam-labs/yahboom).
+Configure a `dofbot` arm to add it to your robot:
 
 {{< tabs >}}
 {{% tab name="Config Builder" %}}
 
 Navigate to the **Config** tab of your robot's page in [the Viam app](https://app.viam.com).
-Click on the **Components** subtab and find the **Create component** pane.
+Click on the **Components** subtab and click **Create component**.
 Select the `arm` type, then select the `rand:yahboom:dofbot` modular resource.
 Enter a name for your arm and click **Create**.
-Note: There are not attributes for this modular arm.
+
+There are no attributes available for this modular arm.
 
 ![Web UI configuration panel for an arm of model yahboom-dofbot in the Viam app, with Attributes & Depends On drop-downs and the option to add a frame.](/components/arm/yahboom-dofbot-ui-config.png)
 
@@ -31,8 +33,8 @@ Edit and fill in the attributes as applicable.
 {
   "components": [
     {
-      "model": "dofbot",
       "name": "<your-arm-name>",
+      "model": "dofbot",
       "type": "arm",
       "attributes": {},
       "depends_on": []


### PR DESCRIPTION
# Description

We're kicking the yahboom arm out of the rdk. I've changed some of the wording and removed the attributes (there are none now https://github.com/viam-labs/yahboom).

I don't have access to viam-labs right now so can't upload it ... boo! So I've used my name as a placeholder for the namespace for now.

We can also not document this arm - I don't think we're uploading it to the viam namespace. 

Should I keep the state of the module (only supports joint position movement for now) in the readme?

Thanks. 
