### PR TITLE
Fix code formatting in Get Started

### DIFF
--- a/docs/get-started/_index.md
+++ b/docs/get-started/_index.md
@@ -14,6 +14,7 @@ Learn about the Viam platform by reading our Viam in 3 minutes guide or try it o
 {{< /cards >}}
 
 <br>
+
 If you're ready to try it on your own machine, start by installing `viam-server`.
 If you need any help along the way, join our community:
 


### PR DESCRIPTION
`viam-server` isn't displaying correctly because of the html tag right before it