### PR TITLE
DOCS-1579: Clarify pixel formats

### DIFF
--- a/docs/appendix/troubleshooting.md
+++ b/docs/appendix/troubleshooting.md
@@ -209,7 +209,7 @@ It will resemble the following:
 
       Replace `/dev/video0` in the above command with the video path you determined for your video device above, if different.
 
-      The command will return a list of pixel formats your camera supports, such as `MJPG` or `YUYV`.
+      The command will return a list of pixel formats your camera supports, such as `MJPG` (also notated as `MJPEG`) or `YUYV` (also notated as `YUY2`).
       In order to use a camera device with Viam, it must support at least one of the [pixel formats supported by Viam](/components/camera/webcam/#using-format).
       If your camera does not support any of these formats, it cannot be used with Viam.
 

--- a/docs/components/camera/webcam.md
+++ b/docs/components/camera/webcam.md
@@ -133,15 +133,23 @@ Viam supports the following pixel formats:
 
 - I420
 - I444
-- MJPEG
+- MJPEG / MJPG
 - NV12
 - NV21
 - RGBA
-- UYVY
-- YUY2
+- UYVY / Y422
+- YUY2 / YUYV / V422
 - Z16
 
 If your machine is connected to the Viam app, the available pixel formats supported by your camera automatically appear in the **Format** dropdown menu, which is visible when you click the **Show more** button.
+
+You can also manually determine the pixel formats your camera supports by running the following command on the machine you have connected your camera to:
+
+```sh {class="command-line" data-prompt="$"}
+v4l2-ctl --list-formats-ext --device /dev/video0
+```
+
+Replace `/dev/video0` in the above command with the video path you [determined for your video device above](#using-video_path), if different.
 
 ## View the camera stream
 

--- a/docs/components/camera/webcam.md
+++ b/docs/components/camera/webcam.md
@@ -143,14 +143,12 @@ Viam supports the following pixel formats:
 
 If your machine is connected to the Viam app, the available pixel formats supported by your camera automatically appear in the **Format** dropdown menu, which is visible when you click the **Show more** button.
 
-On Linux, you can also manually determine which pixel formats your camera supports by running the following command:
+On Linux, you can also manually determine which pixel formats your camera supports by running the following command on the machine your camera is connected to.
+Replace `/dev/video0` with the video path you [determined for your video device above](#using-video_path), if different:
 
 ```sh {class="command-line" data-prompt="$"}
 v4l2-ctl --list-formats-ext --device /dev/video0
 ```
-
-Replace `/dev/video0` in the above command with the video path you [determined for your video device above](#using-video_path), if different.
-Run this command on the Linux machine you have connected your camera to.
 
 ## View the camera stream
 

--- a/docs/components/camera/webcam.md
+++ b/docs/components/camera/webcam.md
@@ -143,13 +143,14 @@ Viam supports the following pixel formats:
 
 If your machine is connected to the Viam app, the available pixel formats supported by your camera automatically appear in the **Format** dropdown menu, which is visible when you click the **Show more** button.
 
-You can also manually determine the pixel formats your camera supports by running the following command on the machine you have connected your camera to:
+On Linux, you can also manually determine which pixel formats your camera supports by running the following command:
 
 ```sh {class="command-line" data-prompt="$"}
 v4l2-ctl --list-formats-ext --device /dev/video0
 ```
 
 Replace `/dev/video0` in the above command with the video path you [determined for your video device above](#using-video_path), if different.
+Run this command on the Linux machine you have connected your camera to.
 
 ## View the camera stream
 


### PR DESCRIPTION
Clarify supported camera pixel formats, which have very similar names.
- Taking opportunity to add additional alternate names for popular pixel formats, to aid with site search and google search users finding the `webcam.md` page.
- Added `v4l2-ctl --list-formats-ext` command to `webcam.md` to assist with self-determination.