### PR TITLE
Update 404 link

### DIFF
--- a/docs/get-started/installation/prepare/beaglebone-setup.md
+++ b/docs/get-started/installation/prepare/beaglebone-setup.md
@@ -32,7 +32,7 @@ You need the following hardware, tools, and software to install `viam-server` on
 4. (Optional) A microSD card and a way to connect the microSD card to the computer (like a microSD slot or microSD reader)
    - This is required if you need to set up your BeagleBone for the first time or update your BeagleBone to the latest software image.
 
-The following instructions mirror the instructions given in the BeagleBoard documentation at [Connecting up your BeagleBone](https://docs.beagleboard.org/latest/boards/beaglebone/ai-64/ch03.html) and [Getting Started with your BeagleBone](https://beagleboard.org/getting-started).
+The following instructions mirror the instructions given in the [BeagleBoard Quick Start Guide](https://docs.beagleboard.org/latest/boards/beaglebone/ai-64/02-quick-start.html).
 
 If you want additional help setting up your BeagleBone, you can follow the guides there and return to the Viam docs after SSH'ing into your BeagleBone.
 


### PR DESCRIPTION
Previous link's target content at Beaglebone appears to have been removed in favor of this new all-in-one guide. Updated link on our docs page to match.
- Removed second link, which appears minimally useful at present, perhaps also recently changed on Beaglebone's side.