### PR TITLE
Remove named dep from step 4

### DIFF
--- a/docs/program/run.md
+++ b/docs/program/run.md
@@ -101,7 +101,7 @@ To be able to run your code from your board, you need to install the relevant SD
    mkdir robot
    ```
 
-3. Then install the Viam Python SDK and the VLC module **into that folder**:
+3. Then install the Viam Python SDK and other required dependencies **into that folder**:
 
    ```sh {class="command-line" data-prompt="$"}
    pip3 install --target=robot viam-sdk <other-required-dependencies>

--- a/docs/program/run.md
+++ b/docs/program/run.md
@@ -101,7 +101,7 @@ To be able to run your code from your board, you need to install the relevant SD
    mkdir robot
    ```
 
-3. Then install the Viam Python SDK and other required dependencies **into that folder**:
+3. Then install the Viam Python SDK (and other dependencies if required) **into that folder**:
 
    ```sh {class="command-line" data-prompt="$"}
    pip3 install --target=robot viam-sdk <other-required-dependencies>


### PR DESCRIPTION
VLC is a specific dependency needed if I coded some video thing in my robot code, not a generic always-add. Removing in favor of re-used example text in code: `other required dependencies`.