### PR TITLE
DOCS-1210: Add pinout table reference and notes for launching `jetson-io.py` to Jetson Setup guides

### DIFF
--- a/docs/installation/prepare/jetson-agx-orin-setup.md
+++ b/docs/installation/prepare/jetson-agx-orin-setup.md
@@ -84,7 +84,7 @@ If this command fails, try using `wget https://storage.googleapis.com/packages.v
 
 To change what pins are in use for modes of serial communication, launch <file>jetson-io.py</file> with the following command:
 
-``` sh { class="command-line" data-prompt="$"}
+```sh { class="command-line" data-prompt="$"}
 sudo /opt/nvidia/jetson-io/jetson-io.py
 ```
 

--- a/docs/installation/prepare/jetson-agx-orin-setup.md
+++ b/docs/installation/prepare/jetson-agx-orin-setup.md
@@ -82,13 +82,14 @@ If this command fails, try using `wget https://storage.googleapis.com/packages.v
 
 ## Serial Communication Protocol Tips
 
-To change what pins are in use for serial communication, launch <file>jetson-io.py</file> with the following command:
+To change what pins are in use for modes of serial communication, launch <file>jetson-io.py</file> with the following command:
 
 ``` sh { class="command-line" data-prompt="$"}
 sudo /opt/nvidia/jetson-io/jetson-io.py
 ```
 
 In the interactive menu that opens, select **Configure Jetson 40 Pin Header** and **Configure header pins manually** to select and deselect pins to enable use.
+For a Jetson AGX Orin, reference the following:
 
 <!-- prettier-ignore -->
 | Data Sheet ID | GPIO Header Pin | Viam Bus ID | `jetson-io.py` ID | `/dev` Path ID | Notes |

--- a/docs/installation/prepare/jetson-agx-orin-setup.md
+++ b/docs/installation/prepare/jetson-agx-orin-setup.md
@@ -121,7 +121,6 @@ See NVIDIA's documentation on [Configuring the Jetson Expansion Headers](https:/
   - Do not run `sudo apt install nvidia-jetpack` in your terminal until after `sudo reboot` has completed.
   - If your board is powered off after `sudo reboot` has completed and refuses to turn on, disconnect and reconnect the power cable.
   - It is normal for JetPack installation to take a very long time, up to an hour or more.
- 
 - If you do not see an interactive menu after launching <file>jetson-io.py</file>, try resizing your window to a large size.
 
 You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).

--- a/docs/installation/prepare/jetson-agx-orin-setup.md
+++ b/docs/installation/prepare/jetson-agx-orin-setup.md
@@ -99,7 +99,7 @@ For a Jetson AGX Orin, reference the following:
 | I2C_GP5_DAT, I2C_GP5_CLK | 27, 28 | `1` | `i2c8` | `/dev/i2c-8` | |
 | SPI1_DOUT, SPI1_DIN, SPI1_SCK, SPI1_CS0, SPI1_CS1 | 19, 21, 23, 24, 26 | `0` | `spi1` | `/dev/spidev0.0`, `/dev/spidev0.1` | Must be enabled to use SPI bus, must add `spidev` to `/etc/modules` |
 
-Note that I2C buses are not configurable through <file>jetson-io.py</file>.
+Note that I2C buses do not need to be configured.
 See NVIDIA's documentation on [Configuring the Jetson Expansion Headers](https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/HR/ConfiguringTheJetsonExpansionHeaders.html) for more information.
 
 ## Troubleshooting

--- a/docs/installation/prepare/jetson-agx-orin-setup.md
+++ b/docs/installation/prepare/jetson-agx-orin-setup.md
@@ -82,7 +82,7 @@ If this command fails, try using `wget https://storage.googleapis.com/packages.v
 
 ## Serial Communication Protocol Tips
 
-To change what pins are in use for modes of serial communication, launch <file>jetson-io.py</file> with the following command:
+To change the pins that are in use for modes of serial communication, launch <file>jetson-io.py</file> with the following command:
 
 ```sh { class="command-line" data-prompt="$"}
 sudo /opt/nvidia/jetson-io/jetson-io.py

--- a/docs/installation/prepare/jetson-agx-orin-setup.md
+++ b/docs/installation/prepare/jetson-agx-orin-setup.md
@@ -82,12 +82,22 @@ If this command fails, try using `wget https://storage.googleapis.com/packages.v
 
 ## Serial Communication Protocol Tips
 
+To change what pins are in use for serial communication, launch <file>jetson-io.py</file> with the following command:
+
+``` sh { class="command-line" data-prompt="$"}
+sudo /opt/nvidia/jetson-io/jetson-io.py
+```
+
+In the interactive menu that opens, select **Configure Jetson 40 Pin Header** and **Configure header pins manually** to select and deselect pins to enable use.
+
 <!-- prettier-ignore -->
 | Data Sheet ID | GPIO Header Pin | Viam Bus ID | `jetson-io.py` ID | `/dev` Path ID | Notes |
 | ------------- | --------------- | ----------- | ----------------- | ----------- | ----- |
 | I2C_GP2_DAT, I2C_GP2_CLK | 3, 5 | `7` | `i2c2` | `/dev/i2c-2` | |
 | I2C_GP5_DAT, I2C_GP5_CLK | 27, 28 | `1` | `i2c8` | `/dev/i2c-8` | |
 | SPI1_DOUT, SPI1_DIN, SPI1_SCK, SPI1_CS0, SPI1_CS1 | 19, 21, 23, 24, 26 | `0` | `spi1` | `/dev/spidev0.0`, `/dev/spidev0.1` | Must be enabled, must add `spidev` to `/etc/modules` |
+
+See NVIDIA's documentation on [Configuring the Jetson Expansion Headers](https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/HR/ConfiguringTheJetsonExpansionHeaders.html) for more information.
 
 ## Troubleshooting
 

--- a/docs/installation/prepare/jetson-agx-orin-setup.md
+++ b/docs/installation/prepare/jetson-agx-orin-setup.md
@@ -97,8 +97,9 @@ For a Jetson AGX Orin, reference the following:
 | ------------- | --------------- | ----------- | ----------------- | ----------- | ----- |
 | I2C_GP2_DAT, I2C_GP2_CLK | 3, 5 | `7` | `i2c2` | `/dev/i2c-2` | |
 | I2C_GP5_DAT, I2C_GP5_CLK | 27, 28 | `1` | `i2c8` | `/dev/i2c-8` | |
-| SPI1_DOUT, SPI1_DIN, SPI1_SCK, SPI1_CS0, SPI1_CS1 | 19, 21, 23, 24, 26 | `0` | `spi1` | `/dev/spidev0.0`, `/dev/spidev0.1` | Must be enabled, must add `spidev` to `/etc/modules` |
+| SPI1_DOUT, SPI1_DIN, SPI1_SCK, SPI1_CS0, SPI1_CS1 | 19, 21, 23, 24, 26 | `0` | `spi1` | `/dev/spidev0.0`, `/dev/spidev0.1` | Must be enabled to use SPI bus, must add `spidev` to `/etc/modules` |
 
+Note that I2C buses are not configurable through <file>jetson-io.py</file>.
 See NVIDIA's documentation on [Configuring the Jetson Expansion Headers](https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/HR/ConfiguringTheJetsonExpansionHeaders.html) for more information.
 
 ## Troubleshooting

--- a/docs/installation/prepare/jetson-agx-orin-setup.md
+++ b/docs/installation/prepare/jetson-agx-orin-setup.md
@@ -99,7 +99,7 @@ For a Jetson AGX Orin, reference the following:
 | I2C_GP5_DAT, I2C_GP5_CLK | 27, 28 | `1` | `i2c8` | `/dev/i2c-8` | |
 | SPI1_DOUT, SPI1_DIN, SPI1_SCK, SPI1_CS0, SPI1_CS1 | 19, 21, 23, 24, 26 | `0` | `spi1` | `/dev/spidev0.0`, `/dev/spidev0.1` | Must be enabled to use SPI bus, must add `spidev` to `/etc/modules` |
 
-Note that I2C buses do not need to be configured.
+Note that I2C buses do not need to be configured through <file>jetson-io.py</file>.
 See NVIDIA's documentation on [Configuring the Jetson Expansion Headers](https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/HR/ConfiguringTheJetsonExpansionHeaders.html) for more information.
 
 ## Troubleshooting

--- a/docs/installation/prepare/jetson-agx-orin-setup.md
+++ b/docs/installation/prepare/jetson-agx-orin-setup.md
@@ -82,9 +82,10 @@ If this command fails, try using `wget https://storage.googleapis.com/packages.v
 
 ## Serial Communication Protocol Tips
 
-To change the pins that are in use for modes of serial communication, launch <file>jetson-io.py</file> with the following command:
+To change the pins that are in use for modes of serial communication, launch <file>jetson-io.py</file> with the following commands:
 
 ```sh { class="command-line" data-prompt="$"}
+cd ~
 sudo /opt/nvidia/jetson-io/jetson-io.py
 ```
 
@@ -119,6 +120,8 @@ See NVIDIA's documentation on [Configuring the Jetson Expansion Headers](https:/
   - Do not run `sudo apt install nvidia-jetpack` in your terminal until after `sudo reboot` has completed.
   - If your board is powered off after `sudo reboot` has completed and refuses to turn on, disconnect and reconnect the power cable.
   - It is normal for JetPack installation to take a very long time, up to an hour or more.
+ 
+- If you do not see an interactive menu after launching <file>jetson-io.py</file>, try resizing your window to a large size.
 
 You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).
 

--- a/docs/installation/prepare/jetson-nano-setup.md
+++ b/docs/installation/prepare/jetson-nano-setup.md
@@ -68,29 +68,24 @@ If this command fails, try using `wget https://storage.googleapis.com/packages.v
 
 ## Serial Communication Protocol Tips
 
-To change what pins are in use for serial communication, launch <file>jetson-io.py</file> with the following command:
+To change what pins are in use for modes of serial communication, launch <file>jetson-io.py</file> with the following command:
 
 ``` sh { class="command-line" data-prompt="$"}
 sudo /opt/nvidia/jetson-io/jetson-io.py
 ```
 
 In the interactive menu that opens, select **Configure Jetson 40 Pin Header** and **Configure header pins manually** to select and deselect pins to enable use.
-
 For a Jetson Orin Nano, reference the following:
 
 <!-- prettier-ignore -->
 GPIO Header Pin | Viam Bus ID | `jetson-io.py` ID
- ---------------| ----------- | -----------------
- 3, 5 | `7` | `i2c2`
- 27, 28 | `1` | `i2c8`
- 19, 21, 23, 24, 26 | `0` | `spi1`
-
-<!-- prettier-ignore -->
-GPIO Header Pin | `jetson-io.py` ID
---------------- | -----------------
-15 | `pwm1`
-33 | `pwm5`
-32 | `pwm7`
+---------------| ----------- | -----------------
+3, 5 | `7` | `i2c2`
+27, 28 | `1` | `i2c8`
+19, 21, 23, 24, 26 | `0` | `spi1`
+15 | | `pwm1`
+33 | | `pwm5`
+32 | | `pwm7`
 
 See NVIDIA's documentation on [Configuring the Jetson Expansion Headers](https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/HR/ConfiguringTheJetsonExpansionHeaders.html) for more information.
 

--- a/docs/installation/prepare/jetson-nano-setup.md
+++ b/docs/installation/prepare/jetson-nano-setup.md
@@ -88,7 +88,7 @@ For a Jetson Orin Nano, reference the following:
 | 15 | | `pwm1` |
 | 33 | | `pwm5` |
 
-Note that I2C buses do not need to be configured.
+Note that I2C buses do not need to be configured through <file>jetson-io.py</file>.
 See NVIDIA's documentation on [Configuring the Jetson Expansion Headers](https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/HR/ConfiguringTheJetsonExpansionHeaders.html) for more information.
 
 ## Troubleshooting

--- a/docs/installation/prepare/jetson-nano-setup.md
+++ b/docs/installation/prepare/jetson-nano-setup.md
@@ -78,14 +78,14 @@ In the interactive menu that opens, select **Configure Jetson 40 Pin Header** an
 For a Jetson Orin Nano, reference the following:
 
 <!-- prettier-ignore -->
-GPIO Header Pin | Viam Bus ID | `jetson-io.py` ID
----------------| ----------- | -----------------
-3, 5 | `7` | `i2c2`
-27, 28 | `1` | `i2c8`
-19, 21, 23, 24, 26 | `0` | `spi1`
-15 | | `pwm1`
-33 | | `pwm5`
-32 | | `pwm7`
+| GPIO Header Pin | Viam Bus ID | `jetson-io.py` ID |
+| ---------------| ----------- | ----------------- |
+| 3, 5 | `7` | `i2c2` |
+| 27, 28 | `1` | `i2c8` |
+| 19, 21, 23, 24, 26 | `0` | `spi1` |
+| 15 | | `pwm1` |
+| 33 | | `pwm5` |
+| 32 | | `pwm7` |
 
 See NVIDIA's documentation on [Configuring the Jetson Expansion Headers](https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/HR/ConfiguringTheJetsonExpansionHeaders.html) for more information.
 

--- a/docs/installation/prepare/jetson-nano-setup.md
+++ b/docs/installation/prepare/jetson-nano-setup.md
@@ -66,6 +66,34 @@ If this command fails, try using `wget https://storage.googleapis.com/packages.v
 
 {{< readfile "/static/include/install/install-linux-aarch.md" >}}
 
+## Serial Communication Protocol Tips
+
+To change what pins are in use for serial communication, launch <file>jetson-io.py</file> with the following command:
+
+``` sh { class="command-line" data-prompt="$"}
+sudo /opt/nvidia/jetson-io/jetson-io.py
+```
+
+In the interactive menu that opens, select **Configure Jetson 40 Pin Header** and **Configure header pins manually** to select and deselect pins to enable use.
+
+For a Jetson Orin Nano, reference the following:
+
+<!-- prettier-ignore -->
+GPIO Header Pin | Viam Bus ID | `jetson-io.py` ID
+ ---------------| ----------- | -----------------
+ 3, 5 | `7` | `i2c2`
+ 27, 28 | `1` | `i2c8`
+ 19, 21, 23, 24, 26 | `0` | `spi1`
+
+<!-- prettier-ignore -->
+GPIO Header Pin | `jetson-io.py` ID
+--------------- | -----------------
+15 | `pwm1`
+33 | `pwm5`
+32 | `pwm7`
+
+See NVIDIA's documentation on [configuring the Jetson Expansion Headers](https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/HR/ConfiguringTheJetsonExpansionHeaders.html) for more information.
+
 ## Troubleshooting
 
 Make sure the polarity on your barrel jack power supply is matched when powering your robot.

--- a/docs/installation/prepare/jetson-nano-setup.md
+++ b/docs/installation/prepare/jetson-nano-setup.md
@@ -88,7 +88,7 @@ For a Jetson Orin Nano, reference the following:
 | 15 | | `pwm1` |
 | 33 | | `pwm5` |
 
-Note that I2C buses are not configurable through <file>jetson-io.py</file>.
+Note that I2C buses do not need to be configured.
 See NVIDIA's documentation on [Configuring the Jetson Expansion Headers](https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/HR/ConfiguringTheJetsonExpansionHeaders.html) for more information.
 
 ## Troubleshooting

--- a/docs/installation/prepare/jetson-nano-setup.md
+++ b/docs/installation/prepare/jetson-nano-setup.md
@@ -84,6 +84,7 @@ For a Jetson Orin Nano, reference the following:
 | 3, 5 | `7` | `i2c2` |
 | 27, 28 | `1` | `i2c8` |
 | 19, 21, 23, 24, 26 | `0` | `spi1` |
+| 13, 16, 18, 22, 37 | `2` | `spi3` |
 | 15 | | `pwm1` |
 | 33 | | `pwm5` |
 

--- a/docs/installation/prepare/jetson-nano-setup.md
+++ b/docs/installation/prepare/jetson-nano-setup.md
@@ -86,8 +86,8 @@ For a Jetson Orin Nano, reference the following:
 | 19, 21, 23, 24, 26 | `0` | `spi1` |
 | 15 | | `pwm1` |
 | 33 | | `pwm5` |
-| 32 | | `pwm7` |
 
+Note that I2C buses are not configurable through <file>jetson-io.py</file>.
 See NVIDIA's documentation on [Configuring the Jetson Expansion Headers](https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/HR/ConfiguringTheJetsonExpansionHeaders.html) for more information.
 
 ## Troubleshooting

--- a/docs/installation/prepare/jetson-nano-setup.md
+++ b/docs/installation/prepare/jetson-nano-setup.md
@@ -68,7 +68,7 @@ If this command fails, try using `wget https://storage.googleapis.com/packages.v
 
 ## Serial Communication Protocol Tips
 
-To change what pins are in use for modes of serial communication, launch <file>jetson-io.py</file> with the following command:
+To change the pins that are in use for modes of serial communication, launch <file>jetson-io.py</file> with the following command:
 
 ```sh { class="command-line" data-prompt="$"}
 sudo /opt/nvidia/jetson-io/jetson-io.py

--- a/docs/installation/prepare/jetson-nano-setup.md
+++ b/docs/installation/prepare/jetson-nano-setup.md
@@ -92,7 +92,7 @@ GPIO Header Pin | `jetson-io.py` ID
 33 | `pwm5`
 32 | `pwm7`
 
-See NVIDIA's documentation on [configuring the Jetson Expansion Headers](https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/HR/ConfiguringTheJetsonExpansionHeaders.html) for more information.
+See NVIDIA's documentation on [Configuring the Jetson Expansion Headers](https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/HR/ConfiguringTheJetsonExpansionHeaders.html) for more information.
 
 ## Troubleshooting
 

--- a/docs/installation/prepare/jetson-nano-setup.md
+++ b/docs/installation/prepare/jetson-nano-setup.md
@@ -68,9 +68,10 @@ If this command fails, try using `wget https://storage.googleapis.com/packages.v
 
 ## Serial Communication Protocol Tips
 
-To change the pins that are in use for modes of serial communication, launch <file>jetson-io.py</file> with the following command:
+To change the pins that are in use for modes of serial communication, launch <file>jetson-io.py</file> with the following commands:
 
 ```sh { class="command-line" data-prompt="$"}
+cd ~
 sudo /opt/nvidia/jetson-io/jetson-io.py
 ```
 
@@ -93,6 +94,8 @@ See NVIDIA's documentation on [Configuring the Jetson Expansion Headers](https:/
 
 Make sure the polarity on your barrel jack power supply is matched when powering your robot.
 See the last step of your appropriate [initial setup guide](#hardware-requirements) for instructions on choosing the correct power supply for your Nano board.
+
+If you do not see an interactive menu after launching <file>jetson-io.py</file>, try resizing your window to a large size.
 
 You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).
 

--- a/docs/installation/prepare/jetson-nano-setup.md
+++ b/docs/installation/prepare/jetson-nano-setup.md
@@ -70,7 +70,7 @@ If this command fails, try using `wget https://storage.googleapis.com/packages.v
 
 To change what pins are in use for modes of serial communication, launch <file>jetson-io.py</file> with the following command:
 
-``` sh { class="command-line" data-prompt="$"}
+```sh { class="command-line" data-prompt="$"}
 sudo /opt/nvidia/jetson-io/jetson-io.py
 ```
 


### PR DESCRIPTION
* Improve Serial Communiation protocol tips for AGX orin with links to NVIDIA's documentation
* Add table to Orin Nano with what Chris thought was helpful 