### PR TITLE
remove pwm_frequency_hz from pca9685 board config

### DIFF
--- a/docs/components/board/pca9685.md
+++ b/docs/components/board/pca9685.md
@@ -31,8 +31,7 @@ Then remove and fill in the attributes as applicable to your board, according to
 {
   "board_name": "<your-board-name>",
   "i2c_name": "<your-bus-name>",
-  "i2c_address": <int>,
-  "pwm_frequency_hz": <int>
+  "i2c_address": <int>
 }
 ```
 
@@ -61,8 +60,7 @@ Then remove and fill in the attributes as applicable to your board, according to
       "type": "board",
       "namespace": "rdk",
       "attributes": {
-        "board_name": "<your-board-name>",
-        "pwm_frequency_hz": <int>
+        "board_name": "<your-board-name>"
       },
       "depends_on": []
     }
@@ -79,7 +77,6 @@ The following attributes are available for `pca9685` boards:
 | Name | Type | Inclusion | Description |
 | ---- | ---- | --------- | ----------- |
 | `board_name` | string | **Required** | The `name` of the board with GPIO pins your `pca9685` is [connected to](https://learn.adafruit.com/16-channel-pwm-servo-driver/hooking-it-up). |
-| `pwm_frequency_hz` | int | Optional | The frequency (in *Hz*) used for PWM control. Should be between about 24 to 1526 Hz. |
 
 <!--
 | `analogs` | object | Optional | Attributes of any pins that can be used as Analog-to-Digital Converter (ADC) inputs. See [configuration info](/components/board/#analogs). |


### PR DESCRIPTION
# Description

This config value was literally unused in the code, and has no semantic meaning (I believe each pin on the board has its own frequency independent of the other pins). So, https://github.com/viamrobotics/rdk/pull/3032 removes the value from the config, and this PR updates the docs to match.

I wasn't sure who should review, so I picked the first person Github suggested. Feel free to reassign if that's wrong.