### PR TITLE
Update contributing.md add video size guidance to regular videos section

### DIFF
--- a/docs/appendix/contributing.md
+++ b/docs/appendix/contributing.md
@@ -311,6 +311,8 @@ For regular videos that should use the video shortcode as follows:
 
 {{<video webm_src="/heart.webm" mp4_src="/heart.mp4" alt="A robot drawing a heart" poster="/general/heart.jpg">}}
 
+Make sure your `webm` and `mp4` files are less than 1MB.
+
 We use `webm` and `mp4` source files for videos because they are generally smaller.
 The poster is an image that gets loaded as a preview.
 


### PR DESCRIPTION
This guidance applies to all videos (re. Naomi feedback on my pr), but in contributing.md this guidance was just for gif-like videos and hidden in there so hard to find. 

* Add to regular videos section
