### PR TITLE
DOCS-1454: Add ffmpeg link to rtsp

### DIFF
--- a/docs/components/camera/ffmpeg.md
+++ b/docs/components/camera/ffmpeg.md
@@ -1,16 +1,15 @@
 ---
-title: "Configure a FFmpeg Camera"
+title: "Configure an ffmpeg Camera"
 linkTitle: "ffmpeg"
 weight: 30
 type: "docs"
-description: "Uses a camera, a video file, or a stream as a camera."
+description: "Uses a camera device, a video file, or a stream as a camera."
 images: ["/icons/components/camera.svg"]
 tags: ["camera", "components"]
 # SMEs: Bijan, vision team
 ---
 
-The `ffmpeg` camera model uses a camera, a video file, or a stream as a camera.
-The `ffmpeg` camera supports streaming cameras with MJPEG, H264, and MP4 tracks.
+The `ffmpeg` camera model uses a camera device, a video file, or a stream as a camera, with support for streaming cameras that use MJPEG, H264, or MP4 tracks.
 
 {{< tabs name="Configure a ffmpeg camera" >}}
 {{% tab name="Config Builder" %}}

--- a/docs/components/camera/ffmpeg.md
+++ b/docs/components/camera/ffmpeg.md
@@ -9,7 +9,8 @@ tags: ["camera", "components"]
 # SMEs: Bijan, vision team
 ---
 
-A `ffmpeg` camera uses a camera, a video file, or a stream as a camera.
+The `ffmpeg` camera model uses a camera, a video file, or a stream as a camera.
+The `ffmpeg` camera supports streaming cameras with MJPEG, H264, and MP4 tracks.
 
 {{< tabs name="Configure a ffmpeg camera" >}}
 {{% tab name="Config Builder" %}}
@@ -118,7 +119,7 @@ The following attributes are available for `ffmpeg` cameras:
 <!-- prettier-ignore -->
 | Name | Type | Inclusion | Description |
 | ---- | ---- | --------- | ----------- |
-| `video_path` | string | **Required** | The file path to the color image. |
+| `video_path` | string | **Required** | The file path to the camera device, color image file, or streaming camera. If you are using a camera with an RTSP stream, provide the RTSP address to this attribute. |
 | `intrinsic_parameters` | object | Optional | The intrinsic parameters of the camera used to do 2D <-> 3D projections: <ul> <li> <code>width_px</code>: The expected width of the aligned image in pixels. </li> <li> <code>height_px</code>: The expected height of the aligned image in pixels. </li> <li> <code>fx</code>: The image center x point. </li> <li> <code>fy</code>: The image center y point. </li> <li> <code>ppx</code>: The image focal x. </li> <li> <code>ppy</code>: The image focal y. </li> </ul> |
 | `distortion_parameters` | object | Optional | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
 | `debug` | boolean | Optional | Enables the debug outputs from the camera if `true`. <br> Default: `false` |

--- a/docs/components/camera/ffmpeg.md
+++ b/docs/components/camera/ffmpeg.md
@@ -9,7 +9,9 @@ tags: ["camera", "components"]
 # SMEs: Bijan, vision team
 ---
 
-The `ffmpeg` camera model uses a camera device, a video file, or a stream as a camera, with support for streaming cameras that use MJPEG, H264, or MP4 tracks.
+The `ffmpeg` camera model uses a camera device, a video file, or a stream as a camera.
+
+When used with a streaming camera, the `ffmpeg` camera model supports any streaming camera format that is supported by the [`ffmpeg` program](https://ffmpeg.org/), including MJPEG, H264, and MP4.
 
 {{< tabs name="Configure a ffmpeg camera" >}}
 {{% tab name="Config Builder" %}}

--- a/docs/components/camera/rtsp.md
+++ b/docs/components/camera/rtsp.md
@@ -10,7 +10,10 @@ tags: ["camera", "components"]
 ---
 
 The `rtsp` camera model supports streaming cameras with MJPEG tracks.
-The model doesn’t support streaming cameras with H264/MP4 tracks.
+
+{{< alert title="Info" color="info" >}}
+If your streaming camera uses H264 or MP4 tracks, use the [`ffmpeg` camera](/components/camera/ffmpeg/) instead.
+{{< /alert >}}
 
 {{< tabs name="Configure an rtsp camera" >}}
 {{% tab name="Config Builder" %}}

--- a/docs/components/camera/rtsp.md
+++ b/docs/components/camera/rtsp.md
@@ -12,7 +12,7 @@ tags: ["camera", "components"]
 The `rtsp` camera model supports streaming cameras with MJPEG tracks.
 
 {{< alert title="Info" color="info" >}}
-If your streaming camera uses H264 or MP4 tracks, use the [`ffmpeg` camera](/components/camera/ffmpeg/) instead.
+If your streaming camera uses other types of tracks, such as H264 or MP4, use the [`ffmpeg` camera](/components/camera/ffmpeg/) instead.
 {{< /alert >}}
 
 {{< tabs name="Configure an rtsp camera" >}}

--- a/docs/components/camera/rtsp.md
+++ b/docs/components/camera/rtsp.md
@@ -12,7 +12,7 @@ tags: ["camera", "components"]
 The `rtsp` camera model supports streaming cameras with MJPEG tracks.
 
 {{< alert title="Info" color="info" >}}
-If your streaming camera uses other types of tracks, such as H264 or MP4, use the [`ffmpeg` camera](/components/camera/ffmpeg/) instead.
+If your streaming camera uses a different streaming video format, such as H264 or MP4, use the [`ffmpeg` camera](/components/camera/ffmpeg/) instead.
 {{< /alert >}}
 
 {{< tabs name="Configure an rtsp camera" >}}


### PR DESCRIPTION
Add link to `ffmpeg` camera from `rtsp` camera, for streaming cameras that use H264 or MP4 tracks.
- Clarified `video_path` attribute on `ffmpeg` camera to highlight usage with `rtsp` cams.