### PR TITLE
Update module build setup docs to have `./setup.sh`

### DIFF
--- a/docs/fleet/cli.md
+++ b/docs/fleet/cli.md
@@ -706,7 +706,7 @@ To configure your module's build steps, add a `build` object to your [`meta.json
 
 ```json {class="line-numbers linkable-line-numbers"}
 "build": {
-  "setup": "setup.sh",                    // optional - command to install your build dependencies
+  "setup": "./setup.sh",                  // optional - command to install your build dependencies
   "build": "make module.tar.gz",          // command that will build your module
   "path" : "module.tar.gz",               // optional - path to your built module
                                           // (passed to the 'viam module upload' command)


### PR DESCRIPTION
# Description

This comes from this PR: https://github.com/viamrobotics/rdk/pull/3572

This came from a misunderstanding of the scope doc and what the setup/build fields should accept.

We are restricting it to only accept valid bash commands (and the name of a shell script without a ./ is not a valid bash shell command)

