### PR TITLE
Change warning about using 5V inputs to a caution message in Jetson Board docs

### DIFF
--- a/docs/components/board/jetson.md
+++ b/docs/components/board/jetson.md
@@ -17,9 +17,9 @@ If you have a CSI camera, follow [these instructions](/modular-resources/example
 
 {{% /alert %}}
 
-{{% alert title="CAUTION: Use 3.3V inputs and outputs" color="warning" %}}
+{{% alert title="CAUTION: Use 3.3V inputs and outputs" color="caution" %}}
 
-The jetson's GPIO pins are rated for inputs and outputs at 3.3V. Signals from encoders and sensors at even 5V can cause damage to a pin. We recommend connecting hardware that can operate and send signals at 3.3V or lower. For details, see pages 1-3 of the [Jetson Nano Developer Kit 40-Pin Expansion Header GPIO Usage Considerations Applications Note](https://developer.nvidia.com/jetson-nano-developer-kit-40-pin-expansion-header-gpio-usage-considerations-applications-note)
+The GPIO pins on Jetson boards are rated 3.3V signals, 5V signals from  encoders and sensors can cause damage to a pin. We recommend selecting hardware that can operate 3.3V signals or lower. For details, see pages 1-3 of the [Jetson Nano Developer Kit 40-Pin Expansion Header GPIO Usage Considerations Applications Note](https://developer.nvidia.com/jetson-nano-developer-kit-40-pin-expansion-header-gpio-usage-considerations-applications-note)
 
 {{% /alert %}}
 

--- a/docs/components/board/jetson.md
+++ b/docs/components/board/jetson.md
@@ -19,7 +19,7 @@ If you have a CSI camera, follow [these instructions](/modular-resources/example
 
 {{% alert title="CAUTION: Use 3.3V inputs and outputs" color="caution" %}}
 
-The GPIO pins on Jetson boards are rated 3.3V signals. 5V signals from encoders and sensors can cause damage to a pin. We recommend selecting hardware that can operate 3.3V signals or lower. For details, see pages 1-3 of the [Jetson Nano Developer Kit 40-Pin Expansion Header GPIO Usage Considerations Applications Note](https://developer.nvidia.com/jetson-nano-developer-kit-40-pin-expansion-header-gpio-usage-considerations-applications-note).
+The GPIO pins on Jetson boards are rated 3.3V signals. 5V signals from encoders and sensors can cause damage to a pin. We recommend selecting hardware that can operate 3.3V signals or lower. For details, see your boards specification. For the Jetson Nano, see pages 1-3 of the [Jetson Nano Developer Kit 40-Pin Expansion Header GPIO Usage Considerations Applications Note](https://developer.nvidia.com/jetson-nano-developer-kit-40-pin-expansion-header-gpio-usage-considerations-applications-note).
 
 {{% /alert %}}
 

--- a/docs/components/board/jetson.md
+++ b/docs/components/board/jetson.md
@@ -19,7 +19,7 @@ If you have a CSI camera, follow [these instructions](/modular-resources/example
 
 {{% alert title="CAUTION: Use 3.3V inputs and outputs" color="caution" %}}
 
-The GPIO pins on Jetson boards are rated 3.3V signals, 5V signals from  encoders and sensors can cause damage to a pin. We recommend selecting hardware that can operate 3.3V signals or lower. For details, see pages 1-3 of the [Jetson Nano Developer Kit 40-Pin Expansion Header GPIO Usage Considerations Applications Note](https://developer.nvidia.com/jetson-nano-developer-kit-40-pin-expansion-header-gpio-usage-considerations-applications-note)
+The GPIO pins on Jetson boards are rated 3.3V signals. 5V signals from  encoders and sensors can cause damage to a pin. We recommend selecting hardware that can operate 3.3V signals or lower. For details, see pages 1-3 of the [Jetson Nano Developer Kit 40-Pin Expansion Header GPIO Usage Considerations Applications Note](https://developer.nvidia.com/jetson-nano-developer-kit-40-pin-expansion-header-gpio-usage-considerations-applications-note).
 
 {{% /alert %}}
 

--- a/docs/components/board/jetson.md
+++ b/docs/components/board/jetson.md
@@ -19,7 +19,7 @@ If you have a CSI camera, follow [these instructions](/modular-resources/example
 
 {{% alert title="CAUTION: Use 3.3V inputs and outputs" color="caution" %}}
 
-The GPIO pins on Jetson boards are rated 3.3V signals. 5V signals from  encoders and sensors can cause damage to a pin. We recommend selecting hardware that can operate 3.3V signals or lower. For details, see pages 1-3 of the [Jetson Nano Developer Kit 40-Pin Expansion Header GPIO Usage Considerations Applications Note](https://developer.nvidia.com/jetson-nano-developer-kit-40-pin-expansion-header-gpio-usage-considerations-applications-note).
+The GPIO pins on Jetson boards are rated 3.3V signals. 5V signals from encoders and sensors can cause damage to a pin. We recommend selecting hardware that can operate 3.3V signals or lower. For details, see pages 1-3 of the [Jetson Nano Developer Kit 40-Pin Expansion Header GPIO Usage Considerations Applications Note](https://developer.nvidia.com/jetson-nano-developer-kit-40-pin-expansion-header-gpio-usage-considerations-applications-note).
 
 {{% /alert %}}
 

--- a/docs/installation/prepare/jetson-agx-orin-setup.md
+++ b/docs/installation/prepare/jetson-agx-orin-setup.md
@@ -29,7 +29,8 @@ If you want to use a different carrier board to incorporate your Orin into your 
 
 {{% alert title="CAUTION: Use 3.3V inputs and outputs" color="caution" %}}
 
-The GPIO pins on Jetson boards are rated 3.3V signals. 5V signals from encoders and sensors can cause damage to a pin. We recommend selecting hardware that can operate 3.3V signals or lower. For details, see pages 1-3 of the [Jetson Nano Developer Kit 40-Pin Expansion Header GPIO Usage Considerations Applications Note](https://developer.nvidia.com/jetson-nano-developer-kit-40-pin-expansion-header-gpio-usage-considerations-applications-note).
+The GPIO pins on Jetson boards are rated 3.3V signals. 5V signals from encoders and sensors can cause damage to a pin. We recommend selecting hardware that can operate 3.3V signals or lower.
+For details, see your boards specification.
 
 {{% /alert %}}
 

--- a/docs/installation/prepare/jetson-agx-orin-setup.md
+++ b/docs/installation/prepare/jetson-agx-orin-setup.md
@@ -27,6 +27,12 @@ If you want to use a different carrier board to incorporate your Orin into your 
 
 {{% /alert %}}
 
+{{% alert title="CAUTION: Use 3.3V inputs and outputs" color="caution" %}}
+
+The GPIO pins on Jetson boards are rated 3.3V signals. 5V signals from encoders and sensors can cause damage to a pin. We recommend selecting hardware that can operate 3.3V signals or lower. For details, see pages 1-3 of the [Jetson Nano Developer Kit 40-Pin Expansion Header GPIO Usage Considerations Applications Note](https://developer.nvidia.com/jetson-nano-developer-kit-40-pin-expansion-header-gpio-usage-considerations-applications-note).
+
+{{% /alert %}}
+
 ## Hardware Requirements
 
 You need the following hardware, tools, and software to install `viam-server` on a Jetson AGX Orin with the Jetson AGX Orin Developer Kit:

--- a/docs/installation/prepare/jetson-nano-setup.md
+++ b/docs/installation/prepare/jetson-nano-setup.md
@@ -26,6 +26,12 @@ If you want to use a different carrier board to incorporate your Nano into your 
 
 {{% /alert %}}
 
+{{% alert title="CAUTION: Use 3.3V inputs and outputs" color="caution" %}}
+
+The GPIO pins on Jetson boards are rated 3.3V signals. 5V signals from encoders and sensors can cause damage to a pin. We recommend selecting hardware that can operate 3.3V signals or lower. For details, see pages 1-3 of the [Jetson Nano Developer Kit 40-Pin Expansion Header GPIO Usage Considerations Applications Note](https://developer.nvidia.com/jetson-nano-developer-kit-40-pin-expansion-header-gpio-usage-considerations-applications-note).
+
+{{% /alert %}}
+
 ## Hardware Requirements
 
 You need the following hardware, tools, and software to install `viam-server` on a Jetson Nano or Jetson Orin Nano:


### PR DESCRIPTION
# Description

This changes and summarizes a warning message on the jetson board to a caution message, as requested.
@npentrel added this to all the other jetson boards rather than just the Xavier.
