### PR TITLE
DOCS-1192: Add CLI board commands

### DIFF
--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -193,6 +193,8 @@ viam organizations --help
 The `board` command allows you to manage your board definition files.
 With it, you can upload new board definition files to the Viam app, download your existing board definition files, and list the files already uploaded.
 
+Board definition files are used to configure pin mappings for [`customlinux` boards](/components/board/customlinux/).
+
 ```sh {class="command-line" data-prompt="$"}
 viam board upload --name=<board name> --organization=<org name> --version=<definition file version> file.json
 viam board download --name=<board name> --organization=<org name> --version=<definition file version>

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -210,7 +210,7 @@ viam board upload --name=my-board --organization=my-org --version=1.0.0 my-board
 # download an existing board definition file named 'my-board' at version '1.0.0' for org 'my-org'
 viam board download --name=my-board --organization=my-org --version=1.0.0
 
-# list all avaialble board definition files for org 'my-org'
+# list all available board definition files for org 'my-org'
 viam board list --organization=my-org
 ```
 

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -229,7 +229,7 @@ viam board list --organization=my-org
 <!-- prettier-ignore -->
 |        argument     |       description | applicable commands | required
 | ----------- | ----------- | ----------- | ----------- |
-| `--name`      | output directory for downloaded data       |`upload`, `download`|true |
+| `--name`      | output directory for downloaded data       | `upload`, `download` | true |
 | `--organization`      | organization name to upload, download, or list board definition files from      |`upload`, `download`, `list`|true |
 | `--version`      | version of the board definition file to tag the upload with, or to specifically download. Defaults to latest if not set.    |`upload`, `download`|true |
 

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -217,7 +217,7 @@ viam board list --organization=my-org
 <!-- prettier-ignore -->
 |        command option     |       description      | positional arguments
 | ----------- | ----------- | ----------- |
-| `upload`      | upload a new board definition file to the Viam app | **board definitions file** : provide the board definition file to upload, in JSON form. |
+| `upload`      | upload a new board definition file to the Viam app | **board definition file** : provide the board definition file to upload, in JSON form. |
 | `download`      | download an existing board definition file | - |
 | `list`      | list available board definition files | - |
 | `--help`      | return help      | - |

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -230,8 +230,8 @@ viam board list --organization=my-org
 |        argument     |       description | applicable commands | required
 | ----------- | ----------- | ----------- | ----------- |
 | `--name`      | output directory for downloaded data       | `upload`, `download` | true |
-| `--organization`      | organization name to upload, download, or list board definition files from      |`upload`, `download`, `list`|true |
-| `--version`      | version of the board definition file to tag the upload with, or to specifically download. Defaults to latest if not set.    |`upload`, `download`|true |
+| `--organization`      | organization name to upload, download, or list board definition files from      | `upload`, `download`, `list` | true |
+| `--version`      | version of the board definition file to tag the upload with, or to specifically download. Defaults to latest if not set.    | `upload`, `download` | true |
 
 ### data
 

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -193,7 +193,7 @@ viam organizations --help
 The `board` command allows you to manage your board definition files.
 With it, you can upload new board definition files to the Viam app, download your existing board definition files, and list the files already uploaded.
 
-Board definition files are used to configure pin mappings for [`customlinux` boards](/components/board/customlinux/).
+You can use board definition files to configure pin mappings for [`customlinux` boards](/components/board/customlinux/).
 
 ```sh {class="command-line" data-prompt="$"}
 viam board upload --name=<board name> --organization=<org name> --version=<definition file version> file.json

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -188,6 +188,49 @@ viam organizations --help
 
 ## Commands
 
+### board
+
+The `board` command allows you to manage your board definition files.
+With it, you can upload new board definition files to the Viam app, download your existing board definition files, and list the files already uploaded.
+
+```sh {class="command-line" data-prompt="$"}
+viam board upload --name=<board name> --organization=<org name> --version=<definition file version> file.json
+viam board download --name=<board name> --organization=<org name> --version=<definition file version>
+viam board list --organization=<org name>
+```
+
+Examples:
+
+```sh {class="command-line" data-prompt="$"}
+# upload a new board definition file named 'my-board' with version '1.0.0' for org 'my-org'
+viam board upload --name=my-board --organization=my-org --version=1.0.0 my-board.json
+
+# download an existing board definition file named 'my-board' at version '1.0.0' for org 'my-org'
+viam board download --name=my-board --organization=my-org --version=1.0.0
+
+# list all avaialble board definition files for org 'my-org'
+viam board list --organization=my-org
+```
+
+#### Command options
+
+<!-- prettier-ignore -->
+|        command option     |       description      | positional arguments
+| ----------- | ----------- | ----------- |
+| `upload`      | upload a new board definition file to the Viam app | **board definitions file** : provide the board definition file to upload, in JSON form. |
+| `download`      | download an existing board definition file | - |
+| `list`      | list available board definition files | - |
+| `--help`      | return help      | - |
+
+##### Named arguments
+
+<!-- prettier-ignore -->
+|        argument     |       description | applicable commands | required
+| ----------- | ----------- | ----------- | ----------- |
+| `--name`      | output directory for downloaded data       |`upload`, `download`|true |
+| `--organization`      | organization name to upload, download, or list board definition files from      |`upload`, `download`, `list`|true |
+| `--version`      | version of the board definition file to tag the upload with, or to specifically download. Defaults to latest if not set.    |`upload`, `download`|true |
+
 ### data
 
 The `data` command allows you to manage robot data.


### PR DESCRIPTION
Add docs for new `viam board list` command, but also for missing `viam board upload` and `viam board download` commands while in here.

Guess: BDFs are for `customlinux` boards. Added that text guessing, but please correct if I guess wrong!