### PR TITLE
DOCS-1430: Add missing DataClient methods

### DIFF
--- a/docs/build/program/apis/data-client.md
+++ b/docs/build/program/apis/data-client.md
@@ -731,11 +731,7 @@ Add a bounding box to an image specified by its id.
 - `GRPCError` – If the X or Y values are outside of the [0, 1] range.
 
 ```python {class="line-numbers linkable-line-numbers"}
-file_id = await data_client.file_upload_from_path(
-    part_id="INSERT YOUR PART ID",
-    tags=["tag_1", "tag_2"],
-    filepath="/Users/<your-username>/<your-directory>/<your-file.txt>"
-)
+placeholder
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.add_bounding_box_to_image_by_id).
@@ -760,11 +756,7 @@ Removes a bounding box from an image specified by its id.
 - None.
 
 ```python {class="line-numbers linkable-line-numbers"}
-file_id = await data_client.file_upload_from_path(
-    part_id="INSERT YOUR PART ID",
-    tags=["tag_1", "tag_2"],
-    filepath="/Users/<your-username>/<your-directory>/<your-file.txt>"
-)
+placeholder
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.remove_bounding_box_from_image_by_id).
@@ -800,11 +792,7 @@ Uploads the metadata and contents of streaming binary data.
 - `GRPCError` – If an invalid part ID is passed.
 
 ```python {class="line-numbers linkable-line-numbers"}
-file_id = await data_client.file_upload_from_path(
-    part_id="INSERT YOUR PART ID",
-    tags=["tag_1", "tag_2"],
-    filepath="/Users/<your-username>/<your-directory>/<your-file.txt>"
-)
+placeholder
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.streaming_data_capture_upload).

--- a/docs/build/program/apis/data-client.md
+++ b/docs/build/program/apis/data-client.md
@@ -776,7 +776,7 @@ Uploads the metadata and contents of streaming binary data.
 - `data` [(bytes)](https://docs.python.org/3/library/stdtypes.html#bytes-objects): the data to be uploaded, represented in bytes.
 - `part_id` [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Part ID of the resource associated with the file.
 - `file_ext` [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): File extension type for the data. required for determining MIME type.
-- `component_type` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional type of the component associated with the file (e.g., “movement_sensor”).
+- `component_type` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional type of the component associated with the file (For example, “movement_sensor”).
 - `component_name` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional name of the component associated with the file.
 - `method_name` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional name of the method associated with the file.
 - `method_parameters` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional dictionary of the method parameters. No longer in active use.

--- a/docs/build/program/apis/data-client.md
+++ b/docs/build/program/apis/data-client.md
@@ -705,3 +705,109 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+
+### AddBoundingBoxToImageById
+
+Add a bounding box to an image specified by its id.
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `binary_id` ([viam.proto.app.data.BinaryID](https://python.viam.dev/autoapi/viam/proto/app/data/index.html#viam.proto.app.data.BinaryID)): The ID of the image to add the bounding box to.
+- `label` [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): A label for the bounding box.
+- `x_min_normalized` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)): Min X value of the bounding box normalized from 0 to 1.
+- `y_min_normalized` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)): Min Y value of the bounding box normalized from 0 to 1.
+- `x_max_normalized` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)): Max X value of the bounding box normalized from 0 to 1.
+- `y_max_normalized` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)): Max Y value of the bounding box normalized from 0 to 1.
+
+**Returns:**
+
+- [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): The bounding box ID of the image.
+
+**Raises:**
+
+- `GRPCError` – If the X or Y values are outside of the [0, 1] range.
+
+```python {class="line-numbers linkable-line-numbers"}
+file_id = await data_client.file_upload_from_path(
+    part_id="INSERT YOUR PART ID",
+    tags=["tag_1", "tag_2"],
+    filepath="/Users/<your-username>/<your-directory>/<your-file.txt>"
+)
+```
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.add_bounding_box_to_image_by_id).
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### RemoveBoundingBoxFromImageById
+
+Removes a bounding box from an image specified by its id.
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `bbox_id` [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): The ID of the bounding box to remove.
+- `binary_id` ([viam.proto.app.data.BinaryID](https://python.viam.dev/autoapi/viam/proto/app/data/index.html#viam.proto.app.data.BinaryID)): Binary ID of the image to to remove the bounding box from.
+
+**Returns:**
+
+- None.
+
+```python {class="line-numbers linkable-line-numbers"}
+file_id = await data_client.file_upload_from_path(
+    part_id="INSERT YOUR PART ID",
+    tags=["tag_1", "tag_2"],
+    filepath="/Users/<your-username>/<your-directory>/<your-file.txt>"
+)
+```
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.remove_bounding_box_from_image_by_id).
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### StreamingDataCaptureUpload
+
+Uploads the metadata and contents of streaming binary data.
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `data` [(bytes)](https://docs.python.org/3/library/stdtypes.html#bytes-objects): the data to be uploaded, represented in bytes.
+- `part_id` [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Part ID of the resource associated with the file.
+- `file_ext` [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): File extension type for the data. required for determining MIME type.
+- `component_type` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional type of the component associated with the file (e.g., “movement_sensor”).
+- `component_name` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional name of the component associated with the file.
+- `method_name` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional name of the method associated with the file.
+- `method_parameters` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional dictionary of the method parameters. No longer in active use.
+- `data_request_times` [(Optional[Tuple[datetime.datetime, datetime.datetime]])](https://docs.python.org/3/library/stdtypes.html#tuples): Optional tuple containing [`datetime`](https://docs.python.org/3/library/datetime.html) objects denoting the times this data was requested and received by the appropriate sensor.
+- `tags` [(Optional[List[str]])](https://docs.python.org/3/library/stdtypes.html#typesseq-list): Optional list of [image tags](/manage/data/label/#image-tags) to allow for tag-based data filtering when retrieving data.
+
+**Returns:**
+
+- [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): the `file_id` of the uploaded data.
+
+**Raises:**
+
+- `GRPCError` – If an invalid part ID is passed.
+
+```python {class="line-numbers linkable-line-numbers"}
+file_id = await data_client.file_upload_from_path(
+    part_id="INSERT YOUR PART ID",
+    tags=["tag_1", "tag_2"],
+    filepath="/Users/<your-username>/<your-directory>/<your-file.txt>"
+)
+```
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.streaming_data_capture_upload).
+
+{{% /tab %}}
+{{< /tabs >}}

--- a/docs/build/program/apis/data-client.md
+++ b/docs/build/program/apis/data-client.md
@@ -634,6 +634,56 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 {{% /tab %}}
 {{< /tabs >}}
 
+### StreamingDataCaptureUpload
+
+Upload the contents of streaming binary data and the relevant metadata to the [Viam app](https://app.viam.com).
+Uploaded streaming data can be found under the [**Data** tab](https://app.viam.com/data).
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `data` [(bytes)](https://docs.python.org/3/library/stdtypes.html#bytes-objects): the data to be uploaded, represented in bytes.
+- `part_id` [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Part ID of the resource associated with the file.
+- `file_ext` [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): File extension type for the data. required for determining MIME type.
+- `component_type` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional type of the component associated with the file (For example, “movement_sensor”).
+- `component_name` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional name of the component associated with the file.
+- `method_name` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional name of the method associated with the file.
+- `method_parameters` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional dictionary of the method parameters. No longer in active use.
+- `data_request_times` [(Optional[Tuple[datetime.datetime, datetime.datetime]])](https://docs.python.org/3/library/stdtypes.html#tuples): Optional tuple containing [`datetime`](https://docs.python.org/3/library/datetime.html) objects denoting the times this data was requested and received by the appropriate sensor.
+- `tags` [(Optional[List[str]])](https://docs.python.org/3/library/stdtypes.html#typesseq-list): Optional list of [image tags](/manage/data/label/#image-tags) to allow for tag-based data filtering when retrieving data.
+
+**Returns:**
+
+- [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): the `file_id` of the uploaded data.
+
+**Raises:**
+
+- `GRPCError` – If an invalid part ID is passed.
+
+```python {class="line-numbers linkable-line-numbers"}
+time_requested = datetime(2023, 6, 5, 11)
+time_received = datetime(2023, 6, 5, 11, 0, 3)
+
+file_id = await data_client.streaming_data_capture_upload(
+    data="byte-data-to-upload",
+    part_id="INSERT YOUR PART ID",
+    file_ext="png"
+    component_type='motor',
+    component_name='left_motor',
+    method_name='IsPowered',
+    data_request_times=[(time_requested, time_received)],
+    tags=["tag_1", "tag_2"]
+
+print(file_id)
+```
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.streaming_data_capture_upload).
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ### FileUpload
 
 Upload arbitrary files stored on your machine to the [Viam app](https://app.viam.com) by file name.
@@ -788,55 +838,6 @@ await data_client.remove_bounding_box_from_image_by_id(
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.remove_bounding_box_from_image_by_id).
-
-{{% /tab %}}
-{{< /tabs >}}
-
-### StreamingDataCaptureUpload
-
-Uploads the metadata and contents of streaming binary data.
-
-{{< tabs >}}
-{{% tab name="Python" %}}
-
-**Parameters:**
-
-- `data` [(bytes)](https://docs.python.org/3/library/stdtypes.html#bytes-objects): the data to be uploaded, represented in bytes.
-- `part_id` [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Part ID of the resource associated with the file.
-- `file_ext` [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): File extension type for the data. required for determining MIME type.
-- `component_type` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional type of the component associated with the file (For example, “movement_sensor”).
-- `component_name` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional name of the component associated with the file.
-- `method_name` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional name of the method associated with the file.
-- `method_parameters` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional dictionary of the method parameters. No longer in active use.
-- `data_request_times` [(Optional[Tuple[datetime.datetime, datetime.datetime]])](https://docs.python.org/3/library/stdtypes.html#tuples): Optional tuple containing [`datetime`](https://docs.python.org/3/library/datetime.html) objects denoting the times this data was requested and received by the appropriate sensor.
-- `tags` [(Optional[List[str]])](https://docs.python.org/3/library/stdtypes.html#typesseq-list): Optional list of [image tags](/manage/data/label/#image-tags) to allow for tag-based data filtering when retrieving data.
-
-**Returns:**
-
-- [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): the `file_id` of the uploaded data.
-
-**Raises:**
-
-- `GRPCError` – If an invalid part ID is passed.
-
-```python {class="line-numbers linkable-line-numbers"}
-time_requested = datetime(2023, 6, 5, 11)
-time_received = datetime(2023, 6, 5, 11, 0, 3)
-
-file_id = await data_client.streaming_data_capture_upload(
-    data="byte-data-to-upload",
-    part_id="INSERT YOUR PART ID",
-    file_ext="png"
-    component_type='motor',
-    component_name='left_motor',
-    method_name='IsPowered',
-    data_request_times=[(time_requested, time_received)],
-    tags=["tag_1", "tag_2"]
-
-print(file_id)
-```
-
-For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.streaming_data_capture_upload).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/docs/build/program/apis/data-client.md
+++ b/docs/build/program/apis/data-client.md
@@ -644,7 +644,7 @@ Uploaded streaming data can be found under the [**Data** tab](https://app.viam.c
 
 **Parameters:**
 
-- `data` [(bytes)](https://docs.python.org/3/library/stdtypes.html#bytes-objects): the data to be uploaded, represented in bytes.
+- `data` [(bytes)](https://docs.python.org/3/library/stdtypes.html#bytes-objects): Data to be uploaded, represented in bytes.
 - `part_id` [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Part ID of the resource associated with the file.
 - `file_ext` [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): File extension type for the data. required for determining MIME type.
 - `component_type` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional type of the component associated with the file (For example, “movement_sensor”).
@@ -656,7 +656,7 @@ Uploaded streaming data can be found under the [**Data** tab](https://app.viam.c
 
 **Returns:**
 
-- [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): the `file_id` of the uploaded data.
+- [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): The `file_id` of the uploaded data.
 
 **Raises:**
 
@@ -759,7 +759,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ### AddBoundingBoxToImageById
 
-Add a bounding box to an image specified by its id.
+Add a bounding box to an image specified by its BinaryID.
 
 {{< tabs >}}
 {{% tab name="Python" %}}
@@ -809,7 +809,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ### RemoveBoundingBoxFromImageById
 
-Removes a bounding box from an image specified by its id.
+Removes a bounding box from an image specified by its BinaryID.
 
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/build/program/apis/data-client.md
+++ b/docs/build/program/apis/data-client.md
@@ -675,6 +675,7 @@ file_id = await data_client.streaming_data_capture_upload(
     method_name='IsPowered',
     data_request_times=[(time_requested, time_received)],
     tags=["tag_1", "tag_2"]
+)
 
 print(file_id)
 ```

--- a/docs/build/program/apis/data-client.md
+++ b/docs/build/program/apis/data-client.md
@@ -652,7 +652,7 @@ Uploaded streaming data can be found under the [**Data** tab](https://app.viam.c
 - `method_name` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional name of the method associated with the file.
 - `method_parameters` [(Optional[str])](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Optional dictionary of the method parameters. No longer in active use.
 - `data_request_times` [(Optional[Tuple[datetime.datetime, datetime.datetime]])](https://docs.python.org/3/library/stdtypes.html#tuples): Optional tuple containing [`datetime`](https://docs.python.org/3/library/datetime.html) objects denoting the times this data was requested and received by the appropriate sensor.
-- `tags` [(Optional[List[str]])](https://docs.python.org/3/library/stdtypes.html#typesseq-list): Optional list of [image tags](/manage/data/label/#image-tags) to allow for tag-based data filtering when retrieving data.
+- `tags` [(Optional[List[str]])](https://docs.python.org/3/library/stdtypes.html#typesseq-list): Optional list of [image tags](/data/dataset/#image-tags) to allow for tag-based data filtering when retrieving data.
 
 **Returns:**
 

--- a/docs/build/program/apis/data-client.md
+++ b/docs/build/program/apis/data-client.md
@@ -717,10 +717,10 @@ Add a bounding box to an image specified by its id.
 
 - `binary_id` ([viam.proto.app.data.BinaryID](https://python.viam.dev/autoapi/viam/proto/app/data/index.html#viam.proto.app.data.BinaryID)): The ID of the image to add the bounding box to.
 - `label` [(str)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): A label for the bounding box.
-- `x_min_normalized` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)): Min X value of the bounding box normalized from 0 to 1.
-- `y_min_normalized` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)): Min Y value of the bounding box normalized from 0 to 1.
-- `x_max_normalized` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)): Max X value of the bounding box normalized from 0 to 1.
-- `y_max_normalized` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)): Max Y value of the bounding box normalized from 0 to 1.
+- `x_min_normalized` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)): Minimum X value of the bounding box normalized from `0` to `1`.
+- `y_min_normalized` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)): Minimum Y value of the bounding box normalized from `0` to `1`.
+- `x_max_normalized` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)): Maximum X value of the bounding box normalized from `0` to `1`.
+- `y_max_normalized` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)): Maximum Y value of the bounding box normalized from `0` to `1`.
 
 **Returns:**
 
@@ -731,7 +731,24 @@ Add a bounding box to an image specified by its id.
 - `GRPCError` – If the X or Y values are outside of the [0, 1] range.
 
 ```python {class="line-numbers linkable-line-numbers"}
-placeholder
+from viam.proto.app.data import BinaryID
+
+MY_BINARY_ID = BinaryID(
+    file_id=your-file_id,
+    organization_id=your-org-id,
+    location_id=your-location-id
+)
+
+bbox_label = await data_client.add_bounding_box_to_image_by_id(
+  binary_id=MY_BINARY_ID,
+  label="label",
+  x_min_normalized=0,
+  y_min_normalized=.1,
+  x_max_normalized=.2,
+  y_max_normalized=.3,
+)
+
+print(bbox_label)
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.add_bounding_box_to_image_by_id).
@@ -756,7 +773,18 @@ Removes a bounding box from an image specified by its id.
 - None.
 
 ```python {class="line-numbers linkable-line-numbers"}
-placeholder
+from viam.proto.app.data import BinaryID
+
+MY_BINARY_ID = BinaryID(
+    file_id=your-file_id,
+    organization_id=your-org-id,
+    location_id=your-location-id
+)
+
+await data_client.remove_bounding_box_from_image_by_id(
+  binary_id=MY_BINARY_ID,
+  bbox_id="your-bounding-box-id-to-delete"
+)
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.remove_bounding_box_from_image_by_id).
@@ -792,7 +820,20 @@ Uploads the metadata and contents of streaming binary data.
 - `GRPCError` – If an invalid part ID is passed.
 
 ```python {class="line-numbers linkable-line-numbers"}
-placeholder
+time_requested = datetime(2023, 6, 5, 11)
+time_received = datetime(2023, 6, 5, 11, 0, 3)
+
+file_id = await data_client.streaming_data_capture_upload(
+    data="byte-data-to-upload",
+    part_id="INSERT YOUR PART ID",
+    file_ext="png"
+    component_type='motor',
+    component_name='left_motor',
+    method_name='IsPowered',
+    data_request_times=[(time_requested, time_received)],
+    tags=["tag_1", "tag_2"]
+
+print(file_id)
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.streaming_data_capture_upload).

--- a/docs/build/program/apis/data-client.md
+++ b/docs/build/program/apis/data-client.md
@@ -669,7 +669,7 @@ time_received = datetime(2023, 6, 5, 11, 0, 3)
 file_id = await data_client.streaming_data_capture_upload(
     data="byte-data-to-upload",
     part_id="INSERT YOUR PART ID",
-    file_ext="png"
+    file_ext="png",
     component_type='motor',
     component_name='left_motor',
     method_name='IsPowered',
@@ -796,7 +796,7 @@ bbox_label = await data_client.add_bounding_box_to_image_by_id(
   x_min_normalized=0,
   y_min_normalized=.1,
   x_max_normalized=.2,
-  y_max_normalized=.3,
+  y_max_normalized=.3
 )
 
 print(bbox_label)

--- a/static/include/services/apis/data-client.md
+++ b/static/include/services/apis/data-client.md
@@ -16,8 +16,8 @@ Method Name | Description
 [`GetDatabaseConnection`](/build/program/apis/data-client/#getdatabaseconnection) | Get a connection to access a MongoDB Atlas Data federation instance.
 [`BinaryDataCaptureUpload`](/build/program/apis/data-client/#binarydatacaptureupload) | Upload binary data collected on your machine through a specific component and the relevant metadata to the Viam app.
 [`TabularDataCaptureUpload`](/build/program/apis/data-client/#tabulardatacaptureupload) | Upload tabular data collected on your machine through a specific component and the relevant metadata to the Viam app.
-[`StreamingDataCaptureUpload`](/program/apis/data-client/#streamingdatacaptureupload) | Upload the contents of streaming binary data and the relevant metadata to the Viam app.
+[`StreamingDataCaptureUpload`](/build/program/apis/data-client/#streamingdatacaptureupload) | Upload the contents of streaming binary data and the relevant metadata to the Viam app.
 [`FileUpload`](/build/program/apis/data-client/#fileupload) | Upload file data stored on your machine and the relevant metadata to the Viam app.
 [`FileUploadFromPath`](/build/program/apis/data-client/#fileuploadfrompath) | Upload file data stored on your machine from the specified filepath and the relevant metadata to the Viam app.
-[`AddBoundingBoxToImageById`](/program/apis/data-client/#addboundingboxtoimagebyid) | Add a bounding box to an image specified by its id.
-[`RemoveBoundingBoxFromImageById`](/program/apis/data-client/#removeboundingboxfromimagebyid) | Removes a bounding box from an image specified by its id.
+[`AddBoundingBoxToImageById`](/build/program/apis/data-client/#addboundingboxtoimagebyid) | Add a bounding box to an image specified by its id.
+[`RemoveBoundingBoxFromImageById`](/build/program/apis/data-client/#removeboundingboxfromimagebyid) | Removes a bounding box from an image specified by its id.

--- a/static/include/services/apis/data-client.md
+++ b/static/include/services/apis/data-client.md
@@ -18,3 +18,6 @@ Method Name | Description
 [`TabularDataCaptureUpload`](/build/program/apis/data-client/#tabulardatacaptureupload) | Upload tabular data collected on your machine through a specific component and the relevant metadata to the Viam app.
 [`FileUpload`](/build/program/apis/data-client/#fileupload) | Upload file data stored on your machine and the relevant metadata to the Viam app.
 [`FileUploadFromPath`](/build/program/apis/data-client/#fileuploadfrompath) | Upload file data stored on your machine from the specified filepath and the relevant metadata to the Viam app.
+[`AddBoundingBoxToImageById`](/program/apis/data-client/#addboundingboxtoimagebyid) | Add a bounding box to an image specified by its id.
+[`RemoveBoundingBoxFromImageById`](/program/apis/data-client/#removeboundingboxfromimagebyid) | Removes a bounding box from an image specified by its id.
+[`StreamingDataCaptureUpload`](/program/apis/data-client/#streamingdatacaptureupload) | Uploads the metadata and contents of streaming binary data.

--- a/static/include/services/apis/data-client.md
+++ b/static/include/services/apis/data-client.md
@@ -19,5 +19,5 @@ Method Name | Description
 [`StreamingDataCaptureUpload`](/build/program/apis/data-client/#streamingdatacaptureupload) | Upload the contents of streaming binary data and the relevant metadata to the Viam app.
 [`FileUpload`](/build/program/apis/data-client/#fileupload) | Upload file data stored on your machine and the relevant metadata to the Viam app.
 [`FileUploadFromPath`](/build/program/apis/data-client/#fileuploadfrompath) | Upload file data stored on your machine from the specified filepath and the relevant metadata to the Viam app.
-[`AddBoundingBoxToImageById`](/build/program/apis/data-client/#addboundingboxtoimagebyid) | Add a bounding box to an image specified by its id.
-[`RemoveBoundingBoxFromImageById`](/build/program/apis/data-client/#removeboundingboxfromimagebyid) | Removes a bounding box from an image specified by its id.
+[`AddBoundingBoxToImageById`](/build/program/apis/data-client/#addboundingboxtoimagebyid) | Add a bounding box to an image specified by its BinaryID.
+[`RemoveBoundingBoxFromImageById`](/build/program/apis/data-client/#removeboundingboxfromimagebyid) | Removes a bounding box from an image specified by its BinaryID.

--- a/static/include/services/apis/data-client.md
+++ b/static/include/services/apis/data-client.md
@@ -16,8 +16,8 @@ Method Name | Description
 [`GetDatabaseConnection`](/build/program/apis/data-client/#getdatabaseconnection) | Get a connection to access a MongoDB Atlas Data federation instance.
 [`BinaryDataCaptureUpload`](/build/program/apis/data-client/#binarydatacaptureupload) | Upload binary data collected on your machine through a specific component and the relevant metadata to the Viam app.
 [`TabularDataCaptureUpload`](/build/program/apis/data-client/#tabulardatacaptureupload) | Upload tabular data collected on your machine through a specific component and the relevant metadata to the Viam app.
+[`StreamingDataCaptureUpload`](/program/apis/data-client/#streamingdatacaptureupload) | Upload the contents of streaming binary data and the relevant metadata to the Viam app.
 [`FileUpload`](/build/program/apis/data-client/#fileupload) | Upload file data stored on your machine and the relevant metadata to the Viam app.
 [`FileUploadFromPath`](/build/program/apis/data-client/#fileuploadfrompath) | Upload file data stored on your machine from the specified filepath and the relevant metadata to the Viam app.
 [`AddBoundingBoxToImageById`](/program/apis/data-client/#addboundingboxtoimagebyid) | Add a bounding box to an image specified by its id.
 [`RemoveBoundingBoxFromImageById`](/program/apis/data-client/#removeboundingboxfromimagebyid) | Removes a bounding box from an image specified by its id.
-[`StreamingDataCaptureUpload`](/program/apis/data-client/#streamingdatacaptureupload) | Uploads the metadata and contents of streaming binary data.


### PR DESCRIPTION
Add three missing DataClient API methods to DataClient API reference page:
- `add_bounding_box_to_image_by_id`
- `remove_bounding_box_from_image_by_id`
- `streaming_data_capture_upload`