### PR TITLE
Update model version and description

### DIFF
--- a/docs/ml/deploy.md
+++ b/docs/ml/deploy.md
@@ -171,13 +171,13 @@ You can search the machine learning models that are available to deploy on this 
 If you upload or train a new version of a model, Viam automatically deploys the `latest` version of the model to the machine.
 If you do not want Viam to automatically deploy the `latest` version of the model, you can change the `packages` configuration in the [Raw JSON machine configuration](/build/configure/#the-config-tab).
 
-You can get the version number from a specific model version by clicking on **COPY** on the model on the models tab of the **DATA** page.
+You can get the version number from a specific model version by navigating to the [models page](https://app.viam.com/data/models) finding the model's row, clicking on the right-side menu marked with **_..._** and selecting **Copy package JSON**. For example: `2024-02-28T13-36-51`.
 The model package config looks like this:
 
 ```json
 {
-  "package": "<model_id>/allblack",
-  "version": "YYYYMMDDHHMMSS",
+  "package": "<model_id>/<model_name>",
+  "version": "YYYY-MM-DDThh-mm-ss",
   "name": "<model_name>",
   "type": "ml_model"
 }

--- a/docs/ml/train-model.md
+++ b/docs/ml/train-model.md
@@ -66,14 +66,15 @@ If you are training a new model, you need to again go to your dataset's page and
 
 If you do not want Viam to automatically deploy the `latest` version of the model, you can change `packages` configuration in the [Raw JSON machine configuration](/build/configure/#the-config-tab).
 
-You can get the version number from a specific model version by clicking on **COPY** on the model on the model page.
+You can get the version number from a specific model version by navigating to the [models page](https://app.viam.com/data/models) finding the model's row, clicking on the right-side menu marked with **_..._** and selecting **Copy package JSON**. For example: `2024-02-28T13-36-51`.
 The model package config looks like this:
 
 ```json
 {
-  "package": "<model_id>/allblack",
-  "version": "YYYYMMDDHHMMSS",
-  "name": "<model_name>"
+  "package": "<model_id>/<model_name>",
+  "version": "YYYY-MM-DDThh-mm-ss",
+  "name": "<model_name>",
+  "type": "ml_model"
 }
 ```
 

--- a/docs/ml/upload-model.md
+++ b/docs/ml/upload-model.md
@@ -74,14 +74,15 @@ If you upload a new version of that model, Viam will automatically deploy the ne
 
 If you do not want Viam to automatically deploy the `latest` version of the model, you can change the `packages` configuration in the [Raw JSON machine configuration](/build/configure/#the-config-tab).
 
-You can get the version number from a specific model version by navigating to the **MODELS** subtab of the Viam app's **DATA** tab, finding the model's row, clicking on the right-side menu marked with **_..._** and selecting **Copy package JSON**.
+You can get the version number from a specific model version by navigating to the [models page](https://app.viam.com/data/models) finding the model's row, clicking on the right-side menu marked with **_..._** and selecting **Copy package JSON**. For example: `2024-02-28T13-36-51`.
 The model package config looks like this:
 
 ```json
 {
-  "package": "<model_id>/allblack",
-  "version": "YYYYMMDDHHMMSS",
-  "name": "<model_name>"
+  "package": "<model_id>/<model_name>",
+  "version": "YYYY-MM-DDThh-mm-ss",
+  "name": "<model_name>",
+  "type": "ml_model"
 }
 ```
 


### PR DESCRIPTION
# Description

Model version format is outdated in 3 documentation pages (the only 3 occurrences). Updated formats, description and package config that was missing "type" key in 2 out of 3 places. Wasn't sure people would understand `T` in `YYYY-MM-DDThh-mm-ss` is just a letter 'T' so also gave an example of a version.