### PR TITLE
DOCS-1268: Add docs for uninstalling `viam-server`

### DIFF
--- a/docs/installation/manage/_index.md
+++ b/docs/installation/manage/_index.md
@@ -273,6 +273,12 @@ sudo rm /etc/systemd/system/viam-server.service
 sudo systemctl daemon-reload
 ```
 
+To remove the configuration file, run:
+
+```sh {class="command-line" data-prompt="$"}
+sudo rm /etc/viam.json
+```
+
 To remove various Viam caches and logs for the root (service) user, run:
 
 ```sh {class="command-line" data-prompt="$"}
@@ -298,6 +304,18 @@ Uninstall `viam-server` with the following command:
 
 ```sh {class="command-line" data-prompt="$"}
 brew uninstall viam-server
+```
+
+To remove various Viam caches and logs, run:
+
+```sh {class="command-line" data-prompt="$"}
+rm -r ~/.viam/
+```
+
+To remove the configuration file, run:
+
+```sh {class="command-line" data-prompt="$"}
+sudo rm /etc/viam.json
 ```
 
 {{% /tab %}}

--- a/docs/installation/manage/_index.md
+++ b/docs/installation/manage/_index.md
@@ -276,7 +276,7 @@ sudo systemctl daemon-reload
 To remove various Viam caches and logs for the root (service) user, run:
 
 ```sh {class="command-line" data-prompt="$"}
-sudo rm -r ~/.viam/
+sudo rm -r /root/.viam/
 ```
 
 If you ever run `viam-server` directly, to remove various Viam caches and logs for your own user run:

--- a/docs/installation/manage/_index.md
+++ b/docs/installation/manage/_index.md
@@ -260,6 +260,23 @@ cat $(brew --prefix)/var/log/viam.log
 {{% /tab %}}
 {{< /tabs >}}
 
+## Uninstall `viam-server`
+
+{{< tabs name="View logs">}}
+{{% tab name="Linux"%}}
+
+{{% /tab %}}
+{{% tab name="macOS" %}}
+
+You can uninstall `viam-server` using the following command:
+
+```sh {class="command-line" data-prompt="$"}
+brew uninstall viam-server
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## Troubleshooting
 
 You can find additional assistance in the [Troubleshooting section](/appendix/troubleshooting/).

--- a/docs/installation/manage/_index.md
+++ b/docs/installation/manage/_index.md
@@ -262,13 +262,39 @@ cat $(brew --prefix)/var/log/viam.log
 
 ## Uninstall `viam-server`
 
-{{< tabs name="View logs">}}
+{{< tabs name="Uninstall viam-server">}}
 {{% tab name="Linux"%}}
+
+Remove the system installed service with the following three commands:
+
+```sh {class="command-line" data-prompt="$"}
+sudo systemctl disable --now viam-server
+sudo rm /etc/systemd/system/viam-server.service
+sudo systemctl daemon-reload
+```
+
+To remove various Viam caches and logs for the root (service) user, run:
+
+```sh {class="command-line" data-prompt="$"}
+sudo rm -r ~/.viam/
+```
+
+If you ever run `viam-server` directly, to remove various Viam caches and logs for your own user run:
+
+```sh {class="command-line" data-prompt="$"}
+rm -r ~/.viam/
+```
+
+To remove the `viam-server` binary itself, run:
+
+```sh {class="command-line" data-prompt="$"}
+sudo rm /usr/local/bin/viam-server
+```
 
 {{% /tab %}}
 {{% tab name="macOS" %}}
 
-You can uninstall `viam-server` using the following command:
+Uninstall `viam-server` with the following command:
 
 ```sh {class="command-line" data-prompt="$"}
 brew uninstall viam-server


### PR DESCRIPTION
* Add docs for uninstalling viam-server on macos and linux

User feedback request 

Reached out to @Otterverse for linux instructions, there's a bit more to do than with MacOS as Andrew detailed on ticket