### PR TITLE
DOCS-1278: Add clearer requirements for movement sensor stack with navigation

### DIFF
--- a/docs/services/navigation/_index.md
+++ b/docs/services/navigation/_index.md
@@ -15,19 +15,20 @@ The Navigation service is the stateful definition of Viam's [motion service](/se
 It uses GPS to autonomously navigate a rover [base](/components/base/) to user defined endpoints called waypoints.
 Configure your base with a navigation service, add waypoints, and set the mode of the service to [**Waypoint**](#setmode) to move your rover along a defined path at your desired motion configuration.
 
+## Requirements
+
+You must configure a [base](/components/base/) with [movement sensors](/components/movement-sensor/) as part of your robot to configure a Navigation service.
+
+Configure a stack of movement sensors that satisfy the following requirements in their {{< glossary_tooltip term_id="model" text="models'" >}} implementations of the [Movement Sensor API](/components/movement-sensor/#api):
+
+- [`GetPosition()`](/components/movement-sensor/#getposition)
+- [`GetAngularVelocity()`](/components/movement-sensor/#getangularvelocity)
+- [`GetLinearVelocity()`](/components/movement-sensor/#getlinearvelocity)
+- At least one of [`GetCompassHeading()`](/components/movement-sensor/#getcompassheading) or [`GetOrientation()`](/components/movement-sensor/#getorientation). If your movement sensor stack provides multiple methods, your robot will default to using the values returned by `GetCompassHeading()`.
+
+See [navigation concepts](#navigation-concepts) for more info on how to implement and use movement sensors taking these measurements.
+
 ## Configuration
-
-You must configure a [base](/components/base/) with a [movement sensor](/components/movement-sensor/) as part of your robot to configure a Navigation service.
-
-{{% alert title="Important" color="note" %}}
-
-Make sure the [movement sensor](/components/movement-sensor/) you use supports [`GetPosition()`](/components/movement-sensor/#getposition) and at least one of [`GetCompassHeading()`](/components/movement-sensor/#getcompassheading) or [`GetOrientation()`](/components/movement-sensor/#getorientation) in its {{< glossary_tooltip term_id="model" text="model's" >}} implementation of the [Movement Sensor API](/components/movement-sensor/#api).
-
-- It must support `GetPosition()` to report the robot's current GPS location.
-- It must also support either `GetCompassHeading()` or `GetOrientation()` to report which way the robot is facing.
-- If your movement sensor provides multiple methods, your robot will default to using the values returned by `GetCompassHeading()`.
-
-{{% /alert %}}
 
 {{< tabs >}}
 {{% tab name="Config Builder" %}}

--- a/docs/tutorials/services/navigate-with-rover-base.md
+++ b/docs/tutorials/services/navigate-with-rover-base.md
@@ -52,13 +52,16 @@ Follow this tutorial to get started using Viam's Navigation service to help your
 
    {{<imgproc src="/tutorials/navigate-with-rover-base/leo-in-office.png" resize="500x" declaredimensions=true alt="Leo rover that is navigating using the navigation service in a robotics lab.">}}
 
-2. **A movement sensor with GPS position and angular and linear velocity readings**
+2. **A movement sensor with GPS position, compass heading or orientation, and angular and linear velocity readings**
 
    We used three movement sensors to satisfy these requirements:
 
    1. A [SparkFun GPS-RTK-SMA Breakout](https://www.sparkfun.com/products/16481) [movement sensor](/components/movement-sensor/) configured as a [`gps-nmea-rtk-serial`](/components/movement-sensor/gps/gps-nmea-rtk-serial/) model, providing GPS position measurements.
    2. A [`wheeled-odometry`](/components/movement-sensor/wheeled-odometry/) model gathering angular and linear velocity information from the [encoders](/components/encoder/) wired to our base's [motors](/components/motor/).
    3. A [`merged`](/components/movement-sensor/merged/) model aggregating the readings together for the navigation service to consume.
+
+   You can use whatever combo of movement sensors you want as long as you are getting all the types of measurements required.
+   See [the navigation service](/services/navigation/#requirements) for more info on movement sensor requirements.
 
 {{% alert title="Tip" color="tip" %}}
 


### PR DESCRIPTION
* Based on message from Fahmina: movement sensors must be able to read “Compass heading, position, linear velocity, angular velocity”
* inferring compass heading or orientation based of info we previously had in there? Getting confirmation