### PR TITLE
DOCS-1529: Add RBAC perms notice to API keys

### DIFF
--- a/docs/fleet/cli.md
+++ b/docs/fleet/cli.md
@@ -163,7 +163,8 @@ You will need both to authenticate.
 
 {{% alert title="Important" color="note" %}}
 Keep these key values safe.
-Authenticating using an organization API key gives the authenticated CLI session full read and write access to all robots within your organization.
+By default, new organization API keys are created with **Owner** permissions, giving the key full read and write access to all robots within your organization.
+You can change an API key's permissions from the Viam app on the [organizations page](/fleet/organizations/), by click the **Show details** link next to your API key.
 {{% /alert %}}
 
 Once created, you can use the organization API key to authenticate future CLI sessions or to [connect to robots with the SDK](/build/program/#authenticate)..
@@ -201,7 +202,8 @@ You will need both to authenticate.
 
 {{% alert title="Important" color="note" %}}
 Keep these key values safe.
-Authenticating using a location API key gives the authenticated CLI session full read and write access to all robots in that location.
+By default, new location API keys are created with **Owner** permissions, giving the key full read and write access to all robots within your location.
+You can change an API key's permissions from the Viam app on the [organizations page](/fleet/organizations/), by click the **Show details** link next to your API key.
 {{% /alert %}}
 
 Once created, you can use the location API key to authenticate future CLI sessions or to [connect to robots with the SDK](/build/program/#authenticate).

--- a/docs/fleet/cli.md
+++ b/docs/fleet/cli.md
@@ -164,7 +164,7 @@ You will need both to authenticate.
 {{% alert title="Important" color="note" %}}
 Keep these key values safe.
 By default, new organization API keys are created with **Owner** permissions, giving the key full read and write access to all robots within your organization.
-You can change an API key's permissions from the Viam app on the [organizations page](/fleet/organizations/), by clicking the **Show details** link next to your API key.
+You can change an API key's permissions from the Viam app on the [organizations page](/fleet/organizations/) by clicking the **Show details** link next to your API key.
 {{% /alert %}}
 
 Once created, you can use the organization API key to authenticate future CLI sessions or to [connect to robots with the SDK](/build/program/#authenticate)..
@@ -203,7 +203,7 @@ You will need both to authenticate.
 {{% alert title="Important" color="note" %}}
 Keep these key values safe.
 By default, new location API keys are created with **Owner** permissions, giving the key full read and write access to all robots within your location.
-You can change an API key's permissions from the Viam app on the [organizations page](/fleet/organizations/), by clicking the **Show details** link next to your API key.
+You can change an API key's permissions from the Viam app on the [organizations page](/fleet/organizations/) by clicking the **Show details** link next to your API key.
 {{% /alert %}}
 
 Once created, you can use the location API key to authenticate future CLI sessions or to [connect to robots with the SDK](/build/program/#authenticate).

--- a/docs/fleet/cli.md
+++ b/docs/fleet/cli.md
@@ -164,7 +164,7 @@ You will need both to authenticate.
 {{% alert title="Important" color="note" %}}
 Keep these key values safe.
 By default, new organization API keys are created with **Owner** permissions, giving the key full read and write access to all robots within your organization.
-You can change an API key's permissions from the Viam app on the [organizations page](/fleet/organizations/), by click the **Show details** link next to your API key.
+You can change an API key's permissions from the Viam app on the [organizations page](/fleet/organizations/), by clicking the **Show details** link next to your API key.
 {{% /alert %}}
 
 Once created, you can use the organization API key to authenticate future CLI sessions or to [connect to robots with the SDK](/build/program/#authenticate)..
@@ -203,7 +203,7 @@ You will need both to authenticate.
 {{% alert title="Important" color="note" %}}
 Keep these key values safe.
 By default, new location API keys are created with **Owner** permissions, giving the key full read and write access to all robots within your location.
-You can change an API key's permissions from the Viam app on the [organizations page](/fleet/organizations/), by click the **Show details** link next to your API key.
+You can change an API key's permissions from the Viam app on the [organizations page](/fleet/organizations/), by clicking the **Show details** link next to your API key.
 {{% /alert %}}
 
 Once created, you can use the location API key to authenticate future CLI sessions or to [connect to robots with the SDK](/build/program/#authenticate).

--- a/docs/registry/upload/_index.md
+++ b/docs/registry/upload/_index.md
@@ -330,7 +330,7 @@ To update an existing module in the [Viam registry](https://app.viam.com/registr
    1. Follow the instructions to [create an organization API key](/fleet/cli/#create-an-organization-api-key).
       These steps will return a `key id` and a `key value` which together comprise your organization API key.
       By default, a new organization API key is created with **Owner** permissions, giving the key full read and write access to all robots within your organization.
-      You can change an API key's permissions from the Viam app on the [organizations page](/fleet/organizations/), by clicking the **Show details** link next to your API key.
+      You can change an API key's permissions from the Viam app on the [organizations page](/fleet/organizations/) by clicking the **Show details** link next to your API key.
 
       If you have already created an organization API key, you can skip this step.
 

--- a/docs/registry/upload/_index.md
+++ b/docs/registry/upload/_index.md
@@ -329,6 +329,9 @@ To update an existing module in the [Viam registry](https://app.viam.com/registr
 
    1. Follow the instructions to [create an organization API key](/fleet/cli/#create-an-organization-api-key).
       These steps will return a `key id` and a `key value` which together comprise your organization API key.
+      By default, a new organization API key is created with **Owner** permissions, giving the key full read and write access to all robots within your organization.
+      You can change an API key's permissions from the Viam app on the [organizations page](/fleet/organizations/), by click the **Show details** link next to your API key.
+
       If you have already created an organization API key, you can skip this step.
 
    1. In the GitHub repository for your project, select **Settings**, then **Secrets and variables**, then **Actions**.

--- a/docs/registry/upload/_index.md
+++ b/docs/registry/upload/_index.md
@@ -330,7 +330,7 @@ To update an existing module in the [Viam registry](https://app.viam.com/registr
    1. Follow the instructions to [create an organization API key](/fleet/cli/#create-an-organization-api-key).
       These steps will return a `key id` and a `key value` which together comprise your organization API key.
       By default, a new organization API key is created with **Owner** permissions, giving the key full read and write access to all robots within your organization.
-      You can change an API key's permissions from the Viam app on the [organizations page](/fleet/organizations/), by click the **Show details** link next to your API key.
+      You can change an API key's permissions from the Viam app on the [organizations page](/fleet/organizations/), by clicking the **Show details** link next to your API key.
 
       If you have already created an organization API key, you can skip this step.
 


### PR DESCRIPTION
Add brief mention of Owner perms by default to API key steps on MR upload page, and also on organizations page.
- Since **Owner** is default, simply advising users on presence of option to change: no change is required for most users.