### PR TITLE
DOCS-1373: Say `IsMoving()` is implemented on micro-RDK motor

### DIFF
--- a/docs/micro-rdk/motor/_index.md
+++ b/docs/micro-rdk/motor/_index.md
@@ -30,3 +30,4 @@ The micro-RDK [motor API](/components/motor/#api) supports only the following cl
 - [`GetPosition()`](/components/motor/#getposition)
 - [`GetProperties()`](/components/motor/#getproperties)
 - [`Stop()`](/components/motor/#stop)
+- [`IsMoving()`](/components/motor/#ismoving)


### PR DESCRIPTION
* Motor `IsMoving` was implemented, this ticket is for docs to reflect that change