### PR TITLE
Convert x64 self-host to ubuntu-latest

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   build:
     if: github.repository_owner == 'viamrobotics'
-    runs-on: [self-hosted, x64, linux]
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/viamrobotics/canon:amd64
     steps:
@@ -78,7 +78,7 @@ jobs:
   generate-index:
     needs: deploy
     if: github.repository_owner == 'viamrobotics'
-    runs-on: [self-hosted, x64]
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/viamrobotics/canon:amd64
     steps:

--- a/.github/workflows/pr-deploy-and-comment.yml
+++ b/.github/workflows/pr-deploy-and-comment.yml
@@ -5,8 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request_target:
-    branches: [ main ]
+  pull_request:
     types: [ labeled, synchronize ]
 
 jobs:

--- a/.github/workflows/pr-deploy-and-comment.yml
+++ b/.github/workflows/pr-deploy-and-comment.yml
@@ -5,7 +5,8 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request:
+  pull_request_target:
+    branches: [ main ]
     types: [ labeled, synchronize ]
 
 jobs:

--- a/.github/workflows/pr-deploy-and-comment.yml
+++ b/.github/workflows/pr-deploy-and-comment.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   pr-deploy-and-comment:
     if: ${{ contains(github.event.*.labels.*.name, 'safe to build') }}
-    runs-on: [self-hosted, x64, linux]
+    runs-on: ubuntu-latest
     container:
        image: ghcr.io/viamrobotics/canon:amd64
     steps:

--- a/.github/workflows/run-htmltest.yml
+++ b/.github/workflows/run-htmltest.yml
@@ -11,7 +11,7 @@ concurrency:
 on: pull_request
 jobs:
   htmltest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-large
     container:
        image: ghcr.io/viamrobotics/canon:amd64
     steps:

--- a/.github/workflows/run-htmltest.yml
+++ b/.github/workflows/run-htmltest.yml
@@ -11,7 +11,7 @@ concurrency:
 on: pull_request
 jobs:
   htmltest:
-    runs-on: [self-hosted, x64, linux]
+    runs-on: ubuntu-latest
     container:
        image: ghcr.io/viamrobotics/canon:amd64
     steps:


### PR DESCRIPTION
## what changed
- use `ubuntu-latest` instead of viam-hosted `x64` runners
- (I don't know this repo well, definitely feel free to close this if it's not helpful)
## why
- long queue times on self-hosted runners
## notes
- this will appear to be queued because the `pr-deploy-and-comment` job is `on: pull_request_target`, which means it uses CI yaml from the `main` branch. here are passing runs of the edited jobs:
  - [htmltest](https://github.com/viamrobotics/docs/actions/runs/7480426227/job/20359817215)
  - [pr-deploy-and-comment](https://github.com/viamrobotics/docs/actions/runs/7480302372/job/20359428258)
- docs job -- I didn't test this one because it has a bunch of deploy steps. I can run it via `workflow_dispatch` if you want, or we can see what it does on `main` and fix if problems