### PR TITLE
DOCS-1681-emphasize cartographer algorithm

### DIFF
--- a/docs/mobility/slam/cartographer/_index.md
+++ b/docs/mobility/slam/cartographer/_index.md
@@ -18,8 +18,8 @@ aliases:
 To use Cartographer with the Viam {{< glossary_tooltip term_id="slam" text="SLAM" >}} service, you can use the [`cartographer`](https://app.viam.com/module/viam/cartographer) {{< glossary_tooltip term_id="modular-resource" text="modular resource" >}}.
 See the [Use Modules](/registry/#use-modules) section for instructions on using a module from the Viam registry on your machine.
 
-This module utilizes the Cartographer SLAM algorithm to provide tools for generating SLAM maps on your machine.
-If you want to use a SLAM algorithm outside of Cartographer, you can modify this module or create a new one to suit your needs.
+This module utilizes the Cartographer SLAM algorithm to provide tools for generating SLAM maps.
+If you want to use a SLAM algorithm outside of Cartographer, you can create a new module to suit your needs.
 
 The source code for this module is available on the [`viam-cartographer` GitHub repository](https://github.com/viamrobotics/viam-cartographer).
 


### PR DESCRIPTION
Emphasize that the cartographer module is providing an algorithm for generating a SLAM map and that there are other types of algorithms for generating a map using SLAM.