### PR TITLE
DOCS-1319: Filter and add correct link for input controller API missing methods

### DIFF
--- a/.github/workflows/check_python_methods.py
+++ b/.github/workflows/check_python_methods.py
@@ -220,8 +220,7 @@ def parse(type, names):
 
             if not found and id != "viam.components.board.client.DigitalInterruptClient.add_callback" \
             and id != "viam.components.board.client.DigitalInterruptClient.add_post_processor" \
-            and id != "viam.components.input.client.ControllerClient.reset_channel" \
-            and id != "viam.components.input.client.ControllerClient.trigger_event":
+            and id != "viam.components.input.client.ControllerClient.reset_channel":
                 sdk_methods_missing.append(id)
 
 

--- a/.github/workflows/check_python_methods.py
+++ b/.github/workflows/check_python_methods.py
@@ -219,7 +219,9 @@ def parse(type, names):
                         break
 
             if not found and id != "viam.components.board.client.DigitalInterruptClient.add_callback" \
-            and id != "viam.components.board.client.DigitalInterruptClient.add_post_processor":
+            and id != "viam.components.board.client.DigitalInterruptClient.add_post_processor" \
+            and id != "viam.components.input.client.ControllerClient.reset_channel" \
+            and id != "viam.components.input.client.ControllerClient.trigger_event":
                 sdk_methods_missing.append(id)
 
 

--- a/docs/components/input-controller/_index.md
+++ b/docs/components/input-controller/_index.md
@@ -354,7 +354,7 @@ logger.Info(controls)
 {{% /tab %}}
 {{< /tabs >}}
 
-<!-- ### TriggerEvent NOTE: This method should be documented when support is available for all input components.
+### TriggerEvent
 
 Directly send an [Event Object](#event-object) from external code.
 
@@ -417,7 +417,7 @@ if err != nil {
 ```
 
 {{% /tab %}}
-{{< /tabs >}} -->
+{{< /tabs >}}
 
 ### DoCommand
 

--- a/docs/components/input-controller/_index.md
+++ b/docs/components/input-controller/_index.md
@@ -310,7 +310,7 @@ Get a list of the [Controls](#control-field) that your controller provides.
 
 - [(List\[Control\])](https://python.viam.dev/autoapi/viam/components/input/index.html#viam.components.input.Control): List of Controls provided by the controller.
 
-For more information, see the [Python SDK Docs](https://python.viam.dev/_modules/viam/components/input/input.html#Controller.get_position).
+For more information, see the [Python SDK Docs](https://python.viam.dev/_modules/viam/components/input/input.html#Controller.get_controls).
 
 ```python {class="line-numbers linkable-line-numbers"}
 # Get the controller from the robot.

--- a/static/include/components/apis/input-controller.md
+++ b/static/include/components/apis/input-controller.md
@@ -1,6 +1,8 @@
+<!-- prettier-ignore -->
 Method Name | Description
 ----------- | -----------
 [`GetControls`](/components/input-controller/#getcontrols) | Get a list of input `Controls` that this Controller provides.
 [`GetEvents`](/components/input-controller/#getevents) | Get the current state of the Controller as a map of the most recent [Event](/components/input-controller/#event-object) for each [Control](/components/input-controller/#control-field).
 [`RegisterControlCallback`](/components/input-controller/#registercontrolcallback) | Define a callback function to execute whenever one of the [`EventTypes`](/components/input-controller/#eventtype-field) selected occurs on the given [Control](/components/input-controller/#control-field).
+[`TriggerEvent`](/components/input-controller/#triggerevent) | Trigger an event on the Controller.
 [`DoCommand`](/components/input-controller/#docommand) | Send or receive model-specific commands.


### PR DESCRIPTION
For two missing methods: 
- `trigger_event` has a note not to be documented without full implementation (raises not implemented error) and `reset_channel` I _think_ is random helper function that shouldn't be documented, no equivalent in Go SDK. 

Paging @cheukt to confirm: is it best not to document [`trigger_event`](https://python.viam.dev/autoapi/viam/components/input/client/index.html#viam.components.input.client.ControllerClient.trigger_event) and [`reset_channel`](https://python.viam.dev/autoapi/viam/components/input/client/index.html#viam.components.input.client.ControllerClient.reset_channel) at the moment, or are they ready to be documented?