### PR TITLE
Remove unnecessary --save option

### DIFF
--- a/docs/build/program/_index.md
+++ b/docs/build/program/_index.md
@@ -59,7 +59,7 @@ go get go.viam.com/rdk/robot/client
 {{% tab name="TypeScript" %}}
 
 ```sh {class="command-line" data-prompt="$"}
-npm install --save @viamrobotics/sdk
+npm install @viamrobotics/sdk
 ```
 
 {{< alert title="Info" color="info" >}}


### PR DESCRIPTION
# Description

`--save` option is no longer necessary when installing JS/TS packages. It's the default since [npm 5.0.0](https://blog.npmjs.org/post/161081169345/v500) which was published in 2017.

[NPM documentation](https://docs.npmjs.com/cli/v6/commands/npm-install) doesn't even list `--save` as an available option.

This is the only occurrence of `--save`.