### PR TITLE
fix: block Sentry Replay for table class

### DIFF
--- a/assets/js/sentry.js
+++ b/assets/js/sentry.js
@@ -1,4 +1,4 @@
-var loadJS = function(url, implementationCode, location){
+var loadJS = function(url, implementationCode, location) {
     var scriptTag = document.createElement('script');
     scriptTag.src = url;
 
@@ -7,15 +7,16 @@ var loadJS = function(url, implementationCode, location){
 
     location.appendChild(scriptTag);
 };
-var startSentry = function(){
+var startSentry = function() {
     Sentry.onLoad(function() {
         Sentry.init({
-          integrations: [
-            new Sentry.Replay({
-                maskAllText: false,
-                blockAllMedia: false,
-            }),
-          ],
+            integrations: [
+                new Sentry.Replay({
+                    block: ['.table'],
+                    maskAllText: false,
+                    blockAllMedia: false,
+                }),
+            ],
         });
     });
 }


### PR DESCRIPTION
# Description

As I was reading through the module creation docs, I noticed that switching tabs for each supported programming language has a noticeable delay. When I traced the performance of that feature using the browser devtools, much of the time is taken up by the JavaScript for the Sentry Replay monitor. This is a [known issue](https://docs.sentry.io/product/session-replay/performance-overhead/?original_referrer=https%3A%2F%2Fduckduckgo.com%2F):

> There's a known performance issue that happens when replays with many DOM mutations are recorded. It generally occurs when rendering large data grids. We're working on a fix, but in the meantime we recommend you [use the blocking feature](https://docs.sentry.io/platforms/javascript/session-replay/privacy/#blocking) to avoid recording large mutations which can degrade performance for your customers.

Following their recommendation to use the blocking feature of their SDK, I updated the configuration to block the `.table` class surrounding this tab nav feature. 

Before:
[slow-docs-tabs.webm](https://github.com/viamrobotics/docs/assets/3051193/14801a9d-92ed-4f26-8d0e-3b88fead5344)

After:
[fast-docs-tabs.webm](https://github.com/viamrobotics/docs/assets/3051193/e54d1fa4-3317-4c2f-a6a2-b11e324c3702)

