### PR TITLE
DOCS-1464: Remove ModelAttributes

### DIFF
--- a/docs/components/board/_index.md
+++ b/docs/components/board/_index.md
@@ -428,55 +428,6 @@ err := myBoard.Status(context.Background(), nil)
 {{% /tab %}}
 {{< /tabs >}}
 
-### ModelAttributes
-
-Get the attributes related to the model of this board.
-
-{{< tabs >}}
-{{% tab name="Python" %}}
-
-**Parameters:**
-
-- None
-
-**Returns:**
-
-- [(Attributes)](https://python.viam.dev/autoapi/viam/components/board/index.html#viam.components.board.Board.Attributes): Attributes related to the model of this board.
-  Will include the board's innate `remote` attribute, which is not specified in configuration and is a `bool` indicating whether this model of board is accessed over a remote connection like gRPC.
-
-For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/board/index.html#viam.components.board.Board.model_attributes).
-
-```python
-my_board = Board.from_robot(robot=robot, name="my_board")
-
-# Get the attributes related to the model of this board.
-attributes = await my_board.model_attributes()
-```
-
-{{% /tab %}}
-{{% tab name="Go" %}}
-
-**Parameters:**
-
-- None
-
-**Returns:**
-
-- [(ModelAttributes)](https://pkg.go.dev/go.viam.com/rdk/components/board#ModelAttributes): Attributes related to the model of this board.
-  Will include the board's innate `remote` attribute, which is not specified in configuration and is a `bool` indicating whether this model of board is accessed over a remote connection like gRPC.
-
-For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/board#ModelAttributes).
-
-```go
-myBoard, err := board.FromRobot(robot, "my_board")
-
-// Get the attributes related to the model of this board.
-attributes := myBoard.ModelAttributes()
-```
-
-{{% /tab %}}
-{{< /tabs >}}
-
 ### SetPowerMode
 
 Set the board to the indicated `PowerMode`.

--- a/static/include/components/apis/board.md
+++ b/static/include/components/apis/board.md
@@ -7,7 +7,6 @@ Method Name | Description
 [`AnalogReaderNames`](/components/board/#analogreadernames) | Get the `name` of every [`AnalogReader`](/components/board/#analogs).
 [`DigitalInterruptNames`](/components/board/#digitalinterruptnames) | Get the `name` of every [`DigitalInterrupt`](/components/board/#digital_interrupts).
 [`Status`](/components/board/#status) | Get the current status of this board.
-[`ModelAttributes`](/components/board/#modelattributes) | Get the attributes related to the model of this board.
 [`SetPowerMode`](/components/board/#setpowermode) | Set the board to the indicated power mode.
 [`WriteAnalog`](/components/board/#writeanalog) | Write an analog value to a pin on the board.
 [`GetGeometries`](/components/board/#getgeometries) | Get all the geometries associated with the board in its current configuration, in the [frame](/mobility/frame-system/) of the board.


### PR DESCRIPTION
Remove ModelAttributes from (docs.viam.com) SDK documentation.
- Ticket asked for Python method removal, but Go method also present in docs; removed both (as it seems both have been removed from the code: former from Python SDK, latter from RDK in the first place!)