### PR TITLE
Change alpha to beta in micro rdk docs

### DIFF
--- a/static/include/micro-rdk.md
+++ b/static/include/micro-rdk.md
@@ -1,5 +1,5 @@
 {{% alert title="ALPHA" color="note" %}}
-The micro-RDK is in alpha mode and many features supported by the RDK are still being added to the micro-RDK.
+The micro-RDK is in beta mode and many features supported by the RDK are still being added to the micro-RDK.
 Stability is not guaranteed.
 Breaking changes are likely to occur, and occur often.
 {{% /alert %}}


### PR DESCRIPTION
# Description

Changes alpha to beta in micro-rdk docs.

I think this is all that's needed. From my understanding this file is included in a few other places and generates the warning. Will double check when the link is generated.
