### PR TITLE
DOCS-1850: Highlight upload GH action

### DIFF
--- a/docs/fleet/cli.md
+++ b/docs/fleet/cli.md
@@ -516,7 +516,7 @@ viam module update
 viam module upload --version "1.0.0" --platform "darwin/arm64" packaged-module.tar.gz
 ```
 
-See [Upload a custom module](/registry/upload/#upload-a-custom-module) and [Update an existing module](/registry/upload/#update-an-existing-module) for a detailed walkthrough of the `viam module` commands.
+See [Upload a custom module](/registry/upload/#upload-a-custom-module-using-the-cli) and [Update an existing module](/registry/upload/#update-an-existing-module) for a detailed walkthrough of the `viam module` commands.
 
 If you update and release your module as part of a continuous integration (CI) workflow, you can also
 [automatically upload new versions of your module on release](/registry/upload/#update-an-existing-module-using-a-github-action) using a GitHub Action.
@@ -691,7 +691,7 @@ In the example above, the model namespace is set to `acme` to match the owning o
 If the two namespaces do not match, the command will return an error.
 {{% /alert %}}
 
-See [Upload a custom module](/registry/upload/#upload-a-custom-module) and [Update an existing module](/registry/upload/#update-an-existing-module) for a detailed walkthrough of the `viam module` commands.
+See [Upload a custom module](/registry/upload/#upload-a-custom-module-using-the-cli) and [Update an existing module](/registry/upload/#update-an-existing-module) for a detailed walkthrough of the `viam module` commands.
 
 See [Modular resources](/registry/) for a conceptual overview of modules and the modular resource system at Viam.
 

--- a/docs/registry/upload/_index.md
+++ b/docs/registry/upload/_index.md
@@ -22,11 +22,15 @@ aliases:
   - "/modular-resources/upload/"
 ---
 
-Once you have [created a custom module](/registry/create/), use the [Viam CLI](/fleet/cli/) to upload it to the Viam registry as a public module that is shared with other Viam users, or as a private module that is shared only within your [organization](/fleet/organizations/).
+Once you have [created a custom module](/registry/create/), use the instructions on this page to upload it to the Viam registry as a public module that is shared with other Viam users, or as a private module that is shared only within your [organization](/fleet/organizations/).
 
-Once uploaded, you can also [update your modules](/registry/upload/#update-an-existing-module).
+You can upload your module in one of two ways:
 
-## Upload a custom module
+- You can [upload your module using the Viam CLI](#upload-a-custom-module-using-the-cli), ideal for testing or on-demand releases.
+  You can also [update your module using the CLI](#update-an-existing-module) to push code changes as needed.
+- You can [use a GitHub Action to automatically upload your module when you make a new GitHub release](#update-an-existing-module-using-a-github-action), ideal for continuous integration (CI) pipelines.
+
+## Upload a custom module using the CLI
 
 To upload your custom module to the [Viam registry](https://app.viam.com/registry), either as a public or private module, use the Viam CLI commands `create`, `upload`, and `update` following these instructions:
 
@@ -235,14 +239,16 @@ Updating your module manually is appropriate for smaller projects, especially th
 Updating your module automatically using CI is better suited for larger, ongoing projects, especially those with multiple contributors.
 
 {{% alert title="Tip" color="tip" %}}
-
 If you would like to test your module locally against its intended target platform before uploading it, you can follow the steps for [Iterative module development](/registry/advanced/iterative-development/) to verify that any code changes you have made work as expected on your target platform.
-
 {{% /alert %}}
 
 ### Update an existing module using the Viam CLI
 
-To update an existing module in the [Viam registry](https://app.viam.com/registry) manually, use the [Viam CLI](/fleet/cli/):
+To update an existing module in the [Viam registry](https://app.viam.com/registry) manually, you can use the [Viam CLI](/fleet/cli/).
+
+{{% alert title="Tip" color="tip" %}}
+If you intend to make frequent code changes to your module, want to support a variety of platforms, or otherwise want to streamline your module development workflow, consider [using a GitHub action to update your module](#update-an-existing-module-using-a-github-action) instead.
+{{% /alert %}}
 
 1. Edit your custom module with the changes you'd like to make.
 
@@ -327,7 +333,7 @@ jobs:
           key-value: ${{ secrets.viam_key_value }}
 ```
 
-The `build-action` GitHub action relies on a build command that you need to specify in the <file>meta.json</file> file that you created for your module when you first [uploaded it](/registry/upload/#upload-a-custom-module).
+The `build-action` GitHub action relies on a build command that you need to specify in the <file>meta.json</file> file that you created for your module when you first [uploaded it](/registry/upload/#upload-a-custom-module-using-the-cli).
 At the end of your <file>meta.json</file>, add the build configuration:
 
 ```json {class="line-numbers linkable-line-numbers" data-line="4-7"}


### PR DESCRIPTION
Add intro to Registry > Upload page to raise awareness of GH upload action, by presenting choice between upload options in page into.
- Added tip to CLI update section to note existence of GH upload option instead.
- Clarifying header for CLI upload steps to use CLI in header title