### PR TITLE
Fix tflite_cpu attributes

### DIFF
--- a/docs/ml/deploy/tflite_cpu.md
+++ b/docs/ml/deploy/tflite_cpu.md
@@ -126,10 +126,10 @@ The following parameters are available for a `"tflite_cpu"` model:
 | `num_threads` | Optional | An integer that defines how many CPU threads to use to run inference. Default: `1`. |
 
 {{% alert title="Note" color="note" %}}
-If you **Deploy Model on Robot**, `model_path` and `label_path` will be automatically configured in the format `"${packages.<model_name>}/<model-name>.tflite"`.
+If you **Deploy Model on Robot**, `model_path` and `label_path` will be automatically configured in the format `"${packages.<model_name>}/<model-name>.tflite"` and `"${packages.<model_name>}/labels.txt"` respectively..
 
 If you take the **Path to existing model on robot** approach, your model and label paths do not have to be in the same format.
-They can look like `home/models/fruit/my_fruit_model.tflite`.
+For example, they might resemble `home/models/fruit/my_fruit_model.tflite`.
 {{% /alert %}}
 
 Save the configuration.

--- a/docs/ml/deploy/tflite_cpu.md
+++ b/docs/ml/deploy/tflite_cpu.md
@@ -73,8 +73,8 @@ Add the `tflite_cpu` ML model object to the services array in your raw JSON conf
     "type": "mlmodel",
     "model": "tflite_cpu",
     "attributes": {
-      "model_path": "${packages.ml_model.<model_name>}/<model-name>.tflite",
-      "label_path": "${packages.ml_model.<model_name>}/labels.txt",
+      "model_path": "${packages.<model_name>}/<model-name>.tflite",
+      "label_path": "${packages.<model_name>}/labels.txt",
       "num_threads": <number>
     }
   },
@@ -101,8 +101,8 @@ Add the `tflite_cpu` ML model object to the services array in your raw JSON conf
     "type": "mlmodel",
     "model": "tflite_cpu",
     "attributes": {
-      "model_path": "${packages.ml_model.my_fruit_model}/my_fruit_model.tflite",
-      "label_path": "${packages.ml_model.my_fruit_model}/labels.txt",
+      "model_path": "${packages.my_fruit_model}/my_fruit_model.tflite",
+      "label_path": "${packages.my_fruit_model}/labels.txt",
       "num_threads": 1
     }
   }
@@ -124,6 +124,13 @@ The following parameters are available for a `"tflite_cpu"` model:
 | `model_path` | **Required** | The absolute path to the `.tflite model` file, as a `string`. |
 | `label_path` | Optional | The absolute path to a `.txt` file that holds class labels for your TFLite model, as a `string`. This text file should contain an ordered listing of class labels. Without this file, classes will read as "1", "2", and so on. |
 | `num_threads` | Optional | An integer that defines how many CPU threads to use to run inference. Default: `1`. |
+
+{{% alert title="Note" color="note" %}}
+If you **Deploy Model on Robot**, `model_path` and `label_path` will be automatically configured in the format `"${packages.<model_name>}/<model-name>.tflite"`.
+
+If you take the **Path to existing model on robot** approach, your model and label paths do not have to be in the same format.
+They can look like `home/models/fruit/my_fruit_model.tflite`.
+{{% /alert %}}
 
 Save the configuration.
 

--- a/docs/ml/deploy/tflite_cpu.md
+++ b/docs/ml/deploy/tflite_cpu.md
@@ -126,7 +126,7 @@ The following parameters are available for a `"tflite_cpu"` model:
 | `num_threads` | Optional | An integer that defines how many CPU threads to use to run inference. Default: `1`. |
 
 {{% alert title="Note" color="note" %}}
-If you **Deploy Model on Robot**, `model_path` and `label_path` will be automatically configured in the format `"${packages.<model_name>}/<model-name>.tflite"` and `"${packages.<model_name>}/labels.txt"` respectively..
+If you **Deploy Model on Robot**, `model_path` and `label_path` will be automatically configured in the format `"${packages.<model_name>}/<model-name>.tflite"` and `"${packages.<model_name>}/labels.txt"` respectively.
 
 If you take the **Path to existing model on robot** approach, your model and label paths do not have to be in the same format.
 For example, they might resemble `home/models/fruit/my_fruit_model.tflite`.


### PR DESCRIPTION
Noticed that other configs did not look like our example format-- confirmed with Steven that out of these 3 options:

`"model_path": "${packages.ml_model.my_fruit_model}/my_fruit_model.tflite"
"model_path": "${[packages.my_fruit_model}/my_fruit_model.tflite"
"model_path": "/some/path/to/my_fruit_model.tflite"`

only 2 and 3 are valid, so our docs example is wrong. 

- Fix docs examples
- Tried to make clear that 3 is possible too