### PR TITLE
DOCS-1360: Fix image spacing on Raspberry Pi install page

### DIFF
--- a/docs/installation/prepare/rpi-setup.md
+++ b/docs/installation/prepare/rpi-setup.md
@@ -50,9 +50,13 @@ To install Raspberry Pi OS (formerly called Raspbian) on a microSD card from whi
 
 2.  Select `CHOOSE OS`.
     Click on `Raspberry Pi OS (other)`.
-    {{< imgproc alt="Raspberry Pi Imager window showing Raspberry Pi OS (Other) is selected." src="/installation/rpi-setup/select-other-custom-os.png" resize="800x" declaredimensions=true >}}
+
+    ![Raspberry Pi Imager window showing Raspberry Pi OS (Other) is selected.](/installation/rpi-setup/select-other-custom-os.png)
+
     Select `Raspberry Pi OS Lite (64-bit)` from the menu.
-    {{< imgproc alt="Raspberry Pi Imager window showing Raspberry Pi OS Lite (64-bit) is selected." src="/installation/rpi-setup/select-other-rpi.png" resize="800x" declaredimensions=true >}}
+
+    ![Raspberry Pi Imager window showing Raspberry Pi OS Lite (64-bit) is selected.](/installation/rpi-setup/select-other-rpi.png)
+
     You should be brought back to the initial launch screen.
 3.  To make your Raspberry Pi easier to access in the next step, configure your Raspberry Pi's hostname, ssh credentials, and wifi.
     Click the gear-shaped settings icon in the lower right to bring up the Advanced options menu.

--- a/docs/installation/prepare/rpi-setup.md
+++ b/docs/installation/prepare/rpi-setup.md
@@ -48,16 +48,16 @@ To install Raspberry Pi OS (formerly called Raspbian) on a microSD card from whi
 
     {{< imgproc alt="Raspberry Pi Imager launcher window showing a 'Choose OS' and 'Choose Storage' buttons." src="/installation/rpi-setup/imager-launch-screen.png" resize="800x" declaredimensions=true >}}
 
-2.  Select `CHOOSE OS`.
-    Click on `Raspberry Pi OS (other)`.
+2. Select `CHOOSE OS`.
+   Click on `Raspberry Pi OS (other)`.
 
-    ![Raspberry Pi Imager window showing Raspberry Pi OS (Other) is selected.](/installation/rpi-setup/select-other-custom-os.png)
+   {{< imgproc alt="Raspberry Pi Imager window showing Raspberry Pi OS (Other) is selected." src="/installation/rpi-setup/select-other-custom-os.png" resize="800x" declaredimensions=true >}}
 
-    Select `Raspberry Pi OS Lite (64-bit)` from the menu.
+   Select `Raspberry Pi OS Lite (64-bit)` from the  menu.
 
-    ![Raspberry Pi Imager window showing Raspberry Pi OS Lite (64-bit) is selected.](/installation/rpi-setup/select-other-rpi.png)
-
-    You should be brought back to the initial launch screen.
+   {{< imgproc alt="Raspberry Pi Imager window showing Raspberry Pi OS Lite (64-bit) is selected." src="/installation/rpi-setup/select-other-rpi.png" resize="800x" declaredimensions=true >}}
+   
+   You should be brought back to the initial launch screen.
 
 3.  To make your Raspberry Pi easier to access in the next step, configure your Raspberry Pi's hostname, ssh credentials, and wifi.
     Click the gear-shaped settings icon in the lower right to bring up the Advanced options menu.

--- a/docs/installation/prepare/rpi-setup.md
+++ b/docs/installation/prepare/rpi-setup.md
@@ -48,16 +48,16 @@ To install Raspberry Pi OS (formerly called Raspbian) on a microSD card from whi
 
     {{< imgproc alt="Raspberry Pi Imager launcher window showing a 'Choose OS' and 'Choose Storage' buttons." src="/installation/rpi-setup/imager-launch-screen.png" resize="800x" declaredimensions=true >}}
 
-2. Select `CHOOSE OS`.
-   Click on `Raspberry Pi OS (other)`.
+2.  Select `CHOOSE OS`.
+    Click on `Raspberry Pi OS (other)`.
 
-   {{< imgproc alt="Raspberry Pi Imager window showing Raspberry Pi OS (Other) is selected." src="/installation/rpi-setup/select-other-custom-os.png" resize="800x" declaredimensions=true >}}
+    {{< imgproc alt="Raspberry Pi Imager window showing Raspberry Pi OS (Other) is selected." src="/installation/rpi-setup/select-other-custom-os.png" resize="800x" declaredimensions=true >}}
 
-   Select `Raspberry Pi OS Lite (64-bit)` from the  menu.
+    Select `Raspberry Pi OS Lite (64-bit)` from the menu.
 
-   {{< imgproc alt="Raspberry Pi Imager window showing Raspberry Pi OS Lite (64-bit) is selected." src="/installation/rpi-setup/select-other-rpi.png" resize="800x" declaredimensions=true >}}
-   
-   You should be brought back to the initial launch screen.
+    {{< imgproc alt="Raspberry Pi Imager window showing Raspberry Pi OS Lite (64-bit) is selected." src="/installation/rpi-setup/select-other-rpi.png" resize="800x" declaredimensions=true >}}
+
+    You should be brought back to the initial launch screen.
 
 3.  To make your Raspberry Pi easier to access in the next step, configure your Raspberry Pi's hostname, ssh credentials, and wifi.
     Click the gear-shaped settings icon in the lower right to bring up the Advanced options menu.

--- a/docs/installation/prepare/rpi-setup.md
+++ b/docs/installation/prepare/rpi-setup.md
@@ -58,6 +58,7 @@ To install Raspberry Pi OS (formerly called Raspbian) on a microSD card from whi
     ![Raspberry Pi Imager window showing Raspberry Pi OS Lite (64-bit) is selected.](/installation/rpi-setup/select-other-rpi.png)
 
     You should be brought back to the initial launch screen.
+
 3.  To make your Raspberry Pi easier to access in the next step, configure your Raspberry Pi's hostname, ssh credentials, and wifi.
     Click the gear-shaped settings icon in the lower right to bring up the Advanced options menu.
 


### PR DESCRIPTION
* Bug Hazal noticed-- not getting same issue with this markdown image format and the size isn't a big difference, but I'm not entirely sure why it was happening with `imgproc`.