### PR TITLE
DOCS-1174: Clarify model triplet

### DIFF
--- a/docs/appendix/glossary/api-namespace-triplet.md
+++ b/docs/appendix/glossary/api-namespace-triplet.md
@@ -6,14 +6,14 @@ short_description: namespace:type:subtype
 aka:
 ---
 
-Every Viam {{< glossary_tooltip term_id="resource" text="resource" >}} subtype exposes an [application programming interface (API)](https://en.wikipedia.org/wiki/API) to describe how you can interact with that resource.
+Every Viam {{< glossary_tooltip term_id="resource" text="resource" >}} {{< glossary_tooltip term_id="subtype" text="subtype" >}} exposes an [application programming interface (API)](https://en.wikipedia.org/wiki/API) to describe how you can interact with that resource.
 
 These APIs are organized by colon-delimited-triplet identifiers, in the form of `namespace:type:subtype`.
 
 The `namespace` for built-in Viam resources is `rdk`, while the `type` is `component` or `service`.
 `subtype` refers to a specific component or service, like a `camera` or `vision`.
 
-One subtype can have various models, custom or built-in, but they all must conform to the subtype's API definition.
+One subtype can have various {{< glossary_tooltip term_id="model" text="models" >}}, custom or built-in, but they all must conform to the subtype's API definition.
 This requirement ensures that when a resource of that model is deployed, you can [interface with it](/program/) using the same [client API methods](/program/apis/) you would when programming resources of the same subtype with a different model.
 
 For example:

--- a/docs/appendix/glossary/model-namespace-triplet.md
+++ b/docs/appendix/glossary/model-namespace-triplet.md
@@ -9,4 +9,4 @@ aka:
 {{< glossary_tooltip term_id="model" text="Models" >}} are uniquely namespaced as colon-delimited-triplets.
 Modular resource model names have the form `namespace:repo-name:name`.
 Built-in model names have the form `rdk:builtin:name`.
-See [Naming your model](#naming-your-model-namespacerepo-namename) for more information.
+See [Naming your model](/modular-resources/key-concepts/#naming-your-model-namespacerepo-namename) for more information.

--- a/docs/appendix/glossary/model-namespace-triplet.md
+++ b/docs/appendix/glossary/model-namespace-triplet.md
@@ -6,10 +6,9 @@ short_description: namespace:repo-name:name or rdk:builtin:name
 aka:
 ---
 
-{{< glossary_tooltip term_id="model" text="Models" >}} are uniquely namespaced as colon-delimited-triplets in the form of `namespace:repo-name:name` for modular resources and `rdk:builtin:name` for builtin models.
+{{< glossary_tooltip term_id="model" text="Models" >}} are uniquely namespaced as colon-delimited-triplets in the form of `namespace:repo-name:name` for modular resources and `rdk:builtin:name` for built-in models.
 
-The `repo-name` segment is generally used for the git repository of your modular resource, but you can also use it to identify a family of models.
-
+The `repo-name` segment generally matches the name of the git repository of your modular resource, but you can also use it to identify a family of models.
 For example:
 
 - The `viam:camera:csi` model implements the `rdk:component:camera` API to support CSI cameras.

--- a/docs/appendix/glossary/model-namespace-triplet.md
+++ b/docs/appendix/glossary/model-namespace-triplet.md
@@ -8,9 +8,18 @@ aka:
 
 {{< glossary_tooltip term_id="model" text="Models" >}} are uniquely namespaced as colon-delimited-triplets in the form of `namespace:repo-name:name` for modular resources and `rdk:builtin:name` for built-in models.
 
-The `repo-name` segment generally matches the name of the git repository of your modular resource, but you can also use it to identify a family of models.
+We recommend to use the name of the git repository of your modular resource as the middle segment.
+The `repo-name` should describe the common functionality provided across the modelor models of that module.
+
 For example:
 
-- The `viam:camera:csi` model implements the `rdk:component:camera` API to support CSI cameras.
-- The `rdk:builtin:gpio` model implements the `rdk:component:motor` API to support [GPIO-controlled DC motors](/components/motor/gpio/).
-- The `rdk:builtin:DMC4000` model implements the `rdk:component:motor` API to support [DMC4000](/components/motor/dmc4000/) motor controllers.
+- The `rand:yahboom:arm` model uses the repository name [yahboom](https://github.com/viam-labs/yahboom).
+  It implements the `rdk:component:arm` API to support the yahboom dofbot arm.
+- The `viam-labs:audioout:pygame` model uses the repository name [audioout](https://github.com/viam-labs/audioout)
+  It implements the custom API `viam-labs:service:audioout`.
+
+Built-in {{< glossary_tooltip term_id="rdk" text="rdk" >}} models use the triplet `rdk:builtin:name`.
+For example:
+
+- The `rdk:builtin:gpio` model.
+  It implements the `rdk:component:motor` API to support [GPIO-controlled DC motors](/components/motor/gpio/).

--- a/docs/appendix/glossary/model-namespace-triplet.md
+++ b/docs/appendix/glossary/model-namespace-triplet.md
@@ -8,7 +8,7 @@ aka:
 
 {{< glossary_tooltip term_id="model" text="Models" >}} are uniquely namespaced as colon-delimited-triplets in the form of `namespace:repo-name:name` for modular resources and `rdk:builtin:name` for built-in models.
 
-We recommend to use the name of the git repository of your modular resource as the middle segment.
+We recommend using the name of the git repository of your modular resource as the middle segment.
 The `repo-name` should describe the common functionality provided across the model or models of that module.
 
 For example:

--- a/docs/appendix/glossary/model-namespace-triplet.md
+++ b/docs/appendix/glossary/model-namespace-triplet.md
@@ -2,13 +2,16 @@
 title: Model Namespace Triplet
 id: model-namespace-triplet
 full_link:
-short_description: namespace:family:name
+short_description: namespace:repo-name:name or rdk:builtin:name
 aka:
 ---
 
-{{< glossary_tooltip term_id="model" text="Models" >}} are uniquely namespaced as colon-delimited-triplets in the form of `namespace:family:name`.
+{{< glossary_tooltip term_id="model" text="Models" >}} are uniquely namespaced as colon-delimited-triplets in the form of `namespace:repo-name:name` for modular resources and `rdk:builtin:name` for builtin models.
+
+The `repo-name` segment is generally used for the git repository of your modular resource, but you can also use it to identify a family of models.
 
 For example:
 
+- The `viam:camera:csi` model implements the `rdk:component:camera` API to support CSI cameras.
 - The `rdk:builtin:gpio` model implements the `rdk:component:motor` API to support [GPIO-controlled DC motors](/components/motor/gpio/).
 - The `rdk:builtin:DMC4000` model implements the `rdk:component:motor` API to support [DMC4000](/components/motor/dmc4000/) motor controllers.

--- a/docs/appendix/glossary/model-namespace-triplet.md
+++ b/docs/appendix/glossary/model-namespace-triplet.md
@@ -1,7 +1,7 @@
 ---
 title: Model Namespace Triplet
 id: model-namespace-triplet
-full_link:
+full_link: /modular-resources/key-concepts/#naming-your-model-namespacerepo-namename
 short_description: namespace:repo-name:name or rdk:builtin:name
 aka:
 ---

--- a/docs/appendix/glossary/model-namespace-triplet.md
+++ b/docs/appendix/glossary/model-namespace-triplet.md
@@ -6,12 +6,7 @@ short_description: namespace:repo-name:name or rdk:builtin:name
 aka:
 ---
 
-{{< glossary_tooltip term_id="model" text="Models" >}} are uniquely namespaced as colon-delimited-triplets in the form of `namespace:repo-name:name` for modular resources and `rdk:builtin:name` for built-in models.
-
-For more information see [Naming your model](/modular-resources/key-concepts/#naming-your-model-namespacerepo-namename).
-
-Built-in {{< glossary_tooltip term_id="rdk" text="rdk" >}} models use the triplet `rdk:builtin:name`.
-For example:
-
-- The `rdk:builtin:gpio` model.
-  It implements the `rdk:component:motor` API to support [GPIO-controlled DC motors](/components/motor/gpio/).
+{{< glossary_tooltip term_id="model" text="Models" >}} are uniquely namespaced as colon-delimited-triplets.
+Modular resource model names have the form `namespace:repo-name:name`.
+Built-in model names have the form `rdk:builtin:name`.
+See [Naming your model](#naming-your-model-namespacerepo-namename) for more information.

--- a/docs/appendix/glossary/model-namespace-triplet.md
+++ b/docs/appendix/glossary/model-namespace-triplet.md
@@ -9,7 +9,7 @@ aka:
 {{< glossary_tooltip term_id="model" text="Models" >}} are uniquely namespaced as colon-delimited-triplets in the form of `namespace:repo-name:name` for modular resources and `rdk:builtin:name` for built-in models.
 
 We recommend to use the name of the git repository of your modular resource as the middle segment.
-The `repo-name` should describe the common functionality provided across the modelor models of that module.
+The `repo-name` should describe the common functionality provided across the model or models of that module.
 
 For example:
 

--- a/docs/appendix/glossary/model-namespace-triplet.md
+++ b/docs/appendix/glossary/model-namespace-triplet.md
@@ -8,15 +8,7 @@ aka:
 
 {{< glossary_tooltip term_id="model" text="Models" >}} are uniquely namespaced as colon-delimited-triplets in the form of `namespace:repo-name:name` for modular resources and `rdk:builtin:name` for built-in models.
 
-We recommend using the name of the git repository of your modular resource as the middle segment.
-The `repo-name` should describe the common functionality provided across the model or models of that module.
-
-For example:
-
-- The `rand:yahboom:arm` model uses the repository name [yahboom](https://github.com/viam-labs/yahboom).
-  It implements the `rdk:component:arm` API to support the yahboom dofbot arm.
-- The `viam-labs:audioout:pygame` model uses the repository name [audioout](https://github.com/viam-labs/audioout)
-  It implements the custom API `viam-labs:service:audioout`.
+For more information see [Naming your model](/modular-resources/key-concepts/#naming-your-model-namespacerepo-namename).
 
 Built-in {{< glossary_tooltip term_id="rdk" text="rdk" >}} models use the triplet `rdk:builtin:name`.
 For example:

--- a/docs/appendix/glossary/type.md
+++ b/docs/appendix/glossary/type.md
@@ -8,6 +8,6 @@ aka:
 
 In the {{< glossary_tooltip term_id="rdk" text="RDK" >}} architecture's {{< glossary_tooltip term_id="api-namespace-triplet" text="namespace triplet" >}} for resource APIs, _type_ refers to the distinction between {{< glossary_tooltip term_id="component" text="component" >}} or {{< glossary_tooltip term_id="service" text="service" >}}.
 
-However, the meaning of "type" can be context dependent across the Viam platform.
+However, the meaning of "type" can be context dependent across the Viam platform:
 
 For example, when [configuring a robot](/manage/configuration/) in the [Viam app](https://app.viam.com), `"type"` is used in the JSON to indicate a particular implementation of a component or service, which is formally designated as the {{< glossary_tooltip term_id="subtype" text="subtype" >}}.

--- a/docs/appendix/glossary/type.md
+++ b/docs/appendix/glossary/type.md
@@ -8,6 +8,6 @@ aka:
 
 In the {{< glossary_tooltip term_id="rdk" text="RDK" >}} architecture's {{< glossary_tooltip term_id="api-namespace-triplet" text="namespace triplet" >}} for resource APIs, _type_ refers to the distinction between {{< glossary_tooltip term_id="component" text="component" >}} or {{< glossary_tooltip term_id="service" text="service" >}}.
 
-However, the meaning of "type" can be context dependent across the Viam platform:
+However, the meaning of "type" can be context dependent across the Viam platform.
 
 For example, when [configuring a robot](/manage/configuration/) in the [Viam app](https://app.viam.com), `"type"` is used in the JSON to indicate a particular implementation of a component or service, which is formally designated as the {{< glossary_tooltip term_id="subtype" text="subtype" >}}.

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -523,7 +523,7 @@ For example, the following represents the configuration of an example `my-module
 ```
 
 {{% alert title="Important" color="note" %}}
-If you are publishing a public module (`"visibility": "public"`), the [namespace of your model](/modular-resources/key-concepts/#naming-your-model) must match the [namespace of your organization](/manage/fleet/organizations/#create-a-namespace-for-your-organization).
+If you are publishing a public module (`"visibility": "public"`), the [namespace of your model](/modular-resources/key-concepts/#naming-your-model-namespacerepo-namename) must match the [namespace of your organization](/manage/fleet/organizations/#create-a-namespace-for-your-organization).
 In the example above, the model namespace is set to `acme` to match the owning organization's namespace.
 If the two namespaces do not match, the command will return an error.
 {{% /alert %}}

--- a/docs/modular-resources/configure.md
+++ b/docs/modular-resources/configure.md
@@ -160,7 +160,7 @@ If the module requires you to configure specific **Attributes**, click the **URL
   "components": [
     {
       "name": "<your-model-instance-name>",
-      "model": "<model-namespace>:<model-family>:<model-name>",
+      "model": "<namespace>:<repo-name>:<name>",
       "type": "<your-resource-subtype>",
       "namespace": "<your-module-namespace>",
       "attributes": {},
@@ -344,7 +344,7 @@ The `attributes` available vary depending on your implementation.
     {
       "namespace": "<your-module-namespace>",
       "type": "<your-resource-subtype>",
-      "model": "<model-namespace>:<model-family>:<model-name>",
+      "model": "<namespace>:<repo-name>:<name>",
       "name": "<your-model-instance-name>",
       "attributes": {},
       "depends_on": []

--- a/docs/modular-resources/create/_index.md
+++ b/docs/modular-resources/create/_index.md
@@ -65,7 +65,7 @@ A custom module can implement one or more [models](/modular-resources/key-concep
 
 ### Code a new resource model
 
-The following example module registers a modular resource implementing Viam's built-in [Base API](/components/base/#api) [(rdk:service:base)](/modular-resources/key-concepts/#models) as a new model, `"mybase"`, using the model family `acme:demo:mybase`.
+The following example module registers a modular resource implementing Viam's built-in [Base API](/components/base/#api) [(rdk:service:base)](/modular-resources/key-concepts/#models) as a new model, `"mybase"`, using the model `acme:demo:mybase`.
 For more information see [Naming your model](/modular-resources/key-concepts/#naming-your-model).
 
 The Go code for the custom model (<file>mybase.go</file>) and module entry point file (<file>main.go</file>) is adapted from the full demo modules available on the [Viam GitHub](https://github.com/viamrobotics/rdk/blob/main/examples/customresources).
@@ -280,7 +280,7 @@ import (
 )
 
 // Here is where we define your new model's colon-delimited-triplet (acme:demo:mybase)
-// acme = namespace, demo = family, mybase = model name.
+// acme = namespace, demo = repo-name, mybase = model name.
 var (
     Model            = resource.NewModel("acme", "demo", "mybase")
     errUnimplemented = errors.New("unimplemented")

--- a/docs/modular-resources/create/_index.md
+++ b/docs/modular-resources/create/_index.md
@@ -49,7 +49,7 @@ A custom module can implement one or more [models](/modular-resources/key-concep
     - For example, the base client is defined in [<file>rdk/components/base/client.go</file>](https://github.com/viamrobotics/rdk/blob/main/components/base/client.go).
     - Base your edits to <file>my_modular_resource.go</file> or <file>my_modular_resource.py</file> on this first file.
     - Name your model according to the namespace of the built-in API you are implementing.
-      For more information see [Naming your model](/modular-resources/key-concepts/#naming-your-model).
+      For more information see [Naming your model](/modular-resources/key-concepts/#naming-your-model-namespacerepo-namename).
 
       <br> **To prepare to import your custom model and your chosen resource subtype's API into your main program and register them with your chosen SDK:**
 
@@ -66,7 +66,7 @@ A custom module can implement one or more [models](/modular-resources/key-concep
 ### Code a new resource model
 
 The following example module registers a modular resource implementing Viam's built-in [Base API](/components/base/#api) [(rdk:service:base)](/modular-resources/key-concepts/#models) as a new model, `"mybase"`, using the model `acme:demo:mybase`.
-For more information see [Naming your model](/modular-resources/key-concepts/#naming-your-model).
+For more information see [Naming your model](/modular-resources/key-concepts/#naming-your-model-namespacerepo-namename).
 
 The Go code for the custom model (<file>mybase.go</file>) and module entry point file (<file>main.go</file>) is adapted from the full demo modules available on the [Viam GitHub](https://github.com/viamrobotics/rdk/blob/main/examples/customresources).
 

--- a/docs/modular-resources/create/_index.md
+++ b/docs/modular-resources/create/_index.md
@@ -119,7 +119,8 @@ class MyBase(Base, Reconfigurable):
     """
 
     # Here is where we define our new model's colon-delimited-triplet
-    # (acme:demo:mybase) acme = namespace, demo = family, mybase = model name.
+    # (acme:demo:mybase) acme = namespace, demo = repo-name,
+    # mybase = model name.
     MODEL: ClassVar[Model] = Model(ModelFamily("acme", "demo"), "mybase")
 
     def __init__(self, name: str, left: str, right: str):

--- a/docs/modular-resources/examples/custom-arm.md
+++ b/docs/modular-resources/examples/custom-arm.md
@@ -21,7 +21,7 @@ aliases:
 # SMEs: Nicole Jung
 ---
 
-The {{< glossary_tooltip term_id="rdk" text="RDK" >}} provides a number of built-in arm {{< glossary_tooltip term_id="model" text="models" >}} that implement the API protocol of the [arm](/components/arm/) {{< glossary_tooltip term_id="subtype" text="subtype" >}} of component, such as the `ur5e`, `xArm6`, and `xArm7`.
+The {{< glossary_tooltip term_id="rdk" text="RDK" >}} provides a number of built-in arm {{< glossary_tooltip term_id="model" text="models" >}} that implement the API protocol of the [arm](/components/arm/) {{< glossary_tooltip term_id="subtype" text="subtype" >}} component, such as the `ur5e`, `xArm6`, and `xArm7`.
 
 {{% alert title="Info" color="info" %}}
 

--- a/docs/modular-resources/examples/custom-arm.md
+++ b/docs/modular-resources/examples/custom-arm.md
@@ -21,7 +21,7 @@ aliases:
 # SMEs: Nicole Jung
 ---
 
-The {{< glossary_tooltip term_id="rdk" text="RDK" >}} provides a number of built-in arm {{< glossary_tooltip term_id="model" text="models" >}} that implement the API protocol of the [arm](/components/arm/) subtype of component, such as the `ur5e`, `xArm6`, and `xArm7`.
+The {{< glossary_tooltip term_id="rdk" text="RDK" >}} provides a number of built-in arm {{< glossary_tooltip term_id="model" text="models" >}} that implement the API protocol of the [arm](/components/arm/) {{< glossary_tooltip term_id="subtype" text="subtype" >}} of component, such as the `ur5e`, `xArm6`, and `xArm7`.
 
 {{% alert title="Info" color="info" %}}
 

--- a/docs/modular-resources/examples/custom-arm.md
+++ b/docs/modular-resources/examples/custom-arm.md
@@ -21,7 +21,7 @@ aliases:
 # SMEs: Nicole Jung
 ---
 
-The {{< glossary_tooltip term_id="rdk" text="RDK" >}} provides a number of built-in arm {{< glossary_tooltip term_id="model" text="models" >}} that implement the API protocol of the [arm](/components/arm/) {{< glossary_tooltip term_id="subtype" text="subtype" >}} component, such as the `ur5e`, `xArm6`, and `xArm7`.
+The {{< glossary_tooltip term_id="rdk" text="RDK" >}} provides a number of built-in arm {{< glossary_tooltip term_id="model" text="models" >}} that implement the API protocol of the [arm](/components/arm/) {{< glossary_tooltip term_id="subtype" text="subtype" >}} of component, such as the `ur5e`, `xArm6`, and `xArm7`.
 
 {{% alert title="Info" color="info" %}}
 

--- a/docs/modular-resources/key-concepts.md
+++ b/docs/modular-resources/key-concepts.md
@@ -105,7 +105,7 @@ If you are [creating a custom module](/modular-resources/create/) and [uploading
 - Your model triplet may only use alphanumeric (`a-z` and `0-9`), hyphen (`-`), and underscore (`_`) characters.
 
 For the middle segment of your model triplet `repo-name`, use the name of the git repository where you store your module's code.
-The `repo-name` should describe the common functionality provided across the modelor models of that module.
+The `repo-name` should describe the common functionality provided across the model or models of that module.
 
 For example:
 - The `rand:yahboom:arm` model and the `rand:yahboom:gripper` model uses the repository name [yahboom](https://github.com/viam-labs/yahboom).

--- a/docs/modular-resources/key-concepts.md
+++ b/docs/modular-resources/key-concepts.md
@@ -112,7 +112,7 @@ The `repo-name` should describe the common functionality provided across the mod
 For example:
 
 - The `rand:yahboom:arm` model and the `rand:yahboom:gripper` model uses the repository name [yahboom](https://github.com/viam-labs/yahboom).
-  The models implement the `rdk:component:arm` and the `rdk:component:gripper` API to support the yahboom dofbot arm and gripper respectively.
+  The models implement the `rdk:component:arm` and the `rdk:component:gripper` API to support the Yahboom DOFBOT arm and gripper respectively.
 
   ```json {class="line-numbers linkable-line-numbers"}
   {

--- a/docs/modular-resources/key-concepts.md
+++ b/docs/modular-resources/key-concepts.md
@@ -109,7 +109,7 @@ The `repo-name` should describe the common functionality provided across the mod
 
 For example:
 - The `rand:yahboom:arm` model and the `rand:yahboom:gripper` model uses the repository name [yahboom](https://github.com/viam-labs/yahboom).
-  They implement the `rdk:component:arm` and the `rdk:component:gripper` API to support the yahboom dofbot arm and gripper respectively.
+  The models implement the `rdk:component:arm` and the `rdk:component:gripper` API to support the yahboom dofbot arm and gripper respectively.
 
   ```json {class="line-numbers linkable-line-numbers"}
   {

--- a/docs/modular-resources/key-concepts.md
+++ b/docs/modular-resources/key-concepts.md
@@ -59,7 +59,7 @@ For example, some DC motors communicate using [GPIO](/components/board/), while 
 Regardless, you can power any motor model that implements the `rdk:component:motor` API with the `SetPower()` method.
 
 Models are uniquely namespaced as colon-delimited-triplets in the form `namespace:repo-name:name` for modular resources and `rdk:builtin:name` for builtin models.
-See [Naming your model](/extend/modular-resources/key-concepts/#naming-your-model-namespacerepo-namename) for more information.
+See [Naming your model](#naming-your-model-namespacerepo-namename) for more information.
 
 Models are either:
 

--- a/docs/modular-resources/key-concepts.md
+++ b/docs/modular-resources/key-concepts.md
@@ -114,26 +114,8 @@ For example:
 - The `rand:yahboom:arm` model and the `rand:yahboom:gripper` model uses the repository name [yahboom](https://github.com/viam-labs/yahboom).
   The models implement the `rdk:component:arm` and the `rdk:component:gripper` API to support the Yahboom DOFBOT arm and gripper respectively.
 
-  ```json {class="line-numbers linkable-line-numbers"}
-  {
-    "api": "rdk:component:arm",
-    "model": "rand:yahboom:arm"
-  },
-  {
-    "api": "rdk:component:gripper",
-    "model": "rand:yahboom:gripper"
-  }
-  ```
-
 - The `viam-labs:audioout:pygame` model uses the repository name [audioout](https://github.com/viam-labs/audioout)
   It implements the custom API `viam-labs:service:audioout`.
-
-  ```json {class="line-numbers linkable-line-numbers"}
-  {
-    "api": "viam-labs:service:audioout",
-    "model": "viam-labs:audioout:pygame"
-  }
-  ```
 
 A model with the `viam` namespace is always Viam-provided.
 

--- a/docs/modular-resources/key-concepts.md
+++ b/docs/modular-resources/key-concepts.md
@@ -120,7 +120,7 @@ For example:
     "model": "rand:yahboom:arm"
   },
   {
-    "api": "rdk:component:arm",
+    "api": "rdk:component:gripper",
     "model": "rand:yahboom:gripper"
   }
   ```

--- a/docs/modular-resources/key-concepts.md
+++ b/docs/modular-resources/key-concepts.md
@@ -58,7 +58,9 @@ Models allow you to control different instances of a resource with a consistent 
 For example, some DC motors communicate using [GPIO](/components/board/), while other DC motors use serial protocols like the [SPI bus](/components/board/#spis).
 Regardless, you can power any motor model that implements the `rdk:component:motor` API with the `SetPower()` method.
 
-Models are uniquely namespaced as colon-delimited-triplets in the form `namespace:repo-name:name` for modular resources and `rdk:builtin:name` for builtin models.
+Models are uniquely namespaced as colon-delimited-triplets.
+Modular resource model names have the form `namespace:repo-name:name`.
+Built-in model names have the form `rdk:builtin:name`.
 See [Naming your model](#naming-your-model-namespacerepo-namename) for more information.
 
 Models are either:

--- a/docs/modular-resources/key-concepts.md
+++ b/docs/modular-resources/key-concepts.md
@@ -59,7 +59,7 @@ For example, some DC motors communicate using [GPIO](/components/board/), while 
 Regardless, you can power any motor model that implements the `rdk:component:motor` API with the `SetPower()` method.
 
 Models are uniquely namespaced as colon-delimited-triplets in the form `namespace:repo-name:name` for modular resources and `rdk:builtin:name` for builtin models.
-See [Naming your model](/extend/modular-resources/key-concepts/#naming-your-model) for more information.
+See [Naming your model](/extend/modular-resources/key-concepts/#naming-your-model-namespacerepo-namename) for more information.
 
 Models are either:
 

--- a/docs/modular-resources/key-concepts.md
+++ b/docs/modular-resources/key-concepts.md
@@ -112,7 +112,7 @@ The `repo-name` should describe the common functionality provided across the mod
 For example:
 
 - The `rand:yahboom:arm` model and the `rand:yahboom:gripper` model uses the repository name [yahboom](https://github.com/viam-labs/yahboom).
-  The models implement the `rdk:component:arm` and the `rdk:component:gripper` API to support the Yahboom DOFBOT arm and gripper respectively.
+  The models implement the `rdk:component:arm` and the `rdk:component:gripper` API to support the Yahboom DOFBOT arm and gripper, respectively.
 - The `viam-labs:audioout:pygame` model uses the repository name [audioout](https://github.com/viam-labs/audioout)
   It implements the custom API `viam-labs:service:audioout`.
 

--- a/docs/modular-resources/key-concepts.md
+++ b/docs/modular-resources/key-concepts.md
@@ -113,7 +113,6 @@ For example:
 
 - The `rand:yahboom:arm` model and the `rand:yahboom:gripper` model uses the repository name [yahboom](https://github.com/viam-labs/yahboom).
   The models implement the `rdk:component:arm` and the `rdk:component:gripper` API to support the Yahboom DOFBOT arm and gripper respectively.
-
 - The `viam-labs:audioout:pygame` model uses the repository name [audioout](https://github.com/viam-labs/audioout)
   It implements the custom API `viam-labs:service:audioout`.
 

--- a/docs/modular-resources/key-concepts.md
+++ b/docs/modular-resources/key-concepts.md
@@ -58,8 +58,8 @@ Models allow you to control different instances of a resource with a consistent 
 For example, some DC motors communicate using [GPIO](/components/board/), while other DC motors use serial protocols like the [SPI bus](/components/board/#spis).
 Regardless, you can power any motor model that implements the `rdk:component:motor` API with the `SetPower()` method.
 
-Models are uniquely namespaced as colon-delimited-triplets in the form `namespace:family:name`.
-See [Naming your model](/modular-resources/key-concepts/#naming-your-model) for more information.
+Models are uniquely namespaced as colon-delimited-triplets in the form `namespace:repo-name:name` for modular resources and `rdk:builtin:name` for builtin models.
+See [Naming your model](/extend/modular-resources/key-concepts/#naming-your-model) for more information.
 
 Models are either:
 
@@ -68,7 +68,7 @@ Models are either:
 
 ### Built-in models
 
-Viam provides many built-in models that implement API capabilities, each using `rdk` as the `namespace`, and `builtin` as the `family`.
+Viam provides many built-in models that implement API capabilities, each using `rdk` as the `namespace`, and `builtin` as the `type`.
 These models run within `viam-server`.
 
 For example:
@@ -95,7 +95,7 @@ When implementing a custom [model](#models) of an existing [service](/services/)
 - `type`: `service`
 - `subtype`: any one of [these service proto files](https://github.com/viamrobotics/api/tree/main/proto/viam/service).
 
-#### Naming your model
+#### Naming your model: namespace:repo-name:name
 
 If you are [creating a custom module](/modular-resources/create/) and [uploading that module](/modular-resources/upload/) to the Viam registry, ensure your model name meets the following requirements:
 
@@ -104,9 +104,11 @@ If you are [creating a custom module](/modular-resources/create/) and [uploading
 - Your model triplet must be all-lowercase.
 - Your model triplet may only use alphanumeric (`a-z` and `0-9`), hyphen (`-`), and underscore (`_`) characters.
 
-In addition, you should chose a name for the `family` of your model based on the whether your module implements a single model, or multiple models:
+In addition, you should use the name of the git repository for your modular resource as the `repo-name`.
+The `repo-name` should identify a single model or multiple models.
+You can use a name that identifies the _family_ of the model or models:
 
-- If your module provides a single model, the `family` should match the `subtype` of whichever API your model implements.
+- If your module provides a single model, the `repo-name` should match the `subtype` of whichever API your model implements.
   For example, the Intel Realsense module `realsense`, available from the [Viam registry](https://app.viam.com/module/viam/realsense), implements the `camera` component API, so it is named as follows:
 
   ```json {class="line-numbers linkable-line-numbers"}
@@ -116,7 +118,7 @@ In addition, you should chose a name for the `family` of your model based on the
   }
   ```
 
-- If your module provides multiple models, the `family` should describe the common functionality provided across all the models of that module.
+- If your module provides multiple models, the `repo-name` should describe the common functionality provided across all the models of that module.
   For example, the ODrive module `odrive`, available from the [Viam registry](https://app.viam.com/module/viam/odrive), implements several `motor` component APIs, so it is named as follows:
 
   ```json {class="line-numbers linkable-line-numbers"}

--- a/docs/modular-resources/key-concepts.md
+++ b/docs/modular-resources/key-concepts.md
@@ -68,7 +68,7 @@ Models are either:
 
 ### Built-in models
 
-Viam provides many built-in models that implement API capabilities, each using `rdk` as the `namespace`, and `builtin` as the `type`.
+Viam provides many built-in models that implement API capabilities, each using `rdk` as the `namespace`, and `builtin` as the `family`.
 These models run within `viam-server`.
 
 For example:

--- a/docs/modular-resources/key-concepts.md
+++ b/docs/modular-resources/key-concepts.md
@@ -121,7 +121,7 @@ For example:
   },
   {
     "api": "rdk:component:arm",
-    "model": "rand:yahboom:arm"
+    "model": "rand:yahboom:gripper"
   }
   ```
 

--- a/docs/modular-resources/key-concepts.md
+++ b/docs/modular-resources/key-concepts.md
@@ -104,31 +104,31 @@ If you are [creating a custom module](/modular-resources/create/) and [uploading
 - Your model triplet must be all-lowercase.
 - Your model triplet may only use alphanumeric (`a-z` and `0-9`), hyphen (`-`), and underscore (`_`) characters.
 
-In addition, you should use the name of the git repository for your modular resource as the `repo-name`.
-The `repo-name` should identify a single model or multiple models.
-You can use a name that identifies the _family_ of the model or models:
+For the middle segment of your model triplet `repo-name`, use the name of the git repository where you store your module's code.
+The `repo-name` should describe the common functionality provided across the modelor models of that module.
 
-- If your module provides a single model, the `repo-name` should match the `subtype` of whichever API your model implements.
-  For example, the Intel Realsense module `realsense`, available from the [Viam registry](https://app.viam.com/module/viam/realsense), implements the `camera` component API, so it is named as follows:
+For example:
+- The `rand:yahboom:arm` model and the `rand:yahboom:gripper` model uses the repository name [yahboom](https://github.com/viam-labs/yahboom).
+  They implement the `rdk:component:arm` and the `rdk:component:gripper` API to support the yahboom dofbot arm and gripper respectively.
 
   ```json {class="line-numbers linkable-line-numbers"}
   {
-    "api": "rdk:component:camera",
-    "model": "viam:camera:realsense"
+    "api": "rdk:component:arm",
+    "model": "rand:yahboom:arm"
+  },
+  {
+    "api": "rdk:component:arm",
+    "model": "rand:yahboom:arm"
   }
   ```
 
-- If your module provides multiple models, the `repo-name` should describe the common functionality provided across all the models of that module.
-  For example, the ODrive module `odrive`, available from the [Viam registry](https://app.viam.com/module/viam/odrive), implements several `motor` component APIs, so it is named as follows:
+- The `viam-labs:audioout:pygame` model uses the repository name [audioout](https://github.com/viam-labs/audioout)
+  It implements the custom API `viam-labs:service:audioout`.
 
   ```json {class="line-numbers linkable-line-numbers"}
   {
-    "api": "rdk:component:motor",
-    "model": "viam:odrive:serial"
-  },
-  {
-    "api": "rdk:component:motor",
-    "model": "viam:odrive:canbus"
+    "api": "viam-labs:service:audioout",
+    "model": "viam-labs:audioout:pygame"
   }
   ```
 

--- a/docs/modular-resources/key-concepts.md
+++ b/docs/modular-resources/key-concepts.md
@@ -108,6 +108,7 @@ For the middle segment of your model triplet `repo-name`, use the name of the gi
 The `repo-name` should describe the common functionality provided across the model or models of that module.
 
 For example:
+
 - The `rand:yahboom:arm` model and the `rand:yahboom:gripper` model uses the repository name [yahboom](https://github.com/viam-labs/yahboom).
   The models implement the `rdk:component:arm` and the `rdk:component:gripper` API to support the yahboom dofbot arm and gripper respectively.
 

--- a/docs/modular-resources/upload/_index.md
+++ b/docs/modular-resources/upload/_index.md
@@ -111,7 +111,7 @@ If you mark your module as public, you cannot change it back to private.
         <td><code>models</code></td>
         <td>object</td>
         <td><strong>Required</strong></td>
-        <td>A list of one or more <a href="/modular-resources/key-concepts/#models">models</a> provided by your custom module. You must provide at least one model, which consists of an <code>api</code> and <code>model</code> key pair. If you are publishing a public module (<code>"visibility": "public"</code>), the <a href="/modular-resources/key-concepts/#naming-your-model">namespace of your model</a> must match the <a href="/manage/fleet/organizations/#create-a-namespace-for-your-organization">namespace of your organization</a>.</td>
+        <td>A list of one or more <a href="/modular-resources/key-concepts/#models">models</a> provided by your custom module. You must provide at least one model, which consists of an <code>api</code> and <code>model</code> key pair. If you are publishing a public module (<code>"visibility": "public"</code>), the <a href="/modular-resources/key-concepts/#naming-your-model-namespacerepo-namename">namespace of your model</a> must match the <a href="/manage/fleet/organizations/#create-a-namespace-for-your-organization">namespace of your organization</a>.</td>
       </tr>
       <tr>
         <td><code>entrypoint</code></td>

--- a/docs/tutorials/custom/controlling-an-intermode-rover-canbus.md
+++ b/docs/tutorials/custom/controlling-an-intermode-rover-canbus.md
@@ -121,7 +121,7 @@ Since you will conform to an existing Viam API for [base](/components/base/), th
 **rdk:component:base**
 
 This base model is being created for tutorial purposes only, and will implement only partial functionality for demonstration purposes.
-Therefore, use the namespace "viamlabs", an (arbitrary) model family called "tutorial" and lastly, a model name of "intermode".
+Therefore, use the namespace "viamlabs", an (arbitrary) repo-name called "tutorial" and lastly, a model name of "intermode".
 The complete triplet is:
 **viamlabs:tutorial:intermode**
 
@@ -129,7 +129,7 @@ The [module.go code](https://github.com/viam-labs/tutorial-intermode) creates th
 The _Subtype_ of a resource contains its API triplet, so using `base.Subtype` (see line 30 below) registers our new model with the _API_ from the RDK's built-in base component (rdk:component:base).
 
 ```go {class="line-numbers linkable-line-numbers"}
-// namespace, model family, model
+// namespace, repo-name, model
 var model = resource.NewModel("viamlabs", "tutorial", "intermode")
 
 func main() {

--- a/docs/tutorials/custom/custom-base-dog.md
+++ b/docs/tutorials/custom/custom-base-dog.md
@@ -225,14 +225,14 @@ As you follow the prompts, it's a good idea to use the same names we used so tha
 
 - Model name: `robotdog`
 - Module namespace: `viamlabs`
-- Module family: `base`
+- Module repo-name: `base`
 - Language: `python`
 - API triplet: `rdk:components:base`
 - Existing API? `Yes`
 
 {{% alert title="Important" color="note" %}}
 
-You can use a different model name, module namespace, and family, but you need to use the existing API triplet `rdk:components:base` in order for your custom base to work properly as a base with `viam-server` and the [Viam app](https://app.viam.com/).
+You can use a different model name, module namespace, and repo-name, but you need to use the existing API triplet `rdk:components:base` in order for your custom base to work properly as a base with `viam-server` and the [Viam app](https://app.viam.com/).
 
 {{% /alert %}}
 


### PR DESCRIPTION
Please review the following very carefully:

- [ ] We are changing the definition of a model namespace triplet to be `namespace:repo-name:name` for modular resources (with `rdk:builtin:name` for builtin models). ([Model Namespace Triplet Glossary Link](https://docs-test.viam.dev//public/appendix/glossary/#term-model-namespace-triplet))
- [ ] A subtype remains defined as "A category within a type of resource" ([Link to Subtype definition](https://docs-test.viam.dev/cde83f560aab3f22ab9a8f946a473ccb4bf2714d/public/appendix/glossary/#term-subtype)): 

  A category within a [type](https://docs-test.viam.dev/1938/public/appendix/glossary/#term-type) of [resource](https://docs-test.viam.dev/1938/public/appendix/glossary/#term-resource). Resource models belonging to a subtype share the same API. [Models](https://docs-test.viam.dev/1938/public/appendix/glossary/#term-model) implement that subtype’s API protocol with different drivers.

  For example, an arm is a subtype of the [component](https://docs-test.viam.dev/1938/public/components/) resource type, while the ur5e is a [model](https://docs-test.viam.dev/1938/public/appendix/glossary/#term-model) of the arm subtype’s API.

  The [Vision Service](https://docs-test.viam.dev/1938/public/services/vision/) is a subtype of the [service](https://docs-test.viam.dev/1938/public/services/) resource type.

  A subtype is designated by its [api-namespace-triplet](https://docs-test.viam.dev/1938/public/appendix/glossary/#term-api-namespace-triplet).
- [ ] A type is defined as:

   In the [RDK](https://docs-test.viam.dev/1938/public/internals/rdk/) architecture’s [namespace triplet](https://docs-test.viam.dev/1938/public/appendix/glossary/#term-api-namespace-triplet) for resource APIs, type refers to the distinction between [component](https://docs-test.viam.dev/1938/public/components/) or [service](https://docs-test.viam.dev/1938/public/services/).

   **However, the meaning of “type” can be context dependent across the Viam platform:**

   For example, when [configuring a robot](https://docs-test.viam.dev/1938/public/manage/configuration/) in the [Viam app](https://app.viam.com/), "type" is used in the JSON to indicate a particular implementation of a component or service, which is formally designated as the [subtype](https://docs-test.viam.dev/1938/public/appendix/glossary/#term-subtype).

