### PR TITLE
DOCS-1323: Document robotclient api key

### DIFF
--- a/docs/program/apis/robot.md
+++ b/docs/program/apis/robot.md
@@ -564,7 +564,7 @@ Create a client to interact with your robot using an API key as credentials.
 
 **Parameters:**
 
-- `api_key` [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Your [organization](/manage/cli/#create-an-organization-api-key), [location](/manage/cli/#create-a-location-api-key), or [robot](/manage/cli/#create-a-robot-api-key) API key.
+- `api_key` [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): [An API key](/manage/cli/#authenticate) with access to the robot.
 
 - `api_key_id` [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Your API key ID.
   Must be a valid UUID.
@@ -573,7 +573,7 @@ Create a client to interact with your robot using an API key as credentials.
 
 - [(RobotClient.Options)](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient): A gRPC client for interacting with your robot.
 
-[(List[viam.proto.common.ResourceName])](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.ResourceName): List of all known resource names. A property of a [RobotClient](https://python.viam.dev/autoapi/viam/robot/client/index.html)
+- [(List[viam.proto.common.ResourceName])](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.ResourceName): List of all known resource names. A property of a [RobotClient](https://python.viam.dev/autoapi/viam/robot/client/index.html)
 
 ```python
 api_key = "your_api_key"
@@ -585,4 +585,3 @@ robot_client = RobotClient.with_api_key(api_key, api_key_id)
 {{< /tabs >}}
 
 For the full list of robot API methods, see the [Viam Python SDK documentation](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient) or the [RDK (the Viam Go SDK) documentation](https://pkg.go.dev/go.viam.com/rdk/robot/client#RobotClient).
-

--- a/docs/program/apis/robot.md
+++ b/docs/program/apis/robot.md
@@ -408,3 +408,32 @@ For more information, see the [Typescript SDK Docs](https://ts.viam.dev/classes/
 
 {{% /tab %}}
 {{< /tabs >}}
+
+### WithAPIKey
+
+Create a client to interact with your robot using an API key as credentials.
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `api_key` [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Your [organization](/manage/cli/#create-an-organization-api-key), [location](/manage/cli/#create-a-location-api-key), or [robot](/manage/cli/#create-a-robot-api-key) API key.
+
+- `api_key_id` [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Your API key ID.
+  Must be a valid UUID.
+
+**Returns:**
+
+- [(RobotClient.Options)](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient): A gRPC client for interacting with your robot.
+
+[(List[viam.proto.common.ResourceName])](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.ResourceName): List of all known resource names. A property of a [RobotClient](https://python.viam.dev/autoapi/viam/robot/client/index.html)
+
+```python
+api_key = "your_api_key"
+api_key_id = "valid_uuid"
+robot_client = RobotClient.with_api_key(api_key, api_key_id)
+```
+
+{{% /tab %}}
+{{< /tabs >}}

--- a/static/include/services/apis/robot.md
+++ b/static/include/services/apis/robot.md
@@ -1,8 +1,9 @@
-Method Name | Description
------------ | -----------
-[`DiscoverComponents`](/program/apis/robot/#discovercomponents) | Get a list of discovered component configurations.
-[`FrameSystemConfig`](/program/apis/robot/#framesystemconfig) | Get the configuration of a robot's frame system.
-[`Status`](/program/apis/robot/#status) | Get the status of each of the resources on the robot.
-[`Close`](/program/apis/robot/#close) | Close the connections and stop periodic tasks across the robot.
-[`StopAll`](/program/apis/robot/#stopall) | Cancel all operations for the robot and stop its movement.
-[`ResourceNames`](/program/apis/robot/#resourcenames) | Get a list of all the robot's resources.
+| Method Name                                                     | Description                                                                  |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| [`DiscoverComponents`](/program/apis/robot/#discovercomponents) | Get a list of discovered component configurations.                           |
+| [`FrameSystemConfig`](/program/apis/robot/#framesystemconfig)   | Get the configuration of a robot's frame system.                             |
+| [`Status`](/program/apis/robot/#status)                         | Get the status of each of the resources on the robot.                        |
+| [`Close`](/program/apis/robot/#close)                           | Close the connections and stop periodic tasks across the robot.              |
+| [`StopAll`](/program/apis/robot/#stopall)                       | Cancel all operations for the robot and stop its movement.                   |
+| [`ResourceNames`](/program/apis/robot/#resourcenames)           | Get a list of all the robot's resources.                                     |
+| [`WithAPIKey`](/program/api/robot/#withapikey)                  | Create a client to interact with your robot using an API key as credentials. |

--- a/static/include/services/apis/robot.md
+++ b/static/include/services/apis/robot.md
@@ -6,4 +6,4 @@
 | [`Close`](/program/apis/robot/#close)                           | Close the connections and stop periodic tasks across the robot.              |
 | [`StopAll`](/program/apis/robot/#stopall)                       | Cancel all operations for the robot and stop its movement.                   |
 | [`ResourceNames`](/program/apis/robot/#resourcenames)           | Get a list of all the robot's resources.                                     |
-| [`WithAPIKey`](/program/api/robot/#withapikey)                  | Create a client to interact with your robot using an API key as credentials. |
+| [`WithAPIKey`](/program/apis/robot/#withapikey)                 | Create a client to interact with your robot using an API key as credentials. |


### PR DESCRIPTION
Add the `with_api_key` method from Python SDK to Robot API docs
