### PR TITLE
DOCS-1321: Add correct link for Gantry method

### DIFF
--- a/docs/components/gantry/_index.md
+++ b/docs/components/gantry/_index.md
@@ -257,7 +257,7 @@ myGantry.Home(context.Background(), nil)
 {{% /tab %}}
 {{< /tabs >}}
 
-### GetLengths
+### Lengths
 
 Get the lengths of the axes of the gantry (mm).
 

--- a/docs/components/gantry/_index.md
+++ b/docs/components/gantry/_index.md
@@ -273,7 +273,7 @@ Get the lengths of the axes of the gantry (mm).
 
 - [(List\[float\])](https://docs.python.org/3/library/typing.html#typing.List): A list of the lengths of the axes of the gantry in millimeters.
 
-For more information, see the [Python SDK Docs](https://python.viam.dev/_modules/viam/components/gantry/gantry.html#Gantry.lengths).
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/gantry/client/index.html#viam.components.gantry.client.GantryClient.get_lengths).
 
 ```python
 my_gantry = Gantry.from_robot(robot=robot, name="my_gantry")

--- a/docs/components/gantry/_index.md
+++ b/docs/components/gantry/_index.md
@@ -273,7 +273,7 @@ Get the lengths of the axes of the gantry (mm).
 
 - [(List\[float\])](https://docs.python.org/3/library/typing.html#typing.List): A list of the lengths of the axes of the gantry in millimeters.
 
-For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/gantry/client/index.html#viam.components.gantry.client.GantryClient.get_lengths).
+For more information, see the [Python SDK Docs](https://python.viam.dev/_modules/viam/components/gantry/gantry.html#Gantry.get_lengths).
 
 ```python
 my_gantry = Gantry.from_robot(robot=robot, name="my_gantry")

--- a/docs/components/gantry/_index.md
+++ b/docs/components/gantry/_index.md
@@ -257,7 +257,7 @@ myGantry.Home(context.Background(), nil)
 {{% /tab %}}
 {{< /tabs >}}
 
-### Lengths
+### GetLengths
 
 Get the lengths of the axes of the gantry (mm).
 


### PR DESCRIPTION
* Was caught in SDK methods checker but was actually documented, just didn't have the right link. 