### PR TITLE
Add icon to ML landing page

### DIFF
--- a/docs/ml/_index.md
+++ b/docs/ml/_index.md
@@ -9,6 +9,7 @@ description: "Use Viam's built-in machine learning capabilities to train image c
 image: "/ml/training.png"
 imageAlt: "Machine Learning"
 images: ["/ml/training.png"]
+icon: "/build/configure/services/icons/ml.svg"
 aliases:
   - /manage/ml/
 menuindent: true


### PR DESCRIPTION
Add SVG icon to ML landing page, so that it shows up with preview icon when viewed on other pages' `## Used With` sections (i.e. using `relatedcard`)