### PR TITLE
Make ESP32 board link to micro-RDK page in internals rather than setup

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -45,7 +45,7 @@ sitemap:
       </a>
     </li>
     <li id="c1_slide5">
-      <a href="/internals/micro-rdk/">
+      <a href="internals/micro-rdk/">
         {{<imgproc src="installation/thumbnails/esp32-espressif.png" resize="148x120" declaredimensions=true alt="E S P 32 - espressif">}}
         <p>Espressif ESP32</p>
       </a>

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -45,7 +45,7 @@ sitemap:
       </a>
     </li>
     <li id="c1_slide5">
-      <a href="installation/prepare/microcontrollers/">
+      <a href="/internals/micro-rdk/">
         {{<imgproc src="installation/thumbnails/esp32-espressif.png" resize="148x120" declaredimensions=true alt="E S P 32 - espressif">}}
         <p>Espressif ESP32</p>
       </a>


### PR DESCRIPTION
Request from Rand/team to surface the internals page more, then the internals page links to setup