### PR TITLE
DOCS-1558 Update docs for "APP-3453 Do not bill for cloud slam compute"

### DIFF
--- a/docs/mobility/slam/cartographer/_index.md
+++ b/docs/mobility/slam/cartographer/_index.md
@@ -46,7 +46,7 @@ For doing pure localization on an existing map, the `cartographer` modular resou
 
 {{% alert title="Info" color="info" %}}
 
-See Viam's [Pricing](https://www.viam.com/product/pricing) page to understand the costs associated with running Cartographer in the cloud.
+Running `cartographer` in the cloud incurs a small cost per Viam's [Pricing](https://www.viam.com/product/pricing). Currently, cost is only incurred for "Data Management", "Cloud Data Upload", and "Cloud Data Egress".
 
 {{% /alert %}}
 

--- a/docs/mobility/slam/cartographer/_index.md
+++ b/docs/mobility/slam/cartographer/_index.md
@@ -47,7 +47,7 @@ For doing pure localization on an existing map, the `cartographer` modular resou
 {{% alert title="Info" color="info" %}}
 
 Running `cartographer` in the cloud incurs cost for Data Management, Cloud Data Upload, and Cloud Data Egress. Currently, you incur no cost for compute.
-See Viam's [Pricing](https://www.viam.com/product/pricing) for more information. 
+See Viam's [Pricing](https://www.viam.com/product/pricing) for more information.
 
 {{% /alert %}}
 

--- a/docs/mobility/slam/cartographer/_index.md
+++ b/docs/mobility/slam/cartographer/_index.md
@@ -46,7 +46,8 @@ For doing pure localization on an existing map, the `cartographer` modular resou
 
 {{% alert title="Info" color="info" %}}
 
-Running `cartographer` in the cloud incurs a small cost per Viam's [Pricing](https://www.viam.com/product/pricing). Currently, cost is only incurred for "Data Management", "Cloud Data Upload", and "Cloud Data Egress".
+Running `cartographer` in the cloud incurs cost for Data Management, Cloud Data Upload, and Cloud Data Egress. Currently, you incur no cost for compute.
+See Viam's [Pricing](https://www.viam.com/product/pricing) for more information. 
 
 {{% /alert %}}
 


### PR DESCRIPTION
Since cloud slam compute is quite expensive under our current pricing model, but it's a large effort to add a separate billing sku for cloud slam compute, for the moment we just stopped charging for cloud slam compute under APP-3453.

I wanted to suggest docs changes to reflect this, and marked APP-3453 as "Docs changes needed", but couldn't figure out if a DOCS ticket was automatically generated. So, I'm just putting up this PR, and adding it to the "Docs changes needed" description on APP-3453.

It's okay if this is merged after APP-3453 is released, since the current line about pricing in the docs is not very specific (and it's unlikely people will complain about getting a lower bill than they expected).