### PR TITLE
DOCS-1901: Fix python error, add cloudmetadata

### DIFF
--- a/.github/workflows/check_python_methods.py
+++ b/.github/workflows/check_python_methods.py
@@ -98,7 +98,7 @@ def parse(type, names):
             service = "data-client"
 
         if service == "app_client":
-            service = "cloud"
+            service = "fleet"
 
         # Find all python methods objects on Python docs site soup
         py_methods_sdk_docs = soup.find_all("dl", class_="py method")

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.venv
 .jpg_original
 .jpeg_original
 .png_original

--- a/docs/build/program/apis/robot.md
+++ b/docs/build/program/apis/robot.md
@@ -938,13 +938,14 @@ fmt.Println(metadata.LocationID)
 
 **Returns:**
 
-- None.
+- [CloudMetadata](https://ts.viam.dev/types/CloudMetadata.html): App-related metadata containing the primary org id, location id, and robot part id for a robot running on the Viam app.
 
 For more information, see the [Typescript SDK Docs](https://ts.viam.dev/classes/RobotClient.html).
 
 ```typescript
 // Get the metadata of the machine.
 const metadata = await robot.getCloudMetadata();
+console.log(metadata);
 ```
 
 {{% /tab %}}

--- a/docs/build/program/apis/robot.md
+++ b/docs/build/program/apis/robot.md
@@ -885,4 +885,28 @@ For more information, see the [Typescript SDK Docs](https://ts.viam.dev/classes/
 {{% /tab %}}
 {{< /tabs >}}
 
+### GetCloudMetadata
+
+Returns app-related information about the robot.
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- None.
+
+**Returns:**
+
+- None.
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient.get_cloud_metadata).
+
+```python
+metadata = robot.get_cloud_metadata()
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
 For the full list of robot API methods, see the [Viam Python SDK documentation](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient) or the [RDK (the Viam Go SDK) documentation](https://pkg.go.dev/go.viam.com/rdk/robot/client#RobotClient).

--- a/docs/build/program/apis/robot.md
+++ b/docs/build/program/apis/robot.md
@@ -898,12 +898,15 @@ Returns app-related information about the robot.
 
 **Returns:**
 
-- [viam.proto.robot.GetCloudMetadataResponse](https://python.viam.dev/autoapi/viam/proto/robot/index.html#viam.proto.robot.GetCloudMetadataResponse): App-related metadata.
+- [viam.proto.robot.GetCloudMetadataResponse](https://python.viam.dev/autoapi/viam/proto/robot/index.html#viam.proto.robot.GetCloudMetadataResponse): App-related metadata containing the primary org id, location id, and robot part id for a robot running on the Viam app.
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient.get_cloud_metadata).
 
 ```python
 metadata = robot.get_cloud_metadata()
+print(metadata.robot_part_id)
+print(metadata.primary_org_id)
+print(metadata.location_id)
 ```
 
 {{% /tab %}}
@@ -915,12 +918,15 @@ metadata = robot.get_cloud_metadata()
 
 **Returns:**
 
-- None.
+- [cloud.Metadata](https://pkg.go.dev/go.viam.com/rdk/cloud): App-related metadata containing the primary org id, location id, and robot part id for a robot running on the Viam app.
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/robot#Robot).
 
 ```go
 metadata := robot.GetCloudMetadata()
+fmt.Println(metadata.RobotPartID)
+fmt.Println(metadata.PrimaryOrgID)
+fmt.Println(metadata.LocationID)
 ```
 
 {{% /tab %}}

--- a/docs/build/program/apis/robot.md
+++ b/docs/build/program/apis/robot.md
@@ -907,6 +907,41 @@ metadata = robot.get_cloud_metadata()
 ```
 
 {{% /tab %}}
+{{% tab name="Go" %}}
+
+**Parameters:**
+
+- None.
+
+**Returns:**
+
+- None.
+
+For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/robot#Robot).
+
+```go
+metadata := robot.GetCloudMetadata()
+```
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- None.
+
+**Returns:**
+
+- None.
+
+For more information, see the [Typescript SDK Docs](https://ts.viam.dev/classes/RobotClient.html).
+
+```typescript
+// Get the metadata of the machine.
+const metadata = await robot.getCloudMetadata();
+```
+
+{{% /tab %}}
 {{< /tabs >}}
 
 For the full list of robot API methods, see the [Viam Python SDK documentation](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient) or the [RDK (the Viam Go SDK) documentation](https://pkg.go.dev/go.viam.com/rdk/robot/client#RobotClient).

--- a/docs/build/program/apis/robot.md
+++ b/docs/build/program/apis/robot.md
@@ -898,7 +898,7 @@ Returns app-related information about the robot.
 
 **Returns:**
 
-- None.
+- [viam.proto.robot.GetCloudMetadataResponse](https://python.viam.dev/autoapi/viam/proto/robot/index.html#viam.proto.robot.GetCloudMetadataResponse): App-related metadata.
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient.get_cloud_metadata).
 

--- a/docs/build/program/apis/robot.md
+++ b/docs/build/program/apis/robot.md
@@ -918,7 +918,7 @@ print(metadata.location_id)
 
 **Returns:**
 
-- [cloud.Metadata](https://pkg.go.dev/go.viam.com/rdk/cloud): App-related metadata containing the primary org id, location id, and robot part id for a robot running on the Viam app.
+- [cloud.Metadata](https://pkg.go.dev/go.viam.com/rdk/internal/cloud#Metadata): App-related metadata containing the primary org id, location id, and robot part id for a robot running on the Viam app.
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/robot#Robot).
 

--- a/static/include/services/apis/robot.md
+++ b/static/include/services/apis/robot.md
@@ -1,6 +1,6 @@
 <!-- prettier-ignore -->
-| Method Name                                                     | Description                                                                  |
-| --------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Method Name | Description |
+| ----------- | ----------- |
 | [`Options.with_api_key`](/build/program/apis/robot/#optionswith_api_key) | Create RobotClient connection options with an API key as credentials. |
 | [`AtAddress`](/build/program/apis/robot/#ataddress) | Create a RobotClient that is connected to the machine at the provided address. |
 | [`WithChannel`](/build/program/apis/robot/#withchannel) | Create a RobotClient that is connected to a machine over the given channel. |
@@ -16,3 +16,4 @@
 | [`Close`](/build/program/apis/robot/#close)                           | Close the connections and stop periodic tasks across the machine.              |
 | [`StopAll`](/build/program/apis/robot/#stopall)                       | Cancel all operations for the machine and stop its movement.                   |
 | [`ResourceNames`](/build/program/apis/robot/#resourcenames)           | Get a list of all the machine's resources.                                     |
+| [`GetCloudMetadata`](/build/program/apis/robot/#getcloudmetadata) | Returns app-related information about the robot. |


### PR DESCRIPTION
 I think the links will start working tomorrow, so won't merge till then