### PR TITLE
DOCS-1275: Add CLI module upload file, dir

### DIFF
--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -356,7 +356,7 @@ This includes:
 ```sh {class="command-line" data-prompt="$"}
 viam module create --name <module-id> [--org-id <org-id> | --public-namespace <namespace>]
 viam module update [--org-id <org-id> | --public-namespace <namespace>] [--module <path to meta.json>]
-viam module upload --version <version> --platform <platform> [--org-id <org-id> | --public-namespace <namespace>] [--module <path to meta.json>] <packaged-module.tar.gz>
+viam module upload --version <version> --platform <platform> [--org-id <org-id> | --public-namespace <namespace>] [--module <path to meta.json>] <module>
 ```
 
 Examples:
@@ -387,7 +387,7 @@ If you update and release your module as part of a continuous integration (CI) w
 | ----------- | ----------- | ----------- |
 | `create`    | generate new metadata for a custom module on your local filesystem  | - |
 | `update`    | update an existing custom module on your local filesystem with recent changes to the [`meta.json` file](#the-metajson-file) | - |
-| `upload`    | validate and upload a new or existing custom module on your local filesystem to the Viam registry. See [Upload validation](#upload-validation) for more information |
+| `upload`    | validate and upload a new or existing custom module on your local filesystem to the Viam registry. See [Upload validation](#upload-validation) for more information | **path** : specify the path to the file, directory, or compressed archive in `tar.gz` or `tar.xz` format that contains your custom module code |
 | `--help`      | return help      | - |
 
 ##### Named arguments
@@ -440,13 +440,13 @@ Therefore, you are able to change the `entrypoint` file from version to version,
 
 ##### Upload validation
 
-When you `upload` a module, the command validates your local packaged module to ensure that it meets the requirements to successfully upload to the Viam registry.
+When you `upload` a module, the command validates your local module to ensure that it meets the requirements to successfully upload to the Viam registry.
 The following criteria are checked for every `upload`:
 
-- The packaged module must exist on the filesystem at the path provided to the `upload` command.
-- The packaged module must use the `.tar.gz` or `.tgz` extension.
+- The module must exist on the filesystem at the path provided to the `upload` command.
 - The entry point file specified in the [`meta.json` file](#the-metajson-file) must exist on the filesystem at the path specified.
 - The entry point file must be executable.
+- If the module is provided to the `upload` command as a compressed archive, the archive must be in `.tar.gz` or `.tgz` format.
 
 ##### The `meta.json` file
 
@@ -498,7 +498,7 @@ The `meta.json` file includes the following configuration options:
     <td><code>entrypoint</code></td>
     <td>string</td>
     <td><strong>Required</strong></td>
-    <td>The name of the file that starts your module program. This can be a compiled executable, a script, or an invocation of another program.</td>
+    <td>The name of the file that starts your module program. This can be a compiled executable, a script, or an invocation of another program. If you are providing a directory containing your module to the <code>upload</code> command, the entry point file must be contained within that directory.</td>
   </tr>
 </table>
 

--- a/docs/modular-resources/upload/_index.md
+++ b/docs/modular-resources/upload/_index.md
@@ -30,7 +30,7 @@ To upload your custom module to the [Viam registry](https://app.viam.com/registr
 
 1. First, [install the Viam CLI](/manage/cli/#install) and [authenticate](/manage/cli/#authenticate) to Viam, from the same machine that you intend to upload your module from.
 
-2. Next, run the `viam module create` command to select a new custom module name and generate module metadata.
+1. Next, run the `viam module create` command to select a new custom module name and generate module metadata.
    By default, a module is created as private.
    Run this command according to your desired visibility for your module:
 
@@ -49,7 +49,7 @@ viam module create --name <your-module-name> --org-id <your-org-id>
 1. If you haven't already, [create a new namespace](/manage/fleet/organizations/#create-a-namespace-for-your-organization) for your organization.
    If you have already created a namespace, you can find it on your organization's **Settings** page in [the Viam App](https://app.viam.com/).
 
-2. To generate metadata for your module using your public namespace, run the following command from the same directory as your custom module:
+1. To generate metadata for your module using your public namespace, run the following command from the same directory as your custom module:
 
 ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
 viam module create --name <your-module-name> --public-namespace <your-unique-namespace>
@@ -61,7 +61,7 @@ viam module create --name <your-module-name> --public-namespace <your-unique-nam
 This command creates a new `meta.json` metadata file in your current working directory, which serves as a template.
 Edit and then upload the `meta.json` file to set important configuration information about your module, such as whether it will be publicly available to all Viam users or only available within your organization.
 
-3. Edit the newly-created `meta.json` file, and provide the required configuration information for your custom module by filling in the following fields.
+1. Edit the newly-created `meta.json` file, and provide the required configuration information for your custom module by filling in the following fields.
    The `name` field is pre-populated using the `--name` you provided in the `viam module create` command, and `visibility` is set to `private` by default.
 
    <table class="table table-striped">
@@ -106,7 +106,7 @@ Edit and then upload the `meta.json` file to set important configuration informa
        <td><code>entrypoint</code></td>
        <td>string</td>
        <td><strong>Required</strong></td>
-       <td>The name of the file that starts your module program. This can be a compiled executable, a script, or an invocation of another program.</td>
+       <td>The name of the file that starts your module program. This can be a compiled executable, a script, or an invocation of another program. If you are providing a directory containing your module to the <code>upload</code> command, the entry point file must be contained within that directory.</td>
      </tr>
    </table>
 
@@ -136,7 +136,7 @@ Edit and then upload the `meta.json` file to set important configuration informa
 
    See [The `meta.json` file](/manage/cli/#the-metajson-file) for more information.
 
-4. Run `viam module update` to register the configuration changes you just made to `meta.json` with the Viam registry.
+1. Run `viam module update` to register the configuration changes you just made to `meta.json` with the Viam registry.
    Run this command from within the same directory as your `meta.json` file:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
@@ -145,31 +145,11 @@ Edit and then upload the `meta.json` file to set important configuration informa
 
    On a successful update, the command will return a link to the updated module in the Viam registry.
 
-5. Package your custom module to get it ready to upload to the Viam registry.
-   Currently, the Registry only supports `tar.gz` or `tar.xz` format.
-   Use the command below specific for the language of your module:
-
-   - To package a module written in Go, run the following commands from the same directory as your `meta.json` file:
-
-     ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-     go build -o bin/module ./module/main.go
-     tar -czf module.tar.gz bin/module
-     ```
-
-     For more information, see [Compile a module into an executable](/modular-resources/create/#compile-the-module-into-an-executable).
-
-   - To package a module written in Python, run the following command from the same directory as your `meta.json` file:
-
-     ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-     tar -czf module.tar.gz run.sh requirements.txt src
-     ```
-
-     Where `run.sh` is your [entrypoint file](/modular-resources/create/#compile-the-module-into-an-executable), `requirements.txt` is your [pip dependency list file](/modular-resources/create/#compile-the-module-into-an-executable), and `src` is the source directory of your module.
-
-6. Run `viam module upload` to upload the updated custom module to the Viam registry:
+1. Run `viam module upload` to upload your custom module to the Viam registry.
+   Specify the path to the file, directory, or compressed archive in `tar.gz` or `tar.xz` format that contains your custom module code:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-   viam module upload --version <version> --platform <platform> module.tar.gz
+   viam module upload --version <version> --platform <platform> <module-path>
    ```
 
    Where:
@@ -182,7 +162,7 @@ Edit and then upload the `meta.json` file to set important configuration informa
      - `darwin/amd64` - macOS computers running the Intel `x86_64` architecture.
      - `linux/arm64` - Linux computers or {{< glossary_tooltip term_id="board" text="boards" >}} running the `arm64` (`aarch64`) architecture, such as the Raspberry Pi.
      - `linux/amd64` - Linux computers or {{< glossary_tooltip term_id="board" text="boards" >}} running the Intel `x86_64` architecture.
-   - `path` - provide the path to the compressed archive, in `tar.gz` or `tar.xz` format, that contains your custom module code.
+   - `module-path` - provide the path to the file, directory, or compressed archive in `tar.gz` or `tar.xz` format that contains your custom module code.
 
    {{% alert title="Important" color="note" %}}
    The `viam module upload` command only supports one `platform` argument at a time.
@@ -191,13 +171,26 @@ Edit and then upload the `meta.json` file to set important configuration informa
    The Viam registry page for your module displays the platforms your module supports for each version you have uploaded.
    {{% /alert %}}
 
-   For example, the following command uploads the compressed `module.tar.gz` archive to the Viam registry when run in the same directory as the corresponding `meta.json` file:
+   For example:
+   - To upload a custom module that is defined in a single file named `my-module-file`, written to a local `bin` directory:
 
-   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-   viam module upload --version 1.0.0 --platform darwin/arm64 module.tar.gz
-   ```
+     ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+     viam module upload --version 1.0.0 --platform darwin/arm64 ./bin/my-module-file
+     ```
 
-   When you `upload` a module, the command performs basic [validation](/manage/cli/#upload-validation) of your packaged module to ensure it is compatible with the Viam registry.
+   - To upload a custom module that includes multiple files, as well as a separate entry point file, all contained with a local `bin` directory:
+
+     ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+     viam module upload --version 1.0.0 --platform darwin/arm64 ./bin
+     ```
+
+   - To upload a custom module that has been compressed as an archive named `packaged-module.tar.gz`:
+
+      ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+      viam module upload --version 1.0.0 --platform darwin/arm64 packaged-module.tar.gz
+      ```
+
+   When you `upload` a module, the command performs basic [validation](/manage/cli/#upload-validation) of your module to ensure it is compatible with the Viam registry.
 
 For more information, see the [`viam module` command](/manage/cli/#module)
 
@@ -229,34 +222,13 @@ To update an existing module in the [Viam registry](https://app.viam.com/registr
 
    On a successful update, the command will return a link to the updated module in the Viam registry.
 
-1. Package your custom module to get it ready to upload to the Viam registry.
-   Currently, the Registry only supports `tar.gz` or `tar.xz` format.
-   Use the command below specific for the language of your module:
-
-   - To package a module written in Go, run the following commands from the same directory as your `meta.json` file:
-
-     ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-     go build -o bin/module ./module/main.go
-     tar -cxf module.tar.gz bin/module
-     ```
-
-     For more information, see [Compile a module into an executable](/modular-resources/create/#compile-the-module-into-an-executable).
-
-   - To package a module written in Python, run the following command from the same directory as your `meta.json` file:
-
-     ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-     tar -czf module.tar.gz run.sh requirements.txt src
-     ```
-
-     Where `run.sh` is your [entrypoint file](/modular-resources/create/#compile-the-module-into-an-executable), `requirements.txt` is your [pip dependency list file](/modular-resources/create/#compile-the-module-into-an-executable), and `src` is the source directory of your module.
-
-1. Run `viam module upload` to upload the updated custom module to the Viam registry:
+1. Run `viam module upload` to upload your custom module to the Viam registry:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-   viam module upload --version <version> --platform <platform> <path-to-tar.gz>
+   viam module upload --version <version> --platform <platform> <module-path>
    ```
 
-   For example, the following command uploads the compressed `my-module.tar.gz` archive to the Viam registry when run in the same directory, and increments the [`version`](/manage/cli/#using-the---version-argument) of the module to version `1.0.1`:
+   For example, the following command uploads a module compressed as an archive named `my-module.tar.gz` to the Viam registry, and increments the [`version`](/manage/cli/#using-the---version-argument) of the module to version `1.0.1`:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    viam module upload --version 1.0.1 --platform darwin/arm64 my-module.tar.gz


### PR DESCRIPTION
Expand `module upload` command to support uploading single files and directories of files as well as just compressed archives (in `tar.gz` and `tgz` format).
- Removed explicit "compress your module into an archive" step from both upload new module and update existing module sections.
- Fixed missing positional parameter on `upload` CLI reference entry.