### PR TITLE
DOCS-1204: Add component service cards

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -999,6 +999,32 @@ td > ul, td > ol {
   }
 }
 
+// relatedcard styling
+
+.relatedcard {
+  display: flex;
+  flex-direction: column;
+}
+
+.relatedcard a {
+  width: 8rem;
+  text-decoration: none;
+  padding: 0.75rem;
+  text-align: center;
+}
+
+.relatedcard a:hover {
+  background-color: whitesmoke;
+}
+
+.relatedcard div {
+  margin: auto;
+}
+
+.relatedcard p {
+  vertical-align: middle;
+}
+
 // sectionlist styling
 
 ul.sectionlist {

--- a/docs/components/arm/_index.md
+++ b/docs/components/arm/_index.md
@@ -26,14 +26,6 @@ When controlling an arm with `viam-server`, the following features are implement
 - Self-collision prevention
 - Obstacle avoidance
 
-## Related Services
-
-{{< cards >}}
-{{< relatedcard link="/services/motion/" >}}
-{{< relatedcard link="/services/frame-system/" >}}
-{{< relatedcard link="/services/data/" >}}
-{{< /cards >}}
-
 ## Motion planning with your arm's built-in software
 
 Each arm model is supported with a driver that is compatible with the software API that the model's manufacturer supports.
@@ -54,6 +46,14 @@ Arm drivers are also paired, in the RDK, with JSON files that describe the kinem
 - When an arm is moved with a `move_to_position` call, the movement will follow a straight line, and not deviate from the start or end orientations more than the start and orientations differ from one another
 
 - If there is no way for the arm to move to the desired location in a straight line, or if it would self-collide or collide with an obstacle that was passed in as something to avoid, then the `move_to_position` call will fail.
+
+## Related Services
+
+{{< cards >}}
+{{< relatedcard link="/services/motion/" >}}
+{{< relatedcard link="/services/frame-system/" >}}
+{{< relatedcard link="/services/data/" >}}
+{{< /cards >}}
 
 ## Supported Models
 

--- a/docs/components/arm/_index.md
+++ b/docs/components/arm/_index.md
@@ -29,8 +29,9 @@ When controlling an arm with `viam-server`, the following features are implement
 ## Related Services
 
 {{< cards >}}
+{{< relatedcard link="/services/motion/" >}}
 {{< relatedcard link="/services/frame-system/" >}}
-{{< relatedcard link="/services/navigation/" >}}
+{{< relatedcard link="/services/data/" >}}
 {{< /cards >}}
 
 ## Motion planning with your arm's built-in software

--- a/docs/components/arm/_index.md
+++ b/docs/components/arm/_index.md
@@ -568,7 +568,6 @@ You can also ask questions on the [Community Discord](https://discord.gg/viam) a
 ## Related Services
 
 {{< cards >}}
-{{% card link="/services/data" class="small" %}}
 {{% card link="/services/frame-system/" class="small" %}}
 {{% card link="/services/motion" class="small" %}}
 {{</ cards >}}

--- a/docs/components/arm/_index.md
+++ b/docs/components/arm/_index.md
@@ -565,10 +565,17 @@ You can find additional assistance in the [Troubleshooting section](/appendix/tr
 
 You can also ask questions on the [Community Discord](https://discord.gg/viam) and we will be happy to help.
 
+## Related Services
+
+{{< cards >}}
+{{% card link="/services/data" class="small" %}}
+{{% card link="/services/frame-system/" class="small" %}}
+{{% card link="/services/motion" class="small" %}}
+{{</ cards >}}
+
 ## Next Steps
 
 {{< cards >}}
 {{% card link="/tutorials/services/accessing-and-moving-robot-arm" %}}
 {{% card link="/tutorials/projects/claw-game/" %}}
-{{% card link="/services/motion" %}}
 {{< /cards >}}

--- a/docs/components/arm/_index.md
+++ b/docs/components/arm/_index.md
@@ -26,6 +26,13 @@ When controlling an arm with `viam-server`, the following features are implement
 - Self-collision prevention
 - Obstacle avoidance
 
+## Related Services
+
+{{< cards >}}
+{{< relatedcard link="/services/frame-system/" >}}
+{{< relatedcard link="/services/navigation/" >}}
+{{< /cards >}}
+
 ## Motion planning with your arm's built-in software
 
 Each arm model is supported with a driver that is compatible with the software API that the model's manufacturer supports.
@@ -564,13 +571,6 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).
 
 You can also ask questions on the [Community Discord](https://discord.gg/viam) and we will be happy to help.
-
-## Related Services
-
-{{< cards >}}
-{{% card link="/services/frame-system/" class="small" %}}
-{{% card link="/services/motion" class="small" %}}
-{{</ cards >}}
 
 ## Next Steps
 

--- a/docs/components/base/_index.md
+++ b/docs/components/base/_index.md
@@ -26,18 +26,15 @@ Most mobile robots with a base need at least the following hardware:
 - A power supply for the actuators.
 - Some sort of chassis to hold everything together.
 
-<<<<<<< HEAD
-## Supported Models
-=======
 ## Related Services
 
 {{< cards >}}
 {{< relatedcard link="/services/base-rc/" >}}
 {{< relatedcard link="/services/frame-system/" >}}
+{{< relatedcard link="/services/navigation/" >}}
 {{< /cards >}}
 
-## Configuration
->>>>>>> 36007f58 (test sectionlist on arm page)
+## Supported Models
 
 To use your base with Viam, check whether one of the following [built-in models](#built-in-models) or [modular resources](#modular-resources) supports your base.
 

--- a/docs/components/base/_index.md
+++ b/docs/components/base/_index.md
@@ -26,7 +26,18 @@ Most mobile robots with a base need at least the following hardware:
 - A power supply for the actuators.
 - Some sort of chassis to hold everything together.
 
+<<<<<<< HEAD
 ## Supported Models
+=======
+## Related Services
+
+{{< cards >}}
+{{< relatedcard link="/services/base-rc/" >}}
+{{< relatedcard link="/services/frame-system/" >}}
+{{< /cards >}}
+
+## Configuration
+>>>>>>> 36007f58 (test sectionlist on arm page)
 
 To use your base with Viam, check whether one of the following [built-in models](#built-in-models) or [modular resources](#modular-resources) supports your base.
 
@@ -653,13 +664,6 @@ For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/
 You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).
 
 {{< snippet "social.md" >}}
-
-## Related Services
-
-{{< cards >}}
-{{% card link="/services/base-rc/" class="small" %}}
-{{% card link="/services/frame-system/" class="small" %}}
-{{</ cards >}}
 
 ## Next Steps
 

--- a/docs/components/base/_index.md
+++ b/docs/components/base/_index.md
@@ -659,7 +659,6 @@ You can find additional assistance in the [Troubleshooting section](/appendix/tr
 {{< cards >}}
 {{% card link="/services/base-rc/" class="small" %}}
 {{% card link="/services/frame-system/" class="small" %}}
-{{% card link="/services/navigation/" class="small" %}}
 {{</ cards >}}
 
 ## Next Steps

--- a/docs/components/base/_index.md
+++ b/docs/components/base/_index.md
@@ -654,6 +654,14 @@ You can find additional assistance in the [Troubleshooting section](/appendix/tr
 
 {{< snippet "social.md" >}}
 
+## Related Services
+
+{{< cards >}}
+{{% card link="/services/base-rc/" class="small" %}}
+{{% card link="/services/frame-system/" class="small" %}}
+{{% card link="/services/navigation/" class="small" %}}
+{{</ cards >}}
+
 ## Next Steps
 
 {{< cards >}}

--- a/docs/components/board/_index.md
+++ b/docs/components/board/_index.md
@@ -1448,7 +1448,6 @@ You can find additional assistance in the [Troubleshooting section](/appendix/tr
 ## Related Services
 
 {{< cards >}}
-{{% card link="/services/data/" class="small" %}}
 {{% card link="/services/frame-system/" class="small" %}}
 {{</ cards >}}
 

--- a/docs/components/board/_index.md
+++ b/docs/components/board/_index.md
@@ -12,7 +12,32 @@ images: ["/icons/components/board.svg"]
 # SMEs: Gautham, Rand
 ---
 
+<<<<<<< HEAD
 A _board_ component on your robot communicates with the other [components](/components/) of the robot.
+=======
+A _board_ is the signal wire hub of a robot that provides access to general purpose input/output [(GPIO)](https://www.howtogeek.com/787928/what-is-gpio/) pins: a collection of pins on the motherboard of a computer that can receive electrical signals.
+
+You can control the flow of electricity to these pins to change their state between "high" (active) and "low" (inactive), and wire them to send [digital signals](https://en.wikipedia.org/wiki/Digital_signal) to and from other hardware.
+
+This control is simplified with [`viam-server`](/installation/).
+When Viam's software is running on a computer with GPIO pins accessible to external hardware [components](/components/), it manages GPIO signaling to abstract control to {{< glossary_tooltip term_id="resource" text="resource" >}} APIs.
+
+{{% figure src="/components/board/board-comp-options.png" alt="Image showing two board options: First, running viam-server locally and second, running via a peripheral plugged into the USB port of a computer that is running the viam-server." title="Two different board options: a single-board computer with GPIO pins running `viam-server` locally, or a GPIO peripheral plugged into a desktop computer's USB port, with the computer running `viam-server`." %}}
+
+The [RDK](/internals/rdk/) also provides the [`GPIOPin` interface](#gpiopin-api) for direct control and monitoring of the state of GPIO pins.
+
+## Related Services
+
+{{< cards >}}
+{{< relatedcard link="/services/frame-system/" >}}
+{{< relatedcard link="/services/ml/" >}}
+{{< /cards >}}
+
+## Configuration
+
+Configure a _board_ component on your robot to communicate with the other [components](/components/) of the robot.
+Signaling is overseen by a computer running `viam-server`.
+>>>>>>> 36007f58 (test sectionlist on arm page)
 
 A board can be:
 
@@ -1444,12 +1469,6 @@ interrupt = await my_board.digital_interrupt_by_name(
 You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).
 
 {{< snippet "social.md" >}}
-
-## Related Services
-
-{{< cards >}}
-{{% card link="/services/frame-system/" class="small" %}}
-{{</ cards >}}
 
 ## Next Steps
 

--- a/docs/components/board/_index.md
+++ b/docs/components/board/_index.md
@@ -12,32 +12,7 @@ images: ["/icons/components/board.svg"]
 # SMEs: Gautham, Rand
 ---
 
-<<<<<<< HEAD
 A _board_ component on your robot communicates with the other [components](/components/) of the robot.
-=======
-A _board_ is the signal wire hub of a robot that provides access to general purpose input/output [(GPIO)](https://www.howtogeek.com/787928/what-is-gpio/) pins: a collection of pins on the motherboard of a computer that can receive electrical signals.
-
-You can control the flow of electricity to these pins to change their state between "high" (active) and "low" (inactive), and wire them to send [digital signals](https://en.wikipedia.org/wiki/Digital_signal) to and from other hardware.
-
-This control is simplified with [`viam-server`](/installation/).
-When Viam's software is running on a computer with GPIO pins accessible to external hardware [components](/components/), it manages GPIO signaling to abstract control to {{< glossary_tooltip term_id="resource" text="resource" >}} APIs.
-
-{{% figure src="/components/board/board-comp-options.png" alt="Image showing two board options: First, running viam-server locally and second, running via a peripheral plugged into the USB port of a computer that is running the viam-server." title="Two different board options: a single-board computer with GPIO pins running `viam-server` locally, or a GPIO peripheral plugged into a desktop computer's USB port, with the computer running `viam-server`." %}}
-
-The [RDK](/internals/rdk/) also provides the [`GPIOPin` interface](#gpiopin-api) for direct control and monitoring of the state of GPIO pins.
-
-## Related Services
-
-{{< cards >}}
-{{< relatedcard link="/services/frame-system/" >}}
-{{< relatedcard link="/services/ml/" >}}
-{{< /cards >}}
-
-## Configuration
-
-Configure a _board_ component on your robot to communicate with the other [components](/components/) of the robot.
-Signaling is overseen by a computer running `viam-server`.
->>>>>>> 36007f58 (test sectionlist on arm page)
 
 A board can be:
 
@@ -50,6 +25,13 @@ The board of a robot is also its signal wire hub that provides access to general
 Signaling is overseen by a computer running `viam-server` which allows you to control the flow of electricity to these pins to change their state between "high" (active) and "low" (inactive), and wire them to send [digital signals](https://en.wikipedia.org/wiki/Digital_signal) to and from other hardware.
 
 {{% figure src="/components/board/board-comp-options.png" alt="Image showing two board options: First, running viam-server locally and second, running via a peripheral plugged into the USB port of a computer that is running the viam-server." title="Two different board options: a single-board computer with GPIO pins running `viam-server` locally, or a GPIO peripheral plugged into a desktop computer's USB port, with the computer running `viam-server`." %}}
+
+## Related Services
+
+{{< cards >}}
+{{< relatedcard link="/services/frame-system/" >}}
+{{< relatedcard link="/services/ml/" >}}
+{{< /cards >}}
 
 ## Supported Models
 

--- a/docs/components/board/_index.md
+++ b/docs/components/board/_index.md
@@ -1445,6 +1445,13 @@ You can find additional assistance in the [Troubleshooting section](/appendix/tr
 
 {{< snippet "social.md" >}}
 
+## Related Services
+
+{{< cards >}}
+{{% card link="/services/data/" class="small" %}}
+{{% card link="/services/frame-system/" class="small" %}}
+{{</ cards >}}
+
 ## Next Steps
 
 {{< cards >}}

--- a/docs/components/camera/_index.md
+++ b/docs/components/camera/_index.md
@@ -395,10 +395,24 @@ For more information, see the [Go SDK Code](https://pkg.go.dev/go.viam.com/rdk/c
 {{% /tab %}}
 {{< /tabs >}}
 
+## Troubleshooting
+
+You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).
+
+{{< snippet "social.md" >}}
+
+## Related Services
+
+{{< cards >}}
+{{% card link="/services/data/" class="small" %}}
+{{% card link="/services/frame-system/" class="small" %}}
+{{% card link="/services/slam" class="small"%}}
+{{% card link="/services/vision" class="small"%}}
+{{</ cards >}}
+
 ## Next Steps
 
 {{< cards >}}
-{{% card link="/services/vision" %}}
 {{% card link="/tutorials/services/try-viam-color-detection" %}}
 {{% card link="/tutorials/services/color-detection-scuttle" %}}
 {{< /cards >}}

--- a/docs/components/camera/_index.md
+++ b/docs/components/camera/_index.md
@@ -31,9 +31,6 @@ You can use different models to:
 - Combine streams from multiple cameras into one.
 - Transform and process images.
 
-<<<<<<< HEAD
-## Supported Models
-=======
 ## Related Services
 
 {{< cards >}}
@@ -44,8 +41,7 @@ You can use different models to:
 {{< relatedcard link="/services/ml/" >}}
 {{< /cards >}}
 
-## Configuration
->>>>>>> 36007f58 (test sectionlist on arm page)
+## Supported Models
 
 To use your camera with Viam, check whether one of the following [built-in models](#built-in-models) or [modular resources](#modular-resources) supports your camera.
 
@@ -408,12 +404,6 @@ For more information, see the [Go SDK Code](https://pkg.go.dev/go.viam.com/rdk/c
 
 {{% /tab %}}
 {{< /tabs >}}
-
-## Troubleshooting
-
-You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).
-
-{{< snippet "social.md" >}}
 
 ## Next Steps
 

--- a/docs/components/camera/_index.md
+++ b/docs/components/camera/_index.md
@@ -31,7 +31,21 @@ You can use different models to:
 - Combine streams from multiple cameras into one.
 - Transform and process images.
 
+<<<<<<< HEAD
 ## Supported Models
+=======
+## Related Services
+
+{{< cards >}}
+{{< relatedcard link="/services/data/" >}}
+{{< relatedcard link="/services/vision/" >}}
+{{< relatedcard link="/services/frame-system/" >}}
+{{< relatedcard link="/services/slam/" >}}
+{{< relatedcard link="/services/ml/" >}}
+{{< /cards >}}
+
+## Configuration
+>>>>>>> 36007f58 (test sectionlist on arm page)
 
 To use your camera with Viam, check whether one of the following [built-in models](#built-in-models) or [modular resources](#modular-resources) supports your camera.
 
@@ -401,18 +415,10 @@ You can find additional assistance in the [Troubleshooting section](/appendix/tr
 
 {{< snippet "social.md" >}}
 
-## Related Services
-
-{{< cards >}}
-{{% card link="/services/data/" class="small" %}}
-{{% card link="/services/frame-system/" class="small" %}}
-{{% card link="/services/slam" class="small"%}}
-{{% card link="/services/vision" class="small"%}}
-{{</ cards >}}
-
 ## Next Steps
 
 {{< cards >}}
+{{% card link="/services/vision" %}}
 {{% card link="/tutorials/services/try-viam-color-detection" %}}
 {{% card link="/tutorials/services/color-detection-scuttle" %}}
 {{< /cards >}}

--- a/docs/components/component/_index.md
+++ b/docs/components/component/_index.md
@@ -28,6 +28,15 @@ Most robots with a COMPONENT need at least the following hardware (optional):
 - Board
 - ...
 
+## Related Services
+
+Add services commonly used with the component.
+
+{{< cards >}}
+{{< relatedcard link="/services/data/" >}}
+{{< relatedcard link="/services/frame-system/" >}}
+{{< /cards >}}
+
 ## Supported Models
 
 To use your COMPONENT with Viam, check whether one of the following [built-in models](#built-in-models) or [modular resources](#modular-resources) supports your COMPONENT.

--- a/docs/components/encoder/_index.md
+++ b/docs/components/encoder/_index.md
@@ -31,6 +31,15 @@ Most robots with an encoder need at least the following hardware:
   For example, a Raspberry Pi, or another model of single-board computer with GPIO (general purpose input/output) pins.
 - Some sort of rotary robot part (like a motor, joint or dial) for which you want to measure movement.
 
+## Related Services
+
+{{< cards >}}
+{{< relatedcard link="/services/motion/" >}}
+{{< relatedcard link="/services/navigation/" >}}
+{{< relatedcard link="/services/data/" >}}
+{{< relatedcard link="/services/frame-system/" >}}
+{{< /cards >}}
+
 ## Supported Models
 
 To use your encoder with Viam, check whether one of the following [built-in models](#built-in-models) supports your encoder.
@@ -316,13 +325,6 @@ For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/
 You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).
 
 You can also ask questions on the [Viam Community Slack](https://join.slack.com/t/viamrobotics/shared_invite/zt-1f5xf1qk5-TECJc1MIY1MW0d6ZCg~Wnw) and we will be happy to help.
-
-## Related Services
-
-{{< cards >}}
-{{% card link="/services/data/" class="small" %}}
-{{% card link="/services/frame-system/" class="small" %}}
-{{</ cards >}}
 
 ## Next Steps
 

--- a/docs/components/encoder/_index.md
+++ b/docs/components/encoder/_index.md
@@ -317,6 +317,13 @@ You can find additional assistance in the [Troubleshooting section](/appendix/tr
 
 You can also ask questions on the [Viam Community Slack](https://join.slack.com/t/viamrobotics/shared_invite/zt-1f5xf1qk5-TECJc1MIY1MW0d6ZCg~Wnw) and we will be happy to help.
 
+## Related Services
+
+{{< cards >}}
+{{% card link="/services/data/" class="small" %}}
+{{% card link="/services/frame-system/" class="small" %}}
+{{</ cards >}}
+
 ## Next Steps
 
 {{< cards >}}

--- a/docs/components/gantry/_index.md
+++ b/docs/components/gantry/_index.md
@@ -463,6 +463,14 @@ For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/
 {{% /tab %}}
 {{< /tabs >}}
 
+## Related Services
+
+{{< cards >}}
+{{% card link="/services/data/" class="small" %}}
+{{% card link="/services/frame-system/" class="small" %}}
+{{% card link="/services/motion/" class="small" %}}
+{{</ cards >}}
+
 ## Troubleshooting
 
 You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).

--- a/docs/components/gantry/_index.md
+++ b/docs/components/gantry/_index.md
@@ -34,6 +34,14 @@ Most robots with a gantry need at least the following hardware:
     Requires setting limit switches in the config of the gantry, or setting offsets in the config of the stepper motor.
 - Limit switches, to attach to the ends of the gantry's axis
 
+## Related Services
+
+{{< cards >}}
+{{< relatedcard link="/services/navigation/" >}}
+{{< relatedcard link="/services/frame-system/" >}}
+{{< relatedcard link="/services/motion/" >}}
+{{< /cards >}}
+
 ## Supported Models
 
 To use your gantry with Viam, check whether one of the following [built-in models](#built-in-models) or [modular resources](#modular-resources) supports your gantry.
@@ -462,14 +470,6 @@ For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/
 
 {{% /tab %}}
 {{< /tabs >}}
-
-## Related Services
-
-{{< cards >}}
-{{% card link="/services/data/" class="small" %}}
-{{% card link="/services/frame-system/" class="small" %}}
-{{% card link="/services/motion/" class="small" %}}
-{{</ cards >}}
 
 ## Troubleshooting
 

--- a/docs/components/gripper/_index.md
+++ b/docs/components/gripper/_index.md
@@ -329,6 +329,14 @@ You can find additional assistance in the [Troubleshooting section](/appendix/tr
 
 You can also ask questions on the [Viam Community Slack](https://join.slack.com/t/viamrobotics/shared_invite/zt-1f5xf1qk5-TECJc1MIY1MW0d6ZCg~Wnw) and we will be happy to help.
 
+## Related Services
+
+{{< cards >}}
+{{% card link="/services/data/" class="small" %}}
+{{% card link="/services/frame-system/" class="small" %}}
+{{% card link="/services/motion/" class="small" %}}
+{{</ cards >}}
+
 ## Next Steps
 
 {{< cards >}}

--- a/docs/components/gripper/_index.md
+++ b/docs/components/gripper/_index.md
@@ -14,6 +14,14 @@ no_list: true
 
 A _gripper_ is a robotic grasping device that can open and close, often attached to the end of an [arm](../arm/) or to a [gantry](../gantry/).
 
+## Related Services
+
+{{< cards >}}
+{{< relatedcard link="/services/data/" >}}
+{{< relatedcard link="/services/frame-system/" >}}
+{{< relatedcard link="/services/motion/" >}}
+{{< /cards >}}
+
 ## Supported Models
 
 To use your gripper with Viam, check whether one of the following [built-in models](#built-in-models) or [modular resources](#modular-resources) supports your gripper.
@@ -328,14 +336,6 @@ For more information, see the [Go SDK Code](https://github.com/viamrobotics/api/
 You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).
 
 You can also ask questions on the [Viam Community Slack](https://join.slack.com/t/viamrobotics/shared_invite/zt-1f5xf1qk5-TECJc1MIY1MW0d6ZCg~Wnw) and we will be happy to help.
-
-## Related Services
-
-{{< cards >}}
-{{% card link="/services/data/" class="small" %}}
-{{% card link="/services/frame-system/" class="small" %}}
-{{% card link="/services/motion/" class="small" %}}
-{{</ cards >}}
 
 ## Next Steps
 

--- a/docs/components/input-controller/_index.md
+++ b/docs/components/input-controller/_index.md
@@ -26,6 +26,14 @@ Most robots with an input controller need at least the following hardware:
 - A power supply cable or batteries for the input device and the robot.
 - A component that you can direct the input to control, like an [arm](/components/arm/) or [motor](/components/motor/).
 
+## Related Services
+
+{{< cards >}}
+{{< relatedcard link="/services/base-rc/" >}}
+{{< relatedcard link="/services/data/" >}}
+{{< relatedcard link="/services/frame-system/" >}}
+{{< /cards >}}
+
 ## Supported Models
 
 To use your input controller with Viam, check whether one of the following [built-in models](#built-in-models) supports your input controller.
@@ -1000,14 +1008,6 @@ for _, control := range []input.Control{input.AbsoluteY, input.AbsoluteRY, input
 You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).
 
 {{< snippet "social.md" >}}
-
-## Related Services
-
-{{< cards >}}
-{{% card link="/services/base-rc/" class="small" %}}
-{{% card link="/services/data/" class="small" %}}
-{{% card link="/services/frame-system/" class="small" %}}
-{{</ cards >}}
 
 ## Next Steps
 

--- a/docs/components/input-controller/_index.md
+++ b/docs/components/input-controller/_index.md
@@ -1001,6 +1001,14 @@ You can find additional assistance in the [Troubleshooting section](/appendix/tr
 
 {{< snippet "social.md" >}}
 
+## Related Services
+
+{{< cards >}}
+{{% card link="/services/base-rc/" class="small" %}}
+{{% card link="/services/data/" class="small" %}}
+{{% card link="/services/frame-system/" class="small" %}}
+{{</ cards >}}
+
 ## Next Steps
 
 {{< cards >}}

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -634,7 +634,6 @@ You can also ask questions on the [Viam Community Slack](https://join.slack.com/
 ## Related Services
 
 {{< cards >}}
-{{% card link="/services/data/" class="small" %}}
 {{% card link="/services/frame-system/" class="small" %}}
 {{</ cards >}}
 

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -26,6 +26,15 @@ Most robots with a motor need at least the following hardware:
 
 [^dmcboard]: The `DMC4000` model does not require a board.
 
+## Related Services
+
+{{< cards >}}
+{{< relatedcard link="/services/frame-system/" >}}
+{{< relatedcard link="/services/motion/" >}}
+{{< relatedcard link="/services/navigation/" >}}
+{{< relatedcard link="/services/slam/" >}}
+{{< /cards >}}
+
 ## Supported Models
 
 To use your motor with Viam, check whether one of the following [built-in models](#built-in-models) or [modular resources](#modular-resources) supports your motor.
@@ -630,12 +639,6 @@ For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/
 You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).
 
 You can also ask questions on the [Viam Community Slack](https://join.slack.com/t/viamrobotics/shared_invite/zt-1f5xf1qk5-TECJc1MIY1MW0d6ZCg~Wnw) and we will be happy to help.
-
-## Related Services
-
-{{< cards >}}
-{{% card link="/services/frame-system/" class="small" %}}
-{{</ cards >}}
 
 ## Next Steps
 

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -631,6 +631,13 @@ You can find additional assistance in the [Troubleshooting section](/appendix/tr
 
 You can also ask questions on the [Viam Community Slack](https://join.slack.com/t/viamrobotics/shared_invite/zt-1f5xf1qk5-TECJc1MIY1MW0d6ZCg~Wnw) and we will be happy to help.
 
+## Related Services
+
+{{< cards >}}
+{{% card link="/services/data/" class="small" %}}
+{{% card link="/services/frame-system/" class="small" %}}
+{{</ cards >}}
+
 ## Next Steps
 
 {{< cards >}}

--- a/docs/components/movement-sensor/_index.md
+++ b/docs/components/movement-sensor/_index.md
@@ -659,7 +659,6 @@ You can also ask questions on the [Viam Community Slack](https://join.slack.com/
 
 {{< cards >}}
 {{% card link="/services/data/" class="small" %}}
-{{% card link="/services/frame-system/" class="small" %}}
 {{% card link="/services/motion/" class="small" %}}
 {{% card link="/services/navigation/" class="small" %}}
 {{</ cards >}}

--- a/docs/components/movement-sensor/_index.md
+++ b/docs/components/movement-sensor/_index.md
@@ -31,14 +31,6 @@ Viam also supports generic [sensors](/components/sensor/) and [encoders](/compon
 {{< relatedcard link="/services/navigation/" >}}
 {{< /cards >}}
 
-## Related Services
-
-{{< cards >}}
-{{< relatedcard link="/services/sensors/" >}}
-{{< relatedcard link="/services/motion/" >}}
-{{< relatedcard link="/services/navigation/" >}}
-{{< /cards >}}
-
 ## Supported Models
 
 To use your GPS, IMU, accelerometer, or other movement sensor with Viam, check whether one of the following [built-in models](#built-in-models) or [modular resources](#modular-resources) supports your movement sensor.

--- a/docs/components/movement-sensor/_index.md
+++ b/docs/components/movement-sensor/_index.md
@@ -655,6 +655,15 @@ You can find additional assistance in the [Troubleshooting section](/appendix/tr
 
 You can also ask questions on the [Viam Community Slack](https://join.slack.com/t/viamrobotics/shared_invite/zt-1f5xf1qk5-TECJc1MIY1MW0d6ZCg~Wnw) and we will be happy to help.
 
+## Related Services
+
+{{< cards >}}
+{{% card link="/services/data/" class="small" %}}
+{{% card link="/services/frame-system/" class="small" %}}
+{{% card link="/services/motion/" class="small" %}}
+{{% card link="/services/navigation/" class="small" %}}
+{{</ cards >}}
+
 ## Next Steps
 
 Try adding a movement sensor to your [mobile robot](../base/) and writing some code with our [SDKs](../../program/apis/) to implement closed-loop movement control for your robot.

--- a/docs/components/movement-sensor/_index.md
+++ b/docs/components/movement-sensor/_index.md
@@ -23,6 +23,22 @@ Viam also supports generic [sensors](/components/sensor/) and [encoders](/compon
 
 {{% /alert %}}
 
+## Related Services
+
+{{< cards >}}
+{{< relatedcard link="/services/sensors/" >}}
+{{< relatedcard link="/services/motion/" >}}
+{{< relatedcard link="/services/navigation/" >}}
+{{< /cards >}}
+
+## Related Services
+
+{{< cards >}}
+{{< relatedcard link="/services/sensors/" >}}
+{{< relatedcard link="/services/motion/" >}}
+{{< relatedcard link="/services/navigation/" >}}
+{{< /cards >}}
+
 ## Supported Models
 
 To use your GPS, IMU, accelerometer, or other movement sensor with Viam, check whether one of the following [built-in models](#built-in-models) or [modular resources](#modular-resources) supports your movement sensor.
@@ -654,14 +670,6 @@ For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/
 You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).
 
 You can also ask questions on the [Viam Community Slack](https://join.slack.com/t/viamrobotics/shared_invite/zt-1f5xf1qk5-TECJc1MIY1MW0d6ZCg~Wnw) and we will be happy to help.
-
-## Related Services
-
-{{< cards >}}
-{{% card link="/services/data/" class="small" %}}
-{{% card link="/services/motion/" class="small" %}}
-{{% card link="/services/navigation/" class="small" %}}
-{{</ cards >}}
 
 ## Next Steps
 

--- a/docs/components/power-sensor/_index.md
+++ b/docs/components/power-sensor/_index.md
@@ -15,6 +15,20 @@ images: ["/icons/components/power-sensor.svg"]
 A power sensor is a device that reports measurements of the voltage, current and power consumption in your robot's system.
 Integrate this component to monitor your power levels.
 
+## Related Services
+
+{{< cards >}}
+{{< relatedcard link="/services/data/" >}}
+{{< relatedcard link="/services/sensors/" >}}
+{{< /cards >}}
+
+## Related Services
+
+{{< cards >}}
+{{< relatedcard link="/services/data/" >}}
+{{< relatedcard link="/services/sensors/" >}}
+{{< /cards >}}
+
 ## Supported Models
 
 To use your power sensor with Viam, check whether one of the following [built-in models](#built-in-models) or [modular resources](#modular-resources) supports your power sensor.
@@ -341,12 +355,6 @@ readings, err := myPowerSensor.Readings(context.Background(), nil)
 
 {{% /tab %}}
 {{< /tabs >}}
-
-## Related Services
-
-{{< cards >}}
-{{% card link="/services/data/" class="small" %}}
-{{</ cards >}}
 
 ## Troubleshooting
 

--- a/docs/components/power-sensor/_index.md
+++ b/docs/components/power-sensor/_index.md
@@ -22,13 +22,6 @@ Integrate this component to monitor your power levels.
 {{< relatedcard link="/services/sensors/" >}}
 {{< /cards >}}
 
-## Related Services
-
-{{< cards >}}
-{{< relatedcard link="/services/data/" >}}
-{{< relatedcard link="/services/sensors/" >}}
-{{< /cards >}}
-
 ## Supported Models
 
 To use your power sensor with Viam, check whether one of the following [built-in models](#built-in-models) or [modular resources](#modular-resources) supports your power sensor.

--- a/docs/components/power-sensor/_index.md
+++ b/docs/components/power-sensor/_index.md
@@ -290,6 +290,64 @@ readings, err := myPowerSensor.Readings(context.Background(), nil)
 {{% /tab %}}
 {{< /tabs >}}
 
+### GetReadings
+
+Get the measurements or readings that this power sensor provides.
+If a sensor is not configured to have a measurement or fails to read a piece of data, it will not appear in the readings dictionary.
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `extra` [(Optional\[Dict\[str, Any\]\])](https://docs.python.org/library/typing.html#typing.Optional): Extra options to pass to the underlying RPC call.
+- `timeout` [(Optional\[float\])](https://docs.python.org/library/typing.html#typing.Optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
+
+**Returns:**
+
+- [(Mapping\[str, Any\])](https://docs.python.org/3/library/typing.html#typing.Mapping): The measurements or readings that this power sensor provides.
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/power_sensor/client/index.html#viam.components.power_sensor.client.PowerSensorClient.get_readings).
+
+```python
+my_sensor = PowerSensor.from_robot(robot=robot, name='my_power_sensor')
+
+# Get the readings provided by the sensor.
+readings = await my_sensor.get_readings()
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+**Parameters:**
+
+- `ctx` [(Context)](https://pkg.go.dev/context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
+- `extra` [(map\[string\]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
+
+**Returns:**
+
+- [(map\[string\]interface{})](https://go.dev/blog/maps): The measurements or readings that this sensor provides.
+- [(error)](https://pkg.go.dev/builtin#error): Report any errors that might occur during operation.
+  For a successful operation, `error` returns `nil`.
+
+For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/powersensor#Readings).
+
+```go
+myPowerSensor, err := powersensor.FromRobot(robot, "my_power_sensor")
+
+// Get the readings provided by the sensor.
+readings, err := myPowerSensor.Readings(context.Background(), nil)
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Related Services
+
+{{< cards >}}
+{{% card link="/services/data/" class="small" %}}
+{{</ cards >}}
+
 ## Troubleshooting
 
 You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).

--- a/docs/components/power-sensor/_index.md
+++ b/docs/components/power-sensor/_index.md
@@ -304,58 +304,6 @@ readings, err := myPowerSensor.Readings(context.Background(), nil)
 {{% /tab %}}
 {{< /tabs >}}
 
-### GetReadings
-
-Get the measurements or readings that this power sensor provides.
-If a sensor is not configured to have a measurement or fails to read a piece of data, it will not appear in the readings dictionary.
-
-{{< tabs >}}
-{{% tab name="Python" %}}
-
-**Parameters:**
-
-- `extra` [(Optional\[Dict\[str, Any\]\])](https://docs.python.org/library/typing.html#typing.Optional): Extra options to pass to the underlying RPC call.
-- `timeout` [(Optional\[float\])](https://docs.python.org/library/typing.html#typing.Optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
-
-**Returns:**
-
-- [(Mapping\[str, Any\])](https://docs.python.org/3/library/typing.html#typing.Mapping): The measurements or readings that this power sensor provides.
-
-For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/power_sensor/client/index.html#viam.components.power_sensor.client.PowerSensorClient.get_readings).
-
-```python
-my_sensor = PowerSensor.from_robot(robot=robot, name='my_power_sensor')
-
-# Get the readings provided by the sensor.
-readings = await my_sensor.get_readings()
-```
-
-{{% /tab %}}
-{{% tab name="Go" %}}
-
-**Parameters:**
-
-- `ctx` [(Context)](https://pkg.go.dev/context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
-- `extra` [(map\[string\]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
-
-**Returns:**
-
-- [(map\[string\]interface{})](https://go.dev/blog/maps): The measurements or readings that this sensor provides.
-- [(error)](https://pkg.go.dev/builtin#error): Report any errors that might occur during operation.
-  For a successful operation, `error` returns `nil`.
-
-For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/powersensor#Readings).
-
-```go
-myPowerSensor, err := powersensor.FromRobot(robot, "my_power_sensor")
-
-// Get the readings provided by the sensor.
-readings, err := myPowerSensor.Readings(context.Background(), nil)
-```
-
-{{% /tab %}}
-{{< /tabs >}}
-
 ## Troubleshooting
 
 You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).

--- a/docs/components/sensor/_index.md
+++ b/docs/components/sensor/_index.md
@@ -204,7 +204,6 @@ You can find additional assistance in the [Troubleshooting section](/appendix/tr
 
 {{< cards >}}
 {{% card link="/services/data/" class="small" %}}
-{{% card link="/services/frame-system/" class="small" %}}
 {{% card link="/services/sensors/" class="small" %}}
 {{</ cards >}}
 

--- a/docs/components/sensor/_index.md
+++ b/docs/components/sensor/_index.md
@@ -29,7 +29,19 @@ Most robots with a sensor need at least the following hardware:
 - A [board](/components/board/)
 - Depending on your sensor's output type (analog or digital), an analog-to-digital converter (ADC) may be necessary to allow the sensor to communicate with the board
 
+<<<<<<< HEAD
 ## Supported Models
+=======
+## Related Services
+
+{{< cards >}}
+{{< relatedcard link="/services/data/" >}}
+{{< relatedcard link="/services/sensors/" >}}
+{{< relatedcard link="/services/navigation/" >}}
+{{< /cards >}}
+
+## Configuration
+>>>>>>> 36007f58 (test sectionlist on arm page)
 
 To use your sensor with Viam, check whether one of the following [built-in models](#built-in-models) or [modular resources](#modular-resources) supports your sensor.
 
@@ -199,13 +211,6 @@ For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/
 You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).
 
 {{< snippet "social.md" >}}
-
-## Related Services
-
-{{< cards >}}
-{{% card link="/services/data/" class="small" %}}
-{{% card link="/services/sensors/" class="small" %}}
-{{</ cards >}}
 
 ## Next Steps
 

--- a/docs/components/sensor/_index.md
+++ b/docs/components/sensor/_index.md
@@ -29,9 +29,6 @@ Most robots with a sensor need at least the following hardware:
 - A [board](/components/board/)
 - Depending on your sensor's output type (analog or digital), an analog-to-digital converter (ADC) may be necessary to allow the sensor to communicate with the board
 
-<<<<<<< HEAD
-## Supported Models
-=======
 ## Related Services
 
 {{< cards >}}
@@ -40,8 +37,7 @@ Most robots with a sensor need at least the following hardware:
 {{< relatedcard link="/services/navigation/" >}}
 {{< /cards >}}
 
-## Configuration
->>>>>>> 36007f58 (test sectionlist on arm page)
+## Supported Models
 
 To use your sensor with Viam, check whether one of the following [built-in models](#built-in-models) or [modular resources](#modular-resources) supports your sensor.
 

--- a/docs/components/sensor/_index.md
+++ b/docs/components/sensor/_index.md
@@ -200,6 +200,14 @@ You can find additional assistance in the [Troubleshooting section](/appendix/tr
 
 {{< snippet "social.md" >}}
 
+## Related Services
+
+{{< cards >}}
+{{% card link="/services/data/" class="small" %}}
+{{% card link="/services/frame-system/" class="small" %}}
+{{% card link="/services/sensors/" class="small" %}}
+{{</ cards >}}
+
 ## Next Steps
 
 {{< cards >}}

--- a/docs/components/servo/_index.md
+++ b/docs/components/servo/_index.md
@@ -29,6 +29,15 @@ Most robots with a servo need at least the following hardware:
 - A power supply for the board
 - A power supply for the servo
 
+## Related Services
+
+{{< cards >}}
+{{< relatedcard link="/services/frame-system/" >}}
+{{< relatedcard link="/services/data/" >}}
+{{< /cards >}}
+
+## Configuration
+
 {{% alert title="Tip" color="tip" %}}
 
 The Viam servo component supports [hobby servos](https://learn.adafruit.com/adafruit-motor-selection-guide/rc-servos).
@@ -350,12 +359,6 @@ For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/
 You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).
 
 {{< snippet "social.md" >}}
-
-## Related Services
-
-{{< cards >}}
-{{% card link="/services/frame-system/" class="small" %}}
-{{</ cards >}}
 
 ## Next Steps
 

--- a/docs/components/servo/_index.md
+++ b/docs/components/servo/_index.md
@@ -36,8 +36,6 @@ Most robots with a servo need at least the following hardware:
 {{< relatedcard link="/services/data/" >}}
 {{< /cards >}}
 
-## Configuration
-
 {{% alert title="Tip" color="tip" %}}
 
 The Viam servo component supports [hobby servos](https://learn.adafruit.com/adafruit-motor-selection-guide/rc-servos).

--- a/docs/components/servo/_index.md
+++ b/docs/components/servo/_index.md
@@ -354,7 +354,6 @@ You can find additional assistance in the [Troubleshooting section](/appendix/tr
 ## Related Services
 
 {{< cards >}}
-{{% card link="/services/data/" class="small" %}}
 {{% card link="/services/frame-system/" class="small" %}}
 {{</ cards >}}
 

--- a/docs/components/servo/_index.md
+++ b/docs/components/servo/_index.md
@@ -351,6 +351,13 @@ You can find additional assistance in the [Troubleshooting section](/appendix/tr
 
 {{< snippet "social.md" >}}
 
+## Related Services
+
+{{< cards >}}
+{{% card link="/services/data/" class="small" %}}
+{{% card link="/services/frame-system/" class="small" %}}
+{{</ cards >}}
+
 ## Next Steps
 
 {{< cards >}}

--- a/layouts/shortcodes/relatedcard.html
+++ b/layouts/shortcodes/relatedcard.html
@@ -1,8 +1,9 @@
 {{ $link := (path.Clean (.Get "link")) }}
+{{ $linkWithSlash := printf "%s/" $link }}
 {{ if site.GetPage ($link | string) }}
 {{ with site.GetPage ($link | string) }}
 <div class="relatedcard">
-  <a href="{{ $link }}" target="_blank" title="{{ .LinkTitle }}">
+  <a href="{{ $linkWithSlash }}" target="_blank" title="{{ .LinkTitle }}">
     <div>
       <div>
         {{ if .Params.icon }}

--- a/layouts/shortcodes/relatedcard.html
+++ b/layouts/shortcodes/relatedcard.html
@@ -1,0 +1,17 @@
+{{ $link := (path.Clean (.Get "link")) }}
+{{ if site.GetPage ($link | string) }}
+{{ with site.GetPage ($link | string) }}
+<div class="relatedcard">
+  <a href="{{ $link }}" target="_blank" title="{{ .LinkTitle }}">
+    <div>
+      <div>
+        {{ if .Params.icon }}
+            {{ partial "imgproc.html" (dict "src" (.Params.icon) "resize" "10x10" "alt" (.Params.linkTitle) "declaredimensions" "true" "style" "") }}
+        {{ end }}
+      </div>
+      <p>{{ .LinkTitle }}</p>
+    </div>
+  </a>
+</div>
+{{ end }}
+{{ end }}


### PR DESCRIPTION
# Description
Add related service cards for components and related components cards for services. 

Possibly should be headed 'Commonly Used With' or 'Related Resources' and contain both services & components, as there are services commonly used with other services and the same with components. 