### PR TITLE
DOCS-514: Add C++ MR create examples

### DIFF
--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -45,7 +45,7 @@ This interface defines how your model's server responds to API requests.
 
 To ensure the client interface you create returns the expected results, use the appropriate client interface defined in <file>components/\<resource-name\>/client.py</file> or <file>services/\<resource-name\>/client.py</file> in the [Viam Python SDK](https://github.com/viamrobotics/viam-python-sdk/blob/main/src/viam/) as a reference.
 
-For example, the `base` component client is defined in the [<file>client.py</file>](https://github.com/viamrobotics/viam-python-sdk/blob/main/src/viam/components/base/client.py) file.
+For example, the `base` component client is defined in the [<file>components/base/client.py</file>](https://github.com/viamrobotics/viam-python-sdk/blob/main/src/viam/components/base/client.py) file.
 
 See [Valid APIs to implement in your model](#valid-apis-to-implement-in-your-model) for more information.
 
@@ -58,7 +58,20 @@ This interface defines how your model's server responds to API requests.
 
 To ensure the client interface you create returns the expected results, use the appropriate client interface defined in <file>components/\<resource-name\>/client.go</file> or <file>services/\<resource-name\>/client.go</file> in the [Viam RDK](https://github.com/viamrobotics/rdk/blob/main/) as a reference.
 
-For example, the `base` component client is defined in the [<file>client.go</file>](https://github.com/viamrobotics/rdk/blob/main/components/base/client.go) file.
+For example, the `base` component client is defined in the [<file>components/base/client.go</file>](https://github.com/viamrobotics/rdk/blob/main/components/base/client.go) file.
+
+See [Valid APIs to implement in your model](#valid-apis-to-implement-in-your-model) for more information.
+
+{{% /tab %}}
+{{% tab name="C++" %}}
+
+To create a new resource model, you need to implement your model's **client** interface in a file called `my_modular_resource.cpp`.
+
+This interface defines how your model's server responds to API requests.
+
+To ensure the client interface you create returns the expected results, use the appropriate client interface defined in <file>components/\<resource-name\>/client.cpp</file> or <file>services/\<resource-name\>/client.cpp</file> in the [Viam C++ SDK](https://github.com/viamrobotics/viam-cpp-sdk/tree/main/src/viam/sdk) as a reference.
+
+For example, the `base` component client is defined in the [<file>components/base/client.cpp</file>](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/src/viam/sdk/components/base/client.cpp) file.
 
 See [Valid APIs to implement in your model](#valid-apis-to-implement-in-your-model) for more information.
 
@@ -82,6 +95,13 @@ For example, the `base` component subtype is defined in [<file>viam-python-sdk/s
 Find the subtype API as defined in the relevant <file>components/\<resource-name\>/\<resource-name\>.go</file> or <file>services/\<resource-name\>/\<resource-name\>.go</file> file in the [RDK](https://github.com/viamrobotics/rdk).
 
 For example, the `base` component subtype is defined in [<file>rdk/components/base/base.go</file>](https://github.com/viamrobotics/rdk/blob/main/components/base/base.go#L37).
+
+{{% /tab %}}
+{{% tab name="C++" %}}
+
+Find the subtype API as defined in the relevant <file>components/\<resource-name\>/\<resource-name>\.cpp</file> or <file>services/\<resource-name\>/<resource-name>.cpp</file> file in the [C++ SDK](https://github.com/viamrobotics/viam-cpp-sdk/).
+
+For example, the `base` component subtype is defined in [<file>viam-cpp-sdk/src/viam/components/base/base.cpp</file>](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/src/viam/sdk/components/base/base.cpp).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -128,11 +148,12 @@ For more information see [Naming your model](/registry/upload/#naming-your-model
 
 {{< tabs >}}
 {{% tab name="Python" %}}
+
 Your new resource model server must have all the methods that the Viam RDK requires, and should match the built-in API client {{< glossary_tooltip term_id="subtype" text="subtype" >}} like [`rdk:component:base`](https://python.viam.dev/autoapi/viam/components/base/index.html).
 
 Create a folder for your module and save your code as a file named <file>my_modular_resource.py</file> inside.
 
-The following example module registers a modular resource implementing Viam's built-in [Base API](/components/base/#api) (`rdk:service:base`) as a new model, `"mybase"`, using the model family `acme:demo:mybase`.
+The following example module registers a modular resource implementing Viam's built-in [Base API](/components/base/#api) (`rdk:components:base`) as a new model, `"mybase"`, using the model family `acme:demo:mybase`.
 
 <details>
   <summary>Click to view sample code for <file>my_base.py</file></summary>
@@ -313,7 +334,7 @@ Your new resource model server must have all the methods that the Viam RDK requi
 
 Create a folder for your module and save your code as a file named <file>my_modular_resource.go</file> inside.
 
-The following example module registers a modular resource implementing Viam's built-in [Base API](/components/base/#api) (`rdk:service:base`) as a new {{< glossary_tooltip term_id="model" text="model" >}}, `"mybase"`, using the model family `acme:demo:mybase`.
+The following example module registers a modular resource implementing Viam's built-in [Base API](/components/base/#api) (`rdk:components:base`) as a new {{< glossary_tooltip term_id="model" text="model" >}}, `"mybase"`, using the model family `acme:demo:mybase`.
 
 <details>
   <summary>Click to view sample code for <file>mybase.go</file></summary>
@@ -513,6 +534,187 @@ The code for the custom model (<file>mybase.go</file>) and module entry point fi
 Additional examples are available in the [examples directory of the RDK](https://github.com/viamrobotics/rdk/blob/main/examples/).
 
 {{% /tab %}}
+{{% tab name="C++" %}}
+
+Your new resource model server must have all the methods that the Viam RDK requires, and should match the built-in API client {{< glossary_tooltip term_id="subtype" text="subtype" >}} like [`rdk:component:base`](https://cpp.viam.dev/classviam_1_1sdk_1_1Base.html).
+
+Create a folder for your module and save your code as a file named <file>my_modular_resource.cpp</file> inside.
+
+The following example module registers a modular resource implementing Viam's built-in [Base API](/build/configure/components/base/#api) (`rdk:components:base`) as a new model, `"MyBase"`.
+
+<details>
+  <summary>Click to view sample code for <file>my_base.cpp</file></summary>
+
+```cpp {class="line-numbers linkable-line-numbers"}
+#include <iostream>
+#include <memory>
+#include <signal.h>
+#include <sstream>
+
+#include <grpcpp/support/status.h>
+
+#include <viam/sdk/components/base/base.hpp>
+#include <viam/sdk/components/component.hpp>
+#include <viam/sdk/config/resource.hpp>
+#include <viam/sdk/resource/resource.hpp>
+
+#include <boost/log/trivial.hpp>
+
+using namespace viam::sdk;
+
+// `MyBase` inherits from the `Base` class defined in the Viam C++ SDK and
+// implements some of the relevant methods along with `reconfigure`. It also
+// specifies a static `validate` method that checks config validity.
+class MyBase : public Base {
+   public:
+    MyBase(Dependencies deps, ResourceConfig cfg) : Base(cfg.name()) {
+        this->reconfigure(deps, cfg);
+    };
+    void reconfigure(Dependencies deps, ResourceConfig cfg) override;
+    static std::vector<std::string> validate(ResourceConfig cfg);
+
+    bool is_moving() override;
+    void stop(const AttributeMap& extra) override;
+    void set_power(const Vector3& linear,
+                   const Vector3& angular,
+                   const AttributeMap& extra) override;
+
+    AttributeMap do_command(const AttributeMap& command) override;
+    std::vector<GeometryConfig> get_geometries(const AttributeMap& extra) override;
+    Base::properties get_properties(const AttributeMap& extra) override;
+
+    void move_straight(int64_t distance_mm, double mm_per_sec, const AttributeMap& extra) override {
+        throw std::runtime_error("move_straight unimplemented");
+    }
+    void spin(double angle_deg, double degs_per_sec, const AttributeMap& extra) override {
+        throw std::runtime_error("spin unimplemented");
+    }
+    void set_velocity(const Vector3& linear,
+                      const Vector3& angular,
+                      const AttributeMap& extra) override {
+        throw std::runtime_error("set_velocity unimplemented");
+    }
+
+   private:
+    std::shared_ptr<Motor> left_;
+    std::shared_ptr<Motor> right_;
+};
+
+std::string find_motor(ResourceConfig cfg, std::string motor_name) {
+    auto base_name = cfg.name();
+    auto motor = cfg.attributes()->find(motor_name);
+    if (motor == cfg.attributes()->end()) {
+        std::ostringstream buffer;
+        buffer << base_name << ": Required parameter `" << motor_name
+               << "` not found in configuration";
+        throw std::invalid_argument(buffer.str());
+    }
+    const auto* const motor_string = motor->second->get<std::string>();
+    if (!motor_string || motor_string->empty()) {
+        std::ostringstream buffer;
+        buffer << base_name << ": Required non-empty string parameter `" << motor_name
+               << "` is either not a string "
+                  "or is an empty string";
+        throw std::invalid_argument(buffer.str());
+    }
+    return *motor_string;
+}
+
+void MyBase::reconfigure(Dependencies deps, ResourceConfig cfg) {
+    // Downcast `left` and `right` dependencies to motors.
+    auto left = find_motor(cfg, "left");
+    auto right = find_motor(cfg, "right");
+    for (const auto& kv : deps) {
+        if (kv.first.short_name() == left) {
+            left_ = std::dynamic_pointer_cast<Motor>(kv.second);
+        }
+        if (kv.first.short_name() == right) {
+            right_ = std::dynamic_pointer_cast<Motor>(kv.second);
+        }
+    }
+}
+
+std::vector<std::string> MyBase::validate(ResourceConfig cfg) {
+    // Custom validation can be done by specifying a validate function at the
+    // time of resource registration (see complex/main.cpp) like this one.
+    // Validate functions can `throw` exceptions that will be returned to the
+    // parent through gRPC. Validate functions can also return a vector of
+    // strings representing the implicit dependencies of the resource.
+    //
+    // Here, we return the names of the "left" and "right" motors as found in
+    // the attributes as implicit dependencies of the base.
+    return {find_motor(cfg, "left"), find_motor(cfg, "right")};
+}
+
+bool MyBase::is_moving() {
+    return left_->is_moving() || right_->is_moving();
+}
+
+void MyBase::stop(const AttributeMap& extra) {
+    std::string err_message;
+    bool throw_err = false;
+
+    // make sure we try to stop both motors, even if the first fails.
+    try {
+        left_->stop(extra);
+    } catch (const std::exception& err) {
+        throw_err = true;
+        err_message = err.what();
+    }
+
+    try {
+        right_->stop(extra);
+    } catch (const std::exception& err) {
+        throw_err = true;
+        err_message = err.what();
+    }
+
+    // if we received an err from either motor, throw it.
+    if (throw_err) {
+        throw std::runtime_error(err_message);
+    }
+}
+
+void MyBase::set_power(const Vector3& linear, const Vector3& angular, const AttributeMap& extra) {
+    // Stop the base if absolute value of linear and angular velocity is less
+    // than 0.01.
+    if (abs(linear.y()) < 0.01 && abs(angular.z()) < 0.01) {
+        stop(extra);  // ignore returned status code from stop
+        return;
+    }
+
+    // Use linear and angular velocity to calculate percentage of max power to
+    // pass to set_power for left & right motors
+    auto sum = abs(linear.y()) + abs(angular.z());
+    left_->set_power(((linear.y() - angular.z()) / sum), extra);
+    right_->set_power(((linear.y() + angular.z()) / sum), extra);
+}
+
+AttributeMap MyBase::do_command(const AttributeMap& command) {
+    std::cout << "Received DoCommand request for MyBase " << Resource::name() << std::endl;
+    return command;
+}
+
+std::vector<GeometryConfig> MyBase::get_geometries(const AttributeMap& extra) {
+    auto left_geometries = left_->get_geometries(extra);
+    auto right_geometries = right_->get_geometries(extra);
+    std::vector<GeometryConfig> geometries(left_geometries);
+    geometries.insert(geometries.end(), right_geometries.begin(), right_geometries.end());
+    return geometries;
+}
+
+Base::properties MyBase::get_properties(const AttributeMap& extra) {
+    // Return fake properties.
+    return {2, 4, 8};
+}
+```
+
+</details>
+<br>
+
+Additional example modules are available in the [C++ SDK GitHub repository](https://github.com/viamrobotics/viam-cpp-sdk/tree/main/src/viam/examples/).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### Code a main entry point program
@@ -564,7 +766,7 @@ if __name__ == "__main__":
 You must define all functions belonging to a built-in resource subtype's API if defining a new model.
 Otherwise, the class will not instantiate.
 
-If you do not wish to implement all methods, raise an`NotImplementedError()` in the body of functions you do not want to implement or put `pass`.
+If you do not wish to implement all methods, raise a `NotImplementedError()` in the body of functions you do not want to implement or put `pass`.
 
 Additionally, return any values designated in the function's return signature, typed correctly.
 
@@ -634,7 +836,105 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) (er
 You must define all functions belonging to a built-in resource subtype's API if defining a new model.
 Otherwise, the class will not instantiate.
 
-If you do not wish to implement all methods, raise `errUnimplemented` for the functions you do not want to implement.
+If you do not wish to implement all methods, raise an `errUnimplemented` error for the functions you do not want to implement.
+
+Additionally, return any values designated in the function's return signature, typed correctly.
+
+{{% /alert %}}
+
+{{% /tab %}}
+{{% tab name="C++" %}}
+
+The main program starts the module.
+<file>main.cpp</file> is the module's entry point file.
+
+Import your custom model and API into the main program and register them with the C++ SDK.
+When executed, the main program registers the `MyBase` custom model custom model and API helper functions with the C++ SDK, using the model family `acme:demo:mybase`, and creates and starts the new module.
+
+<details>
+  <summary>Click to view sample code for <file>main.cpp</file></summary>
+
+```cpp {class="line-numbers linkable-line-numbers"}
+#include <memory>
+#include <signal.h>
+
+#include <boost/log/trivial.hpp>
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/server_context.h>
+
+#include <viam/api/common/v1/common.grpc.pb.h>
+#include <viam/api/component/generic/v1/generic.grpc.pb.h>
+#include <viam/api/robot/v1/robot.pb.h>
+
+#include <viam/sdk/components/base/base.hpp>
+#include <viam/sdk/components/component.hpp>
+#include <viam/sdk/config/resource.hpp>
+#include <viam/sdk/module/module.hpp>
+#include <viam/sdk/module/service.hpp>
+#include <viam/sdk/registry/registry.hpp>
+#include <viam/sdk/resource/resource.hpp>
+#include <viam/sdk/rpc/dial.hpp>
+#include <viam/sdk/rpc/server.hpp>
+
+#include "base/impl.hpp"
+
+using namespace viam::sdk;
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "Need socket path as command line argument" << std::endl;
+        return EXIT_FAILURE;
+    }
+    std::string socket_addr = argv[1];
+
+    // Use set_logger_severity_from_args to set the boost trivial logger's
+    // severity depending on commandline arguments.
+    set_logger_severity_from_args(argc, argv);
+    BOOST_LOG_TRIVIAL(debug) << "Starting module with debug level logging";
+
+    // C++ modules must handle SIGINT and SIGTERM. You can use the SignalManager
+    // class and its wait method to handle the correct signals.
+    SignalManager signals;
+
+    // Here is where we define your new model's colon-delimited-triplet (acme:demo:mybase)
+    // acme = namespace, demo = repo-name, mybase = model name.
+    API base_api = Base::static_api();
+    Model mybase_model("acme", "demo", "mybase");
+
+    std::shared_ptr<ModelRegistration> mybase_mr = std::make_shared<ModelRegistration>(
+        ResourceType("Base"),
+        base_api,
+        mybase_model,
+        [](Dependencies deps, ResourceConfig cfg) { return std::make_unique<MyBase>(deps, cfg); },
+        MyBase::validate);
+
+    Registry::register_model(mybase_mr);
+
+    // The `ModuleService_` must outlive the Server, so the declaration order
+    // here matters.
+    auto my_mod = std::make_shared<ModuleService_>(socket_addr);
+    auto server = std::make_shared<Server>();
+
+    my_mod->add_model_from_registry(server, base_api, mybase_model);
+    my_mod->start(server);
+    BOOST_LOG_TRIVIAL(info) << "Complex example module listening on " << socket_addr;
+
+    server->start();
+    int sig = 0;
+    auto result = signals.wait(&sig);
+    server->shutdown();
+    return EXIT_SUCCESS;
+};
+```
+
+</details>
+
+{{% alert title="Important" color="note" %}}
+
+You must define all functions belonging to a built-in resource subtype's API if defining a new model.
+Otherwise, the class will not instantiate.
+
+If you do not wish to implement all methods, `throw` a `runtime_error` in the body of functions you do not want to implement.
 
 Additionally, return any values designated in the function's return signature, typed correctly.
 
@@ -774,12 +1074,24 @@ Use Go to [compile](https://pkg.go.dev/cmd/go#hdr-Compile_packages_and_dependenc
 Expand the [Go module code](#code-a-main-entry-point-program) to view <file>main.go</file> for an example of this.
 
 {{% /tab %}}
+{{% tab name="C++" %}}
+
+Use C++ to [compile](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md) and obtain a single executable for your module:
+
+- Navigate to your module directory in your terminal.
+- Follow the steps to [build and compile the C++ SDK](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md), which compiles your entry point (main program) file <file>main.cpp</file> and all other <file>.cpp</file> files in the directory, building your module and all dependencies into a single executable file.
+- Run `ls` in your module directory to find the executable, which should have the same name as the module directory.
+
+<file>main.cpp</file> adds the custom model <file>mybase.cpp</file> from the resource registry, while <file>mybase.cpp</file> defines and registers the module.
+Expand the [C++ module code](#code-a-main-entry-point-program) to view <file>main.cpp</file> for an example of this.
+
+{{% /tab %}}
 {{% /tabs %}}
 
 ### Configure logging
 
 To enable your module to write logs to the [Viam app](https://app.viam.com/), ensure that you have added the following lines of code to your respective module code.
-Log messages are sent to the Viam app and appear under the **Logs** tab for your machine.
+Log messages are sent to the Viam app and appear under the [**Logs** tab](/fleet/machines/#logs) for your machine.
 
 {{< tabs name="Configure logging">}}
 {{% tab name="Python"%}}
@@ -787,7 +1099,7 @@ Log messages are sent to the Viam app and appear under the **Logs** tab for your
 To enable your Python module to write log messages to the Viam app, add the following lines to your code:
 
 ```python {class="line-numbers linkable-line-numbers" data-line="2,5"}
-# In your import block, import viam.logging getLogger:
+# In your import block, import the logging package:
 from viam.logging import getLogger
 
 # Before your first class or function, define the LOGGER variable:
@@ -800,7 +1112,7 @@ LOGGER = getLogger(__name__)
 To enable your Go module to write log messages to the Viam app, add the following lines to your code:
 
 ```go {class="line-numbers linkable-line-numbers"}
-// In your import() block, import the logger package:
+// In your import() block, import the logging package:
 import(
        ...
        "go.viam.com/rdk/logging"
@@ -832,6 +1144,25 @@ fn (c *component) someFunction(a int) {
   // Log with severity error without a parameter:
   c.logger.Errorln("performing some function")
 }
+```
+
+{{% /tab %}}
+{{% tab name="C++" %}}
+
+To enable your C++ module to write log messages to the Viam app, add the following lines to your code:
+
+```go {class="line-numbers linkable-line-numbers"}
+// Include the boost trivial logger:
+#include <boost/log/trivial.hpp>
+
+// Within your main() program, before logging anything, accept command line arguments to control log severity:
+set_logger_severity_from_args(argc, argv);
+
+// When ready to log an action, use the following notation:
+   // To log a simple message at debug level:
+   BOOST_LOG_TRIVIAL(debug) << "Starting module with debug level logging";
+   // To log a message that contains a variable at info level:
+   BOOST_LOG_TRIVIAL(info) << "Detected the following variable value: " << my_var;
 ```
 
 {{% /tab %}}

--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -1106,8 +1106,6 @@ To compile your C++ module's executable, you must create a <file>CMakeLists.txt<
    set -euo pipefail
 
    cd $(dirname $0)
-   # get bundled .so files from this directory
-   export LD_LIBRARY_PATH=${LD_LIBRARY_PATH-}:$PWD
    exec ./my-module $@
    ```
 

--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -65,16 +65,12 @@ See [Valid APIs to implement in your model](#valid-apis-to-implement-in-your-mod
 {{% /tab %}}
 {{% tab name="C++" %}}
 
-To create a new resource model, you need to implement your model's **client** interface in a file called `my_modular_resource.cpp`.
+To create a new resource model, start by referencing the corresponding built-in resource's implementation in the [Viam C++ SDK](https://github.com/viamrobotics/viam-cpp-sdk/tree/main/src/viam/sdk).
 
-This interface defines how your model's server responds to API requests.
+For example, if you are implementing a new custom `base` component model, reference the [<file>components/base/base.hpp</file>](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/src/viam/sdk/components/base/base.hpp) implementation file to learn how the `BaseClient` class is implemented.
 
-To ensure the client interface you create returns the expected results, use the appropriate client interface defined in <file>components/\<resource-name\>/client.hpp</file> or <file>services/\<resource-name\>/client.hpp</file> in the [Viam C++ SDK](https://github.com/viamrobotics/viam-cpp-sdk/tree/main/src/viam/sdk) as a reference.
-
-For example, the `base` component client is defined in the [<file>components/base/client.hpp</file>](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/src/viam/sdk/components/base/client.hpp) implementation file.
-
-Depending on your needs, you may also wish to create a corresponding implementation (header) file, `my_modular_resource.hpp`, as well.
-The example code in the following sections demonstrates using both files together.
+You can create your own derivative class in a <file>.cpp</file>, such as <file>my_modular_resource.cpp</file>, and optionally define the implementation of that class in a <file>.hpp</file> header file, such as <file>my_modular_resource.hpp</file>.
+The example code in the following sections demonstrates an implementation using both files.
 
 See [Valid APIs to implement in your model](#valid-apis-to-implement-in-your-model) for more information.
 
@@ -152,7 +148,7 @@ For more information see [Naming your model](/registry/upload/#naming-your-model
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-Your new resource model server must have all the methods that the Viam RDK requires, and should match the built-in API client {{< glossary_tooltip term_id="subtype" text="subtype" >}} like [`rdk:component:base`](https://python.viam.dev/autoapi/viam/components/base/index.html).
+Your new resource model must implement all the methods that the Viam RDK requires, and should match the built-in {{< glossary_tooltip term_id="subtype" text="subtype" >}} API, like [`rdk:component:base`](https://python.viam.dev/autoapi/viam/components/base/index.html).
 
 Create a folder for your module and save your code as a file named <file>my_modular_resource.py</file> inside.
 
@@ -333,7 +329,7 @@ Additional example modules are available in the [Python SDK GitHub repository](h
 {{% /tab %}}
 {{% tab name="Go"%}}
 
-Your new resource model server must have all the methods that the Viam RDK requires, and should match the built-in API client {{< glossary_tooltip term_id="subtype" text="subtype" >}} like [`rdk:component:base`](https://pkg.go.dev/go.viam.com/rdk/components/base#pkg-functions).
+Your new resource model must implement all the methods that the Viam RDK requires, and should match the built-in {{< glossary_tooltip term_id="subtype" text="subtype" >}} API, like [`rdk:component:base`](https://pkg.go.dev/go.viam.com/rdk/components/base#pkg-functions).
 
 Create a folder for your module and save your code as a file named <file>my_modular_resource.go</file> inside.
 
@@ -539,7 +535,7 @@ Additional examples are available in the [examples directory of the RDK](https:/
 {{% /tab %}}
 {{% tab name="C++" %}}
 
-Your new resource model server must have all the methods that the Viam RDK requires, and should match the built-in API client {{< glossary_tooltip term_id="subtype" text="subtype" >}} like [`rdk:component:base`](https://cpp.viam.dev/classviam_1_1sdk_1_1Base.html).
+Your new resource model must implement all the methods that the Viam RDK requires, and should match the built-in {{< glossary_tooltip term_id="subtype" text="subtype" >}} API, like [`rdk:component:base`](https://cpp.viam.dev/classviam_1_1sdk_1_1Base.html).
 
 Create a folder for your module and save your code as a file named <file>my_modular_resource.cpp</file> inside.
 

--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -540,7 +540,7 @@ Your new resource model server must have all the methods that the Viam RDK requi
 
 Create a folder for your module and save your code as a file named <file>my_modular_resource.cpp</file> inside.
 
-The following example module registers a modular resource implementing Viam's built-in [Base API](/build/configure/components/base/#api) (`rdk:components:base`) as a new model, `"MyBase"`.
+The following example module registers a modular resource implementing Viam's built-in [Base API](/build/configure/components/base/#api) (`rdk:component:base`) as a new model, `"MyBase"`.
 
 <details>
   <summary>Click to view sample code for <file>my_base.cpp</file></summary>

--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -546,9 +546,11 @@ The following example module registers a modular resource implementing Viam's bu
   <summary>Click to view sample code for <file>my_base.cpp</file></summary>
 
 ```cpp {class="line-numbers linkable-line-numbers"}
+#include "my_base.hpp"
+
+#include <exception>
+#include <fstream>
 #include <iostream>
-#include <memory>
-#include <signal.h>
 #include <sstream>
 
 #include <grpcpp/support/status.h>
@@ -558,47 +560,7 @@ The following example module registers a modular resource implementing Viam's bu
 #include <viam/sdk/config/resource.hpp>
 #include <viam/sdk/resource/resource.hpp>
 
-#include <boost/log/trivial.hpp>
-
 using namespace viam::sdk;
-
-// `MyBase` inherits from the `Base` class defined in the Viam C++ SDK and
-// implements some of the relevant methods along with `reconfigure`. It also
-// specifies a static `validate` method that checks config validity.
-class MyBase : public Base {
-   public:
-    MyBase(Dependencies deps, ResourceConfig cfg) : Base(cfg.name()) {
-        this->reconfigure(deps, cfg);
-    };
-    void reconfigure(Dependencies deps, ResourceConfig cfg) override;
-    static std::vector<std::string> validate(ResourceConfig cfg);
-
-    bool is_moving() override;
-    void stop(const AttributeMap& extra) override;
-    void set_power(const Vector3& linear,
-                   const Vector3& angular,
-                   const AttributeMap& extra) override;
-
-    AttributeMap do_command(const AttributeMap& command) override;
-    std::vector<GeometryConfig> get_geometries(const AttributeMap& extra) override;
-    Base::properties get_properties(const AttributeMap& extra) override;
-
-    void move_straight(int64_t distance_mm, double mm_per_sec, const AttributeMap& extra) override {
-        throw std::runtime_error("move_straight unimplemented");
-    }
-    void spin(double angle_deg, double degs_per_sec, const AttributeMap& extra) override {
-        throw std::runtime_error("spin unimplemented");
-    }
-    void set_velocity(const Vector3& linear,
-                      const Vector3& angular,
-                      const AttributeMap& extra) override {
-        throw std::runtime_error("set_velocity unimplemented");
-    }
-
-   private:
-    std::shared_ptr<Motor> left_;
-    std::shared_ptr<Motor> right_;
-};
 
 std::string find_motor(ResourceConfig cfg, std::string motor_name) {
     auto base_name = cfg.name();
@@ -876,7 +838,8 @@ When executed, the main program registers the `MyBase` custom model custom model
 #include <viam/sdk/rpc/dial.hpp>
 #include <viam/sdk/rpc/server.hpp>
 
-#include "base/impl.hpp"
+// NOTE: You must update the following line to import your local "my_base.hpp" header file:
+#include "my_base.hpp"
 
 using namespace viam::sdk;
 

--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -87,21 +87,21 @@ See [Valid APIs to implement in your model](#valid-apis-to-implement-in-your-mod
 
 Find the subtype API as defined in the relevant <file>components/\<resource-name\>/\<resource-name>\.py</file> or <file>services/\<resource-name\>/<resource-name>.py</file> file in the [Python SDK](https://github.com/viamrobotics/viam-python-sdk).
 
-For example, the `base` component subtype is defined in [<file>viam-python-sdk/src/viam/components/base/base.py</file>](https://github.com/viamrobotics/viam-python-sdk/blob/main/src/viam/components/base/base.py).
+For example, the `base` component subtype is defined in [<file>components/base/base.py</file>](https://github.com/viamrobotics/viam-python-sdk/blob/main/src/viam/components/base/base.py#L11).
 
 {{% /tab %}}
 {{% tab name="Go" %}}
 
 Find the subtype API as defined in the relevant <file>components/\<resource-name\>/\<resource-name\>.go</file> or <file>services/\<resource-name\>/\<resource-name\>.go</file> file in the [RDK](https://github.com/viamrobotics/rdk).
 
-For example, the `base` component subtype is defined in [<file>rdk/components/base/base.go</file>](https://github.com/viamrobotics/rdk/blob/main/components/base/base.go#L37).
+For example, the `base` component subtype is defined in [<file>components/base/base.go</file>](https://github.com/viamrobotics/rdk/blob/main/components/base/base.go#L37).
 
 {{% /tab %}}
 {{% tab name="C++" %}}
 
 Find the subtype API as defined in the relevant <file>components/\<resource-name\>/\<resource-name>\.cpp</file> or <file>services/\<resource-name\>/<resource-name>.cpp</file> file in the [C++ SDK](https://github.com/viamrobotics/viam-cpp-sdk/).
 
-For example, the `base` component subtype is defined in [<file>viam-cpp-sdk/src/viam/components/base/base.cpp</file>](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/src/viam/sdk/components/base/base.cpp).
+For example, the `base` component subtype is defined in [<file>components/base/base.cpp</file>](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/src/viam/sdk/components/base/base.cpp).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -1076,7 +1076,7 @@ Expand the [Go module code](#code-a-main-entry-point-program) to view <file>main
 {{% /tab %}}
 {{% tab name="C++" %}}
 
-Use C++ to [compile](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md) and obtain a single executable for your module:
+Use C++ to compile and obtain a single executable for your module:
 
 - Navigate to your module directory in your terminal.
 - Follow the steps to [build and compile the C++ SDK](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md), which compiles your entry point (main program) file <file>main.cpp</file> and all other <file>.cpp</file> files in the directory, building your module and all dependencies into a single executable file.
@@ -1151,7 +1151,7 @@ fn (c *component) someFunction(a int) {
 
 To enable your C++ module to write log messages to the Viam app, add the following lines to your code:
 
-```go {class="line-numbers linkable-line-numbers"}
+```cpp {class="line-numbers linkable-line-numbers"}
 // Include the boost trivial logger:
 #include <boost/log/trivial.hpp>
 

--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -543,7 +543,7 @@ Your new resource model server must have all the methods that the Viam RDK requi
 
 Create a folder for your module and save your code as a file named <file>my_modular_resource.cpp</file> inside.
 
-The following example module registers a modular resource implementing Viam's built-in [Base API](/build/configure/components/base/#api) (`rdk:component:base`) as a new model, `"MyBase"`.
+The following example module registers a modular resource implementing Viam's built-in [Base API](/components/base/#api) (`rdk:component:base`) as a new model, `"MyBase"`.
 The `my_base.cpp` file defines the specific functionality of the module, while the `my_base.hpp` file defines the implementation of that functionality.
 
 <details>

--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -1205,10 +1205,9 @@ fn (c *component) someFunction(a int) {
 
 Messages sent to `std::cout` in your C++ code are automatically sent to the Viam app over gRPC when a network connection is available.
 
-We recommend that you use a C+ logging library to assist with log message format and creation, such as the boost trivial logger:
+We recommend that you use a C++ logging library to assist with log message format and creation, such as the Boost trivial logger:
 
 ```cpp {class="line-numbers linkable-line-numbers"}
-// Include the boost trivial logger:
 #include <boost/log/trivial.hpp>
 ```
 

--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -546,7 +546,7 @@ The `my_base.cpp` file defines the specific functionality of the module, while t
   <summary>Click to view sample code for <file>my_base.cpp</file></summary>
 
 ```cpp {class="line-numbers linkable-line-numbers"}
-#include "base.hpp"
+#include "my_base.hpp"
 
 #include <exception>
 #include <fstream>
@@ -598,7 +598,7 @@ void MyBase::reconfigure(Dependencies deps, ResourceConfig cfg) {
 
 std::vector<std::string> MyBase::validate(ResourceConfig cfg) {
     // Custom validation can be done by specifying a validate function at the
-    // time of resource registration (see complex/main.cpp) like this one.
+    // time of resource registration (see main.cpp) like this one.
     // Validate functions can `throw` exceptions that will be returned to the
     // parent through gRPC. Validate functions can also return a vector of
     // strings representing the implicit dependencies of the resource.
@@ -729,7 +729,7 @@ class MyBase : public Base {
 </details>
 <br>
 
-Additional example modules are available in the [C++ SDK GitHub repository](https://github.com/viamrobotics/viam-cpp-sdk/tree/main/src/viam/examples/).
+Additional example modules are available in the [C++ SDK GitHub repository](https://github.com/viamrobotics/viam-cpp-sdk/tree/main/src/viam/examples/modules/).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -893,7 +893,7 @@ When executed, the main program registers the `MyBase` custom model custom model
 #include <viam/sdk/rpc/dial.hpp>
 #include <viam/sdk/rpc/server.hpp>
 
-#include "base.hpp"
+#include "my_base.hpp"
 
 using namespace viam::sdk;
 
@@ -1071,7 +1071,7 @@ To compile your C++ module's executable, you must create a <file>CMakeLists.txt<
 
    The following example shows a basic configuration that automatically downloads the C++ SDK and handles compile-time linking for a module named `my-module`:
 
-   ```cpp {class="line-numbers linkable-line-numbers"}
+   ```sh {class="line-numbers linkable-line-numbers"}
    cmake_minimum_required(VERSION 3.7 FATAL_ERROR)
 
    project(my-module LANGUAGES CXX)
@@ -1098,7 +1098,7 @@ To compile your C++ module's executable, you must create a <file>CMakeLists.txt<
 
    The following example shows a simple configuration that performs some basic sanity checks and handles system-level linking for a module named `my-module`:
 
-   ```sh { class="command-line"}
+   ```sh {class="line-numbers linkable-line-numbers"}
    #!/usr/bin/env bash
    # run.sh -- entrypoint wrapper for the module
 
@@ -1132,7 +1132,7 @@ To compile your C++ module's executable, you must create a <file>CMakeLists.txt<
 
 For more information on building a module in C++, see the [C++ SDK Build Documentation](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/BUILDING.md).
 
-<file>main.cpp</file> adds the custom model <file>mybase.cpp</file> from the resource registry, while <file>mybase.cpp</file> defines and registers the module.
+<file>main.cpp</file> adds the custom model <file>my_base.cpp</file> from the resource registry, while <file>my_base.cpp</file> defines and registers the module.
 Expand the [C++ module code](#code-a-main-entry-point-program) to view <file>main.cpp</file> for an example of this.
 
 {{% /tab %}}
@@ -1199,7 +1199,7 @@ fn (c *component) someFunction(a int) {
 {{% /tab %}}
 {{% tab name="C++" %}}
 
-Messages sent to `std::cout` in your C++ code are automatically sent to the Viam app over gRPC when a network connection is available.
+`viam-server` automatically gathers all output sent to the standard output (`STDOUT`) in your C++ code and forwards it to the Viam app when a network connection is available.
 
 We recommend that you use a C++ logging library to assist with log message format and creation, such as the Boost trivial logger:
 

--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -676,7 +676,7 @@ Base::properties MyBase::get_properties(const AttributeMap& extra) {
 ```
 
 </details>
-
+<br>
 <details>
   <summary>Click to view sample code for the <file>my_base.hpp</file> header file</summary>
 

--- a/docs/tutorials/custom/custom-base-dog.md
+++ b/docs/tutorials/custom/custom-base-dog.md
@@ -227,12 +227,12 @@ As you follow the prompts, it's a good idea to use the same names we used so tha
 - Module namespace: `viamlabs`
 - Module repo-name: `base`
 - Language: `python`
-- API triplet: `rdk:components:base`
+- API triplet: `rdk:component:base`
 - Existing API? `Yes`
 
 {{% alert title="Important" color="note" %}}
 
-You can use a different model name, module namespace, and repo-name, but you need to use the existing API triplet `rdk:components:base` in order for your custom base to work properly as a base with `viam-server` and the [Viam app](https://app.viam.com/).
+You can use a different model name, module namespace, and repo-name, but you need to use the existing API triplet `rdk:component:base` in order for your custom base to work properly as a base with `viam-server` and the [Viam app](https://app.viam.com/).
 
 {{% /alert %}}
 


### PR DESCRIPTION
Add C++ example code to Create docs for MR.
- Drew from [complex](https://github.com/viamrobotics/viam-cpp-sdk/tree/main/src/viam/examples/modules/complex) example in C++ SDK, as well as [`module-example-cpp` repo](https://github.com/viamrobotics/module-example-cpp).
- Fixed instances of `rdk:service:base`, which should be `rdk:component:base` instead, per Rand.
- (out of scope): Fixed instances of `rdk:components:*` elsewhere in the docs, these should use singular `component`.

CODE SAMPLES:
- Thanks so much Benji and Ethan for the help! Compiles and appears to run without errors.

QUESTIONS:
- You've answered all my questions, thank you!

NOTES:
- Changing 'client' language outside of C++ scope on this page to be handled separately in DOCS - 1527, per discussion thread. LMK if there are other opportunities to fix C++-specific language that I missed though!