### PR TITLE
DOCS-794: Add camera troubleshooting

### DIFF
--- a/docs/appendix/troubleshooting.md
+++ b/docs/appendix/troubleshooting.md
@@ -216,6 +216,10 @@ It will resemble the following:
       In order to use a camera device with Viam, it must support at least one of the [pixel formats supported by Viam](/components/camera/webcam/#using-format).
       If your camera does not support any of these formats, it cannot be used with Viam.
 
+If you are still having issues with your camera component on the Linux platform, and would like to [file an issue](https://github.com/viamrobotics/rdk), include your smart machine's camera debug file contained in the <file>/root/.viam/debug/components/camera</file> directory.
+If you are running `viam-server` as a different user, find the <file>.viam/debug/components/camera</file> directory in that user's home directory instead.
+This file contains basic diagnostic and configuration information about your camera that helps to quickly troubleshoot issues.
+
 ### Error: failed to find the best driver that fits the constraints
 
 **Description:** When working with a [camera](/components/camera/) component, depending on the camera, you may need to explicitly provide some camera-specific configuration parameters.

--- a/docs/appendix/troubleshooting.md
+++ b/docs/appendix/troubleshooting.md
@@ -158,6 +158,65 @@ It will resemble the following:
 }
 ```
 
+### Error: failed to find camera
+
+**Additional Errors:** `cannot open webcam`, and `found no webcams`.
+
+**Description:** When working with a [camera](/components/camera/) component on the Linux platform, your Linux OS must be able to access the camera properly, and the camera must be configured to use a pixel format that Viam supports.
+
+**Solution:** On your Linux system, verify each of the following:
+
+1. Ensure that your Linux OS is able to access your camera:
+
+   1. First, find your video device:
+
+   ```sh {class="command-line" data-prompt="$"}
+   ls -l /dev/v4l/*
+   ```
+
+   In the list of camera devices returned, find the entry that matches the `video_path` from your camera component's configuration in the Viam app.
+   For example, if your camera is configured with a `video_path` of `usb-GENERAL_GENERAL_WEBCAM-video-index0`, you would find it in the output of the above command like so:
+
+   ```sh
+   usb-GENERAL_GENERAL_WEBCAM-video-index0 -> ../../video0
+   ```
+
+   The video device number is the number after `video` appearing on the symlink target for that device, in this case `0`.
+
+   1. Then, [stop `viam-server`](/installation/manage/#run-viam-server), and verify that your Linux OS is able to access that video device properly:
+
+   ```sh {class="command-line" data-prompt="$"}
+   v4l2-ctl -d0 --stream-mmap
+   ```
+
+   Replace the `0` in the above command with the number you determined for your video device above.
+   You should receive output resembling like the following, which indicates that your Linux OS is successfully able to use your video device:
+
+   ```sh
+   <<<<<<<<<<<<<<<<<<<<<<<< 22.81 fps
+   <<<<<<<<<<<<<<<<<<<<<<<< 23.50 fps
+   ```
+
+   If the command does not return FPS readings as shown above, consult the documentation for your camera and Linux distribution to troubleshoot.
+
+   If you receive the error `Device or resource busy` instead, be sure you have [stopped `viam-server`](/installation/manage/#run-viam-server) first, then re-run the command above.
+
+1. Ensure that your camera uses a supported pixel format:
+
+   1. Determine your video device number, like `0`, following the instructions above.
+   1. Then run the following command:
+
+   ```sh {class="command-line" data-prompt="$"}
+   v4l2-ctl --list-formats-ext --device /dev/video0
+   ```
+
+   Replace the `0` in the above command with the number you determined for your video device above.
+   Or, if your video device uses a different path, supply that path to this command instead of `/dev/video0`.
+
+   The command will return a list of pixel formats your camera supports, such as `MJPG` or `YUYV`.
+   In order to use a camera device with Viam, it must support at least one of the [pixel formats supported by Viam](/components/camera/webcam/#using-format).
+   If your camera does not support any of these formats, it cannot be used with Viam.
+
 ### Error: failed to find the best driver that fits the constraints
 
 **Description:** When working with a [camera](/components/camera/) component, depending on the camera, you may need to explicitly provide some camera-specific configuration parameters.

--- a/docs/appendix/troubleshooting.md
+++ b/docs/appendix/troubleshooting.md
@@ -166,56 +166,55 @@ It will resemble the following:
 
 **Solution:** On your Linux system, verify each of the following:
 
-1. Ensure that your Linux OS is able to access your camera:
+- Ensure that your Linux OS is able to access your camera:
 
    1. First, find your video device:
 
-   ```sh {class="command-line" data-prompt="$"}
-   ls -l /dev/v4l/*
-   ```
+      ```sh {class="command-line" data-prompt="$"}
+      ls -l /dev/v4l/*
+      ```
 
-   In the list of camera devices returned, find the entry that matches the `video_path` from your camera component's configuration in the Viam app.
-   For example, if your camera is configured with a `video_path` of `usb-GENERAL_GENERAL_WEBCAM-video-index0`, you would find it in the output of the above command like so:
+      In the list of camera devices returned, find the entry that matches the `video_path` from your camera component's configuration in the Viam app.
+      For example, if your camera is configured with a `video_path` of `usb-GENERAL_GENERAL_WEBCAM-video-index0`, you would find it in the output of the above command like so:
 
-   ```sh
-   usb-GENERAL_GENERAL_WEBCAM-video-index0 -> ../../video0
-   ```
+      ```sh
+      usb-GENERAL_GENERAL_WEBCAM-video-index0 -> ../../video0
+      ```
 
-   The video device number is the number after `video` appearing on the symlink target for that device, in this case `0`.
+      The video device number is the number after `video` appearing on the symlink target for that device, in this case `0`.
 
    1. Then, [stop `viam-server`](/installation/manage/#run-viam-server), and verify that your Linux OS is able to access that video device properly:
 
-   ```sh {class="command-line" data-prompt="$"}
-   v4l2-ctl -d0 --stream-mmap
-   ```
+      ```sh {class="command-line" data-prompt="$"}
+      v4l2-ctl -d0 --stream-mmap
+      ```
 
-   Replace the `0` in the above command with the number you determined for your video device above.
-   You should receive output resembling like the following, which indicates that your Linux OS is successfully able to use your video device:
+      Replace the `0` in the above command with the number you determined for your video device above.
+      You should receive output resembling like the following, which indicates that your Linux OS is successfully able to use your video device:
 
-   ```sh
-   <<<<<<<<<<<<<<<<<<<<<<<< 22.81 fps
-   <<<<<<<<<<<<<<<<<<<<<<<< 23.50 fps
-   ```
+      ```sh
+      <<<<<<<<<<<<<<<<<<<<<<<< 22.81 fps
+      <<<<<<<<<<<<<<<<<<<<<<<< 23.50 fps
+      ```
 
-   If the command does not return FPS readings as shown above, consult the documentation for your camera and Linux distribution to troubleshoot.
+      If the command does not return FPS readings as shown above, consult the documentation for your camera and Linux distribution to troubleshoot.
+      If you receive the error `Device or resource busy` instead, be sure you have [stopped `viam-server`](/installation/manage/#run-viam-server) first, then re-run the command above.
 
-   If you receive the error `Device or resource busy` instead, be sure you have [stopped `viam-server`](/installation/manage/#run-viam-server) first, then re-run the command above.
+- Ensure that your camera uses a supported pixel format:
 
-1. Ensure that your camera uses a supported pixel format:
+   1. First, determine your video device number, like `0`, following the instructions above.
+   1. Then, run the following command:
 
-   1. Determine your video device number, like `0`, following the instructions above.
-   1. Then run the following command:
+      ```sh {class="command-line" data-prompt="$"}
+      v4l2-ctl --list-formats-ext --device /dev/video0
+      ```
 
-   ```sh {class="command-line" data-prompt="$"}
-   v4l2-ctl --list-formats-ext --device /dev/video0
-   ```
+      Replace the `0` in the above command with the number you determined for your video device above.
+      Or, if your video device uses a different path, supply that path to this command instead of `/dev/video0`.
 
-   Replace the `0` in the above command with the number you determined for your video device above.
-   Or, if your video device uses a different path, supply that path to this command instead of `/dev/video0`.
-
-   The command will return a list of pixel formats your camera supports, such as `MJPG` or `YUYV`.
-   In order to use a camera device with Viam, it must support at least one of the [pixel formats supported by Viam](/components/camera/webcam/#using-format).
-   If your camera does not support any of these formats, it cannot be used with Viam.
+      The command will return a list of pixel formats your camera supports, such as `MJPG` or `YUYV`.
+      In order to use a camera device with Viam, it must support at least one of the [pixel formats supported by Viam](/components/camera/webcam/#using-format).
+      If your camera does not support any of these formats, it cannot be used with Viam.
 
 ### Error: failed to find the best driver that fits the constraints
 

--- a/docs/appendix/troubleshooting.md
+++ b/docs/appendix/troubleshooting.md
@@ -184,7 +184,7 @@ It will resemble the following:
               /dev/media4
       ```
 
-      The video path for your camera device is the first path listed, in this case `/dev/video0`.
+      The video path for your camera device is the first path listed under that camera, in this case `/dev/video0`.
 
   1.  Then, [stop `viam-server`](/installation/manage/#run-viam-server), and verify that your Linux OS is able to access that video device properly:
 
@@ -194,7 +194,7 @@ It will resemble the following:
 
       Replace `/dev/video0` in the above command with the video path you determined for your video device above, if different.
 
-      The command will return successfully (with no output) if Linux is able to successfully communicate with the camera, or will error with `Cannot open device`, if there was a problem communicating.
+      The command returns successfully (with no output) if Linux is able to successfully communicate with the camera, or errors with `Cannot open device` if there was a problem communicating.
       If this command errors, you should consult the documentation for your camera and Linux distribution to troubleshoot.
       If you receive the error `Device or resource busy` instead, be sure you have [stopped `viam-server`](/installation/manage/#run-viam-server) first, then re-run the command above.
 

--- a/docs/appendix/troubleshooting.md
+++ b/docs/appendix/troubleshooting.md
@@ -168,7 +168,7 @@ It will resemble the following:
 
 - Ensure that your Linux OS is able to access your camera:
 
-   1. First, find your video device:
+  1.  First, find your video device:
 
       ```sh {class="command-line" data-prompt="$"}
       ls -l /dev/v4l/*
@@ -183,7 +183,7 @@ It will resemble the following:
 
       The video device number is the number after `video` appearing on the symlink target for that device, in this case `0`.
 
-   1. Then, [stop `viam-server`](/installation/manage/#run-viam-server), and verify that your Linux OS is able to access that video device properly:
+  1.  Then, [stop `viam-server`](/installation/manage/#run-viam-server), and verify that your Linux OS is able to access that video device properly:
 
       ```sh {class="command-line" data-prompt="$"}
       v4l2-ctl -d0 --stream-mmap
@@ -202,8 +202,8 @@ It will resemble the following:
 
 - Ensure that your camera uses a supported pixel format:
 
-   1. First, determine your video device number, like `0`, following the instructions above.
-   1. Then, run the following command:
+  1.  First, determine your video device number, like `0`, following the instructions above.
+  1.  Then, run the following command:
 
       ```sh {class="command-line" data-prompt="$"}
       v4l2-ctl --list-formats-ext --device /dev/video0

--- a/docs/appendix/troubleshooting.md
+++ b/docs/appendix/troubleshooting.md
@@ -168,49 +168,46 @@ It will resemble the following:
 
 - Ensure that your Linux OS is able to access your camera:
 
-  1.  First, find your video device:
+  1.  Run the following command to list compatible camera devices on your system:
 
       ```sh {class="command-line" data-prompt="$"}
-      ls -l /dev/v4l/*
+      v4l2-ctl --list-devices
       ```
 
-      In the list of camera devices returned, find the entry that matches the `video_path` from your camera component's configuration in the Viam app.
-      For example, if your camera is configured with a `video_path` of `usb-GENERAL_GENERAL_WEBCAM-video-index0`, you would find it in the output of the above command like so:
+      In the list of camera devices returned, find the entry for your camera.
+      For example, the webcam on the [Viam Rover](https://docs.viam.com/try-viam/) appears as follows:
 
       ```sh
-      usb-GENERAL_GENERAL_WEBCAM-video-index0 -> ../../video0
+      GENERAL WEBCAM: GENERAL WEBCAM (usb-0000:01:00.0-1.4):
+              /dev/video0
+              /dev/video1
+              /dev/media4
       ```
 
-      The video device number is the number after `video` appearing on the symlink target for that device, in this case `0`.
+      The video path for your camera device is the first path listed, in this case `/dev/video0`.
 
   1.  Then, [stop `viam-server`](/installation/manage/#run-viam-server), and verify that your Linux OS is able to access that video device properly:
 
       ```sh {class="command-line" data-prompt="$"}
-      v4l2-ctl -d0 --stream-mmap
+      v4l2-ctl --stream-count 1 --device /dev/video0
       ```
 
-      Replace the `0` in the above command with the number you determined for your video device above.
-      You should receive output resembling like the following, which indicates that your Linux OS is successfully able to use your video device:
+      Replace `/dev/video0` in the above command with the video path you determined for your video device above, if different.
 
-      ```sh
-      <<<<<<<<<<<<<<<<<<<<<<<< 22.81 fps
-      <<<<<<<<<<<<<<<<<<<<<<<< 23.50 fps
-      ```
-
-      If the command does not return FPS readings as shown above, consult the documentation for your camera and Linux distribution to troubleshoot.
+      The command will return successfully (with no output) if Linux is able to successfully communicate with the camera, or will error with `Cannot open device`, if there was a problem communicating.
+      If this command errors, you should consult the documentation for your camera and Linux distribution to troubleshoot.
       If you receive the error `Device or resource busy` instead, be sure you have [stopped `viam-server`](/installation/manage/#run-viam-server) first, then re-run the command above.
 
 - Ensure that your camera uses a supported pixel format:
 
-  1.  First, determine your video device number, like `0`, following the instructions above.
+  1.  First, determine your video path, like `/dev/video0`, following the instructions above.
   1.  Then, run the following command:
 
       ```sh {class="command-line" data-prompt="$"}
       v4l2-ctl --list-formats-ext --device /dev/video0
       ```
 
-      Replace the `0` in the above command with the number you determined for your video device above.
-      Or, if your video device uses a different path, supply that path to this command instead of `/dev/video0`.
+      Replace `/dev/video0` in the above command with the video path you determined for your video device above, if different.
 
       The command will return a list of pixel formats your camera supports, such as `MJPG` or `YUYV`.
       In order to use a camera device with Viam, it must support at least one of the [pixel formats supported by Viam](/components/camera/webcam/#using-format).

--- a/docs/components/camera/webcam.md
+++ b/docs/components/camera/webcam.md
@@ -83,8 +83,8 @@ The following attributes are available for `webcam` cameras:
 <!-- prettier-ignore -->
 | Name | Type | Inclusion | Description |
 | ---- | ---- | --------- | ----------- |
-| `video_path` | string | Optional | The ID of or the path to the webcam. If you don't provide a `video_path`, it defaults to the first valid video path it finds. Using the ID of a webcam is more consistent than the path. |
-| `format` | string | Optional | The camera image format, used with `video_path` to find the camera. |
+| `video_path` | string | Optional | The ID of or the path to the webcam. If you don't provide a `video_path`, it defaults to the first valid video path it finds. Using the ID of a webcam is more consistent than the path. See [Using `video_path`](#using-video_path). |
+| `format` | string | Optional | The camera image format, used with `video_path` to find the camera. See [Using `format`](#using-format). |
 | `width_px` | int | Optional | The camera image width in pixels, used with `video_path` to find a camera with this resolution. <br> Default: Closest possible value to `480` |
 | `height_px` | int | Optional | The camera image height in pixels, used with `video_path` to find a camera with this resolution. <br> Default: Closest possible value to `640` |
 | `frame_rate` | float | Optional | The camera capture frequency as frames per second, used with `video_path` to find a camera with this throughput. <br> Default: Closest possible value to `30.0` |
@@ -92,13 +92,7 @@ The following attributes are available for `webcam` cameras:
 | `distortion_parameters` | object | Optional | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> `rk1`: The radial distortion x. </li> <li> `rk2`: The radial distortion y. </li> <li> `rk3`: The radial distortion z. </li> <li> `tp1`: The tangential distortion x. </li> <li> `tp2`: The tangential distortion y. </li> </ul> |
 | `debug` | boolean | Optional | Enables the debug outputs from the camera if `true`. <br> Default: `false` |
 
-## View the camera stream
-
-{{< readfile "/static/include/components/camera-view-camera-stream.md" >}}
-
-## Troubleshooting
-
-## Find the `video_path`
+## Using `video_path`
 
 To list available `video_path`s use the following command:
 
@@ -117,6 +111,8 @@ v4l2-ctl --list-devices
 
 The `id` listed by `ls /dev/v4l/by-id/` is a more consistent way to refer to the webcam.
 
+See [Camera troubleshooting](/appendix/troubleshooting/#error-failed-to-find-camera) for Linux-specific camera troubleshooting steps.
+
 {{% /tab %}}
 {{% tab name="Mac" %}}
 
@@ -128,6 +124,28 @@ The Unique ID displayed for each camera is the `video_path`.
 
 {{% /tab %}}
 {{< /tabs >}}
+
+## Using `format`
+
+Viam supports the following pixel formats:
+
+- I420
+- I444
+- MJPEG
+- NV12
+- NV21
+- RGBA
+- UYVY
+- YUY2
+- Z16
+
+If your smart machine is connected to the Viam app, the available pixel formats supported by your camera automatically appear in the **Format** drop down menu, which is visible when you click the **Show more** button.
+
+## View the camera stream
+
+{{< readfile "/static/include/components/camera-view-camera-stream.md" >}}
+
+## Troubleshooting
 
 ### No visible live video feed
 

--- a/docs/tutorials/services/webcam-line-follower-robot.md
+++ b/docs/tutorials/services/webcam-line-follower-robot.md
@@ -104,7 +104,7 @@ On the [`Raw JSON` tab](/manage/configuration/#the-config-tab), replace the conf
 
 {{< alert title="Note" color="note" >}}
 Your `"video_path"` value may be different.
-To find yours, follow [these instructions](/components/camera/webcam/#find-the-video_path).
+To find yours, follow [these instructions](/components/camera/webcam/#using-video_path).
 {{< /alert >}}
 
 ```json {class="line-numbers linkable-line-numbers"}


### PR DESCRIPTION
Add troubleshooting entry (in appendix > troubleshooting) detailing two steps to troubleshooting problematic video devices on Linux.

- Converted webcam > video_path section from troubleshooting into "Using `video_path`" section.
- Added new "Using `format`" section, with a list of pixel formats supported by Viam, drawn from [webcam.go](https://github.com/viamrobotics/rdk/blob/55a0cbadbe4c4875110ec41452818b99ddce3785/components/camera/videosource/webcam.go#L207-L215).

Question:
- Should we be documenting supported pixel formats this directly? Since there is an explicit attribute for it, even if it is often auto-populated, I think it's worthwhile to present.
- Am I correct when I say "your camera must support at least one format to be used with Viam"?