### PR TITLE
Update adxl345.md fix wrong I2C info

### DIFF
--- a/docs/components/movement-sensor/adxl345.md
+++ b/docs/components/movement-sensor/adxl345.md
@@ -78,7 +78,7 @@ Then remove and fill in the attributes as applicable to your movement sensor, ac
       "namespace": "rdk",
       "attributes": {
         "board": "<your-board-name>",
-        "i2c_bus": "<your-spi-bus-name-on-board>",
+        "i2c_bus": "<your-i2c-bus-name-on-board>",
         "use_alternate_i2c_address": <boolean>,
         "tap": {
           "accelerometer_pin": <int>,

--- a/docs/components/movement-sensor/adxl345.md
+++ b/docs/components/movement-sensor/adxl345.md
@@ -32,7 +32,7 @@ Then remove and fill in the attributes as applicable to your movement sensor, ac
 ```json {class="line-numbers linkable-line-numbers"}
 {
   "board": "<your-board-name>",
-  "i2c_bus": "<your-spi-bus-name-on-board>",
+  "i2c_bus": "<your-i2c-bus-name-on-board>",
   "use_alternate_i2c_address": <boolean>,
   "tap": {
     "accelerometer_pin": <int>,

--- a/docs/components/movement-sensor/adxl345.md
+++ b/docs/components/movement-sensor/adxl345.md
@@ -147,7 +147,7 @@ Then remove and fill in the attributes as applicable to your movement sensor, ac
 | --------------------- | ------ | ------------ | ----------- |
 | `board`               | string | **Required** | The `name` of the [board](/components/board/) to which the device is wired. |
 | `i2c_bus`             | string | **Required** | The `name` of the [I<sup>2</sup>C bus configured](/components/board/#i2cs) on the [board](/components/board/) wired to this device. |
-| `use_alt_i2c_address` | bool   | Optional     | Depends on whether you wire SDO low (leaving the default address of 0x53) or high (making the address 0x1D). If high, set true. If low, set false or omit the attribute. <br> Default: `false` |
+| `use_alternate_i2c_address` | bool   | Optional     | Depends on whether you wire SDO low (leaving the default address of 0x53) or high (making the address 0x1D). If high, set true. If low, set false or omit the attribute. <br> Default: `false` |
 | `tap`                 | object | Optional     | Holds the configuration values necessary to use the tap detection interrupt on the ADXL345. See [Tap attributes](#tap-attributes). |
 | `free_fall`           | object | Optional     | Holds the configuration values necessary to use the free-fall detection interrupt on the ADXL345. See [Freefall attributes](#freefall-attributes). |
 


### PR DESCRIPTION
* Change "spi bus" to "i2c bus" for I2C attribute
* Updates incorrect attribute name (I checked in https://pkg.go.dev/go.viam.com/rdk@v0.11.1/components/movementsensor/adxl345)