### PR TITLE
Remove mention of Oak-D and Intel Real Sense from Dual and Single Server Camera model Docs

### DIFF
--- a/docs/components/camera/single-stream.md
+++ b/docs/components/camera/single-stream.md
@@ -121,7 +121,6 @@ The following attributes are available for `single_stream` cameras:
 | `distortion_parameters` | object | Optional | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
 | `debug` | boolean | Optional | Enables the debug outputs from the camera if `true`. <br> Default: `false` |
 
-
 ## View the camera stream
 
 {{< readfile "/static/include/components/camera-view-camera-stream.md" >}}

--- a/docs/components/camera/single-stream.md
+++ b/docs/components/camera/single-stream.md
@@ -121,8 +121,6 @@ The following attributes are available for `single_stream` cameras:
 | `distortion_parameters` | object | Optional | Modified Brown-Conrady parameters used to correct for distortions caused by the shape of the camera lens: <ul> <li> <code>rk1</code>: The radial distortion x. </li> <li> <code>rk2</code>: The radial distortion y. </li> <li> <code>rk3</code>: The radial distortion z. </li> <li> <code>tp1</code>: The tangential distortion x. </li> <li> <code>tp2</code>: The tangential distortion y. </li> </ul> |
 | `debug` | boolean | Optional | Enables the debug outputs from the camera if `true`. <br> Default: `false` |
 
-If you have a camera that uses its own SDK to access its images and point clouds (like an [Intel RealSense](https://app.viam.com/module/viam/realsense) or a [Luxonis OAK-D](https://app.viam.com/module/viam/oak-d)), you can add a camera server as a {{< glossary_tooltip term_id="remote" text="remote" >}} component of your machine.
-These remote cameras are treated like any other camera on your machine.
 
 ## View the camera stream
 


### PR DESCRIPTION
The way to consume these cameras now is by using the modules.

# Description

Please include a summary of the change and what is does. Please also include relevant motivation and context.
