### PR TITLE
DOCS-1129: Add clarifying note that color and depth streams can come from same camera in `join_color_depth` model

### DIFF
--- a/docs/components/camera/join-color-depth.md
+++ b/docs/components/camera/join-color-depth.md
@@ -9,7 +9,7 @@ tags: ["camera", "components"]
 # SMEs: Bijan, vision team
 ---
 
-Combine the streams of a color and a depth camera already registered in your config to create a view that outputs the combined and aligned image.
+Combine the streams of a color and depth camera already registered in your config to create a view that outputs the combined and aligned image.
 
 This specific model is good if you don’t need to align the streams.
 If you need to adjust the alignment between the depth and color frames, use the [`align_color_depth_extrinsics`](../align-color-depth-extrinsics/) model or the[`align_color_depth_homography`](../align-color-depth-homography/) model.
@@ -68,7 +68,7 @@ The following attributes are available for `join_color_depth` views:
 | ---- | ---- | --------- | ----------- |
 | `output_image_type` | string | **Required** | Specify `color` or `depth` for the output stream. |
 | `color_camera_name` | string | **Required** | `name` of the color camera to pull images from. |
-| `depth_camera_name` | string | **Required** | `name` of the depth camera to pull images from. |
+| `depth_camera_name` | string | **Required** | `name` of the depth camera to pull images from. If your camera provides both color and depth image streams, you can set this to be the same as `color_camera_name`. |
 | `intrinsic_parameters` | object | **Required** | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
 | `distortion_parameters` | object | Optional | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
 | `debug` | boolean | Optional | Enables the debug outputs from the camera if `true`. <br> Default: `false`. |


### PR DESCRIPTION
* Adds note in attribute information-- not sure if should add to top as well? Can if @bhaney thinks appropriate