### PR TITLE
Add more info about vision service and camera to `mlmodel` page

### DIFF
--- a/docs/ml/deploy.md
+++ b/docs/ml/deploy.md
@@ -34,7 +34,8 @@ For some models, like the [Triton MLModel](https://github.com/viamrobotics/viam-
 {{< relatedcard link="/components/camera/">}}
 {{< /cards >}}
 
-After deploying your model, configure an [`mlmodel` vision service](/ml/vision/) and [`transform` camera](/components/camera/transform/) to visualize the predictions your model makes.
+After deploying your model, you need to configure an additional service to use the deployed model.
+For example, you can configure an [`mlmodel` vision service](/ml/vision/) and a [`transform` camera](/components/camera/transform/) to visualize the predictions your model makes.
 
 ### Modular Resources
 

--- a/docs/ml/deploy.md
+++ b/docs/ml/deploy.md
@@ -34,6 +34,8 @@ For some models, like the [Triton MLModel](https://github.com/viamrobotics/viam-
 {{< relatedcard link="/components/camera/">}}
 {{< /cards >}}
 
+After deploying your model, configure an [`mlmodel` vision service](/ml/vision/) and [`transform` camera](/components/camera/transform/) to visualize the predictions your model makes.
+
 ### Modular Resources
 
 {{<modular-resources api="rdk:service:mlmodel" type="mlmodel">}}


### PR DESCRIPTION
Matt Vella sent over feedback from a community user where he filmed a YouTube video and apparently spent a lot of time on this docs page not realizing he needed a vision service/that that was his "next steps". We do make it pretty clear already on that page but this is what I could think of to make it even more clear

* Add sentence under "Used with" talking about combination of mlmodel service, mlmodel vision service, and transform camera