### PR TITLE
DOCS-1824: Add link to rgb-d-overlay

### DIFF
--- a/docs/components/camera/_index.md
+++ b/docs/components/camera/_index.md
@@ -203,6 +203,9 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 {{% alert title="Usage" color="note" %}}
 Intended specifically for use with cameras that support simultaneous depth and color image streams, like the [Intel RealSense](https://app.viam.com/module/viam/realsense) or the [Luxonis OAK-D](https://app.viam.com/module/viam/oak-d).
 If your camera does not have multiple imagers, this method will work without capturing multiple images simultaneously.
+
+You can use the [`rgb-d-overlay` module](https://app.viam.com/module/viam/rgb-d-overlay) to view and compare the camera streams returned by this method.
+See the [module readme](https://github.com/viam-labs/rgb-d-overlay) for further instructions.
 {{% /alert %}}
 
 Get simultaneous images from different imagers, along with associated metadata.


### PR DESCRIPTION
Add link from `GetImages` usage note to `rgb-d-overlay` module for testing returned camera streams.