### PR TITLE
Fix typos in INA219 docs

### DIFF
--- a/docs/components/power-sensor/ina219.md
+++ b/docs/components/power-sensor/ina219.md
@@ -63,7 +63,7 @@ Then remove and fill in the attributes as applicable to your power sensor, accor
       "namespace": "rdk",
       "attributes": {
         "i2c_bus": <int>,
-        "i2c-addr": <int>,
+        "i2c_addr": <int>,
         "max_current_amps": <float>,
         "shunt_resistance": <float>
       },
@@ -82,7 +82,7 @@ The following attributes are available for `INA219` sensors:
 | Attribute | Type | Inclusion | Description |
 | --------- | -----| --------- | ----------- |
 | `i2c_bus` | integer | **Required** | The `number` of the [I<sup>2</sup>C bus](/components/board/#i2cs) that the sensor is connected to. |
-| `i2c_address` | integer | Optional | The sensor's unique [I<sup>2</sup>C address](https://learn.adafruit.com/i2c-addresses/overview). <br>Default: `0x40`
+| `i2c_addr` | integer | Optional | The sensor's unique [I<sup>2</sup>C address](https://learn.adafruit.com/i2c-addresses/overview). <br>Default: `0x40`
 | `max_current_amps` | float | Optional | Default: 3.2A. The maximum current that the sensor can measure in amperes (A).
 | `shunt_resistance` | float | Optional | Default: 0.1Ω. The shunt resistance value of the sensor in Ohms (Ω).
 

--- a/docs/components/power-sensor/ina226.md
+++ b/docs/components/power-sensor/ina226.md
@@ -30,7 +30,7 @@ Then remove and fill in the attributes as applicable to your power sensor, accor
 ```json {class="line-numbers linkable-line-numbers"}
 {
   "i2c_bus": <int>,
-  "i2c-addr": <int>,
+  "i2c_addr": <int>,
   "max_current_amps": <float>,
   "shunt_resistance": <float>
 }
@@ -80,7 +80,7 @@ The following attributes are available for `INA226` sensors:
 | Attribute | Type | Inclusion | Description |
 | --------- | -----| --------- | ----------- |
 | `i2c_bus` | integer | **Required** | The `number` of the [I<sup>2</sup>C bus](/components/board/#i2cs) that the sensor is connected to. |
-| `i2c_address` | integer | Optional | Default: `0x40`. The sensor's unique [I<sup>2</sup>C address](https://learn.adafruit.com/i2c-addresses/overview). |
+| `i2c_addr` | integer | Optional | Default: `0x40`. The sensor's unique [I<sup>2</sup>C address](https://learn.adafruit.com/i2c-addresses/overview). |
 | `max_current_amps` | number | Optional | Default: 20A. The maximum current that the sensor can measure in amperes (A).
 | `shunt_resistance` | number | Optional | Default: 0.1Ω. The shunt resistance value of the sensor in Ohms (Ω).
 


### PR DESCRIPTION
# Description
The config attribute `i2c_addr` was previously stated as `i2c-addr` and `i2c_address` in other locations. This fixes that
