### PR TITLE
DOCS-1257: Add more FUSE guidance

### DIFF
--- a/docs/appendix/troubleshooting.md
+++ b/docs/appendix/troubleshooting.md
@@ -67,6 +67,7 @@ This is only required for the first `ssh` connection you make to a newly-imaged 
 **Description:** `viam-server` is distributed for Linux as an [AppImage](https://appimage.org/), which requires FUSE (Filesystem-in-Userspace) version 2.
 FUSE version 2 is included in almost all modern Linux distributions by default, but some older Linux distros or minimal installs might not provide it out of the box, and some newer systems may ship with FUSE version 3 installed by default, which is not compatible with `viam-server`.
 For example, the latest Raspberry Pi OS (Debian GNU/Linux 12 bookworm) includes FUSE version 3 as its default FUSE installation, and requires FUSE version 2 to be installed as well to support `viam-server`.
+
 In addition, if you are installing `viam-server` within a Docker container, you may also experience this error due to its default security restrictions.
 FUSE is not required for macOS installations of `viam-server`.
 

--- a/docs/appendix/troubleshooting.md
+++ b/docs/appendix/troubleshooting.md
@@ -84,7 +84,7 @@ To support a `viam-server` installation, only install `libfuse2`.
   sudo apt install libfuse2
   ```
 
-- If installing `viam-server` on Ubuntu 22.04 or later, install FUSE version 2 with the following command:
+- If installing `viam-server` on Ubuntu, install FUSE version 2 with the following command:
 
   ```sh {class="command-line" data-prompt="$"}
   sudo add-apt-repository universe

--- a/docs/appendix/troubleshooting.md
+++ b/docs/appendix/troubleshooting.md
@@ -62,11 +62,24 @@ This is only required for the first `ssh` connection you make to a newly-imaged 
 
 ### AppImages require FUSE to run
 
-**Description:** `viam-server` is distributed for Linux as an [AppImage](https://appimage.org/), which relies on FUSE (Filesystem-in-Userspace).
+**Related Error:** `dlopen(): error loading libfuse.so.2`
+
+**Description:** `viam-server` is distributed for Linux as an [AppImage](https://appimage.org/), which requires FUSE (Filesystem-in-Userspace) version 2.
 FUSE is included in almost all modern Linux distributions by default, but some older Linux distros or minimal installs might not provide it out of the box.
+For example, the latest Raspberry Pi OS (Debian GNU/Linux 12 bookworm) does not include FUSE with its default installation.
 In addition, if you are installing `viam-server` within a Docker container, you may also experience this error due to its default security restrictions.
 
-**Solution:** See [I get some errors related to something called "FUSE" - AppImage documentation](https://docs.appimage.org/user-guide/troubleshooting/fuse.html) for assistance in resolving FUSE errors on Linux or in Docker.
+**Solution:** If you receive this error, install FUSE on your Linux system according to one of the following steps:
+
+- If installing `viam-server` on a Raspberry Pi running Raspberry Pi OS (Debian GNU/Linux 12 bookworm) or later, install FUSE version 2 with the following command:
+
+  ```sh {class="command-line" data-prompt="$"}
+  sudo apt install libfuse2
+  ```
+
+- If installing `viam-server` on a different Linux distribution, see the [AppImage FUSE troubleshooting article](https://github.com/AppImage/AppImageKit/wiki/FUSE) for more information.
+
+- If installing `viam-server` on a Docker image, see [I get some errors related to something called "FUSE" - AppImage documentation](https://docs.appimage.org/user-guide/troubleshooting/fuse.html) for Docker-specific troubleshooting steps.
 
 ### PulseAudio: Unable to connect: Connection refused
 
@@ -77,7 +90,7 @@ In addition, if you are installing `viam-server` within a Docker container, you 
 **Solution:** Consult the documentation for your Linux OS and chosen sound library for guidance on installing any missing software dependencies.
 For example, if you are using `jackd` and `PulseAudio` on a Raspberry Pi, you can run the following to install any missing dependencies:
 
-```sh
+```sh {class="command-line" data-prompt="$"}
 sudo apt install jackd qjackctl libpulse-dev pulseaudio
 ```
 

--- a/docs/appendix/troubleshooting.md
+++ b/docs/appendix/troubleshooting.md
@@ -65,15 +65,28 @@ This is only required for the first `ssh` connection you make to a newly-imaged 
 **Related Error:** `dlopen(): error loading libfuse.so.2`
 
 **Description:** `viam-server` is distributed for Linux as an [AppImage](https://appimage.org/), which requires FUSE (Filesystem-in-Userspace) version 2.
-FUSE is included in almost all modern Linux distributions by default, but some older Linux distros or minimal installs might not provide it out of the box.
-For example, the latest Raspberry Pi OS (Debian GNU/Linux 12 bookworm) does not include FUSE with its default installation.
+FUSE version 2 is included in almost all modern Linux distributions by default, but some older Linux distros or minimal installs might not provide it out of the box, and some newer systems may ship with FUSE version 3 installed by default, which is not compatible with `viam-server`.
+For example, the latest Raspberry Pi OS (Debian GNU/Linux 12 bookworm) includes FUSE version 3 as its default FUSE installation, and requires FUSE version 2 to be installed as well to support `viam-server`.
 In addition, if you are installing `viam-server` within a Docker container, you may also experience this error due to its default security restrictions.
+FUSE is not required for macOS installations of `viam-server`.
+
+{{% alert title="Important" color="note" %}}
+`viam-server` requires FUSE version 2 (`libfuse2`), _not_ FUSE version 3 (`fuse3` or `libfuse3`) or versions of FUSE previous to FUSE version 2 (`fuse`).
+To support a `viam-server` installation, only install `libfuse2`.
+{{% /alert %}}
 
 **Solution:** If you receive this error, install FUSE on your Linux system according to one of the following steps:
 
-- If installing `viam-server` on a Raspberry Pi running Raspberry Pi OS (Debian GNU/Linux 12 bookworm) or later, install FUSE version 2 with the following command:
+- If installing `viam-server` on a Raspberry Pi running Raspberry Pi OS (Debian GNU/Linux 12 bookworm or later), install FUSE version 2 with the following command:
 
   ```sh {class="command-line" data-prompt="$"}
+  sudo apt install libfuse2
+  ```
+
+- If installing `viam-server` on Ubuntu 22.04 or later, install FUSE version 2 with the following command:
+
+  ```sh {class="command-line" data-prompt="$"}
+  sudo add-apt-repository universe
   sudo apt install libfuse2
   ```
 

--- a/docs/appendix/troubleshooting.md
+++ b/docs/appendix/troubleshooting.md
@@ -76,7 +76,7 @@ FUSE is not required for macOS installations of `viam-server`.
 To support a `viam-server` installation, you must install `libfuse2`.
 {{% /alert %}}
 
-**Solution:** If you receive this error, install FUSE on your Linux system according to one of the following steps:
+**Solution:** If you receive this error, install FUSE version 2 on your Linux system according to one of the following steps:
 
 - If installing `viam-server` on a Raspberry Pi running Raspberry Pi OS (Debian GNU/Linux 12 bookworm or later), install FUSE version 2 with the following command:
 

--- a/docs/appendix/troubleshooting.md
+++ b/docs/appendix/troubleshooting.md
@@ -73,7 +73,7 @@ FUSE is not required for macOS installations of `viam-server`.
 
 {{% alert title="Important" color="note" %}}
 `viam-server` requires FUSE version 2 (`libfuse2`), _not_ FUSE version 3 (`fuse3` or `libfuse3`) or versions of FUSE previous to FUSE version 2 (`fuse`).
-To support a `viam-server` installation, only install `libfuse2`.
+To support a `viam-server` installation, you must install `libfuse2`.
 {{% /alert %}}
 
 **Solution:** If you receive this error, install FUSE on your Linux system according to one of the following steps:

--- a/docs/modular-resources/examples/csi.md
+++ b/docs/modular-resources/examples/csi.md
@@ -41,6 +41,10 @@ The source code for this module is available on the [`viam-csi` GitHub repositor
 
 If you haven't already, [install `viam-server`](/installation/) on your robot.
 
+The `csi-cam` module is distributed as an AppImage.
+AppImages require FUSE version 2 to run.
+See [FUSE troubleshooting](/appendix/troubleshooting/#appimages-require-fuse-to-run) for instructions on installing FUSE 2 on your system if it is not already installed.
+
 Currently, the `csi-cam` module supports the Linux platform only.
 
 ## Configuration

--- a/docs/modular-resources/examples/rplidar.md
+++ b/docs/modular-resources/examples/rplidar.md
@@ -29,6 +29,10 @@ The source code for this module is available on the [`rplidar` GitHub repository
 
 If you haven't already, [install `viam-server`](/installation/) on your robot.
 
+The `rplidar` module is distributed as an AppImage.
+AppImages require FUSE version 2 to run.
+See [FUSE troubleshooting](/appendix/troubleshooting/#appimages-require-fuse-to-run) for instructions on installing FUSE 2 on your system if it is not already installed.
+
 Currently, the `rplidar` module supports the Linux platform only.
 
 Your robot must have an RPlidar installed to be able to use the `rplidar` module, such as the [RPlidar A1](https://www.slamtec.com/en/Lidar/A1) or [RPlidar A3](https://www.slamtec.com/en/Lidar/A3).

--- a/docs/services/slam/cartographer/_index.md
+++ b/docs/services/slam/cartographer/_index.md
@@ -30,6 +30,10 @@ See the notes next to the 'config_params' for recommended settings for an RPlida
 
 In addition, you must [add the `rplidar` module to your robot](/modular-resources/examples/rplidar/) to support the RPlidar hardware, if you have not done so already.
 
+Both the `cartographer` and `rplidar` modules are distributed as an AppImage.
+AppImages require FUSE version 2 to run.
+See [FUSE troubleshooting](/appendix/troubleshooting/#appimages-require-fuse-to-run) for instructions on installing FUSE 2 on your system if it is not already installed.
+
 Currently, the `rplidar` and `cartographer` modules support the Linux platform only.
 
 Physically connect the RPlidar to your robot.

--- a/static/include/install/install-linux.md
+++ b/static/include/install/install-linux.md
@@ -24,10 +24,10 @@ To install `viam-server` on a Linux computer:
      sudo apt install libfuse2
      ```
 
+   - If installing `viam-server` on other Linux distributions, or for more information, see [FUSE troubleshooting](/appendix/troubleshooting/#appimages-require-fuse-to-run).
+
    **Do not** install the `fuse` package (that is, without a version number).
    Only install the `libfuse2` package.
-
-   For other linux distributions, or for more information, see [FUSE troubleshooting](/appendix/troubleshooting/#appimages-require-fuse-to-run).
 
 1. Go to the [Viam app](https://app.viam.com) and [add a new robot](/manage/fleet/robots/#add-a-new-robot).
    If this is your first time using the Viam app, you must create an account first.

--- a/static/include/install/install-linux.md
+++ b/static/include/install/install-linux.md
@@ -17,7 +17,7 @@ To install `viam-server` on a Linux computer:
      sudo apt install libfuse2
      ```
 
-   - If installing `viam-server` on Ubuntu, install FUSE version 2 with the following command:
+   - If installing `viam-server` on Ubuntu, install FUSE version 2 with the following commands:
 
      ```sh {class="command-line" data-prompt="$"}
      sudo add-apt-repository universe
@@ -27,7 +27,7 @@ To install `viam-server` on a Linux computer:
    - If installing `viam-server` on other Linux distributions, or for more information, see [FUSE troubleshooting](/appendix/troubleshooting/#appimages-require-fuse-to-run).
 
    **Do not** install the `fuse` package (that is, without a version number).
-   Only install the `libfuse2` package.
+   `viam-server` requires FUSE version 2 specifically (`libfuse2`).
 
 1. Go to the [Viam app](https://app.viam.com) and [add a new robot](/manage/fleet/robots/#add-a-new-robot).
    If this is your first time using the Viam app, you must create an account first.

--- a/static/include/install/install-linux.md
+++ b/static/include/install/install-linux.md
@@ -3,13 +3,26 @@ The AppImage is a single, self-contained binary that runs on 64-bit Linux system
 
 To install `viam-server` on a Linux computer:
 
-1. Install FUSE version 2 if it is not already installed on your Linux system.
-   For example, on Ubuntu (including Raspberry Pi OS), run the following commands:
+1. Determine if FUSE version 2 is installed on your Linux system:
 
    ```sh {class="command-line" data-prompt="$"}
-   sudo add-apt-repository universe
-   sudo apt install libfuse2
+   find /usr -name libfuse.so.2
    ```
+
+   If the above command does not return a path to the `libfuse.so.2` file, install FUSE version 2 according to your Linux platform:
+
+   - If installing `viam-server` on a Raspberry Pi running Raspberry Pi OS (Debian GNU/Linux 12 bookworm or later), install FUSE version 2 with the following command:
+
+     ```sh {class="command-line" data-prompt="$"}
+     sudo apt install libfuse2
+     ```
+
+   - If installing `viam-server` on Ubuntu 22.04 or later, install FUSE version 2 with the following command:
+
+     ```sh {class="command-line" data-prompt="$"}
+     sudo add-apt-repository universe
+     sudo apt install libfuse2
+     ```
 
    **Do not** install the `fuse` package (that is, without a version number).
    Only install the `libfuse2` package.

--- a/static/include/install/install-linux.md
+++ b/static/include/install/install-linux.md
@@ -17,7 +17,7 @@ To install `viam-server` on a Linux computer:
      sudo apt install libfuse2
      ```
 
-   - If installing `viam-server` on Ubuntu 22.04 or later, install FUSE version 2 with the following command:
+   - If installing `viam-server` on Ubuntu, install FUSE version 2 with the following command:
 
      ```sh {class="command-line" data-prompt="$"}
      sudo add-apt-repository universe

--- a/static/include/install/install-linux.md
+++ b/static/include/install/install-linux.md
@@ -1,7 +1,20 @@
 `viam-server` is distributed for Linux as an [AppImage](https://appimage.org/).
-The AppImage is a single, self-contained binary that runs on 64-bit Linux systems running the `aarch64` or `x86_64` architectures, with no need to install any dependencies.
+The AppImage is a single, self-contained binary that runs on 64-bit Linux systems running the `aarch64` or `x86_64` architectures, with no need to install any dependencies (except for FUSE, which is required by the AppImage format).
 
 To install `viam-server` on a Linux computer:
+
+1. Install FUSE version 2 if it is not already installed on your Linux system.
+   For example, on Ubuntu (including Raspberry Pi OS), run the following commands:
+
+   ```sh {class="command-line" data-prompt="$"}
+   sudo add-apt-repository universe
+   sudo apt install libfuse2
+   ```
+
+   **Do not** install the `fuse` package (that is, without a version number).
+   Only install the `libfuse2` package.
+
+   For other linux distributions, or for more information, see [FUSE troubleshooting](/appendix/troubleshooting/#appimages-require-fuse-to-run).
 
 1. Go to the [Viam app](https://app.viam.com) and [add a new robot](/manage/fleet/robots/#add-a-new-robot).
    If this is your first time using the Viam app, you must create an account first.


### PR DESCRIPTION
Add prominent mention of the need to install FUSE v2 in applicable places:
- For Linux installs, via the include file `static/include/install/install-linux.md`, which is included in parent pages:
	- Installation Guide
	- Raspberry Pi, Beaglebones, and SK-TDA4VM board Prepare Guides.
- Expanded troubleshooting section accordingly. Linked above here as well.
- Added need to install FUSE v2 to Requirements section on three modules that I was able to confirm require it:
	- `csi-cam`
	- `rplidar`
	- `cartographer`

Questions

- Is there a good way to tell if FUSE 2 is installed, what version its running, that is platform agnostic? I would love something like `sshfs -v` or similar, if anyone knows of such an approach.
- Are there other modules that ship as AppImages that I missed??