### PR TITLE
RSDK-5612: Correct the use of the logging package name.

### DIFF
--- a/docs/components/input-controller/_index.md
+++ b/docs/components/input-controller/_index.md
@@ -214,7 +214,7 @@ func handleController(controller input.Controller) {
 }
 
 func main() {
-    utils.ContextualMain(mainWithArgs, logging.NewDevelopmentLogger("client"))
+    utils.ContextualMain(mainWithArgs, logging.NewLogger("client"))
 }
 
 

--- a/docs/components/input-controller/_index.md
+++ b/docs/components/input-controller/_index.md
@@ -214,11 +214,11 @@ func handleController(controller input.Controller) {
 }
 
 func main() {
-    utils.ContextualMain(mainWithArgs, logger.NewDevelopmentLogger("client"))
+    utils.ContextualMain(mainWithArgs, logging.NewDevelopmentLogger("client"))
 }
 
 
-func mainWithArgs(ctx context.Context, args []string, logger logger.Logger) (err error) {
+func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) (err error) {
     // ... < INSERT CONNECTION CODE FROM ROBOT'S CODE SAMPLE TAB >
 
     // Get the controller from the robot.

--- a/docs/program/_index.md
+++ b/docs/program/_index.md
@@ -136,7 +136,7 @@ import (
 )
 
 func main() {
-  logger := logging.NewDevelopmentLogger("client")
+  logger := logging.NewLogger("client")
   robot, err := client.New(
       context.Background(),
       "ADDRESS FROM THE VIAM APP",

--- a/docs/program/_index.md
+++ b/docs/program/_index.md
@@ -136,7 +136,7 @@ import (
 )
 
 func main() {
-  logger := logger.NewDevelopmentLogger("client")
+  logger := logging.NewDevelopmentLogger("client")
   robot, err := client.New(
       context.Background(),
       "ADDRESS FROM THE VIAM APP",

--- a/docs/program/apis/robot.md
+++ b/docs/program/apis/robot.md
@@ -64,14 +64,14 @@ package main
 import (
   "context"
 
-  "github.com/edaniels/golog"
+  "go.viam.com/rdk/logging"
   "go.viam.com/rdk/robot/client"
   "go.viam.com/rdk/utils"
   "go.viam.com/utils/rpc"
 )
 
 func main() {
-  logger := golog.NewDevelopmentLogger("client")
+  logger := logging.NewLogger("client")
   robot, err := client.New(
       context.Background(),
       "ADDRESS FROM THE VIAM APP",

--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -359,7 +359,7 @@ func init() {
     })
 }
 
-func newBase(ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logger.Logger) (base.Base, error) {
+func newBase(ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger) (base.Base, error) {
     b := &myBase{
         Named:  conf.ResourceName().AsNamed(),
         logger: logger,
@@ -434,7 +434,7 @@ type myBase struct {
     resource.Named
     left       motor.Motor
     right      motor.Motor
-    logger     logger.Logger
+    logger     logging.Logger
     geometries []spatialmath.Geometry
 }
 
@@ -599,12 +599,12 @@ import (
 )
 
 func main() {
-    // NewLoggerFromArgs will create a logger.Logger at "DebugLevel" if
+    // NewLoggerFromArgs will create a logging.Logger at "DebugLevel" if
     // "--log-level=debug" is an argument in os.Args and at "InfoLevel" otherwise.
     utils.ContextualMain(mainWithArgs, module.NewLoggerFromArgs("yourmodule"))
 }
 
-func mainWithArgs(ctx context.Context, args []string, logger logger.Logger) (err error) {
+func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) (err error) {
     myMod, err := module.NewModuleFromArgs(ctx, logger)
     if err != nil {
         return err
@@ -743,12 +743,12 @@ import(
 // Alter your component to hold a logger
 type component struct {
     ...
- logger logger.Logger
+ logger logging.Logger
 }
 // Then, alter your component's constructor to save the logger:
 func init() {
  registration := resource.Registration[resource.Resource, *Config]{
-  Constructor: func(ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logger.Logger) (resource.Resource, error) {
+  Constructor: func(ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger) (resource.Resource, error) {
      ...
      return &component {
          ...

--- a/docs/tutorials/custom/controlling-an-intermode-rover-canbus.md
+++ b/docs/tutorials/custom/controlling-an-intermode-rover-canbus.md
@@ -133,10 +133,10 @@ The _Subtype_ of a resource contains its API triplet, so using `base.Subtype` (s
 var model = resource.NewModel("viamlabs", "tutorial", "intermode")
 
 func main() {
-    goutils.ContextualMain(mainWithArgs, logger.NewDevelopmentLogger("intermodeBaseModule"))
+    goutils.ContextualMain(mainWithArgs, logging.NewDevelopmentLogger("intermodeBaseModule"))
 }
 
-func mainWithArgs(ctx context.Context, args []string, logger logger.Logger) (err error) {
+func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) (err error) {
     registerBase()
     modalModule, err := module.NewModuleFromArgs(ctx, logger)
 
@@ -164,7 +164,7 @@ func registerBase() {
             ctx context.Context,
             deps registry.Dependencies,
             config config.Component,
-            logger logger.Logger,
+            logger logging.Logger,
         ) (interface{}, error) {
             return newBase(config.Name, logger) // note: newBase() is not shown in this tutorial
         }})
@@ -207,7 +207,7 @@ func (base *interModeBase) setNextCommand(ctx context.Context, cmd modalCommand)
 }
 
 // toFrame convert the drive command to a CANBUS data frame.
-func (cmd *driveCommand) toFrame(logger logger.Logger) canbus.Frame {
+func (cmd *driveCommand) toFrame(logger logging.Logger) canbus.Frame {
     frame := canbus.Frame{
         ID:   driveId,
         Data: make([]byte, 0, 8),

--- a/docs/tutorials/custom/controlling-an-intermode-rover-canbus.md
+++ b/docs/tutorials/custom/controlling-an-intermode-rover-canbus.md
@@ -133,7 +133,7 @@ The _Subtype_ of a resource contains its API triplet, so using `base.Subtype` (s
 var model = resource.NewModel("viamlabs", "tutorial", "intermode")
 
 func main() {
-    goutils.ContextualMain(mainWithArgs, logging.NewDevelopmentLogger("intermodeBaseModule"))
+    goutils.ContextualMain(mainWithArgs, logging.NewLogger("intermodeBaseModule"))
 }
 
 func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) (err error) {

--- a/docs/tutorials/get-started/blink-an-led.md
+++ b/docs/tutorials/get-started/blink-an-led.md
@@ -396,7 +396,7 @@ async def main():
 
 ```go {class="line-numbers linkable-line-numbers"}
 func main() {
-  logger := logger.NewDevelopmentLogger("client")
+  logger := logging.NewDevelopmentLogger("client")
   robot, err := client.New(
       context.Background(),
       "ADDRESS FROM THE VIAM APP",

--- a/docs/tutorials/get-started/blink-an-led.md
+++ b/docs/tutorials/get-started/blink-an-led.md
@@ -396,7 +396,7 @@ async def main():
 
 ```go {class="line-numbers linkable-line-numbers"}
 func main() {
-  logger := logging.NewDevelopmentLogger("client")
+  logger := logging.NewLogger("client")
   robot, err := client.New(
       context.Background(),
       "ADDRESS FROM THE VIAM APP",

--- a/docs/tutorials/get-started/try-viam-sdk.md
+++ b/docs/tutorials/get-started/try-viam-sdk.md
@@ -304,7 +304,7 @@ func main() {
         rpc.Credentials{
             Type:    rpc.CredentialsTypeAPIKey,
             // Replace "<API-KEY>" (including brackets) with your robot's api key
-            Payload: "<API-KEY>"
+            Payload: "<API-KEY>",
         })),
     )
     if err != nil {
@@ -578,7 +578,7 @@ func main() {
       rpc.Credentials{
           Type:    rpc.CredentialsTypeAPIKey,
           // Replace "<API-KEY>" (including brackets) with your robot's api key
-          Payload: "<API-KEY>"
+          Payload: "<API-KEY>",
       })),
     )
     if err != nil {

--- a/docs/tutorials/get-started/try-viam-sdk.md
+++ b/docs/tutorials/get-started/try-viam-sdk.md
@@ -293,7 +293,7 @@ Your main function should look like this:
 
 ```go {class="line-numbers linkable-line-numbers" data-line="19-22"}
 func main() {
-    logger := logging.NewDevelopmentLogger("client")
+    logger := logging.NewLogger("client")
     robot, err := client.New(
         context.Background(),
         "ADDRESS FROM THE VIAM APP",
@@ -567,7 +567,7 @@ func moveInSquare(ctx context.Context, base base.Base, logger logging.Logger) {
 }
 
 func main() {
-    logger := logging.NewDevelopmentLogger("client")
+    logger := logging.NewLogger("client")
     robot, err := client.New(
       context.Background(),
       "ADDRESS FROM THE VIAM APP",

--- a/docs/tutorials/get-started/try-viam-sdk.md
+++ b/docs/tutorials/get-started/try-viam-sdk.md
@@ -293,7 +293,7 @@ Your main function should look like this:
 
 ```go {class="line-numbers linkable-line-numbers" data-line="19-22"}
 func main() {
-    logger := logger.NewDevelopmentLogger("client")
+    logger := logging.NewDevelopmentLogger("client")
     robot, err := client.New(
         context.Background(),
         "ADDRESS FROM THE VIAM APP",
@@ -325,7 +325,7 @@ Now that your rover base has been initialized, you can write code to drive it in
 Paste this snippet above your `main()` function:
 
 ```go
-func moveInSquare(ctx context.Context, base base.Base, logger logger.Logger) {
+func moveInSquare(ctx context.Context, base base.Base, logger logging.Logger) {
     for i := 0; i < 4; i++ {
         // moves the rover forward 600mm at 500mm/s
         base.MoveStraight(ctx, 600, 500.0, nil)
@@ -555,7 +555,7 @@ import (
     "go.viam.com/utils/rpc"
 )
 
-func moveInSquare(ctx context.Context, base base.Base, logger logger.Logger) {
+func moveInSquare(ctx context.Context, base base.Base, logger logging.Logger) {
     for i := 0; i < 4; i++ {
         // moves the rover forward 600mm at 500mm/s
         base.MoveStraight(ctx, 600, 500.0, nil)
@@ -567,7 +567,7 @@ func moveInSquare(ctx context.Context, base base.Base, logger logger.Logger) {
 }
 
 func main() {
-    logger := logger.NewDevelopmentLogger("client")
+    logger := logging.NewDevelopmentLogger("client")
     robot, err := client.New(
       context.Background(),
       "ADDRESS FROM THE VIAM APP",

--- a/docs/tutorials/projects/bedtime-songs-bot.md
+++ b/docs/tutorials/projects/bedtime-songs-bot.md
@@ -348,7 +348,7 @@ To start, add in the code that initializes your speaker and plays the songs.
 Tess used the platform-flexible [Go `os` package](https://pkg.go.dev/os) and an audio processing package from [GitHub](https://github.com/faiface/beep/) to do this.
 
 ```go {class="line-numbers linkable-line-numbers"}
-func initSpeaker(logger logger.Logger) {
+func initSpeaker(logger logging.Logger) {
    f, err := os.Open("square.mp3")
    if err != nil {
        logger.Fatal(err)
@@ -367,7 +367,7 @@ func initSpeaker(logger logger.Logger) {
 }
 
 
-func play(label string, logger logger.Logger) {
+func play(label string, logger logging.Logger) {
    f, err := os.Open(label + ".mp3")
    if err != nil {
        logger.Fatal(err)
@@ -467,7 +467,7 @@ import (
 )
 
 // Initialize the speaker
-func initSpeaker(logger logger.Logger) {
+func initSpeaker(logger logging.Logger) {
    f, err := os.Open("square.mp3")
    if err != nil {
        logger.Fatal(err)
@@ -486,7 +486,7 @@ func initSpeaker(logger logger.Logger) {
 }
 
 // Play a song
-func play(label string, logger logger.Logger) {
+func play(label string, logger logging.Logger) {
    f, err := os.Open(label + ".mp3")
    if err != nil {
        logger.Fatal(err)
@@ -512,7 +512,7 @@ func play(label string, logger logger.Logger) {
 
 // Code Sample Connect() Code
 func main() {
- logger := logger.NewDevelopmentLogger("client")
+ logger := logging.NewDevelopmentLogger("client")
  robot, err := client.New(
     context.Background(),
     "ADDRESS FROM THE VIAM APP",

--- a/docs/tutorials/projects/bedtime-songs-bot.md
+++ b/docs/tutorials/projects/bedtime-songs-bot.md
@@ -512,7 +512,7 @@ func play(label string, logger logging.Logger) {
 
 // Code Sample Connect() Code
 func main() {
- logger := logging.NewDevelopmentLogger("client")
+ logger := logging.NewLogger("client")
  robot, err := client.New(
     context.Background(),
     "ADDRESS FROM THE VIAM APP",

--- a/docs/tutorials/services/accessing-and-moving-robot-arm.md
+++ b/docs/tutorials/services/accessing-and-moving-robot-arm.md
@@ -406,7 +406,7 @@ import (
 )
 
 func main() {
-  logger := logging.NewDevelopmentLogger("client")
+  logger := logging.NewLogger("client")
   robot, err := client.New(
       context.Background(),
       "ADDRESS FROM THE VIAM APP",

--- a/docs/tutorials/services/accessing-and-moving-robot-arm.md
+++ b/docs/tutorials/services/accessing-and-moving-robot-arm.md
@@ -406,7 +406,7 @@ import (
 )
 
 func main() {
-  logger := logger.NewDevelopmentLogger("client")
+  logger := logging.NewDevelopmentLogger("client")
   robot, err := client.New(
       context.Background(),
       "ADDRESS FROM THE VIAM APP",

--- a/docs/tutorials/services/plan-motion-with-arm-gripper.md
+++ b/docs/tutorials/services/plan-motion-with-arm-gripper.md
@@ -546,7 +546,7 @@ import (
 )
 
 func main() {
-  logger := logger.NewDevelopmentLogger("client")
+  logger := logging.NewDevelopmentLogger("client")
   robot, err := client.New(
       context.Background(),
       "<ROBOT ADDRESS>",

--- a/docs/tutorials/services/plan-motion-with-arm-gripper.md
+++ b/docs/tutorials/services/plan-motion-with-arm-gripper.md
@@ -546,7 +546,7 @@ import (
 )
 
 func main() {
-  logger := logging.NewDevelopmentLogger("client")
+  logger := logging.NewLogger("client")
   robot, err := client.New(
       context.Background(),
       "<ROBOT ADDRESS>",


### PR DESCRIPTION
* There was a typo in the package name. `logger.NewDevelopmentalLogger` and `logger.Logger` should have been `logging.*`.
* Steer away from the Developmental logger as an API. Developmental for viam employees is not the same as external users.
* I noticed the "go in a square" example still did not compile. The example code was missing trailing commas.