### PR TITLE
DOCS-1291: Add env vars to module conf

### DIFF
--- a/docs/registry/configure.md
+++ b/docs/registry/configure.md
@@ -314,7 +314,7 @@ To delete an environment variable configuration, delete the `env` section from y
 
 #### Default environment variables
 
-What a module is instantiated, it has access to the following default environment variables:
+When a module is instantiated, it has access to the following default environment variables:
 
 <!-- prettier-ignore -->
 | Name | Description |

--- a/docs/registry/configure.md
+++ b/docs/registry/configure.md
@@ -332,6 +332,8 @@ What a module from the Viam registry is instantiated, it has access to the follo
 | `VIAM_MODULE_DATA` | A persistent folder location a module can use to store data across reboots and versions. Use this directory to store [python virtual environments](/program/python-venv/) when writing and deploying multiple python modules that share the same dependencies, for example.<br>`$VIAM_HOME/module-data/my-namespace_my-module/` |
 | `VIAM_MODULE_ID` | The module ID of the module. <br>`viam:realsense` |
 
+If you are using a [local module](#local-modules), you must set these variables manually.
+
 ## Local modules
 
 If you wish to add a module to your robot without uploading it to the Viam registry, you can add your module as a _local module_.

--- a/docs/registry/configure.md
+++ b/docs/registry/configure.md
@@ -325,13 +325,7 @@ Add these properties to your module's configuration:
 {{% /tab %}}
 {{% /tabs %}}
 
-<<<<<<< HEAD
 ### Add a local modular resource
-||||||| parent of 81bc0f96 (DOCS-1291: Add env vars to module conf)
-### Configure a modular resource
-=======
-### Configure a modular resource from a local module
->>>>>>> 81bc0f96 (DOCS-1291: Add env vars to module conf)
 
 Once you have added a local module to your robot, you can add any number of the {{< glossary_tooltip term_id="resource" text="resources" >}} provided by that module to your robot by adding new components or services that use your modular resource's {{< glossary_tooltip term_id="model" text="model" >}}.
 

--- a/docs/registry/configure.md
+++ b/docs/registry/configure.md
@@ -299,7 +299,7 @@ To configure a modular resource with an environment variable, navigate to the **
       "module_id": "my-namespace:my-module",
       "version": "1.0.0",
       "env": {
-        "PATH": "${environment.PATH}:/home/username/scripts",
+        "PATH": "/home/username/bin:${environment.PATH}",
         "MY_USER": "username"
       }
     }

--- a/docs/registry/configure.md
+++ b/docs/registry/configure.md
@@ -325,7 +325,13 @@ Add these properties to your module's configuration:
 {{% /tab %}}
 {{% /tabs %}}
 
+<<<<<<< HEAD
 ### Add a local modular resource
+||||||| parent of 81bc0f96 (DOCS-1291: Add env vars to module conf)
+### Configure a modular resource
+=======
+### Configure a modular resource from a local module
+>>>>>>> 81bc0f96 (DOCS-1291: Add env vars to module conf)
 
 Once you have added a local module to your robot, you can add any number of the {{< glossary_tooltip term_id="resource" text="resources" >}} provided by that module to your robot by adding new components or services that use your modular resource's {{< glossary_tooltip term_id="model" text="model" >}}.
 

--- a/docs/registry/configure.md
+++ b/docs/registry/configure.md
@@ -263,7 +263,7 @@ Or if you are using a module that requires access to an additional program or li
 This configures a module environment variable `PATH` that uses your system's `PATH` (which you can view by running `echo $PATH`) as a base, and adds one additional filesystem path: <file>/home/username/bin</file>.
 
 The notation `${environment.<ENV-VAR-NAME>}"` can be used to access any system environment variable that `viam-server` has access to, where `<ENV-VAR-NAME>` represents a system environment variable, like `PATH`, `USER`, or `PWD`.
-For example, you can use `${environment.HOME}"`
+For example, you can use `${environment.HOME}"` to access the `HOME` environment variable for the user running `viam-server`.
 
 To configure a modular resource with an environment variable, navigate to the **Config** tab on your robot's page in the Viam app, toggle **Raw JSON** mode, and add the following `env` configuration to the `modules` section:
 

--- a/docs/registry/configure.md
+++ b/docs/registry/configure.md
@@ -329,7 +329,7 @@ What a module from the Viam registry is instantiated, it has access to the follo
 | ---- | ----------- |
 | `VIAM_HOME` | The root of the `viam-server` configuration.<br>Is always: `$HOME/.viam` |
 | `VIAM_MODULE_ROOT` | The root of the module install directory. Useful for file navigation that is relative to the root of the module.<br>`$VIAM_HOME/packages/.data/modules/verxxxx-my-module/` |
-| `VIAM_MODULE_DATA` | A persistent folder location a module can use to store data across reboots and versions. Use this directory to store [python virtual environments](/program/python-venv.md) when writing and deploying multiple python modules that share the same dependencies, for example.<br>`$VIAM_HOME/module-data/my-namespace_my-module/` |
+| `VIAM_MODULE_DATA` | A persistent folder location a module can use to store data across reboots and versions. Use this directory to store [python virtual environments](/program/python-venv/) when writing and deploying multiple python modules that share the same dependencies, for example.<br>`$VIAM_HOME/module-data/my-namespace_my-module/` |
 | `VIAM_MODULE_ID` | The module ID of the module. <br>`viam:realsense` |
 
 ## Local modules

--- a/docs/registry/configure.md
+++ b/docs/registry/configure.md
@@ -332,7 +332,7 @@ What a module from the Viam registry is instantiated, it has access to the follo
 | `VIAM_MODULE_DATA` | A persistent folder location a module can use to store data across reboots and versions. Use this directory to store [python virtual environments](/program/python-venv/) when writing and deploying multiple python modules that share the same dependencies, for example.<br>`$VIAM_HOME/module-data/my-namespace_my-module/` |
 | `VIAM_MODULE_ID` | The module ID of the module. <br>`viam:realsense` |
 
-If you are using a [local module](#local-modules), you must set these variables manually.
+If you are using a [local module](#local-modules), you would need to set these variables manually if your module requires them.
 
 ## Local modules
 

--- a/docs/registry/configure.md
+++ b/docs/registry/configure.md
@@ -229,7 +229,6 @@ Module environment variables can be either:
 
 - Static string values, or
 - References to a system environment variable.
-  Any system environment variable available to the `viam-server` instance can be referenced in this way.
 
 For example, if your module requires a `MODULE_USER` environment variable, you can add it with the following configuration:
 
@@ -291,24 +290,17 @@ To configure a modular resource with an environment variable, navigate to the **
 {{% /tab %}}
 {{% tab name="JSON Example" %}}
 
-The following is an example configuration for the [Viam ROS2 Integration module](https://app.viam.com/module/viam-soleng/viam-ros2-integration).
-The configuration adds three environment variables required by the module: `PATH`, `ROS_SETUP`, and `MODULE_USER`:
-
-- `PATH` is sourced from the local system environment variable `PATH`, and is appended with the additional search path `/home/viam/scripts`.
-- `ROS_SETUP` and `MODULE_USER` are configured with static values.
-
 ```json {class="line-numbers linkable-line-numbers"}
 {
   "modules": [
     {
       "type": "registry",
-      "name": "my-ros2-integration",
-      "module_id": "viam:viam-ros2-integration",
+      "name": "my-module",
+      "module_id": "my-namespace:my-module",
       "version": "1.0.0",
       "env": {
-        "PATH": "${environment.PATH}:/home/viam/scripts",
-        "ROS_SETUP": "/opt/ros/kinetic/setup.bash",
-        "MODULE_USER": "my-ros-user"
+        "PATH": "${environment.PATH}:/home/username/scripts",
+        "MY_USER": "username"
       }
     }
   ]
@@ -322,17 +314,15 @@ To delete an environment variable configuration, delete the `env` section from y
 
 #### Default environment variables
 
-What a module from the Viam registry is instantiated, it has access to the following default environment variables:
+What a module is instantiated, it has access to the following default environment variables:
 
 <!-- prettier-ignore -->
 | Name | Description |
 | ---- | ----------- |
-| `VIAM_HOME` | The root of the `viam-server` configuration.<br>Is always: `$HOME/.viam` |
-| `VIAM_MODULE_ROOT` | The root of the module install directory. Useful for file navigation that is relative to the root of the module.<br>`$VIAM_HOME/packages/.data/modules/verxxxx-my-module/` |
-| `VIAM_MODULE_DATA` | A persistent folder location a module can use to store data across reboots and versions. Use this directory to store [python virtual environments](/program/python-venv/) when writing and deploying multiple python modules that share the same dependencies, for example.<br>`$VIAM_HOME/module-data/my-namespace_my-module/` |
-| `VIAM_MODULE_ID` | The module ID of the module. <br>`viam:realsense` |
-
-If you are using a [local module](#local-modules), you would need to set these variables manually if your module requires them.
+| `VIAM_HOME` | The root of the `viam-server` configuration.<br>Default: `$HOME/.viam` |
+| `VIAM_MODULE_ROOT` | The root of the module install directory. Useful for file navigation that is relative to the root of the module. If you are using a [local module](#local-modules), you must set this value manually if your module requires it.<br>Example: `$VIAM_HOME/packages/.data/modules/verxxxx-my-module/` |
+| `VIAM_MODULE_DATA` | A persistent folder location a module can use to store data across reboots and versions. This location is a good place to store [python virtual environments](/program/python-venv/).<br>Example: `$VIAM_HOME/module-data/cloud-robot-id/my-module-name/` |
+| `VIAM_MODULE_ID` | The module ID of the module. <br>Example: `viam:realsense` |
 
 ## Local modules
 


### PR DESCRIPTION
Add docs for configuring environment variables in module configuration.
- Supports static string vars, and referencing system env vars.
- Adds 4 new default env variables for registry modules
- Not discussing local modules yet
- No UI yet, so Raw JSON only.

Thanks for the helpful review, Zach!!