### PR TITLE
Update TypeScript import for Driver rover tutorial

### DIFF
--- a/docs/tutorials/get-started/try-viam-sdk.md
+++ b/docs/tutorials/get-started/try-viam-sdk.md
@@ -155,7 +155,7 @@ Create another file named <file>package.json</file> with the following contents:
   "author": "Viam Docs Team",
   "license": "ISC",
   "devDependencies": {
-    "esbuild": "0.16.12"
+    "esbuild": "*"
   },
   "dependencies": {
     "@viamrobotics/sdk": "*"
@@ -613,10 +613,10 @@ func main() {
   "author": "Viam Docs Team",
   "license": "ISC",
   "devDependencies": {
-    "esbuild": "0.16.12"
+    "esbuild": "*"
   },
   "dependencies": {
-    "@viamrobotics/sdk": "^0.0.28"
+    "@viamrobotics/sdk": "*"
   }
 }
 ```


### PR DESCRIPTION
# Description

1. `git clone https://github.com/viamrobotics/viam-typescript-sdk`
2. Go to `examples/vanilla`.
3. Remove `package.json` and create a new one with contents from [this tutorial](https://docs.viam.com/tutorials/get-started/try-viam-sdk/). You can change in the new `package.json` `./main.ts` to `./src/main.ts` but not necessary.
4. Run `npm install`.

You'll get a message `npm WARN deprecated @viamrobotics/sdk@0.0.28: this version is not supported`.
Why not use the latest `esbuild` as well?