### PR TITLE
DOCS-1105: Add mlmodel extra for PySDK

### DIFF
--- a/docs/program/_index.md
+++ b/docs/program/_index.md
@@ -42,7 +42,7 @@ If you are using the Python SDK, [set up a virtual environment](/program/python-
 pip install viam-sdk
 ```
 
-If you intend to use the [ML (machine learning) model service](/services/ml/) with the Python SDK, you must also install the `mlmodel` extra:
+If you intend to use the [ML (machine learning) model service](/services/ml/), use the following command instead, which installs additional required dependencies along with the Python SDK:
 
 ```sh {class="command-line" data-prompt="$"}
 pip install 'viam-sdk[mlmodel]'

--- a/docs/program/_index.md
+++ b/docs/program/_index.md
@@ -42,6 +42,12 @@ If you are using the Python SDK, [set up a virtual environment](/program/python-
 pip install viam-sdk
 ```
 
+If you intend to use the [ML (machine learning) model service](/services/ml/) with the Python SDK, you must also install the `mlmodel` extra:
+
+```sh {class="command-line" data-prompt="$"}
+pip install 'viam-sdk[mlmodel]'
+```
+
 {{% /tab %}}
 {{% tab name="Go" %}}
 

--- a/docs/program/python-venv.md
+++ b/docs/program/python-venv.md
@@ -66,7 +66,7 @@ This installs the Viam Python SDK and all required general dependencies.
 If you intend to use the [ML (machine learning) model service](/services/ml/) with the Python SDK, you must also install the `mlmodel` extra:
 
 ```sh {class="command-line" data-prompt="$"}
-pip install 'viam-sdk[mlmodel]'
+pip3 install 'viam-sdk[mlmodel]'
 ```
 
 If you need to install your own requirements, also install them in this virtual environment.

--- a/docs/program/python-venv.md
+++ b/docs/program/python-venv.md
@@ -55,7 +55,7 @@ You can exit this environment by running `deactivate`.
 
 ## Install Viam
 
-Inside the activated `viam-env` python environment, you can now install the Viam SDK:
+Inside the activated `viam-env` python environment, you can now install the Viam Python SDK:
 
 ```sh {class="command-line" data-prompt="$"}
 pip3 install viam-sdk
@@ -63,11 +63,15 @@ pip3 install viam-sdk
 
 This installs the Viam Python SDK and all required general dependencies.
 
-If you intend to use the [ML (machine learning) model service](/services/ml/) with the Python SDK, you must also install the `mlmodel` extra:
+If you intend to use the [ML (machine learning) model service](/services/ml/), install the Python SDK using the `mlmodel` extra:
 
 ```sh {class="command-line" data-prompt="$"}
 pip3 install 'viam-sdk[mlmodel]'
 ```
+
+This installs the Viam Python SDK and all required dependencies, including for the ML model service.
+
+You can also run this command on an existing Python SDK install to add support for the ML model service.
 
 If you need to install your own requirements, also install them in this virtual environment.
 To make your required packages easier to install in the future, you can also [create a](https://openclassrooms.com/en/courses/6900846-set-up-a-python-environment/6990546-manage-virtual-environments-using-requirements-files) <file>requirements.txt</file> file with a list of all the packages you need and then install the requirements for your client application by running `pip3 install -r requirements.txt`.

--- a/docs/program/python-venv.md
+++ b/docs/program/python-venv.md
@@ -61,7 +61,13 @@ Inside the activated `viam-env` python environment, you can now install the Viam
 pip3 install viam-sdk
 ```
 
-This installs Viam and all required dependencies.
+This installs the Viam Python SDK and all required general dependencies.
+
+If you intend to use the [ML (machine learning) model service](/services/ml/) with the Python SDK, you must also install the `mlmodel` extra:
+
+```sh {class="command-line" data-prompt="$"}
+pip install 'viam-sdk[mlmodel]'
+```
 
 If you need to install your own requirements, also install them in this virtual environment.
 To make your required packages easier to install in the future, you can also [create a](https://openclassrooms.com/en/courses/6900846-set-up-a-python-environment/6990546-manage-virtual-environments-using-requirements-files) <file>requirements.txt</file> file with a list of all the packages you need and then install the requirements for your client application by running `pip3 install -r requirements.txt`.

--- a/docs/services/ml/_index.md
+++ b/docs/services/ml/_index.md
@@ -149,12 +149,13 @@ You can use one of these architectures or build your own.
 
 ## Use the ML model service with the Viam Python SDK
 
-To use the ML model service from the [Viam Python SDK](https://python.viam.dev/), you must install both the Python SDK itself and the `mlmodel` extra:
+To use the ML model service from the [Viam Python SDK](https://python.viam.dev/), install the Python SDK using the `mlmodel` extra:
 
 ```sh {class="command-line" data-prompt="$"}
-pip install viam-sdk
 pip install 'viam-sdk[mlmodel]'
 ```
+
+You can also run this command on an existing Python SDK install to add support for the ML model service.
 
 See the [Python documentation](https://python.viam.dev/autoapi/viam/services/mlmodel/mlmodel/index.html#viam.services.mlmodel.mlmodel.MLModel) for more information about the `MLModel` service in Python.
 

--- a/docs/services/ml/_index.md
+++ b/docs/services/ml/_index.md
@@ -147,6 +147,19 @@ In the absence of metadata, your `.tflite_cpu` model must satisfy the following 
 These requirements are satisfied by a few publicly available model architectures including EfficientDet, MobileNet, and SSD MobileNet V1.
 You can use one of these architectures or build your own.
 
+## Use the ML model service with the Viam Python SDK
+
+To use the ML model service from the [Viam Python SDK](https://python.viam.dev/), you must install both the Python SDK itself and the `mlmodel` extra:
+
+```sh
+pip install viam-sdk
+pip install 'viam-sdk[mlmodel]'
+```
+
+See the [Python documentation](https://python.viam.dev/autoapi/viam/services/mlmodel/mlmodel/index.html#viam.services.mlmodel.mlmodel.MLModel) for more information about the `MLModel` service in Python
+
+See [program your smart machine](/program/) for more information.
+
 ## Next Steps
 
 To make use of your model with your smart machine, add a [vision service](/services/vision/) or a [modular resource](/modular-resources/):

--- a/docs/services/ml/_index.md
+++ b/docs/services/ml/_index.md
@@ -151,14 +151,14 @@ You can use one of these architectures or build your own.
 
 To use the ML model service from the [Viam Python SDK](https://python.viam.dev/), you must install both the Python SDK itself and the `mlmodel` extra:
 
-```sh
+```sh {class="command-line" data-prompt="$"}
 pip install viam-sdk
 pip install 'viam-sdk[mlmodel]'
 ```
 
-See the [Python documentation](https://python.viam.dev/autoapi/viam/services/mlmodel/mlmodel/index.html#viam.services.mlmodel.mlmodel.MLModel) for more information about the `MLModel` service in Python
+See the [Python documentation](https://python.viam.dev/autoapi/viam/services/mlmodel/mlmodel/index.html#viam.services.mlmodel.mlmodel.MLModel) for more information about the `MLModel` service in Python.
 
-See [program your smart machine](/program/) for more information.
+See [Program a smart machine](/program/) for more information about using an SDK to control your smart machine.
 
 ## Next Steps
 

--- a/docs/tutorials/projects/guardian.md
+++ b/docs/tutorials/projects/guardian.md
@@ -426,11 +426,14 @@ python3 -m venv env
 source env/bin/activate
 ```
 
-Now, install the Python Viam SDK and the VLC module:
+Now, install the Python Viam SDK, the `mlmodel` extra, and the VLC module:
 
 ```sh {class="command-line" data-prompt="$"}
 pip3 install viam-sdk python-vlc
+pip3 install 'viam-sdk[mlmodel]'
 ```
+
+The `mlmodel` extra includes additional dependency support for the [ML (machine learning) model service](/services/ml/).
 
 ### Connect
 

--- a/docs/tutorials/projects/guardian.md
+++ b/docs/tutorials/projects/guardian.md
@@ -426,11 +426,10 @@ python3 -m venv env
 source env/bin/activate
 ```
 
-Now, install the Python Viam SDK, the `mlmodel` extra, and the VLC module:
+Now, install the Python Viam SDK with the `mlmodel` extra, and the VLC module:
 
 ```sh {class="command-line" data-prompt="$"}
-pip3 install viam-sdk python-vlc
-pip3 install 'viam-sdk[mlmodel]'
+pip3 install 'viam-sdk[mlmodel]' python-vlc
 ```
 
 The `mlmodel` extra includes additional dependency support for the [ML (machine learning) model service](/services/ml/).


### PR DESCRIPTION
Add notice that Python SDK users must now also install the `mlmodel` extra alongside the Python SDK in order to use the ML Model service.
- Notice to central Program and ML Model service reference pages
- Inclusion on tutorials that present Python code, and use the ML Model service (though none used the deprecated 
`input_data` or `output_data` nomenclature). Guess: no changes needed to these tutorials, besides additional dep install step now documentation.