### PR TITLE
DOCS-1582: Add micro-RDK in parenthesis to titles

### DIFF
--- a/docs/build/micro-rdk/base/two_wheeled_base.md
+++ b/docs/build/micro-rdk/base/two_wheeled_base.md
@@ -1,9 +1,9 @@
 ---
-title: "Configure a Two Wheeled Base (Micro-RDK)"
+title: "Configure a Two-Wheeled Base (Micro-RDK)"
 linkTitle: "two_wheeled_base"
 weight: 30
 type: "docs"
-description: "Configure and wire a two wheeled base with a microcontroller."
+description: "Configure and wire a two-wheeled base with a microcontroller."
 images: ["/icons/components/base.svg"]
 tags: ["base", "components"]
 aliases:

--- a/docs/build/micro-rdk/base/two_wheeled_base.md
+++ b/docs/build/micro-rdk/base/two_wheeled_base.md
@@ -3,7 +3,7 @@ title: "Configure a Two Wheeled Base (Micro-RDK)"
 linkTitle: "two_wheeled_base"
 weight: 30
 type: "docs"
-description: "Configure and wire a two wheeled base."
+description: "Configure and wire a two wheeled base with a microcontroller."
 images: ["/icons/components/base.svg"]
 tags: ["base", "components"]
 aliases:

--- a/docs/build/micro-rdk/base/two_wheeled_base.md
+++ b/docs/build/micro-rdk/base/two_wheeled_base.md
@@ -1,9 +1,9 @@
 ---
-title: "Configure an ESP32 Wheeled Base"
+title: "Configure a Two Wheeled Base (Micro-RDK)"
 linkTitle: "two_wheeled_base"
 weight: 30
 type: "docs"
-description: "Configure and wire an esp32 wheeled base."
+description: "Configure and wire a two wheeled base."
 images: ["/icons/components/base.svg"]
 tags: ["base", "components"]
 aliases:

--- a/docs/build/micro-rdk/board/esp32.md
+++ b/docs/build/micro-rdk/board/esp32.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure an ESP32 board"
+title: "Configure an ESP32 board (Micro-RDK)"
 linkTitle: "esp32"
 weight: 20
 type: "docs"

--- a/docs/build/micro-rdk/board/esp32.md
+++ b/docs/build/micro-rdk/board/esp32.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure an ESP32 board (Micro-RDK)"
+title: "Configure an ESP32 Board (Micro-RDK)"
 linkTitle: "esp32"
 weight: 20
 type: "docs"

--- a/docs/build/micro-rdk/encoder/incremental.md
+++ b/docs/build/micro-rdk/encoder/incremental.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure an incremental Encoder (Micro-RDK)"
+title: "Configure an Incremental Encoder (Micro-RDK)"
 linkTitle: "incremental"
 type: "docs"
 description: "Configure an incremental encoder with a microcontroller."

--- a/docs/build/micro-rdk/encoder/incremental.md
+++ b/docs/build/micro-rdk/encoder/incremental.md
@@ -1,8 +1,8 @@
 ---
-title: "Configure an incremental encoder (Micro-RDK)"
+title: "Configure an incremental Encoder (Micro-RDK)"
 linkTitle: "incremental"
 type: "docs"
-description: "Configure an incremental encoder."
+description: "Configure an incremental encoder with a microcontroller."
 images: ["/icons/components/encoder.svg"]
 tags: ["encoder", "components"]
 aliases:

--- a/docs/build/micro-rdk/encoder/incremental.md
+++ b/docs/build/micro-rdk/encoder/incremental.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure an incremental encoder"
+title: "Configure an incremental encoder (Micro-RDK)"
 linkTitle: "incremental"
 type: "docs"
 description: "Configure an incremental encoder."

--- a/docs/build/micro-rdk/encoder/single.md
+++ b/docs/build/micro-rdk/encoder/single.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure a single Encoder (Micro-RDK)"
+title: "Configure a Single Encoder (Micro-RDK)"
 linkTitle: "single"
 type: "docs"
 description: "Configure a single encoder with a microcontroller."

--- a/docs/build/micro-rdk/encoder/single.md
+++ b/docs/build/micro-rdk/encoder/single.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure a single encoder"
+title: "Configure a single encoder (Micro-RDK)"
 linkTitle: "single"
 type: "docs"
 description: "Configure a single encoder."

--- a/docs/build/micro-rdk/encoder/single.md
+++ b/docs/build/micro-rdk/encoder/single.md
@@ -1,8 +1,8 @@
 ---
-title: "Configure a single encoder (Micro-RDK)"
+title: "Configure a single Encoder (Micro-RDK)"
 linkTitle: "single"
 type: "docs"
-description: "Configure a single encoder."
+description: "Configure a single encoder with a microcontroller."
 images: ["/icons/components/encoder.svg"]
 tags: ["encoder", "components"]
 aliases:

--- a/docs/build/micro-rdk/motor/gpio.md
+++ b/docs/build/micro-rdk/motor/gpio.md
@@ -1,9 +1,9 @@
 ---
-title: "Configure a gpio motor (Micro-RDK)"
+title: "Configure a gpio Motor (Micro-RDK)"
 linkTitle: "gpio"
 weight: 10
 type: "docs"
-description: "Configure brushed or brushless DC motors."
+description: "Configure brushed or brushless DC motors with a microcontroller."
 images: ["/icons/components/motor.svg"]
 aliases:
   - /micro-rdk/motor/gpio/

--- a/docs/build/micro-rdk/motor/gpio.md
+++ b/docs/build/micro-rdk/motor/gpio.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure a gpio Motor (Micro-RDK)"
+title: "Configure a GPIO Motor (Micro-RDK)"
 linkTitle: "gpio"
 weight: 10
 type: "docs"

--- a/docs/build/micro-rdk/motor/gpio.md
+++ b/docs/build/micro-rdk/motor/gpio.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure a gpio motor"
+title: "Configure a gpio motor (Micro-RDK)"
 linkTitle: "gpio"
 weight: 10
 type: "docs"

--- a/docs/build/micro-rdk/movement-sensor/accel-adxl345.md
+++ b/docs/build/micro-rdk/movement-sensor/accel-adxl345.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure an ADXL345 Accelerometer"
+title: "Configure an ADXL345 Accelerometer (Micro-RDK)"
 linkTitle: "accel-adxl345"
 weight: 20
 type: "docs"

--- a/docs/build/micro-rdk/movement-sensor/accel-adxl345.md
+++ b/docs/build/micro-rdk/movement-sensor/accel-adxl345.md
@@ -3,7 +3,7 @@ title: "Configure an ADXL345 Accelerometer (Micro-RDK)"
 linkTitle: "accel-adxl345"
 weight: 20
 type: "docs"
-description: "Configure an ADXL345 digital accelerometer."
+description: "Configure an ADXL345 digital accelerometer with a microcontroller."
 images: ["/icons/components/imu.svg"]
 aliases:
   - /micro-rdk/movement-sensor/accel-adxl345/

--- a/docs/build/micro-rdk/movement-sensor/gyro-mpu6050.md
+++ b/docs/build/micro-rdk/movement-sensor/gyro-mpu6050.md
@@ -3,7 +3,7 @@ title: "Configure an MPU-6050 (Micro-RDK)"
 linkTitle: "gyro-mpu6050"
 weight: 40
 type: "docs"
-description: "Configure an MPU-6050 movement sensor."
+description: "Configure an MPU-6050 movement sensor with a microcontroller."
 images: ["/icons/components/imu.svg"]
 aliases:
   - /micro-rdk/movement-sensor/gyro-mpu6050/

--- a/docs/build/micro-rdk/movement-sensor/gyro-mpu6050.md
+++ b/docs/build/micro-rdk/movement-sensor/gyro-mpu6050.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure an MPU-6050 Gyroscope/Accelerometer (Micro-RDK)"
+title: "Configure an MPU-6050 (Micro-RDK)"
 linkTitle: "gyro-mpu6050"
 weight: 40
 type: "docs"

--- a/docs/build/micro-rdk/movement-sensor/gyro-mpu6050.md
+++ b/docs/build/micro-rdk/movement-sensor/gyro-mpu6050.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure an MPU-6050 Gyroscope/Accelerometer"
+title: "Configure an MPU-6050 Gyroscope/Accelerometer (Micro-RDK)"
 linkTitle: "gyro-mpu6050"
 weight: 40
 type: "docs"

--- a/docs/build/micro-rdk/servo/gpio.md
+++ b/docs/build/micro-rdk/servo/gpio.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure a gpio Servo"
+title: "Configure a gpio Servo (Micro-RDK)"
 linkTitle: "gpio"
 weight: 90
 type: "docs"

--- a/docs/build/micro-rdk/servo/gpio.md
+++ b/docs/build/micro-rdk/servo/gpio.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure a gpio Servo (Micro-RDK)"
+title: "Configure a GPIO Servo (Micro-RDK)"
 linkTitle: "gpio"
 weight: 90
 type: "docs"

--- a/docs/build/micro-rdk/servo/gpio.md
+++ b/docs/build/micro-rdk/servo/gpio.md
@@ -3,7 +3,7 @@ title: "Configure a gpio Servo (Micro-RDK)"
 linkTitle: "gpio"
 weight: 90
 type: "docs"
-description: "Configure a gpio servo."
+description: "Configure a gpio servo with a microcontroller."
 tags: ["servo", "components"]
 icon: "/icons/components/servo.svg"
 aliases:


### PR DESCRIPTION
* Add micro-RDK in parenthesis to micro-RDK component titles so that they are clearly separate from RDK component pages when searching for a page or looking at the top of a page

I opted not to also add a sentence linking to the full component page because I think with this addition they should be ending up in the right place anyways, and it's pretty easy to find viam-server components section (at top level in nav). If people get confused again happy to add it in. 