### PR TITLE
Remove unused import in Go code in Try Viam SDK tutorial

### DIFF
--- a/docs/tutorials/get-started/try-viam-sdk.md
+++ b/docs/tutorials/get-started/try-viam-sdk.md
@@ -551,7 +551,6 @@ import (
     "go.viam.com/rdk/components/base"
     "go.viam.com/rdk/logging"
     "go.viam.com/rdk/robot/client"
-    "go.viam.com/rdk/utils"
     "go.viam.com/utils/rpc"
 )
 


### PR DESCRIPTION
# Description

When we execute [Drive a Rover with the Viam SDK](https://docs.viam.com/tutorials/get-started/try-viam-sdk) tutorial and run Go code from that page, we get an error:
```
$ go run sdk.go 
# command-line-arguments
./sdk.go:9:5: imported and not used: "go.viam.com/rdk/utils"
