### PR TITLE
DOCS-1581: clarify API key role req

### DIFF
--- a/docs/registry/upload/_index.md
+++ b/docs/registry/upload/_index.md
@@ -394,21 +394,22 @@ For more details, see the [`upload-module` GitHub Action documentation](https://
 {{% /tab %}}
 {{< /tabs >}}
 
-1. Create an organization API key and configure your GitHub repository to use it to authenticate during GitHub action runs, following the steps below:
+1. Create an [organization API key](/fleet/cli/#create-an-organization-api-key) with the [owner](/fleet/#permissions) role, which the GitHub action will use to authenticate to the Viam platform, using one of the following methods:
 
-   1. Use the CLI to create an organization API key:
+   - Use the Viam CLI to create an organization API key, which includes the owner role by default:
 
-      ```sh {class="command-line" data-prompt="$"}
-      viam organizations api-key create --org-id <org-id> --name <key-name>
-      ```
+     ```sh {class="command-line" data-prompt="$"}
+     viam organizations api-key create --org-id <org-id> --name <key-name>
+     ```
 
-      For more information, see [create an organization API key](/fleet/cli/#create-an-organization-api-key).
+   - Use the [organizations page](/fleet/organizations/) on the Viam app to generate a new organization API key.
+     Make sure your organization API key is set to **Role: Owner**, or the GitHub action will not be able to successfully authenticate during runs.
+     If you are using an existing organization API key which is not set to **Role: Owner**, you can change an API key's permissions from the Viam app on the [organizations page](/fleet/organizations/) by clicking the **Show details** link next to your API key.
+     The operator role cannot be used to authenticate GitHub action runs.
 
-      The command returns a `key id` and a `key value` which together comprise your organization API key.
-      By default, a new organization API key is created with **Owner** permissions, giving the key full read and write access to all machines within your organization.
-      You can change an API key's permissions from the Viam app on the [organizations page](/fleet/organizations/) by clicking the **Show details** link next to your API key.
+   Both methods return a `key id` and a `key value` which together comprise your organization API key.
 
-      If you have already created an organization API key, you can skip this step.
+1. Then, configure your GitHub repository to use your organization API key to authenticate during GitHub action runs, following the steps below:
 
    1. In the GitHub repository for your project, select **Settings**, then **Secrets and variables**, then **Actions**.
 

--- a/docs/registry/upload/_index.md
+++ b/docs/registry/upload/_index.md
@@ -406,7 +406,7 @@ For more details, see the [`upload-module` GitHub Action documentation](https://
      Make sure your organization API key is set to **Role: Owner**, or the GitHub action will not be able to successfully authenticate during runs.
      If you are using an existing organization API key which is not set to **Role: Owner**, you can change an API key's permissions from the Viam app on the organizations page by clicking the **Show details** link next to your API key.
      The operator role cannot be used to authenticate GitHub action runs.
-     For more information see the [Manage organizations](/fleet/organizations/).
+     For more information see [Manage organizations](/fleet/organizations/).
 
    Both methods return a `key id` and a `key value` which together comprise your organization API key.
 

--- a/docs/registry/upload/_index.md
+++ b/docs/registry/upload/_index.md
@@ -402,10 +402,11 @@ For more details, see the [`upload-module` GitHub Action documentation](https://
      viam organizations api-key create --org-id <org-id> --name <key-name>
      ```
 
-   - Use the [organizations page](/fleet/organizations/) on the Viam app to generate a new organization API key.
+   - Use the organizations page on the [Viam app](https://app.viam.com/) to generate a new organization API key.
      Make sure your organization API key is set to **Role: Owner**, or the GitHub action will not be able to successfully authenticate during runs.
-     If you are using an existing organization API key which is not set to **Role: Owner**, you can change an API key's permissions from the Viam app on the [organizations page](/fleet/organizations/) by clicking the **Show details** link next to your API key.
+     If you are using an existing organization API key which is not set to **Role: Owner**, you can change an API key's permissions from the Viam app on the organizations page by clicking the **Show details** link next to your API key.
      The operator role cannot be used to authenticate GitHub action runs.
+     For more information see the [Manage organizations](/fleet/organizations/).
 
    Both methods return a `key id` and a `key value` which together comprise your organization API key.
 


### PR DESCRIPTION
Clarify in module upload docs that the owner role is required for organization API keys to be usable with the upload-module GitHub action.

Thanks for a great docs ticket!!