### PR TITLE
DOCS-1181: Add robot API timeout

### DIFF
--- a/docs/program/apis/robot.md
+++ b/docs/program/apis/robot.md
@@ -36,7 +36,7 @@ async def connect():
         payload='YOUR LOCATION SECRET')
     opts = RobotClient.Options(
         refresh_interval=0,
-        dial_options = DialOptions(credentials=creds)
+        dial_options=DialOptions(credentials=creds)
     )
     return await RobotClient.at_address('smart-machine-main.YOUR LOCATION ID.viam.cloud', opts)
 

--- a/docs/program/apis/robot.md
+++ b/docs/program/apis/robot.md
@@ -10,7 +10,7 @@ tags: ["robot state", "sdk", "apis", "robot api"]
 The _robot API_ is the application programming interface that manages each of your smart machines running `viam-server`.
 Use the robot API to connect to your smart machine from within a supported [Viam SDK](/program/apis/), and send commands remotely.
 
-The robot API is supported for use with the [Viam Python SDK](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient), the [the Viam Go SDK](https://pkg.go.dev/go.viam.com/rdk/robot/client#RobotClient), and the [Viam C++ SDK](https://cpp.viam.dev/classviam_1_1sdk_1_1RobotClient.html).
+The robot API is supported for use with the [Viam Python SDK](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient), the [Viam Go SDK](https://pkg.go.dev/go.viam.com/rdk/robot/client#RobotClient), and the [Viam C++ SDK](https://cpp.viam.dev/classviam_1_1sdk_1_1RobotClient.html).
 
 ## Establish a connection
 

--- a/docs/program/apis/robot.md
+++ b/docs/program/apis/robot.md
@@ -37,7 +37,7 @@ async def connect():
         refresh_interval=0,
         dial_options=DialOptions(credentials=creds)
     )
-    return await RobotClient.at_address('smart-machine-name-main.YOUR LOCATION ID.viam.cloud', opts)
+    return await RobotClient.at_address('smart-machine-main.YOUR LOCATION ID.viam.cloud', opts)
 
 async def main():
 
@@ -74,7 +74,7 @@ func main() {
   logger := golog.NewDevelopmentLogger("client")
   robot, err := client.New(
       context.Background(),
-      "smart-machine-name-main.YOUR LOCATION ID.viam.cloud",
+      "smart-machine-main.YOUR LOCATION ID.viam.cloud",
       logger,
       client.WithDialOptions(rpc.WithCredentials(rpc.Credentials{
           Type:    utils.CredentialsTypeRobotLocationSecret,

--- a/docs/program/apis/robot.md
+++ b/docs/program/apis/robot.md
@@ -116,13 +116,12 @@ Add a `timeout` to [`DialOptions`](https://python.viam.dev/autoapi/viam/rpc/dial
 dial_options = DialOptions(credentials=creds, timeout=10)
 ```
 
-The default timeout in Python is 20 seconds.
 The example above shows a timeout of 10 seconds configured.
 
 {{% /tab %}}
 {{% tab name="Go" %}}
 
-Import the `time` package, add a timeout to your context, and check the timeout as needed:
+Import the `time` package, then add a timeout to your context using `WithTimeout`:
 
 ```go {class="line-numbers linkable-line-numbers"}
 // Import the time package in addition to the other imports:
@@ -132,19 +131,24 @@ import (
   ...
 )
 
-// Add a timeout to the context ctx in your main() connection function:
-timeoutContext, cancel := context.WithTimeout(ctx, 10 * time.Second)
-
-// Add a check to see if the deadline has elapsed:
-deadline, ok := timeoutContext.Deadline()
-      if ok {
-          // deadline not yet elapsed
-      } else {
-          // deadline elapsed
-      }
+// Edit your main() to configure a timeoutContext, then pass this context to the dial invocation:
+func main() {
+  ctx := context.Background()
+  timeoutContext, cancel := context.WithTimeout(ctx, 10*time.Second)
+  defer cancel()
+  robot, err := client.New(
+      timeoutContext,
+      "ADDRESS FROM THE VIAM APP",
+      logger,
+      client.WithDialOptions(rpc.WithCredentials(rpc.Credentials{
+          Type:    utils.CredentialsTypeRobotLocationSecret,
+          Payload: "YOUR LOCATION SECRET",
+      })),
+  )
+...
+}
 ```
 
-The default timeout in Go is 20 seconds.
 The example above shows a timeout of 10 seconds configured.
 
 {{% /tab %}}

--- a/docs/program/apis/robot.md
+++ b/docs/program/apis/robot.md
@@ -10,7 +10,7 @@ tags: ["robot state", "sdk", "apis", "robot api"]
 The _robot API_ is the application programming interface that manages each of your smart machines running `viam-server`.
 Use the robot API to connect to your smart machine from within a supported [Viam SDK](/program/apis/), and send commands remotely.
 
-The robot API is supported for use with the [Viam Python SDK](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient), the [RDK (the Viam Go SDK)](https://pkg.go.dev/go.viam.com/rdk/robot/client#RobotClient), and the [Viam C++ SDK](https://cpp.viam.dev/classviam_1_1sdk_1_1RobotClient.html).
+The robot API is supported for use with the [Viam Python SDK](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient), the [the Viam Go SDK](https://pkg.go.dev/go.viam.com/rdk/robot/client#RobotClient), and the [Viam C++ SDK](https://cpp.viam.dev/classviam_1_1sdk_1_1RobotClient.html).
 
 ## Establish a connection
 
@@ -157,7 +157,7 @@ The example above shows a timeout of 10 seconds configured.
 ## API
 
 The robot API support the following selected methods.
-For the full list of methods, see the [Viam Python SDK documentation](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient) or the [RDK (the Viam Go SDK) documentation](https://pkg.go.dev/go.viam.com/rdk/robot/client#RobotClient).
+For the full list of methods, see the [Viam Python SDK documentation](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient) or the [Viam Go SDK documentation](https://pkg.go.dev/go.viam.com/rdk/robot/client#RobotClient).
 
 {{< readfile "/static/include/services/apis/robot.md" >}}
 

--- a/docs/program/apis/robot.md
+++ b/docs/program/apis/robot.md
@@ -16,9 +16,8 @@ The robot API is supported for use with the [Viam Python SDK](<[`RobotClient`](h
 
 To interact with the robot API with Viam's SDKs, instantiate a `RobotClient` ([gRPC](https://grpc.io/) client) and use that class for all interactions.
 
-To find the location secret, go to [Viam app](https://app.viam.com/), and go to the [**Code sample**](https://docs.viam.com/manage/fleet/robots/#code-sample) tab of any of the robots in the location.
-Toggle **Include secret** on and copy the `payload`.
-For the URL, use the address of any of the robots in the location (also found on the **Code sample** tab).
+To find the location secret and smart machine address, go to [Viam app](https://app.viam.com/), select the robot you wish to connect to, and go to the [**Code sample**](https://docs.viam.com/manage/fleet/robots/#code-sample) tab.
+Toggle **Include secret**, then copy the location secret and robot address into the code below where indicated:
 
 {{< tabs >}}
 {{% tab name="Python" %}}
@@ -38,10 +37,10 @@ async def connect():
         refresh_interval=0,
         dial_options=DialOptions(credentials=creds)
     )
-    return await RobotClient.at_address('smart-machine-main.YOUR LOCATION ID.viam.cloud', opts)
+    return await RobotClient.at_address('ADDRESS FROM THE VIAM APP', opts)
+
 
 async def main():
-
     # Make a RobotClient
     robot_client = await connect()
     print('Resources:')

--- a/docs/program/apis/robot.md
+++ b/docs/program/apis/robot.md
@@ -10,7 +10,7 @@ tags: ["robot state", "sdk", "apis", "robot api"]
 The _robot API_ is the application programming interface that manages each of your smart machines running `viam-server`.
 Use the robot API to connect to your smart machine from within a supported [Viam SDK](/program/apis/), and send commands remotely.
 
-The robot API is supported for use with the [Viam Python SDK]([`RobotClient`](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient)), the [RDK (the Viam go SDK)](https://pkg.go.dev/go.viam.com/rdk/robot/client#RobotClient), and the [Viam C++ SDK](https://cpp.viam.dev/classviam_1_1sdk_1_1RobotClient.html).
+The robot API is supported for use with the [Viam Python SDK](<[`RobotClient`](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient)>), the [RDK (the Viam go SDK)](https://pkg.go.dev/go.viam.com/rdk/robot/client#RobotClient), and the [Viam C++ SDK](https://cpp.viam.dev/classviam_1_1sdk_1_1RobotClient.html).
 
 ## Establish a connection
 
@@ -55,7 +55,6 @@ You can use this code to connect to your smart machine and instantiate a `RobotC
 As an example, this code uses the instantiated `RobotClient` to return the {{< glossary_tooltip term_id="resource" text="resources" >}} currently configured.
 Remember to always close the connection (using `close()`) when done.
 
-
 {{% /tab %}}
 {{% tab name="Go" %}}
 
@@ -85,7 +84,7 @@ func main() {
   if err != nil {
       logger.Fatal(err)
   }
- 
+
   defer robot.Close(context.Background())
   logger.Info("Resources:")
   logger.Info(robot.ResourceNames())
@@ -150,7 +149,8 @@ The example above shows a timeout of 10 seconds configured.
 
 ## API
 
-These are some of the supported robot API methods. For the full list, see the [Viam Python SDK](https://python.viam.dev/autoapi/viam/proto/robot/index.html#module-viam.proto.robot).
+The robot API support the following selected methods.
+For the full list of methods, see the [Viam Python SDK](https://python.viam.dev/autoapi/viam/proto/robot/index.html#module-viam.proto.robot).
 
 {{< readfile "/static/include/services/apis/robot.md" >}}
 

--- a/docs/program/apis/robot.md
+++ b/docs/program/apis/robot.md
@@ -109,20 +109,23 @@ To configure a timeout when using the robot API:
 {{< tabs >}}
 {{% tab name="Python" %}}
 
+Add a `timeout` to [`DialOptions`](https://python.viam.dev/autoapi/viam/rpc/dial/index.html#viam.rpc.dial.DialOptions):
+
 ```python {class="line-numbers linkable-line-numbers"}
 # Add the timeout argument to DialOptions:
 dial_options = DialOptions(credentials=creds, timeout=10)
 ```
 
-By default, Python does not use a timeout, and will wait for a response as long as needed.
-You can use set the `timeout` to a maximum of 20 seconds.
+The default timeout in Python is 20 seconds.
 The example above shows a timeout of 10 seconds configured.
 
 {{% /tab %}}
 {{% tab name="Go" %}}
 
+Import the `time` package, add a timeout to your context, and check the timeout as needed:
+
 ```go {class="line-numbers linkable-line-numbers"}
-// Additionally import the time package:
+// Import the time package in addition to the other imports:
 import (
   ...
   "time"
@@ -141,7 +144,7 @@ deadline, ok := timeoutContext.Deadline()
       }
 ```
 
-The Go default timeout is 5 seconds, and the maximum configurable timeout is 20 seconds.
+The default timeout in Go is 20 seconds.
 The example above shows a timeout of 10 seconds configured.
 
 {{% /tab %}}

--- a/docs/program/apis/robot.md
+++ b/docs/program/apis/robot.md
@@ -10,7 +10,7 @@ tags: ["robot state", "sdk", "apis", "robot api"]
 The _robot API_ is the application programming interface that manages each of your smart machines running `viam-server`.
 Use the robot API to connect to your smart machine from within a supported [Viam SDK](/program/apis/), and send commands remotely.
 
-The robot API is supported for use with the [Viam Python SDK](<[`RobotClient`](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient)>), the [RDK (the Viam go SDK)](https://pkg.go.dev/go.viam.com/rdk/robot/client#RobotClient), and the [Viam C++ SDK](https://cpp.viam.dev/classviam_1_1sdk_1_1RobotClient.html).
+The robot API is supported for use with the [Viam Python SDK](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient), the [RDK (the Viam go SDK)](https://pkg.go.dev/go.viam.com/rdk/robot/client#RobotClient), and the [Viam C++ SDK](https://cpp.viam.dev/classviam_1_1sdk_1_1RobotClient.html).
 
 ## Establish a connection
 

--- a/docs/program/apis/robot.md
+++ b/docs/program/apis/robot.md
@@ -29,13 +29,14 @@ import asyncio
 from viam.rpc.dial import DialOptions, Credentials
 from viam.robot.client import RobotClient
 
+
 async def connect():
     creds = Credentials(
         type='robot-location-secret',
         payload='YOUR LOCATION SECRET')
     opts = RobotClient.Options(
         refresh_interval=0,
-        dial_options=DialOptions(credentials=creds)
+        dial_options = DialOptions(credentials=creds)
     )
     return await RobotClient.at_address('smart-machine-main.YOUR LOCATION ID.viam.cloud', opts)
 
@@ -111,7 +112,7 @@ To configure a timeout when using the robot API:
 
 ```python {class="line-numbers linkable-line-numbers"}
 # Add the timeout argument to DialOptions:
-dial_options=DialOptions(credentials=creds, timeout=10)
+dial_options = DialOptions(credentials=creds, timeout=10)
 ```
 
 By default, Python does not use a timeout, and will wait for a response as long as needed.

--- a/docs/program/apis/robot.md
+++ b/docs/program/apis/robot.md
@@ -10,13 +10,13 @@ tags: ["robot state", "sdk", "apis", "robot api"]
 The _robot API_ is the application programming interface that manages each of your smart machines running `viam-server`.
 Use the robot API to connect to your smart machine from within a supported [Viam SDK](/program/apis/), and send commands remotely.
 
-The robot API is supported for use with the [Viam Python SDK](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient), the [RDK (the Viam go SDK)](https://pkg.go.dev/go.viam.com/rdk/robot/client#RobotClient), and the [Viam C++ SDK](https://cpp.viam.dev/classviam_1_1sdk_1_1RobotClient.html).
+The robot API is supported for use with the [Viam Python SDK](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient), the [RDK (the Viam Go SDK)](https://pkg.go.dev/go.viam.com/rdk/robot/client#RobotClient), and the [Viam C++ SDK](https://cpp.viam.dev/classviam_1_1sdk_1_1RobotClient.html).
 
 ## Establish a connection
 
 To interact with the robot API with Viam's SDKs, instantiate a `RobotClient` ([gRPC](https://grpc.io/) client) and use that class for all interactions.
 
-To find the location secret and smart machine address, go to [Viam app](https://app.viam.com/), select the robot you wish to connect to, and go to the [**Code sample**](https://docs.viam.com/manage/fleet/robots/#code-sample) tab.
+To find the location secret and robot address, go to [Viam app](https://app.viam.com/), select the robot you wish to connect to, and go to the [**Code sample**](https://docs.viam.com/manage/fleet/robots/#code-sample) tab.
 Toggle **Include secret**, then copy the location secret and robot address into the code below where indicated:
 
 {{< tabs >}}
@@ -51,7 +51,7 @@ if __name__ == '__main__':
     asyncio.run(main())
 ```
 
-You can use this code to connect to your smart machine and instantiate a `RobotClient` that you can then use with the [Robot API](#api).
+You can use this code to connect to your smart machine and instantiate a `RobotClient` that you can then use with the [robot API](#api).
 As an example, this code uses the instantiated `RobotClient` to return the {{< glossary_tooltip term_id="resource" text="resources" >}} currently configured.
 Remember to always close the connection (using `close()`) when done.
 
@@ -74,7 +74,7 @@ func main() {
   logger := golog.NewDevelopmentLogger("client")
   robot, err := client.New(
       context.Background(),
-      "smart-machine-main.YOUR LOCATION ID.viam.cloud",
+      "ADDRESS FROM THE VIAM APP",
       logger,
       client.WithDialOptions(rpc.WithCredentials(rpc.Credentials{
           Type:    utils.CredentialsTypeRobotLocationSecret,
@@ -98,7 +98,7 @@ Remember to always close the connection (using `Close()`) when done.
 {{% /tab %}}
 {{< /tabs >}}
 
-Once you have instantiated the robot client, you can run any of the [Robot API methods](#api) against the `robot` object to communicate with your smart machine.
+Once you have instantiated the robot client, you can run any of the [robot API methods](#api) against the `robot` object to communicate with your smart machine.
 
 ### Configure a timeout
 
@@ -150,7 +150,7 @@ The example above shows a timeout of 10 seconds configured.
 ## API
 
 The robot API support the following selected methods.
-For the full list of methods, see the [Viam Python SDK](https://python.viam.dev/autoapi/viam/proto/robot/index.html#module-viam.proto.robot).
+For the full list of methods, see the [Viam Python SDK documentation](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient) or the [RDK (the Viam Go SDK) documentation](https://pkg.go.dev/go.viam.com/rdk/robot/client#RobotClient).
 
 {{< readfile "/static/include/services/apis/robot.md" >}}
 
@@ -547,3 +547,5 @@ For more information, see the [Typescript SDK Docs](https://ts.viam.dev/classes/
 
 {{% /tab %}}
 {{< /tabs >}}
+
+For the full list of robot API methods, see the [Viam Python SDK documentation](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient) or the [RDK (the Viam Go SDK) documentation](https://pkg.go.dev/go.viam.com/rdk/robot/client#RobotClient).

--- a/docs/program/connectivity.md
+++ b/docs/program/connectivity.md
@@ -24,3 +24,7 @@ When a robot loses its connection to LAN or WAN, all client sessions will timeou
 When your client cannot connect to your robot's `viam-server` instance, `viam-server` will end any current client [_sessions_](/program/apis/sessions/) on this robot and all client operations will [timeout automatically](/program/apis/sessions/#heartbeats) and halt: any active commands will be cancelled, stopping any moving parts, and no new commands will be able to reach the robot until the connection is restored.
 
 To disable the default behavior and manage resource timeout and reconfiguration over a networking session yourself, you can [disable the default behavior](/program/apis/sessions/#disable-default-session-management) of session management, then use [Viam's SDKs](/program/) in your code to make calls to [the session management API](https://pkg.go.dev/go.viam.com/rdk/session#hdr-API).
+
+## Configure a connection timeout
+
+When connecting to a smart machine using the [robot API](/program/apis/robot/) from a supported [Viam SDK](/program/apis/), you can configure an [optional timeout](docs/program/apis/robot/#configure-a-timeout) to account for intermittent or delayed network connectivity.

--- a/docs/program/connectivity.md
+++ b/docs/program/connectivity.md
@@ -27,4 +27,4 @@ To disable the default behavior and manage resource timeout and reconfiguration 
 
 ## Configure a connection timeout
 
-When connecting to a smart machine using the [robot API](/program/apis/robot/) from a supported [Viam SDK](/program/apis/), you can configure an [optional timeout](docs/program/apis/robot/#configure-a-timeout) to account for intermittent or delayed network connectivity.
+When connecting to a smart machine using the [robot API](/program/apis/robot/) from a supported [Viam SDK](/program/apis/), you can configure an [optional timeout](/program/apis/robot/#configure-a-timeout) to account for intermittent or delayed network connectivity.


### PR DESCRIPTION
Add reference docs for new timeout support for the robot API.
- Includes new timeouts section to robot API reference page, with examples for both python and go
- We didn't have a "but first, connect to the robot using this template code" section yet, as we have for the [cloud API](https://docs.viam.com/program/apis/cloud/#establish-a-connection) so I added that in too. Can't have "configure a timeout on your connection" if you don't have "your connection".
- Some language tweaks while in there.

Noticed:
- C++ also supports a configurable timeout for `RobotClient`, but no DOCS ticket for that, [upstream ticket](https://viam.atlassian.net/browse/RSDK-5195) says docs changes needed: No.
- No timeout reference in [Go SDK docs for `RobotClient`](https://pkg.go.dev/go.viam.com/rdk/robot/client#RobotClient)

TODO:
- Likely will want to update this to use the new location API key, I think? Naomi's PR [here](https://github.com/viamrobotics/docs/pull/1916) from earlier today (location secrets still supported, but deprecated as of today). Will handle separately after this ticket.
