### PR TITLE
Change glossary item styling

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1531,3 +1531,10 @@ input[type=search]::-webkit-search-cancel-button {
 }
 
 // styling for model list from modular resources END
+
+// Glossary tooltips
+
+.glossary-tooltip {
+  color: black;
+  text-decoration-style: dotted;
+}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1536,5 +1536,6 @@ input[type=search]::-webkit-search-cancel-button {
 
 .glossary-tooltip {
   color: black;
+  text-decoration: underline;
   text-decoration-style: dotted;
 }

--- a/layouts/shortcodes/glossary_tooltip.html
+++ b/layouts/shortcodes/glossary_tooltip.html
@@ -18,8 +18,8 @@
 
 {{- $tooltip := $tooltip | replaceRE "(?s)<a class='glossary-tooltip'.*?>(.*?).*</a>" "$1" | plainify -}}
 {{- $tooltip := trim $tooltip " \n" -}}
-<a class='glossary-tooltip' title='{{- $tooltip | safeHTML -}}' data-toggle='tooltip' data-placement='top' href='{{- if (eq (substr $baseurl -1) "/" ) -}}{{(substr $baseurl 0 -1)}}{{- else -}}{{$baseurl}}{{- end }}{{$external_link}}' target='_blank' aria-label='{{ $text }}'>
+<span class='glossary-tooltip' title='{{- $tooltip | safeHTML -}}' data-toggle='tooltip' data-placement='top' aria-label='{{ $text }}'>
     {{- $text -}}
-</a>
+</span>
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Glossary tooltip items (the ones you add with `{{< glossary_tooltip term_id="term" text="text" >}}`) are now no longer clickable. They are also styled differently (black with a dotted line underneath).