### PR TITLE
DOCS-1112: Clarify RPi raspi-config

### DIFF
--- a/docs/installation/prepare/rpi-setup.md
+++ b/docs/installation/prepare/rpi-setup.md
@@ -186,10 +186,10 @@ These protocols are required to support certain hardware, such as analog-to-digi
 
 1. Enable the relevant protocols to support your specific hardware:
 
-   - If you are using an analog-to-digital converter (ADC), enable SPI.
-   - If you are using an accelerometer, enable I2C.
-   - If you are using a CSI v1.3 or v2.0 camera, enable legacy camera support.
-   - If you are using a movement sensor or power sensor, you will likely need to enable the serial port.
+   - If you are using an analog-to-digital converter (ADC), enable **SPI**.
+   - If you are using an accelerometer, enable **I2C**.
+   - If you are using a CSI v1.3 or v2.0 camera, enable **Legacy Camera** support.
+   - If you are using a movement sensor or power sensor, you will likely need to enable the **Serial Port**.
      Check the documentation for your specific [movement sensor](/components/movement-sensor/) or [power sensor](/components/power-sensor/) to confirm.
 
 1. Then, to apply the changes, restart your Raspberry Pi if it hasn't already prompted you to do so.

--- a/docs/installation/prepare/rpi-setup.md
+++ b/docs/installation/prepare/rpi-setup.md
@@ -172,26 +172,31 @@ sudo apt upgrade
 ## Enable Communication Protocols
 
 If you are using hardware that requires I2C, SPI, serial, or one-wire protocols to communicate with your Pi, you will need to enable them using `raspi-config`.
+These protocols are required to support certain hardware, such as analog-to-digital converters (ADCs), accelerometers, and sensors.
 
-Launch the config tool by running the following command:
+1. Launch the config tool by running the following command:
 
-```sh {class="command-line" data-prompt="$"}
-sudo raspi-config
-```
+   ```sh {class="command-line" data-prompt="$"}
+   sudo raspi-config
+   ```
 
-Use your keyboard to select "Interface Options" and enable the relevant protocols.
+1. Use your keyboard to select "Interface Options", and press return.
 
-{{< imgproc alt="Screenshot of the Raspi Config screen with a red box and red arrow pointing to the '3 Interface Options' option where you can find the I2C and other drivers" src="/installation/rpi-setup/Installation-Raspberry-Pi-I2C-Raspi-Config-Interfacing-Options.png" resize="800x" declaredimensions=true >}}
+   {{< imgproc alt="Screenshot of the Raspi Config screen with a red box and red arrow pointing to the '3 Interface Options' option where you can find the I2C and other drivers" src="/installation/rpi-setup/Installation-Raspberry-Pi-I2C-Raspi-Config-Interfacing-Options.png" resize="800x" declaredimensions=true >}}
 
-{{< alert title="Important" color="note" >}}
-When using a CSI v1.3 or v2.0 camera, you need to enable legacy camera support.
-{{< /alert >}}
+1. Enable the relevant protocols to support your specific hardware:
 
-For these changes to take effect, you need to restart your Raspberry Pi if it hasn't already prompted you to do so.
+    - If you are using an analog-to-digital converter (ADC), enable SPI.
+    - If you are using an accelerometer, enable I2C.
+    - If you are using a CSI v1.3 or v2.0 camera, enable legacy camera support.
+    - If you are using a movement sensor or power sensor, you will likely need to enable the serial port.
+      Check the documentation for your specific [movement sensor](/components/movement-sensor/) or [power sensor](/components/power-sensor/) to confirm.
 
-```sh {class="command-line" data-prompt="$"}
-sudo reboot
-```
+1. Then, to apply the changes, restart your Raspberry Pi if it hasn't already prompted you to do so.
+
+   ```sh {class="command-line" data-prompt="$"}
+   sudo reboot
+   ```
 
 ## Install `viam-server`
 

--- a/docs/installation/prepare/rpi-setup.md
+++ b/docs/installation/prepare/rpi-setup.md
@@ -184,7 +184,7 @@ If you are using hardware that requires these protocols, you must enable support
 
    {{< imgproc alt="Screenshot of the Raspi Config screen with a red box and red arrow pointing to the '3 Interface Options' option where you can find the I2C and other drivers" src="/installation/rpi-setup/Installation-Raspberry-Pi-I2C-Raspi-Config-Interfacing-Options.png" resize="800x" declaredimensions=true >}}
 
-1. Enable the relevant protocols to support your specific hardware:
+1. Enable the relevant protocols to support your specific hardware. For example:
 
    - If you are using an analog-to-digital converter (ADC), motor, or other device that requires the SPI protocol, enable **SPI**.
    - If you are using an accelerometer, sensor, or other device that requires the I<sup>2</sup>C protocol, enable **I2C**.

--- a/docs/installation/prepare/rpi-setup.md
+++ b/docs/installation/prepare/rpi-setup.md
@@ -171,10 +171,10 @@ sudo apt upgrade
 
 ## Enable Communication Protocols
 
-If you are using hardware that requires I2C, SPI, serial, or one-wire protocols to communicate with your Pi, you will need to enable them using `raspi-config`.
-These protocols are required to support certain hardware, such as analog-to-digital converters (ADCs), accelerometers, and sensors.
+Certain hardware, such as analog-to-digital converters (ADCs), accelerometers, and sensors, communicate with your Pi using specialized communications protocols: including I2C, SPI, serial, or one-wire protocols.
+If you are using hardware that requires these protocols, you must enable support for them on your Pi using `raspi-config`:
 
-1. Launch the config tool by running the following command:
+1. Launch the configuration tool by running the following command:
 
    ```sh {class="command-line" data-prompt="$"}
    sudo raspi-config
@@ -186,11 +186,12 @@ These protocols are required to support certain hardware, such as analog-to-digi
 
 1. Enable the relevant protocols to support your specific hardware:
 
-   - If you are using an analog-to-digital converter (ADC), enable **SPI**.
-   - If you are using an accelerometer, enable **I2C**.
+   - If you are using an analog-to-digital converter (ADC), motor, or other device that requires the SPI protocol, enable **SPI**.
+   - If you are using an accelerometer, sensor, or other device that requires the I<sup>2</sup>C protocol, enable **I2C**.
    - If you are using a CSI v1.3 or v2.0 camera, enable **Legacy Camera** support.
-   - If you are using a movement sensor or power sensor, you will likely need to enable the **Serial Port**.
-     Check the documentation for your specific [movement sensor](/components/movement-sensor/) or [power sensor](/components/power-sensor/) to confirm.
+   - If you are using a sensor, motor, or other device that communicates over the serial port, enable **Serial Port**.
+
+   Check the documentation for your specific component to verify the communication protocols it requires.
 
 1. Then, to apply the changes, restart your Raspberry Pi if it hasn't already prompted you to do so.
 

--- a/docs/installation/prepare/rpi-setup.md
+++ b/docs/installation/prepare/rpi-setup.md
@@ -171,7 +171,7 @@ sudo apt upgrade
 
 ## Enable Communication Protocols
 
-Certain hardware, such as analog-to-digital converters (ADCs), accelerometers, and sensors, communicate with your Pi using specialized communications protocols: including I2C, SPI, serial, or one-wire protocols.
+Certain hardware, such as analog-to-digital converters (ADCs), accelerometers, and sensors, communicate with your Pi using specialized communications protocols, including I2C, SPI, serial, or one-wire protocols.
 If you are using hardware that requires these protocols, you must enable support for them on your Pi using `raspi-config`:
 
 1. Launch the configuration tool by running the following command:

--- a/docs/installation/prepare/rpi-setup.md
+++ b/docs/installation/prepare/rpi-setup.md
@@ -186,11 +186,11 @@ These protocols are required to support certain hardware, such as analog-to-digi
 
 1. Enable the relevant protocols to support your specific hardware:
 
-    - If you are using an analog-to-digital converter (ADC), enable SPI.
-    - If you are using an accelerometer, enable I2C.
-    - If you are using a CSI v1.3 or v2.0 camera, enable legacy camera support.
-    - If you are using a movement sensor or power sensor, you will likely need to enable the serial port.
-      Check the documentation for your specific [movement sensor](/components/movement-sensor/) or [power sensor](/components/power-sensor/) to confirm.
+   - If you are using an analog-to-digital converter (ADC), enable SPI.
+   - If you are using an accelerometer, enable I2C.
+   - If you are using a CSI v1.3 or v2.0 camera, enable legacy camera support.
+   - If you are using a movement sensor or power sensor, you will likely need to enable the serial port.
+     Check the documentation for your specific [movement sensor](/components/movement-sensor/) or [power sensor](/components/power-sensor/) to confirm.
 
 1. Then, to apply the changes, restart your Raspberry Pi if it hasn't already prompted you to do so.
 

--- a/docs/installation/prepare/rpi-setup.md
+++ b/docs/installation/prepare/rpi-setup.md
@@ -171,7 +171,7 @@ sudo apt upgrade
 
 ## Enable Communication Protocols
 
-Certain hardware, such as analog-to-digital converters (ADCs), accelerometers, and sensors, communicate with your Pi using specialized communications protocols, including I2C, SPI, serial, or one-wire protocols.
+Certain hardware, such as analog-to-digital converters (ADCs), accelerometers, and sensors, communicates with your Pi using specialized communications protocols, including I2C, SPI, serial, or one-wire protocols.
 If you are using hardware that requires these protocols, you must enable support for them on your Pi using `raspi-config`:
 
 1. Launch the configuration tool by running the following command:


### PR DESCRIPTION
Add explicit recommendations on which protocols to enable for your Rpi, based on which hardware you are using, without mentioning the Rover.
- Rover set up doc already links [directly to](https://docs.viam.com/try-viam/rover-resources/rover-tutorial/#install-raspberry-pi-os) this edited section, so also benefits from this clarification.

GUESS: "will likely need to enable the serial port" is just 'cause most of our ( movement | power ) sensors require a `serial_path`. Did I guess right?