### PR TITLE
Update Titles.yml

### DIFF
--- a/.github/vale/styles/Viam/Titles.yml
+++ b/.github/vale/styles/Viam/Titles.yml
@@ -1,5 +1,6 @@
 extends: capitalization
 message: "'%s' should be in sentence case."
+link: 'https://docs.mongodb.com/meta/style-guide/style/titles-and-headings/'
 level: warning
 scope: heading
 match: $sentence

--- a/.github/vale/styles/Viam/Titles.yml
+++ b/.github/vale/styles/Viam/Titles.yml
@@ -1,6 +1,5 @@
 extends: capitalization
 message: "'%s' should be in sentence case."
-link: 'https://docs.mongodb.com/meta/style-guide/style/titles-and-headings/'
 level: warning
 scope: heading
 match: $sentence


### PR DESCRIPTION
@npentrel Is it ok to keep this `warning` level and not `error` like on local? There's lots of cases where it flags nouns being capitalized and creates errors-- thinking these would cause checks to fail-- 
