### PR TITLE
Update segmentation.md

### DIFF
--- a/docs/services/vision/segmentation.md
+++ b/docs/services/vision/segmentation.md
@@ -326,13 +326,7 @@ If you want to identify multiple boxes over the flat plane with your segmenter:
 - First, [configure your frame system](/services/frame-system/#configuration) to configure the relative spatial orientation of the components of your robot, including your [camera](/components/camera/), within Viam's [frame system service](/services/frame-system/).
   - After configuring your frame system, your camera will populate its own `Properties` with these spatial intrinsic parameters from the frame system.
   - You can get those parameters from your camera through the [camera API](/components/camera/#getproperties).
-- Next, set your segmenter's attribute `with_geometries: true`.
 - The segmenter now returns multiple boxes within the `GeometryInFrame` object it captures.
-
-If you choose not to configure the frame system, you can still identify single points over the flat plane with your segmenter:
-
-- Set `with_geometries: false`.
-- The segmenter now returns a single point within the `GeometryInFrame` object it captures.
 
 Click **Save config** and proceed to [test your segmenter](#test-your-segmenter).
 


### PR DESCRIPTION
# With_Geometries is not used

This description of how "with_geometries" works for `obstalces_depth` was removed in the final iteration of the scope doc. We don't have a "with_geometries" attribute any more.
