### PR TITLE
Pare some related services

### DIFF
--- a/docs/components/board/_index.md
+++ b/docs/components/board/_index.md
@@ -29,13 +29,6 @@ Signaling is overseen by a computer running `viam-server` which allows you to co
 
 {{% figure src="/components/board/board-comp-options.png" alt="Image showing two board options: First, running viam-server locally and second, running via a peripheral plugged into the USB port of a computer that is running the viam-server." title="Two different board options: a single-board computer with GPIO pins running `viam-server` locally, or a GPIO peripheral plugged into a desktop computer's USB port, with the computer running `viam-server`." %}}
 
-## Related Services
-
-{{< cards >}}
-{{< relatedcard link="/mobility/frame-system/" >}}
-{{< relatedcard link="/ml/" >}}
-{{< /cards >}}
-
 ## Supported Models
 
 To use your board with Viam, check whether one of the following [built-in models](#built-in-models) or [modular resources](#modular-resources) supports your board.

--- a/docs/components/gantry/_index.md
+++ b/docs/components/gantry/_index.md
@@ -40,7 +40,6 @@ Most robots with a gantry need at least the following hardware:
 ## Related Services
 
 {{< cards >}}
-{{< relatedcard link="/mobility/navigation/" >}}
 {{< relatedcard link="/mobility/frame-system/" >}}
 {{< relatedcard link="/mobility/motion/" >}}
 {{< /cards >}}

--- a/docs/components/input-controller/_index.md
+++ b/docs/components/input-controller/_index.md
@@ -33,7 +33,6 @@ Most robots with an input controller need at least the following hardware:
 
 {{< cards >}}
 {{< relatedcard link="/mobility/base-rc/" >}}
-{{< relatedcard link="/data/" >}}
 {{< relatedcard link="/mobility/frame-system/" >}}
 {{< /cards >}}
 

--- a/docs/components/sensor/_index.md
+++ b/docs/components/sensor/_index.md
@@ -38,7 +38,6 @@ Most robots with a sensor need at least the following hardware:
 {{< cards >}}
 {{< relatedcard link="/data/" >}}
 {{< relatedcard link="/mobility/sensors/" >}}
-{{< relatedcard link="/mobility/navigation/" >}}
 {{< /cards >}}
 
 ## Supported Models


### PR DESCRIPTION
Somewhat subjective but, some of these don't seem directly related so I suggest we take these ones out.

If we *don't* take ML out of board, we need to replace the icon because it's currently empty.