### PR TITLE
DOCS-1335: Add queryable sensor data docs

### DIFF
--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -348,9 +348,9 @@ viam data export --destination=/home/robot/data --data_type=tabular \
 viam data export --destination=/home/robot/data --data-type=binary \
 --component-name myComponent
 
-# configure a new database use for use with data query
+# configure a new database user for use with data query
 viam data database hostname --org-id=abc
-viam data database configure --org-id=abc --password my_new_secure_password123
+viam data database configure --org-id=abc --password=my_new_secure_password123
 ```
 
 #### Command options

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -334,7 +334,7 @@ With it, you can export data in the format of your choice, delete specified data
 ```sh {class="command-line" data-prompt="$"}
 viam data export --destination=<output path> --data-type=<output data type> [...named args]
 viam data delete [...named args]
-viam data database configure --org-id <org-id> --password <db-user-password>
+viam data database configure --org-id=<org-id> --password=<db-user-password>
 ```
 
 Examples:

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -329,12 +329,12 @@ viam board list --organization=my-org
 ### data
 
 The `data` command allows you to manage robot data.
-With it, you can export data in the format of your choice or delete specified data.
-You can filter the data this command operates on.
+With it, you can export data in the format of your choice, delete specified data, or configure a database user to enable querying synced data directly in the cloud.
 
 ```sh {class="command-line" data-prompt="$"}
 viam data export --destination=<output path> --data-type=<output data type> [...named args]
 viam data delete [...named args]
+viam data database configure --org-id <org-id> --password <db-user-password>
 ```
 
 Examples:
@@ -347,6 +347,10 @@ viam data export --destination=/home/robot/data --data_type=tabular \
 # export binary data from all orgs and locations, component name myComponent
 viam data export --destination=/home/robot/data --data-type=binary \
 --component-name myComponent
+
+# configure a new database use for use with data query
+viam data database hostname --org-id=abc
+viam data database configure --org-id=abc --password my_new_secure_password123
 ```
 
 #### Command options
@@ -378,7 +382,7 @@ viam data export --destination=/home/robot/data --data-type=binary \
 | `--method`       | filter by specified method       |`export`, `delete`| false |
 | `--mime-types`      | filter by specified MIME type (accepts comma-separated list)       |`export`, `delete`|false |
 | `--org-ids`     | filter by specified organizations id (accepts comma-separated list)       |`export`, `delete`| false |
-| `--parallel`      | number of download requests to make in parallel, with a default value of 10       |`export`, `delete`|f alse |
+| `--parallel`      | number of download requests to make in parallel, with a default value of 10       |`export`, `delete`|false |
 | `--part-id`      | filter by specified part id      |`export`, `delete`| false |
 | `--part-name`     | filter by specified part name       |`export`, `delete`| false |
 | `--robot-id`     | filter by specified robot id       |`export`, `delete`| false |

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -361,7 +361,7 @@ viam data database hostname --org-id=abc
 | ----------- | ----------- | ----------- |
 | `export`      | export data in a specified format to a specified location  | - |
 | `database configure`      | create a new database user for the Viam organization's MongoDB Atlas Data Federation instance, or change the password of an existing user. See [Configure data query](/services/data/configure-data-query)  | - |
-| `database hostname`      | get your organization's MongoDB Atlas Data Federation instance hostname. See [Configure data query](/services/data/configure-data-query)  | - |
+| `database hostname`      | get the MongoDB Atlas Data Federation instance hostname and database name. See [Configure data query](/services/data/configure-data-query)  | - |
 | `delete binary`      | delete binary data  | - |
 | `delete tabular`      | delete tabular data  | - |
 | `--help`      | return help      | - |

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -329,7 +329,7 @@ viam board list --organization=my-org
 ### data
 
 The `data` command allows you to manage robot data.
-With it, you can export data in the format of your choice, delete specified data, or configure a database user to enable querying synced data directly in the cloud.
+With it, you can export data in the format of your choice, delete specified data, or configure a database user to enable querying synced tabular data directly in the cloud.
 
 ```sh {class="command-line" data-prompt="$"}
 viam data export --destination=<output path> --data-type=<output data type> [...named args]
@@ -348,9 +348,10 @@ viam data export --destination=/home/robot/data --data_type=tabular \
 viam data export --destination=/home/robot/data --data-type=binary \
 --component-name myComponent
 
-# configure a new database user for use with data query
-viam data database hostname --org-id=abc
+# configure a database user for the Viam organization's MongoDB Atlas Data
+# Federation instance, in order to query tabular data
 viam data database configure --org-id=abc --password=my_new_secure_password123
+viam data database hostname --org-id=abc
 ```
 
 #### Command options
@@ -359,8 +360,8 @@ viam data database configure --org-id=abc --password=my_new_secure_password123
 |        command option     |       description      | positional arguments
 | ----------- | ----------- | ----------- |
 | `export`      | export data in a specified format to a specified location  | - |
-| `database configure`      | configure a database user for the Viam org's MongoDB Atlas Data Federation instance  | - |
-| `database hostname`      | get the hostname to access a MongoDB Atlas Data Federation Instance  | - |
+| `database configure`      | create a new database user for the Viam organization's MongoDB Atlas Data Federation instance, or change the password of an existing user. See [Configure data query](/services/data/configure-data-query)  | - |
+| `database hostname`      | get your organization's MongoDB Atlas Data Federation instance hostname. See [Configure data query](/services/data/configure-data-query)  | - |
 | `delete binary`      | delete binary data  | - |
 | `delete tabular`      | delete tabular data  | - |
 | `--help`      | return help      | - |

--- a/docs/manage/CLI.md
+++ b/docs/manage/CLI.md
@@ -350,7 +350,7 @@ viam data export --destination=/home/robot/data --data-type=binary \
 
 # configure a database user for the Viam organization's MongoDB Atlas Data
 # Federation instance, in order to query tabular data
-viam data database configure --org-id=abc --password=my_new_secure_password123
+viam data database configure --org-id=abc --password=my_password123
 viam data database hostname --org-id=abc
 ```
 
@@ -360,8 +360,8 @@ viam data database hostname --org-id=abc
 |        command option     |       description      | positional arguments
 | ----------- | ----------- | ----------- |
 | `export`      | export data in a specified format to a specified location  | - |
-| `database configure`      | create a new database user for the Viam organization's MongoDB Atlas Data Federation instance, or change the password of an existing user. See [Configure data query](/services/data/configure-data-query)  | - |
-| `database hostname`      | get the MongoDB Atlas Data Federation instance hostname and database name. See [Configure data query](/services/data/configure-data-query)  | - |
+| `database configure`      | create a new database user for the Viam organization's MongoDB Atlas Data Federation instance, or change the password of an existing user. See [Configure data query](/services/data/configure-data-query/)  | - |
+| `database hostname`      | get the MongoDB Atlas Data Federation instance hostname and database name. See [Configure data query](/services/data/configure-data-query/)  | - |
 | `delete binary`      | delete binary data  | - |
 | `delete tabular`      | delete tabular data  | - |
 | `--help`      | return help      | - |

--- a/docs/services/data/_index.md
+++ b/docs/services/data/_index.md
@@ -14,12 +14,12 @@ icon: "/services/icons/data-capture.svg"
 ---
 
 The data management service captures data from Viam components and securely syncs data to Viam's cloud.
-You can configure capture frequency individually for each component.
+You can configure capture frequency individually for each component, and you can directly query select types of synced data in the cloud.
 The service is designed for flexibility and efficiency while preventing data loss, data duplication, and other data management issues.
 
-The service has two parts: [Data Capture](#data-capture) and [Cloud Sync](#cloud-sync).
+The service has three parts: [data capture](#data-capture), [cloud sync](#cloud-sync), and [data query](#data-query).
 
-## Data Capture
+## Data capture
 
 The data management service captures data from one or more components locally on the robot's storage.
 The process runs in the background and, by default, stores data in the `~/.viam/capture` directory.
@@ -41,9 +41,9 @@ If your requirements change and you want to capture data from both components at
 Data capture is frequently used with [Cloud Sync](#cloud-sync).
 However, if you want to manage your robot's captured data yourself, you can enable only data capture without cloud sync.
 
-To configure data capture, see [data capture](../data/configure-data-capture/).
+To configure data capture, see [data capture](/services/data/configure-data-capture/).
 
-## Used With
+## Used with
 
 {{< cards >}}
 {{< relatedcard link="/components/arm/">}}
@@ -59,7 +59,7 @@ To configure data capture, see [data capture](../data/configure-data-capture/).
 
 {{% snippet "required-legend.md" %}}
 
-## Cloud Sync
+## Cloud sync
 
 The data management service securely syncs the specified data to the cloud at the user-defined frequency.
 Viam does not impose a minimum or maximum on the frequency of data syncing.
@@ -75,7 +75,7 @@ As before, consider the example of a tomato picking robot.
 When you initially set the robot up you may want to sync captured data to the cloud every five minutes.
 If you change your mind and want your robot to sync less frequently, you can change the sync frequency, for example, to once a day.
 
-To configure cloud sync, see [configure cloud sync](../data/configure-cloud-sync/).
+To configure cloud sync, see [configure cloud sync](/services/data/configure-cloud-sync/).
 
 ### Considerations
 
@@ -102,6 +102,19 @@ To configure cloud sync, see [configure cloud sync](../data/configure-cloud-sync
   Currently, Viam does not safeguard against this.
 
   {{< /alert >}}
+
+
+## Data query
+
+Once you have synced data to the cloud, you can query certain types of data directly in the cloud using MQL, the [MongoDB query language](https://www.mongodb.com/docs/manual/tutorial/query-documents/).
+Synced data is stored in a MongoDB [Atlas Data Federation](https://www.mongodb.com/docs/atlas/data-federation/overview/) instance.
+
+Both the captured data itself as well as its metadata (such as robot ID, organization ID, and [tags](docs/manage/data/label/#image-tags)) are available for queries.
+
+In order to query data using MQL, you must have first [captured data](/services/data/configure-data-capture/) and [synced data](/services/data/configure-cloud-sync/) to the cloud.
+You must also configure a new database connection to the Viam cloud data store using the Viam CLI.
+
+To configure data query, see [configure data query](/services/data/configure-data-query/).
 
 ## API
 
@@ -150,18 +163,18 @@ err := data.Sync(context.Background(), nil)
 {{% /tab %}}
 {{< /tabs >}}
 
-## Next Steps
+## Next steps
 
 To use the data management service, [add the data management service](configure-data-capture/#add-the-data-management-service) to your robot.
 Then [configure data capture](configure-data-capture/) as needed and [configure cloud sync](configure-cloud-sync/).
 
 For a comprehensive tutorial on data management, see [Intro to Data Management](../../tutorials/services/data-management-tutorial/).
 
-### Access and Export Data
+### Access and export data
 
 Once you have configured data capture and cloud sync, you can [view](../../manage/data/view/) and [export](../../manage/data/export/) your data.
 
-### Train and Deploy Machine Learning
+### Train and deploy machine learning
 
 You can use data synced to the cloud to [train machine learning models](../../manage/ml/train-model/) and then [deploy these models to your robots](../../services/ml/) from the Viam app.
 You can also [upload and use existing models](../../manage/ml/upload-model/).

--- a/docs/services/data/_index.md
+++ b/docs/services/data/_index.md
@@ -108,7 +108,7 @@ To configure cloud sync, see [configure cloud sync](/services/data/configure-clo
 Once you have synced data to the cloud, you can query certain types of data directly in the cloud using MQL, the [MongoDB query language](https://www.mongodb.com/docs/manual/tutorial/query-documents/).
 Synced data is stored in a MongoDB [Atlas Data Federation](https://www.mongodb.com/docs/atlas/data-federation/overview/) instance.
 
-Both the captured data itself as well as its metadata (such as robot ID, organization ID, and [tags](/manage/data/label/#image-tags)) are available for queries.
+You can query both the captured data itself as well as its metadata (such as robot ID, organization ID, and [tags](/manage/data/label/#image-tags)).
 
 In order to query data using MQL, you must have first [captured data](/services/data/configure-data-capture/) and [synced data](/services/data/configure-cloud-sync/) to the cloud.
 You must also configure a new database connection to the Viam cloud data store using the Viam CLI.

--- a/docs/services/data/_index.md
+++ b/docs/services/data/_index.md
@@ -103,7 +103,6 @@ To configure cloud sync, see [configure cloud sync](/services/data/configure-clo
 
   {{< /alert >}}
 
-
 ## Data query
 
 Once you have synced data to the cloud, you can query certain types of data directly in the cloud using MQL, the [MongoDB query language](https://www.mongodb.com/docs/manual/tutorial/query-documents/).

--- a/docs/services/data/_index.md
+++ b/docs/services/data/_index.md
@@ -113,7 +113,7 @@ You can query both the captured tabular data itself as well as its metadata (suc
 In order to query data, you must have first [captured data](/services/data/configure-data-capture/) and [synced data](/services/data/configure-cloud-sync/) to the cloud.
 You must also configure a new database connection to the Viam organization's MongoDB Atlas Data Federation instance using the Viam CLI.
 
-To configure data query, see [configure data query](/services/data/configure-data-query/).
+To configure data query, see [Configure data query](/services/data/configure-data-query/).
 
 ## API
 

--- a/docs/services/data/_index.md
+++ b/docs/services/data/_index.md
@@ -105,10 +105,10 @@ To configure cloud sync, see [configure cloud sync](/services/data/configure-clo
 
 ## Data query
 
-Once you have synced data to the cloud, you can query certain types of data directly in the cloud using MQL, the [MongoDB query language](https://www.mongodb.com/docs/manual/tutorial/query-documents/).
+Once you have synced data to the cloud, you can query tabular data directly in the cloud using either SQL or MQL, the [MongoDB query language](https://www.mongodb.com/docs/manual/tutorial/query-documents/).
 Synced data is stored in a MongoDB [Atlas Data Federation](https://www.mongodb.com/docs/atlas/data-federation/overview/) instance.
 
-You can query both the captured data itself as well as its metadata (such as robot ID, organization ID, and [tags](/manage/data/label/#image-tags)).
+You can query both the captured tabular data itself as well as its metadata (such as robot ID, organization ID, and [tags](/manage/data/label/#image-tags)).
 
 In order to query data using MQL, you must have first [captured data](/services/data/configure-data-capture/) and [synced data](/services/data/configure-cloud-sync/) to the cloud.
 You must also configure a new database connection to the Viam cloud data store using the Viam CLI.

--- a/docs/services/data/_index.md
+++ b/docs/services/data/_index.md
@@ -14,10 +14,10 @@ icon: "/services/icons/data-capture.svg"
 ---
 
 The data management service captures data from Viam components and securely syncs data to Viam's cloud.
-You can configure capture frequency individually for each component, and you can directly query select types of synced data in the cloud.
+You can configure capture frequency individually for each component.
 The service is designed for flexibility and efficiency while preventing data loss, data duplication, and other data management issues.
 
-The service has three parts: [data capture](#data-capture), [cloud sync](#cloud-sync), and [data query](#data-query).
+The service has two parts: [data capture](#data-capture) and [cloud sync](#cloud-sync).
 
 ## Data capture
 
@@ -103,18 +103,6 @@ To configure cloud sync, see [configure cloud sync](/services/data/configure-clo
 
   {{< /alert >}}
 
-## Data query
-
-Once you have synced data to the cloud, you can query tabular data directly in the cloud using either MQL, the [MongoDB query language](https://www.mongodb.com/docs/manual/tutorial/query-documents/), or SQL.
-Synced data is stored in a MongoDB [Atlas Data Federation](https://www.mongodb.com/docs/atlas/data-federation/overview/) instance.
-
-You can query both the captured tabular data itself as well as its metadata (such as robot ID, organization ID, and [tags](/manage/data/label/#image-tags)).
-
-In order to query data, you must have first [captured data](/services/data/configure-data-capture/) and [synced data](/services/data/configure-cloud-sync/) to the cloud.
-You must also configure a new database connection to the Viam organization's MongoDB Atlas Data Federation instance using the Viam CLI.
-
-To configure data query, see [Configure data query](/services/data/configure-data-query/).
-
 ## API
 
 The data management service supports the following methods:
@@ -162,18 +150,25 @@ err := data.Sync(context.Background(), nil)
 {{% /tab %}}
 {{< /tabs >}}
 
-## Next steps
+## Use the data management service
 
-To use the data management service, [add the data management service](configure-data-capture/#add-the-data-management-service) to your robot.
-Then [configure data capture](configure-data-capture/) as needed and [configure cloud sync](configure-cloud-sync/).
+To use the data management service, [add the data management service](/services/data/configure-data-capture/#add-the-data-management-service) to your smart machine.
 
-For a comprehensive tutorial on data management, see [Intro to Data Management](../../tutorials/services/data-management-tutorial/).
+Then, [configure data capture](/services/data/configure-data-capture/) and [configure cloud sync](/services/data/configure-cloud-sync/) as needed.
 
-### Access and export data
+### Access, query, and export data
 
-Once you have configured data capture and cloud sync, you can [view](../../manage/data/view/) and [export](../../manage/data/export/) your data.
+Once you have configured data capture and cloud sync, you can [view your data](/manage/data/view/) in the Viam app from the **Data** tab.
+
+If you have uploaded tabular data, such as sensor readings, you can [configure data query](/services/data/configure-data-query/) to be able to query directly against that data using common query languages.
+
+You can also [export](/manage/data/export/) your data as needed.
 
 ### Train and deploy machine learning
 
 You can use data synced to the cloud to [train machine learning models](../../manage/ml/train-model/) and then [deploy these models to your robots](../../services/ml/) from the Viam app.
 You can also [upload and use existing models](../../manage/ml/upload-model/).
+
+## Next steps
+
+For a comprehensive tutorial on data management, see [Intro to Data Management](/tutorials/services/data-management-tutorial/).

--- a/docs/services/data/_index.md
+++ b/docs/services/data/_index.md
@@ -160,7 +160,7 @@ Then, [configure data capture](/services/data/configure-data-capture/) and [conf
 
 Once you have configured data capture and cloud sync, you can [view your data](/manage/data/view/) in the Viam app from the **Data** tab.
 
-If you have uploaded tabular data, such as sensor readings, you can [configure data query](/services/data/configure-data-query/) to be able to query directly against that data using common query languages.
+If you have uploaded tabular data, such as sensor readings, you can [configure data query](/services/data/configure-data-query/) to be able to query directly against that data using MQL or SQL.
 
 You can also [export](/manage/data/export/) your data as needed.
 

--- a/docs/services/data/_index.md
+++ b/docs/services/data/_index.md
@@ -108,7 +108,7 @@ To configure cloud sync, see [configure cloud sync](/services/data/configure-clo
 Once you have synced data to the cloud, you can query certain types of data directly in the cloud using MQL, the [MongoDB query language](https://www.mongodb.com/docs/manual/tutorial/query-documents/).
 Synced data is stored in a MongoDB [Atlas Data Federation](https://www.mongodb.com/docs/atlas/data-federation/overview/) instance.
 
-Both the captured data itself as well as its metadata (such as robot ID, organization ID, and [tags](docs/manage/data/label/#image-tags)) are available for queries.
+Both the captured data itself as well as its metadata (such as robot ID, organization ID, and [tags](/manage/data/label/#image-tags)) are available for queries.
 
 In order to query data using MQL, you must have first [captured data](/services/data/configure-data-capture/) and [synced data](/services/data/configure-cloud-sync/) to the cloud.
 You must also configure a new database connection to the Viam cloud data store using the Viam CLI.

--- a/docs/services/data/_index.md
+++ b/docs/services/data/_index.md
@@ -105,13 +105,13 @@ To configure cloud sync, see [configure cloud sync](/services/data/configure-clo
 
 ## Data query
 
-Once you have synced data to the cloud, you can query tabular data directly in the cloud using either SQL or MQL, the [MongoDB query language](https://www.mongodb.com/docs/manual/tutorial/query-documents/).
+Once you have synced data to the cloud, you can query tabular data directly in the cloud using either MQL, the [MongoDB query language](https://www.mongodb.com/docs/manual/tutorial/query-documents/), or SQL.
 Synced data is stored in a MongoDB [Atlas Data Federation](https://www.mongodb.com/docs/atlas/data-federation/overview/) instance.
 
 You can query both the captured tabular data itself as well as its metadata (such as robot ID, organization ID, and [tags](/manage/data/label/#image-tags)).
 
-In order to query data using MQL, you must have first [captured data](/services/data/configure-data-capture/) and [synced data](/services/data/configure-cloud-sync/) to the cloud.
-You must also configure a new database connection to the Viam cloud data store using the Viam CLI.
+In order to query data, you must have first [captured data](/services/data/configure-data-capture/) and [synced data](/services/data/configure-cloud-sync/) to the cloud.
+You must also configure a new database connection to the Viam organization's MongoDB Atlas Data Federation instance using the Viam CLI.
 
 To configure data query, see [configure data query](/services/data/configure-data-query/).
 

--- a/docs/services/data/configure-data-capture.md
+++ b/docs/services/data/configure-data-capture.md
@@ -87,7 +87,6 @@ For example, a camera has the options `ReadImage` and `NextPointCloud` and a mot
 {{%expand "Click to view an example JSON configuration capturing data from the ReadImage method of a camera" %}}
 
 ```json {class="line-numbers linkable-line-numbers"}
-
 {
   "services": [
     ...
@@ -178,50 +177,52 @@ The following example shows the configuration of the remote part, in this case a
 This config is just like that of a non-remote part; the remote connection is established by the main part (in the next expandable example).
 
 ```json {class="line-numbers linkable-line-numbers"}
-"components": [
-  {
-    "name": "my-esp32",
-    "model": "esp32",
-    "type": "board",
-    "namespace": "rdk",
-    "attributes": {
-      "pins": [27],
-      "analogs": [
+{
+  "components": [
+    {
+      "name": "my-esp32",
+      "model": "esp32",
+      "type": "board",
+      "namespace": "rdk",
+      "attributes": {
+        "pins": [27],
+        "analogs": [
+          {
+            "pin": "34",
+            "name": "A1"
+          },
+          {
+            "pin": "35",
+            "name": "A2"
+          }
+        ]
+      },
+      "service_configs": [
         {
-          "pin": "34",
-          "name": "A1"
-        },
-        {
-          "pin": "35",
-          "name": "A2"
+          "type": "data_manager",
+          "attributes": {
+            "capture_methods": [
+              {
+                "method": "Analogs",
+                "additional_params": {
+                  "reader_name": "A1"
+                },
+                "capture_frequency_hz": 10
+              },
+              {
+                "method": "Analogs",
+                "additional_params": {
+                  "reader_name": "A2"
+                },
+                "capture_frequency_hz": 10
+              }
+            ]
+          }
         }
       ]
-    },
-    "service_configs": [
-      {
-        "type": "data_manager",
-        "attributes": {
-          "capture_methods": [
-            {
-              "method": "Analogs",
-              "additional_params": {
-                "reader_name": "A1"
-              },
-              "capture_frequency_hz": 10
-            },
-            {
-              "method": "Analogs",
-              "additional_params": {
-                "reader_name": "A2"
-              },
-              "capture_frequency_hz": 10
-            }
-          ]
-        }
-      }
-    ]
-  }
-]
+    }
+  ]
+}
 ```
 
 {{% /expand%}}

--- a/docs/services/data/configure-data-capture.md
+++ b/docs/services/data/configure-data-capture.md
@@ -122,6 +122,7 @@ For example, a camera has the options `ReadImage` and `NextPointCloud` and a mot
                 "disabled": false,
                 "method": "ReadImage",
                 "additional_params": {
+                  "reader_name": "cam1",
                   "mime_type": "image/jpeg"
                 }
               }
@@ -177,29 +178,50 @@ The following example shows the configuration of the remote part, in this case a
 This config is just like that of a non-remote part; the remote connection is established by the main part (in the next expandable example).
 
 ```json {class="line-numbers linkable-line-numbers"}
-{
-  "components": [
-    {
-      "name": "my-esp32",
-      "model": "esp32",
-      "type": "board",
-      "attributes": {
-        "pins": [27],
-        "analogs": [
-          {
-            "pin": "34",
-            "name": "A1"
-          },
-          {
-            "pin": "35",
-            "name": "A2"
-          }
-        ]
-      },
-      "depends_on": []
-    }
-  ]
-}
+"components": [
+  {
+    "name": "my-esp32",
+    "model": "esp32",
+    "type": "board",
+    "namespace": "rdk",
+    "attributes": {
+      "pins": [27],
+      "analogs": [
+        {
+          "pin": "34",
+          "name": "A1"
+        },
+        {
+          "pin": "35",
+          "name": "A2"
+        }
+      ]
+    },
+    "service_configs": [
+      {
+        "type": "data_manager",
+        "attributes": {
+          "capture_methods": [
+            {
+              "method": "Analogs",
+              "additional_params": {
+                "reader_name": "A1"
+              },
+              "capture_frequency_hz": 10
+            },
+            {
+              "method": "Analogs",
+              "additional_params": {
+                "reader_name": "A2"
+              },
+              "capture_frequency_hz": 10
+            }
+          ]
+        }
+      }
+    ]
+  }
+]
 ```
 
 {{% /expand%}}
@@ -301,7 +323,8 @@ The following example captures data from the `ReadImage` method of a camera:
                 "disabled": false,
                 "method": "ReadImage",
                 "additional_params": {
-                  "mime_type": "image/jpeg"
+                  "mime_type": "image/jpeg",
+                  "reader_name": "cam1"
                 }
               }
             ]

--- a/docs/services/data/configure-data-query.md
+++ b/docs/services/data/configure-data-query.md
@@ -21,9 +21,9 @@ Before you can configure data query, you must:
 
 - [Add the data management service](/services/data/configure-data-capture/#add-the-data-management-service)
 - [Configure data capture](/services/data/configure-data-capture/) for at least one component, such as a sensor.
-   Only components that capture tabular data support data query.
+  Only components that capture tabular data support data query.
 - [Configure cloud sync](/services/data/configure-cloud-sync/), and sync data to the Viam app.
-   When you are able to [view your data in the Viam app](/manage/data/view/), you are ready to proceed.
+  When you are able to [view your data in the Viam app](/manage/data/view/), you are ready to proceed.
 
 ## Configure data query
 

--- a/docs/services/data/configure-data-query.md
+++ b/docs/services/data/configure-data-query.md
@@ -5,7 +5,7 @@ description: "Configure data query to query tabular data with MQL or SQL"
 weight: 35
 type: "docs"
 tags: ["data management", "cloud", "query", "sensor"]
-# SME: Aaron Casas
+# SME: Devin Hilly
 ---
 
 Configure data query to be able to directly query captured tabular data in the Viam cloud using [MQL](https://www.mongodb.com/docs/manual/tutorial/query-documents/) or SQL.
@@ -19,11 +19,11 @@ Only tabular data, such as [sensor](/components/sensor/) readings, can be querie
 
 Before you can configure data query, you must:
 
-- [Add the data management service](/services/data/configure-data-capture/#add-the-data-management-service)
-- [Configure data capture](/services/data/configure-data-capture/) for at least one component, such as a sensor.
-  Only components that capture tabular data support data query.
-- [Configure cloud sync](/services/data/configure-cloud-sync/), and sync data to the Viam app.
-  When you are able to [view your data in the Viam app](/manage/data/view/), you are ready to proceed.
+1. [Add the data management service](/services/data/configure-data-capture/#add-the-data-management-service)
+1. [Configure data capture](/services/data/configure-data-capture/) for at least one component, such as a sensor.
+   Only components that capture tabular data support data query.
+1. [Configure cloud sync](/services/data/configure-cloud-sync/), and sync data to the Viam app.
+   When you are able to [view your data in the Viam app](/manage/data/view/), you are ready to proceed.
 
 ## Configure data query
 
@@ -47,8 +47,7 @@ Once your smart machine has synced captured data to the Viam app, you can config
    This command configures a new database user for your org for use with data query.
    If you have already created this user, this command updates the password for that user instead.
 
-1. Determine the hostname for your organization's MongoDB Atlas Data Federation instance.
-   Provide your organization's `org-id` from step 2:
+1. Determine the hostname for your organization's MongoDB Atlas Data Federation instance by running the following command with the organization's `org-id` from step 2:
 
    ```sh {class="line-numbers linkable-line-numbers"}
    viam data database hostname --org-id=<YOUR-ORGANIZATION-ID>

--- a/docs/services/data/configure-data-query.md
+++ b/docs/services/data/configure-data-query.md
@@ -44,6 +44,9 @@ Once your smart machine has synced captured data to the Viam app, you can config
    viam data database configure --org-id=<YOUR-ORGANIZATION-ID> --password=<NEW-DBUSER-PASSWORD>
    ```
 
+   This command configures a new database user for your org for use with data query.
+   If you have already created this user, this command updates the password for that user instead.
+
 1. Determine the hostname for your organization's MongoDB Atlas Data Federation instance.
    Provide your organization's `org-id` from step 2:
 
@@ -70,13 +73,14 @@ For example, to connect to your Viam organization's MongoDB Atlas instance and q
 1. Run the following command to connect to the Viam organization's MongoDB Atlas instance from `mongosh`:
 
    ```sh {class="line-numbers linkable-line-numbers"}
-   mongosh "mongodb+srv://<YOUR-DB-HOSTNAME>" --apiVersion 1 --username <YOUR-DB-USER>
+   mongosh "mongodb+srv://<YOUR-DB-HOSTNAME>" --apiVersion 1 --username db-user-<YOUR-ORG-ID>
    ```
 
    Where:
 
    - `<YOUR-DB-HOSTNAME>` is your organization's assigned MongoDB Atlas instance hostname (including database name), as returned from `viam data database hostname` above.
-   - `<YOUR-DB-USER>` is your organization's database user for that Atlas instance, as returned from `viam data database configure` above.
+   - `<YOUR-ORG-ID>` is your organization ID as determined above.
+     The full username you provide to the `--username` flag should therefore resemble `db-user-abcdef12-abcd-abcd-abcd-abcdef123456`.
 
 1. Once connected, you can run [MQL](https://www.mongodb.com/docs/manual/tutorial/query-documents/) or SQL to query captured data directly. For example:
 

--- a/docs/services/data/configure-data-query.md
+++ b/docs/services/data/configure-data-query.md
@@ -4,7 +4,7 @@ linkTitle: "Configure Data Query"
 description: "Configure data query to query tabular data with MQL or SQL"
 weight: 35
 type: "docs"
-tags: ["data management", "cloud", "query"]
+tags: ["data management", "cloud", "query", "sensor"]
 # SME: Aaron Casas
 ---
 
@@ -14,7 +14,7 @@ Only tabular data, such as sensor data, can be queried in this fashion.
 
 ## Requirements
 
-Before you can configure [data query](../#data-query), you must [add the data management service](/services/data/configure-data-capture/#add-the-data-management-service) and [configure cloud sync](/services/data/configure-cloud-sync/).
+Before you can configure data query, you must [add the data management service](/services/data/configure-data-capture/#add-the-data-management-service) and [configure cloud sync](/services/data/configure-cloud-sync/).
 
 ## Configure data query
 
@@ -28,23 +28,23 @@ Once your smart machine has synced captured data to the Viam app, you can config
    viam organizations list
    ```
 
-1. Run the following command to determine the hostname for your organization's MongoDB [Atlas Data Federation](https://www.mongodb.com/docs/atlas/data-federation/overview/) instance, which is where your smart machine's synced data is stored.
-   Provide your organizations `org-id` from step 2:
-
-   ```sh {class="line-numbers linkable-line-numbers"}
-   viam data database hostname --org-id=<YOUR-ORGANIZATION-ID>
-   ```
-
-   This command returns the `hostname` of your Viam organization's assigned MongoDB Atlas instance.
-
-1. Then, configure a new database user for that database instance.
+1. Configure a new database user for the Viam organization's MongoDB [Atlas Data Federation](https://www.mongodb.com/docs/atlas/data-federation/overview/) instance, which is where your smart machine's synced data is stored.
    Provide your organization's `org-id` from step 2, and a desired new password for your database user.
 
    ```sh {class="line-numbers linkable-line-numbers"}
    viam data database configure --org-id=<YOUR-ORGANIZATION-ID> --password=<NEW-DBUSER-PASSWORD>
    ```
 
-   This command creates a new database `user` for your organization's MongoDB Atlas instance.
+   This command returns the `user` name you can use to connect to the Viam organization's MongoDB Atlas instance.
+
+1. Determine the hostname for your organization's MongoDB Atlas Data Federation instance.
+   Provide your organizations `org-id` from step 2:
+
+   ```sh {class="line-numbers linkable-line-numbers"}
+   viam data database hostname --org-id=<YOUR-ORGANIZATION-ID>
+   ```
+
+   This command returns the `hostname` (including database name) you can use to connect to your data store on the Viam organization's MongoDB Atlas instance.
 
 For more information, see the documentation for the [Viam CLI `database` command](/manage/cli/#data).
 
@@ -60,7 +60,7 @@ For example, to connect to your Viam organization's MongoDB Atlas instance and q
 1. If you haven't already, [download the `mongosh` shell](https://www.mongodb.com/try/download/shell).
    See the [`mongosh` documentation](https://www.mongodb.com/docs/mongodb-shell/) for more information.
 
-1. Run the following command to connect to your Viam organization's MongoDB Atlas instance from `mongosh`:
+1. Run the following command to connect to the Viam organization's MongoDB Atlas instance from `mongosh`:
 
    ```sh {class="line-numbers linkable-line-numbers"}
    mongosh "mongodb+srv://<YOUR-DB-HOSTNAME>" --apiVersion 1 --username <YOUR-DB-USER>
@@ -68,12 +68,12 @@ For example, to connect to your Viam organization's MongoDB Atlas instance and q
 
    Where:
 
-   - `<YOUR-DB-HOSTNAME>` is your organization's assigned MongoDB Atlas instance hostname, as returned from `viam data database hostname` above.
+   - `<YOUR-DB-HOSTNAME>` is your organization's assigned MongoDB Atlas instance hostname (including database name), as returned from `viam data database hostname` above.
    - `<YOUR-DB-USER>` is your organization's database user for that Atlas instance, as returned from `viam data database configure` above.
 
-1. Once connected, you can run MQL or SQL to query captured data directly. For example:
+1. Once connected, you can run [MQL](https://www.mongodb.com/docs/manual/tutorial/query-documents/) or SQL to query captured data directly. For example:
 
-   - The following MQL query searches the `sensorData` database and `readings` collection, and returns sensor readings from a specific `robot_id` and ultrasonic sensor where the recorded `distance` measurement is greater than `.2` meters:
+   - The following MQL query searches the `sensorData` database and `readings` collection, and returns sensor readings from an ultrasonic sensor on a specific `robot_id` where the recorded `distance` measurement is greater than `.2` meters:
 
      ```sql {class="line-numbers linkable-line-numbers"}
      AtlasDataFederation sensorData> db.readings.aggregate(

--- a/docs/services/data/configure-data-query.md
+++ b/docs/services/data/configure-data-query.md
@@ -45,6 +45,8 @@ Once your smart machine has synced captured data to the Viam app, you can config
 
    This command creates a new database `user` for your organization's MongoDB Atlas instance.
 
+For more information, see the documentation for the [Viam CLI `database` command](/manage/CLI/#data).
+
 ## Query data using MQL
 
 Once you have [configured data query](#configure-data-query), you can directly query synced data using MQL.

--- a/docs/services/data/configure-data-query.md
+++ b/docs/services/data/configure-data-query.md
@@ -8,7 +8,7 @@ tags: ["data management", "cloud", "query"]
 # SME: Aaron Casas
 ---
 
-Configure data query to be able to directly query captured tabular data in the Viam cloud using SQL or [MQL]((https://www.mongodb.com/docs/manual/tutorial/query-documents/).
+Configure data query to be able to directly query captured tabular data in the Viam cloud using [MQL](https://www.mongodb.com/docs/manual/tutorial/query-documents/) or SQL.
 
 Only tabular data, such as sensor data, can be queried in this fashion.
 
@@ -50,7 +50,7 @@ For more information, see the documentation for the [Viam CLI `database` command
 
 ## Query data
 
-Once you have [configured data query](#configure-data-query), you can directly query synced tabular data using SQL or MQL.
+Once you have [configured data query](#configure-data-query), you can directly query synced tabular data using MQL or SQL.
 
 You can use any client that is capable of connecting to MongoDB Atlas instances, including [the `mongosh` shell](https://www.mongodb.com/docs/mongodb-shell/), [MongoDB Compass](https://www.mongodb.com/docs/compass/current/), and many third-party tools.
 Use the `hostname` and `user` returned from the setup above to connect from your desired client to the MongoDB Atlas instance.

--- a/docs/services/data/configure-data-query.md
+++ b/docs/services/data/configure-data-query.md
@@ -82,7 +82,8 @@ For example, to connect to your Viam organization's MongoDB Atlas instance and q
    db.sensors.find( { sensor_type: "temp_sensor", current_temperature: { $gt: 32 } } )
    ```
 
-Consult the documentation for the specific MQL client you are using for more information.
+For more information on the MQL syntax used in this query, see the [MongoDB query language](https://www.mongodb.com/docs/manual/tutorial/query-documents/) documentation.
+For information on connecting to your Atlas instance from other MQL clients, see the MongoDB Atlas [Connect to your cluster tutorial](https://www.mongodb.com/docs/atlas/tutorial/connect-to-your-cluster/).
 
 ## Next Steps
 

--- a/docs/services/data/configure-data-query.md
+++ b/docs/services/data/configure-data-query.md
@@ -9,12 +9,20 @@ tags: ["data management", "cloud", "query", "sensor"]
 ---
 
 Configure data query to be able to directly query captured tabular data in the Viam cloud using [MQL](https://www.mongodb.com/docs/manual/tutorial/query-documents/) or SQL.
+Synced data is stored in a MongoDB [Atlas Data Federation](https://www.mongodb.com/docs/atlas/data-federation/overview/) instance.
 
-Only tabular data, such as sensor data, can be queried in this fashion.
+You can query both the captured tabular data itself as well as its metadata (such as robot ID, organization ID, and [tags](/manage/data/label/#image-tags)).
+
+Only tabular data, such as [sensor](/components/sensor/) readings, can be queried in this fashion.
 
 ## Requirements
 
-Before you can configure data query, you must [add the data management service](/services/data/configure-data-capture/#add-the-data-management-service) and [configure cloud sync](/services/data/configure-cloud-sync/).
+Before you can configure data query, you must:
+
+- [Add the data management service](/services/data/configure-data-capture/#add-the-data-management-service)
+- [Configure data capture](/services/data/configure-data-capture/) for at least one component, such as a sensor.
+   Only components that capture tabular data support data query.
+- [Configure cloud sync](/services/data/configure-cloud-sync/), and sync data to the Viam app.
 
 ## Configure data query
 
@@ -34,8 +42,6 @@ Once your smart machine has synced captured data to the Viam app, you can config
    ```sh {class="line-numbers linkable-line-numbers"}
    viam data database configure --org-id=<YOUR-ORGANIZATION-ID> --password=<NEW-DBUSER-PASSWORD>
    ```
-
-   This command returns the `user` name you can use to connect to the Viam organization's MongoDB Atlas instance.
 
 1. Determine the hostname for your organization's MongoDB Atlas Data Federation instance.
    Provide your organization's `org-id` from step 2:
@@ -75,7 +81,7 @@ For example, to connect to your Viam organization's MongoDB Atlas instance and q
 
    - The following MQL query searches the `sensorData` database and `readings` collection, and returns sensor readings from an ultrasonic sensor on a specific `robot_id` where the recorded `distance` measurement is greater than `.2` meters:
 
-     ```sql {class="line-numbers linkable-line-numbers"}
+     ```mongodb {class="line-numbers linkable-line-numbers"}
      AtlasDataFederation sensorData> db.readings.aggregate(
          [
              { $match: {
@@ -89,7 +95,7 @@ For example, to connect to your Viam organization's MongoDB Atlas instance and q
 
    - The following SQL query uses the MongoDB [`$sql` aggregation pipeline stage](https://www.mongodb.com/docs/atlas/data-federation/query/sql/shell/connect/#aggregation-pipeline-stage-syntax) to perform the same query as the MQL above, but using SQL syntax:
 
-     ```sql {class="line-numbers linkable-line-numbers"}
+     ```mongodb {class="line-numbers linkable-line-numbers"}
      AtlasDataFederation sensorData> db.aggregate(
          [
              { $sql: {

--- a/docs/services/data/configure-data-query.md
+++ b/docs/services/data/configure-data-query.md
@@ -1,0 +1,91 @@
+---
+title: "Configure Data Query"
+linkTitle: "Configure Data Query"
+description: "Configure data query to query synced data directly in the cloud."
+weight: 35
+type: "docs"
+tags: ["data management", "cloud", "query"]
+# SME: Aaron Casas
+---
+
+Configure data query to be able to directly query captured data in the Viam cloud using the [MongoDB Query Language (MQL)](https://www.mongodb.com/docs/manual/tutorial/query-documents/).
+
+## Requirements
+
+Before you can configure [data query](../#data-query), you must [add the data management service](../configure-data-capture/#add-the-data-management-service) and [configure cloud sync](/services/data/configure-cloud-sync/).
+
+## Configure data query
+
+Once your smart machine has synced captured data to the Viam app, you can configure data query using the Viam CLI:
+
+1. If you haven't already, [install the Viam CLI](/manage/cli/#install) and [authenticate](/manage/cli/#authenticate) to Viam.
+
+1. Find your organization ID by running the following command, or from your organization's **Settings** page in [the Viam App](https://app.viam.com/):
+
+   ```sh {class="line-numbers linkable-line-numbers"}
+   viam organizations list
+   ```
+
+1. Run the following command to determine the hostname for your organization's MongoDB [Atlas Data Federation](https://www.mongodb.com/docs/atlas/data-federation/overview/) instance, which is where your smart machine's synced data is stored.
+   Provide your organizations `org-id` from step 2:
+
+   ```sh {class="line-numbers linkable-line-numbers"}
+   viam data database hostname --org-id=<YOUR-ORGANIZATION-ID>
+   ```
+
+   This command returns the `hostname` of your Viam organization's assigned MongoDB Atlas instance.
+
+
+1. Then, configure a new database user for that database instance.
+   Provide your organization's `org-id` from step 2, and a desired new password for your database user.
+
+   ```sh {class="line-numbers linkable-line-numbers"}
+   viam data database configure --org-id=<YOUR-ORGANIZATION-ID> --password=<NEW-DBUSER-PASSWORD>
+   ```
+
+   This command creates a new database `user` for your organization's MongoDB Atlas instance.
+
+## Query data using MQL
+
+Once you have [configured data query](#configure-data-query), you can directly query synced data using MQL.
+
+You can use any client that supports MQL that is capable of connecting to MongoDB Atlas instances, including [the `mongosh` shell](https://www.mongodb.com/docs/mongodb-shell/), [MongoDB Compass](https://www.mongodb.com/docs/compass/current/), and many third-party tools.
+Use the `hostname` and `user` returned from the setup above to connect from your desired client to the MongoDB Atlas instance.
+
+For example, to connect to your Viam organization's MongoDB Atlas instance and query data using the `mongosh` shell:
+
+1. If you haven't already, [download the `mongosh` shell](https://www.mongodb.com/try/download/shell).
+   See the [`mongosh` documentation](https://www.mongodb.com/docs/mongodb-shell/) for more information.
+
+1. Run the following command to connect to your Viam organization's MongoDB Atlas instance from `mongosh`:
+
+   ```sh {class="line-numbers linkable-line-numbers"}
+   mongosh "mongodb+srv://<YOUR-DB-HOSTNAME>" --apiVersion 1 --username <YOUR-DB-USER>
+   ```
+
+   Where:
+
+   - `<YOUR-DB-HOSTNAME>` is your organization's assigned MongoDB Atlas instance, as returned from `viam data database hostname` above.
+   - `<YOUR-DB-USER>` is your organization's database user for that Atlas instance, as returned from `viam data database configure` above.
+
+1. Once connected, you can run MQL to query captured data directly.
+   For example, the following MQL queries all synced data in the `sensors` database:
+
+   ```sql {class="line-numbers linkable-line-numbers"}
+   db.sensors.find( {} )
+   ```
+
+   The following MQL queries synced data in the `sensors` database and returns `sensor_type: temp_sensor` readings greater than a certain `current_temperature`:
+
+   ```sql {class="line-numbers linkable-line-numbers"}
+   db.sensors.find( { sensor_type: "temp_sensor", current_temperature: { $gt: 32 } } )
+   ```
+
+Consult the documentation for the specific MQL client you are using for more information.
+
+## Next Steps
+
+To view your captured data in the cloud, see [View Data](../../../manage/data/view/).
+To export your synced data, see [Export data](../../manage/data/export/).
+
+For a comprehensive tutorial on data management, see [Intro to Data Management](../../../tutorials/services/data-management-tutorial/).

--- a/docs/services/data/configure-data-query.md
+++ b/docs/services/data/configure-data-query.md
@@ -38,7 +38,7 @@ Once your smart machine has synced captured data to the Viam app, you can config
    This command returns the `user` name you can use to connect to the Viam organization's MongoDB Atlas instance.
 
 1. Determine the hostname for your organization's MongoDB Atlas Data Federation instance.
-   Provide your organizations `org-id` from step 2:
+   Provide your organization's `org-id` from step 2:
 
    ```sh {class="line-numbers linkable-line-numbers"}
    viam data database hostname --org-id=<YOUR-ORGANIZATION-ID>

--- a/docs/services/data/configure-data-query.md
+++ b/docs/services/data/configure-data-query.md
@@ -11,7 +11,7 @@ tags: ["data management", "cloud", "query", "sensor"]
 Configure data query to be able to directly query captured tabular data in the Viam cloud using [MQL](https://www.mongodb.com/docs/manual/tutorial/query-documents/) or SQL.
 Synced data is stored in a MongoDB [Atlas Data Federation](https://www.mongodb.com/docs/atlas/data-federation/overview/) instance.
 
-You can query both the captured tabular data itself as well as its metadata (such as robot ID, organization ID, and [tags](/manage/data/label/#image-tags)).
+You can query against both the captured tabular data itself as well as its metadata, including robot ID, organization ID, and [tags](/manage/data/label/#image-tags).
 
 Only tabular data, such as [sensor](/components/sensor/) readings, can be queried in this fashion.
 
@@ -23,6 +23,7 @@ Before you can configure data query, you must:
 - [Configure data capture](/services/data/configure-data-capture/) for at least one component, such as a sensor.
    Only components that capture tabular data support data query.
 - [Configure cloud sync](/services/data/configure-cloud-sync/), and sync data to the Viam app.
+   When you are able to [view your data in the Viam app](/manage/data/view/), you are ready to proceed.
 
 ## Configure data query
 

--- a/docs/services/data/configure-data-query.md
+++ b/docs/services/data/configure-data-query.md
@@ -35,7 +35,6 @@ Once your smart machine has synced captured data to the Viam app, you can config
 
    This command returns the `hostname` of your Viam organization's assigned MongoDB Atlas instance.
 
-
 1. Then, configure a new database user for that database instance.
    Provide your organization's `org-id` from step 2, and a desired new password for your database user.
 

--- a/docs/services/data/configure-data-query.md
+++ b/docs/services/data/configure-data-query.md
@@ -12,7 +12,7 @@ Configure data query to be able to directly query captured data in the Viam clou
 
 ## Requirements
 
-Before you can configure [data query](../#data-query), you must [add the data management service](../configure-data-capture/#add-the-data-management-service) and [configure cloud sync](/services/data/configure-cloud-sync/).
+Before you can configure [data query](../#data-query), you must [add the data management service](/services/data/configure-data-capture/#add-the-data-management-service) and [configure cloud sync](/services/data/configure-cloud-sync/).
 
 ## Configure data query
 
@@ -44,7 +44,7 @@ Once your smart machine has synced captured data to the Viam app, you can config
 
    This command creates a new database `user` for your organization's MongoDB Atlas instance.
 
-For more information, see the documentation for the [Viam CLI `database` command](/manage/CLI/#data).
+For more information, see the documentation for the [Viam CLI `database` command](/manage/cli/#data).
 
 ## Query data using MQL
 
@@ -86,7 +86,7 @@ Consult the documentation for the specific MQL client you are using for more inf
 
 ## Next Steps
 
-To view your captured data in the cloud, see [View Data](../../../manage/data/view/).
-To export your synced data, see [Export data](../../manage/data/export/).
+To view your captured data in the cloud, see [View Data](/manage/data/view/).
+To export your synced data, see [Export data](/manage/data/export/).
 
-For a comprehensive tutorial on data management, see [Intro to Data Management](../../../tutorials/services/data-management-tutorial/).
+For a comprehensive tutorial on data management, see [Intro to Data Management](/tutorials/services/data-management-tutorial/).

--- a/docs/tutorials/projects/bedtime-songs-bot.md
+++ b/docs/tutorials/projects/bedtime-songs-bot.md
@@ -160,6 +160,7 @@ At this point, the full **Raw JSON** configuration of your robot should look lik
             "capture_methods": [
               {
                 "additional_params": {
+                 "reader_name": "cam1",
                   "mime_type": "image/jpeg"
                 },
                 "capture_frequency_hz": 0.333,

--- a/docs/tutorials/projects/bedtime-songs-bot.md
+++ b/docs/tutorials/projects/bedtime-songs-bot.md
@@ -160,7 +160,7 @@ At this point, the full **Raw JSON** configuration of your robot should look lik
             "capture_methods": [
               {
                 "additional_params": {
-                 "reader_name": "cam1",
+                  "reader_name": "cam1",
                   "mime_type": "image/jpeg"
                 },
                 "capture_frequency_hz": 0.333,


### PR DESCRIPTION
Add new data service sub page documenting querying captured data directly in the cloud.
- Walkthrough of configuration
- Quick `mongosh` usage example.
- Linking to relevant CLI commands.
- Linking to helpful MDB reference docs.
- Updating `"type": "data_manager",` `service_configs` to now include additional `"reader_name"` key on steps to configure, and in one tutorial that uses this configuration.

### Questions:
- What are the password constraints for the Atlas DB user we create? Does Viam check anything, or do we just hand off to Atlas' check and just faithfully forward any encountered error to the user?
- Do you have a better `mongosh` shell example command? Something practical ideally. How did you test this with actual sensor data -- can I use that example test command here please?
- What is the `database` in the `mongosh` shell command? I use `sensors` but it's probably not that.
- Is the Atlas database name part of the returned `hostname` from the `viam data database hostname` command? If not, are we just using the default `defaultdb` database? If not, what is it, so I can clarify that either:
	- The user must determine what it is, and append it to `hostname`, or
	- The user may happily paste the verbatim output from `viam data database hostname` into the connection string for `mongosh` or Compass or whatever.
- Is only tabular data supported? Only data behind the Viam App's DATA > X tab (is it **Sensors** only, as tabular anyways)? I say "select data" a few places. If tabular specifically, I will clarify.

EDIT: Thanks so much for helpful answers!!