### PR TITLE
Fix expander shortcode

### DIFF
--- a/layouts/shortcodes/expand.html
+++ b/layouts/shortcodes/expand.html
@@ -1,17 +1,17 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
 <div class="expand">
-    <div class="expand-label" style="cursor: pointer;" onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? 'fas fa-chevron-down' : 'fas fa-chevron-right';});});">
-        <i style="font-size:x-small;" class="fas fa-chevron-right"></i>
-        <span>
-        {{$expandMessage := T "Expand-title"}}
-    	{{ if .IsNamedParams }}
-    	{{.Get "default" | default $expandMessage}}
-    	{{else}}
-    	{{.Get 0 | default $expandMessage}}
-    	{{end}}
-    	</span>
-    </div>
-    <div class="expand-content" style="display: none;">
-        {{.Inner | safeHTML}}
-    </div>
+  <div class="expand-label" style="cursor: pointer;" onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? 'fas fa-chevron-down' : 'fas fa-chevron-right';});});">
+    <i style="font-size:x-small;" class="fas fa-chevron-right"></i>
+      <span>
+      {{$expandMessage := "Click to expand"}}
+      {{- if .IsNamedParams -}}
+        {{.Get "default" | default $expandMessage}}
+      {{- else -}}
+        {{.Get 0 | default $expandMessage}}
+      {{- end -}}
+      </span>
+  </div>
+  <div class="expand-content" style="display: none;">
+    {{.Inner | safeHTML}}
+  </div>
 </div>


### PR DESCRIPTION
Fixes a few issues with the expander shortcode:
- Fixes indents and logic scope (`-`) to be renderable within HTML, and retain CSS styling.
	- This should allow this shortcode to be useable outside of pure MD, such as in HTML tables. I think!
- Fixes typo in default expander title to now display a default title on the expander if one is not otherwise supplied.
	- Previously, unset titles would result in blank expander titles.