### PR TITLE
DOCS-1707/DOCS-1997: Refresh ML landing page and model frameworks

### DIFF
--- a/docs/ml/_index.md
+++ b/docs/ml/_index.md
@@ -39,8 +39,8 @@ See [Use machine learning with your machine](#use-machine-learning-with-your-mac
 {{< cards >}}
 {{% manualcard link="/tutorials/projects/integrating-viam-with-openai/" %}}
 
-<h4>Integrate Viam with ChatGPT</h4>
 {{<imgproc src="/tutorials/ai-integration/rosey_robot.jpg" resize="150x" declaredimensions=true alt="Rosey the robot from the ChatGPT tutorial">}}
+<h4>Integrate Viam with ChatGPT</h4>
 
 Add object detection, speech recognition, natural language processing, and speech synthesis capabilities to a machine.
 

--- a/docs/ml/_index.md
+++ b/docs/ml/_index.md
@@ -25,10 +25,6 @@ Common use cases include:
 
 For other use cases, consider [creating custom functionality with a module](/registry/create/).
 
-{{% alert title="Note" color="note" %}}
-See [Integrate Viam with ChatGPT to Create a Companion Robot](/tutorials/projects/integrating-viam-with-openai/) for an example of using Viam to add object detection, speech recognition, natural language processing, and speech synthesis capabilities to a machine.
-{{% /alert %}}
-
 Viam provides two services that enable machine learning capabilities: the [ML model](/ml/deploy/) service and the [Computer Vision](/ml/vision/) service.
 
 The ML model service deploys and runs a machine learning model, such as a TensorFlow or ONNX model, on your machine and makes its output accessible to other services.
@@ -36,7 +32,23 @@ One service that is built on top of the ML model service is the [Computer Vision
 As a detector, the service interprets image data from images on your computer or a [camera](/components/camera/) and draws bounding boxes around objects.
 As a classifier, the service returns class labels and confidence score based off the [inferences](/ml/deploy/#infer) the underlying ML model makes from image data.
 
-See [Use machine learning with your machine](#use-machine-learning-with-your-machine) for a full guide to this workflow.
+See [Use machine learning with your machine](#use-machine-learning-with-your-machine) for step by step instructions.
+
+## Example tutorials
+
+{{< cards >}}
+{{% manualcard link="/tutorials/projects/integrating-viam-with-openai/" %}}
+
+<h4>Integrate Viam with ChatGPT to Create a Companion Robot</h4>
+Add object detection, speech recognition, natural language processing, and speech synthesis capabilities to a machine.
+
+{{% /manualcard %}}
+{{% card link="/tutorials/projects/helmet/" %}}
+{{% card link="/tutorials/services/data-mlmodel-tutorial/" %}}
+{{% card link="/tutorials/projects/pet-treat-dispenser/" customTitle="Smart Pet Feeder" %}}
+{{< /cards >}}
+
+## Model support
 
 You have four options when choosing a model to deploy onto an [ML model](/ml/deploy/) deployment service.
 You can:
@@ -47,7 +59,6 @@ You can:
 - deploy a model trained outside the Viam platform that's already available on your machine
 
 The model you use must be supported on the Viam platform.
-
 Viam supports the following model frameworks:
 
 - [TensorFlow Lite](https://www.tensorflow.org/lite) (as long as your models adhere to the [model requirements](/ml/deploy/tflite_cpu/#model-requirements)): with the [`tflite_cpu` ML model service](/ml/deploy/)
@@ -98,11 +109,3 @@ For more information, see [Model framework support](/ml/upload-model/#model-fram
     </td>
   </tr>
 </table>
-
-## Tutorials
-
-{{< cards >}}
-{{% card link="/tutorials/projects/helmet/" %}}
-{{% card link="/tutorials/projects/pet-treat-dispenser/" customTitle="Smart Pet Feeder" %}}
-{{% card link="/tutorials/services/data-mlmodel-tutorial/" %}}
-{{< /cards >}}

--- a/docs/ml/_index.md
+++ b/docs/ml/_index.md
@@ -39,7 +39,7 @@ See [Use machine learning with your machine](#use-machine-learning-with-your-mac
 {{< cards >}}
 {{% manualcard link="/tutorials/projects/integrating-viam-with-openai/" %}}
 
-<h4>Integrate Viam with ChatGPT</h4>
+<h4>Integrate Viam with ChatGPT to Create a Companion Robot</h4>
 
 Add object detection, speech recognition, natural language processing, and speech synthesis capabilities to a machine.
 

--- a/docs/ml/_index.md
+++ b/docs/ml/_index.md
@@ -40,6 +40,9 @@ See [Use machine learning with your machine](#use-machine-learning-with-your-mac
 {{% manualcard link="/tutorials/projects/integrating-viam-with-openai/" %}}
 
 <h4>Integrate Viam with ChatGPT to Create a Companion Robot</h4>
+
+{{<imgproc src="/tutorials/ai-integration/rosey_robot.jpg" resize="200x" declaredimensions=true alt="Rosey the robot from the ChatGPT tutorial">}}
+
 Add object detection, speech recognition, natural language processing, and speech synthesis capabilities to a machine.
 
 {{% /manualcard %}}

--- a/docs/ml/_index.md
+++ b/docs/ml/_index.md
@@ -39,7 +39,6 @@ See [Use machine learning with your machine](#use-machine-learning-with-your-mac
 {{< cards >}}
 {{% manualcard link="/tutorials/projects/integrating-viam-with-openai/" %}}
 
-{{<imgproc src="/tutorials/ai-integration/rosey_robot.jpg" resize="150x" declaredimensions=true alt="Rosey the robot from the ChatGPT tutorial">}}
 <h4>Integrate Viam with ChatGPT</h4>
 
 Add object detection, speech recognition, natural language processing, and speech synthesis capabilities to a machine.

--- a/docs/ml/_index.md
+++ b/docs/ml/_index.md
@@ -39,9 +39,8 @@ See [Use machine learning with your machine](#use-machine-learning-with-your-mac
 {{< cards >}}
 {{% manualcard link="/tutorials/projects/integrating-viam-with-openai/" %}}
 
+<h4>Integrate Viam with ChatGPT</h4>
 {{<imgproc src="/tutorials/ai-integration/rosey_robot.jpg" resize="150x" declaredimensions=true alt="Rosey the robot from the ChatGPT tutorial">}}
-
-<h4>Integrate Viam with ChatGPT to Create a Companion Robot</h4>
 
 Add object detection, speech recognition, natural language processing, and speech synthesis capabilities to a machine.
 

--- a/docs/ml/_index.md
+++ b/docs/ml/_index.md
@@ -38,8 +38,7 @@ As a classifier, the service returns class labels and confidence score based off
 
 See [Use machine learning with your machine](#use-machine-learning-with-your-machine) for a full guide to this workflow.
 
-The ML model service works with models trained inside and outside the Viam app, and with models that are private to an organization or shared on the registry.
-Thus, you have four options when choosing a model to deploy onto an [ML model](/ml/deploy/) deployment service.
+You have four options when choosing a model to deploy onto an [ML model](/ml/deploy/) deployment service.
 You can:
 
 - [train a model on the Viam app](/ml/train-model/) and deploy it

--- a/docs/ml/_index.md
+++ b/docs/ml/_index.md
@@ -104,8 +104,6 @@ For more information, see [Model framework support](/ml/upload-model/#model-fram
 
 {{< cards >}}
 {{% card link="/tutorials/projects/helmet/" %}}
-{{% card link="/tutorials/projects/filtered-camera/" %}}
 {{% card link="/tutorials/projects/pet-treat-dispenser/" customTitle="Smart Pet Feeder" %}}
-{{% card link="/registry/examples/tflite-module/" %}}
 {{% card link="/tutorials/services/data-mlmodel-tutorial/" %}}
 {{< /cards >}}

--- a/docs/ml/_index.md
+++ b/docs/ml/_index.md
@@ -16,19 +16,42 @@ menuindent: true
 {{<imgproc src="/ml/training.png" class="alignright" resize="400x" declaredimensions=true alt="ML training">}}
 
 Machine Learning (ML) provides your machines with the ability to adjust its behavior based on models that recognize patterns or make predictions.
+
 Common use cases include:
 
-- Object detection and classification which enable machines to detect people, animals, plants, or other objects with bounding boxes, and to perform actions when they are detected.
+- Object detection, which enables machines to detect people, animals, plants, or other objects with bounding boxes, and to perform actions when they are detected.
+- Object classification, which enables machines to separate people, animals, plants, or other objects into predefined categories based on their characteristics.
 - Speech recognition, natural language processing, and speech synthesis, which enable machines to verbally communicate with us.
 
 However, your machine can make use of machine learning with nearly any kind of data.
 
-Viam supports:
+{{% alert title="Note" color="note" %}}
+See [Integrate Viam with ChatGPT to Create a Companion Robot](/tutorials/projects/integrating-viam-with-openai/) for an example of using Viam to add object detection, speech recognition, natural language processing, and speech synthesis capabilities to a machine.
+{{% /alert %}}
 
-- [TensorFlow Lite](https://www.tensorflow.org/lite) ML models as long as your models adhere to the [model requirements](/ml/deploy/tflite_cpu/#model-requirements)
-- TensorFlow
-- PyTorch
-- ONNX
+Viam provides models of [ML model](/ml/deploy/) and [Computer Vision](/ml/vision/) services to facilitate model deployment and object detection and classification.
+
+The ML model service runs the model on your machine so that the [Computer Vision](/ml/vision) `mlmodel` service can use it as a detector or classifier, interpreting image data from images on your computer or a [camera](/components/camera/) to draw bounding boxes around objects (detection) or return a class label and confidence score (classification) based off the [inferences](/ml/deploy/#infer) the underlying ML model makes.
+
+See [Use machine learning with your machine](#use-machine-learning-with-your-machine) for a full guide to this workflow.
+
+The ML model service works with models trained inside and outside the Viam app, and with models that are private to an organization or shared on the registry.
+Thus, you have four options when choosing a model to deploy onto an [ML model](/ml/deploy/) deployment service.
+You can:
+
+- [train a model on the Viam app](ml/train-model/) and deploy it
+- deploy a pre-trained model another user has published from [the registry](https://app.viam.com/registry)
+- [upload](/ml/upload-model/) a model trained outside the Viam platform to the registry privately or publicly and deploy it
+- deploy a model trained outside the Viam platform that's already available on your machine
+
+The model you use must be supported on the Viam platform.
+
+Viam supports the following model frameworks:
+
+- [TensorFlow Lite](https://www.tensorflow.org/lite) (as long as your models adhere to the [model requirements](/ml/deploy/tflite_cpu/#model-requirements)): with the [`tflite_cpu` ML model service](/ml/deploy/)
+- [TensorFlow](https://www.tensorflow.org/): with the [`triton` ML model service](https://github.com/viamrobotics/viam-mlmodelservice-triton)
+- [PyTorch](https://pytorch.org/): with the [`triton` ML model service](https://github.com/viamrobotics/viam-mlmodelservice-triton)
+- [ONNX](https://onnx.ai/): with the [`onnx_cpu` ML model service](https://github.com/viam-labs/onnx-cpu)
 
 For more information, see [Model framework support](/ml/upload-model/#model-framework-support).
 
@@ -77,6 +100,8 @@ For more information, see [Model framework support](/ml/upload-model/#model-fram
 ## Tutorials
 
 {{< cards >}}
+{{% card link="/tutorials/projects/helmet/" %}}
+{{% card link="/tutorials/projects/filtered-camera/" %}}
 {{% card link="/tutorials/projects/pet-treat-dispenser/" customTitle="Smart Pet Feeder" %}}
 {{% card link="/registry/examples/tflite-module/" %}}
 {{% card link="/tutorials/services/data-mlmodel-tutorial/" %}}

--- a/docs/ml/_index.md
+++ b/docs/ml/_index.md
@@ -28,7 +28,7 @@ For other use cases, consider [creating custom functionality with a module](/reg
 Viam provides two services that enable machine learning capabilities: the [ML model](/ml/deploy/) service and the [Computer Vision](/ml/vision/) service.
 
 The ML model service deploys and runs a machine learning model, such as a TensorFlow or ONNX model, on your machine and makes its output accessible to other services.
-One service that is built on top of the ML model service is the [Computer Vision](/ml/vision/mlmodel/) `mlmodel` service which can detect or classify objects.
+For example, the [Computer Vision](/ml/vision/mlmodel/) `mlmodel` service, which can detect or classify objects, is built to work with the inferences from an ML model service.
 As a detector, the service uses these inferences to interpret image data from images on your computer or a [camera](/components/camera/), drawing bounding boxes around objects.
 As a classifier, the service returns class labels and confidence score based off the [inferences](/ml/deploy/#infer) the underlying ML model makes from image data.
 

--- a/docs/ml/_index.md
+++ b/docs/ml/_index.md
@@ -39,9 +39,9 @@ See [Use machine learning with your machine](#use-machine-learning-with-your-mac
 {{< cards >}}
 {{% manualcard link="/tutorials/projects/integrating-viam-with-openai/" %}}
 
-<h4>Integrate Viam with ChatGPT to Create a Companion Robot</h4>
+{{<imgproc src="/tutorials/ai-integration/rosey_robot.jpg" resize="150x" declaredimensions=true alt="Rosey the robot from the ChatGPT tutorial">}}
 
-{{<imgproc src="/tutorials/ai-integration/rosey_robot.jpg" resize="200x" declaredimensions=true alt="Rosey the robot from the ChatGPT tutorial">}}
+<h4>Integrate Viam with ChatGPT to Create a Companion Robot</h4>
 
 Add object detection, speech recognition, natural language processing, and speech synthesis capabilities to a machine.
 

--- a/docs/ml/_index.md
+++ b/docs/ml/_index.md
@@ -20,18 +20,21 @@ Machine Learning (ML) provides your machines with the ability to adjust its beha
 Common use cases include:
 
 - Object detection, which enables machines to detect people, animals, plants, or other objects with bounding boxes, and to perform actions when they are detected.
-- Object classification, which enables machines to separate people, animals, plants, or other objects into predefined categories based on their characteristics.
+- Object classification, which enables machines to separate people, animals, plants, or other objects into predefined categories based on their characteristics, and to perform different actions based on the classes of objects.
 - Speech recognition, natural language processing, and speech synthesis, which enable machines to verbally communicate with us.
 
-However, your machine can make use of machine learning with nearly any kind of data.
+For other use cases, consider [creating custom functionality with a module](/registry/create/).
 
 {{% alert title="Note" color="note" %}}
 See [Integrate Viam with ChatGPT to Create a Companion Robot](/tutorials/projects/integrating-viam-with-openai/) for an example of using Viam to add object detection, speech recognition, natural language processing, and speech synthesis capabilities to a machine.
 {{% /alert %}}
 
-Viam provides models of [ML model](/ml/deploy/) and [Computer Vision](/ml/vision/) services to facilitate model deployment and object detection and classification.
+Viam provides two services that enable machine learning capabilities: the [ML model](/ml/deploy/) service and the [Computer Vision](/ml/vision/) service.
 
-The ML model service runs the model on your machine so that the [Computer Vision](/ml/vision/) `mlmodel` service can use it as a detector or classifier, interpreting image data from images on your computer or a [camera](/components/camera/) to draw bounding boxes around objects (detection) or return a class label and confidence score (classification) based off the [inferences](/ml/deploy/#infer) the underlying ML model makes.
+The ML model service deploys and runs a machine learning model, such as a TensorFlow or ONNX model, on your machine and makes its output accessible to other services.
+One service that is built on top of the ML model service is the [Computer Vision](/ml/vision/mlmodel/) `mlmodel` service which can detect or classify objects.
+As a detector, the service interprets image data from images on your computer or a [camera](/components/camera/) and draws bounding boxes around objects.
+As a classifier, the service returns class labels and confidence score based off the [inferences](/ml/deploy/#infer) the underlying ML model makes from image data.
 
 See [Use machine learning with your machine](#use-machine-learning-with-your-machine) for a full guide to this workflow.
 

--- a/docs/ml/_index.md
+++ b/docs/ml/_index.md
@@ -29,7 +29,7 @@ Viam provides two services that enable machine learning capabilities: the [ML mo
 
 The ML model service deploys and runs a machine learning model, such as a TensorFlow or ONNX model, on your machine and makes its output accessible to other services.
 One service that is built on top of the ML model service is the [Computer Vision](/ml/vision/mlmodel/) `mlmodel` service which can detect or classify objects.
-As a detector, the service interprets image data from images on your computer or a [camera](/components/camera/) and draws bounding boxes around objects.
+As a detector, the service uses these inferences to interpret image data from images on your computer or a [camera](/components/camera/), drawing bounding boxes around objects.
 As a classifier, the service returns class labels and confidence score based off the [inferences](/ml/deploy/#infer) the underlying ML model makes from image data.
 
 See [Use machine learning with your machine](#use-machine-learning-with-your-machine) for step by step instructions.

--- a/docs/ml/_index.md
+++ b/docs/ml/_index.md
@@ -31,7 +31,7 @@ See [Integrate Viam with ChatGPT to Create a Companion Robot](/tutorials/project
 
 Viam provides models of [ML model](/ml/deploy/) and [Computer Vision](/ml/vision/) services to facilitate model deployment and object detection and classification.
 
-The ML model service runs the model on your machine so that the [Computer Vision](/ml/vision) `mlmodel` service can use it as a detector or classifier, interpreting image data from images on your computer or a [camera](/components/camera/) to draw bounding boxes around objects (detection) or return a class label and confidence score (classification) based off the [inferences](/ml/deploy/#infer) the underlying ML model makes.
+The ML model service runs the model on your machine so that the [Computer Vision](/ml/vision/) `mlmodel` service can use it as a detector or classifier, interpreting image data from images on your computer or a [camera](/components/camera/) to draw bounding boxes around objects (detection) or return a class label and confidence score (classification) based off the [inferences](/ml/deploy/#infer) the underlying ML model makes.
 
 See [Use machine learning with your machine](#use-machine-learning-with-your-machine) for a full guide to this workflow.
 
@@ -39,7 +39,7 @@ The ML model service works with models trained inside and outside the Viam app, 
 Thus, you have four options when choosing a model to deploy onto an [ML model](/ml/deploy/) deployment service.
 You can:
 
-- [train a model on the Viam app](ml/train-model/) and deploy it
+- [train a model on the Viam app](/ml/train-model/) and deploy it
 - deploy a pre-trained model another user has published from [the registry](https://app.viam.com/registry)
 - [upload](/ml/upload-model/) a model trained outside the Viam platform to the registry privately or publicly and deploy it
 - deploy a model trained outside the Viam platform that's already available on your machine

--- a/docs/ml/deploy/_index.md
+++ b/docs/ml/deploy/_index.md
@@ -17,7 +17,7 @@ images: ["/services/icons/ml.svg"]
 The Machine Learning (ML) model service allows you to deploy machine learning models to your machine.
 This can mean deploying:
 
-- a model you [trained](ml/train-model/)
+- a model you [trained](/ml/train-model/)
 - a model from [the registry](https://app.viam.com/registry) that another user has shared publicly
 - a model trained outside the Viam platform that you have [uploaded](/ml/upload-model/) to the registry privately or publicly
 - a model trained outside the Viam platform that's already available on your machine

--- a/docs/ml/deploy/_index.md
+++ b/docs/ml/deploy/_index.md
@@ -17,9 +17,10 @@ images: ["/services/icons/ml.svg"]
 The Machine Learning (ML) model service allows you to deploy machine learning models to your machine.
 This can mean deploying:
 
-- a model from [the registry](https://app.viam.com/registry)
-- a model trained outside the Viam platform that you have [uploaded](/ml/upload-model/)
-- a model that's already available on your machine
+- a model you [trained](ml/train-model/)
+- a model from [the registry](https://app.viam.com/registry) that another user has shared publicly
+- a model trained outside the Viam platform that you have [uploaded](/ml/upload-model/) to the registry privately or publicly
+- a model trained outside the Viam platform that's already available on your machine
 
 After deploying your model, you need to configure an additional service to use the deployed model.
 For example, you can configure an [`mlmodel` vision service](/ml/vision/) and a [`transform` camera](/components/camera/transform/) to visualize the predictions your model makes.
@@ -49,12 +50,6 @@ Follow [these instructions](/registry/advanced/mlmodel-design/) to design your m
 {{< alert title="Note" color="note" >}}
 For some models of the ML model service, like the [Triton ML model service](https://github.com/viamrobotics/viam-mlmodelservice-triton/tree/main/) for Jetson boards, you can configure the service to use either the available CPU or a dedicated GPU.
 {{< /alert >}}
-
-You can use an ML model service to deploy:
-
-- a model from [the registry](https://app.viam.com/registry)
-- a model trained outside the Viam platform that you have uploaded
-- a model available on your machine
 
 ## Used with
 

--- a/docs/ml/deploy/tflite_cpu.md
+++ b/docs/ml/deploy/tflite_cpu.md
@@ -38,7 +38,9 @@ You can choose to configure your service with an existing model on the machine o
 1. To configure your service and deploy a model onto your machine, select **Deploy Model On Robot** for the **Deployment** field.
 
 2. Click on **Models** to open a dropdown with all of the ML models available to you privately, as well as all of the ML models available in [the registry](https://app.viam.com), which are shared by users.
+   Models that your organization has trained that are not uploaded to the registry will appear first in the dropdown.
    You can select from any of these models to deploy on your robot.
+   Only TensorFlow Lite models are shown.
 
 {{<imgproc src="/services/deploy-model-menu.png" resize="700x" alt="Models dropdown menu with models from the registry.">}}
 
@@ -46,7 +48,7 @@ You can choose to configure your service with an existing model on the machine o
 To see more details about a model, open its page in [the registry](https://app.viam.com).
 {{% /alert %}}
 
-3. Also, optionally select the **Number of threads**.
+1. Also, optionally select the **Number of threads**.
 
 {{<imgproc src="/services/deploy-model.png" resize="700x" alt="Create a machine learning models service with a model to be deployed">}}
 

--- a/docs/ml/deploy/tflite_cpu.md
+++ b/docs/ml/deploy/tflite_cpu.md
@@ -48,7 +48,7 @@ You can choose to configure your service with an existing model on the machine o
 To see more details about a model, open its page in [the registry](https://app.viam.com).
 {{% /alert %}}
 
-1. Also, optionally select the **Number of threads**.
+3. Also, optionally select the **Number of threads**.
 
 {{<imgproc src="/services/deploy-model.png" resize="700x" alt="Create a machine learning models service with a model to be deployed">}}
 

--- a/docs/ml/upload-model.md
+++ b/docs/ml/upload-model.md
@@ -25,7 +25,7 @@ Before uploading your model to the cloud, check and see if you will be able to d
 Model framework support is currently as follows:
 
 <!-- prettier-ignore -->
-| Model Framework | Deploy Service | Hardware Support | System Architecture | Description |
+| Model Framework | ML Model Service | Hardware Support | System Architecture | Description |
 | --------------- | --------------- | ---------------- | ------------------- | ----------- |
 | [TensorFlow Lite](https://www.tensorflow.org/lite) | [`tflite_cpu`](/ml/deploy/) | Any CPU <br> Nvidia GPU | Linux, Raspbian, MacOS, Android | Quantized version of TensorFlow that has reduced compatibility for models but supports more hardware. Uploaded models must adhere to the [model requirements](/ml/deploy/tflite_cpu/#model-requirements). |
 | [ONNX](https://onnx.ai/) | [`onnx_cpu`](https://github.com/viam-labs/onnx-cpu) | Any CPU <br> Nvidia GPU | Android, MacOS, Linux arm-64 | Universal format that is not optimized for hardware inference but runs on a wide variety of machines. |

--- a/docs/ml/upload-model.md
+++ b/docs/ml/upload-model.md
@@ -1,5 +1,5 @@
 ---
-title: "Upload a Model"
+title: "Upload a Model to the Registry"
 linkTitle: "Upload Model"
 weight: 50
 type: "docs"
@@ -7,7 +7,7 @@ tags: ["data management", "ml", "model training"]
 aliases:
   - /manage/data/upload-model/
   - /manage/ml/upload-model/
-description: "Upload a Machine Learning model to Viam to use it with the ML Model service."
+description: "Upload a Machine Learning model to the Viam registry to use it with the ML Model service."
 # SME: Steven B.
 ---
 
@@ -25,12 +25,12 @@ Before uploading your model to the cloud, check and see if you will be able to d
 Model framework support is currently as follows:
 
 <!-- prettier-ignore -->
-| Model Framework | Hardware Support | System Architecture | Description |
-| --------------- | ---------------- | ------------------- | ----------- |
-| [TensorFlow Lite](https://www.tensorflow.org/lite) | Any CPU <br> Nvidia GPU | Linux, Raspbian, MacOS, Android | Quantized version of TensorFlow that has reduced compatibility for models but supports more hardware. |
-| [ONNX](https://onnx.ai/) | Any CPU <br> Nvidia GPU | Android, MacOS, Linux arm-64 | Universal format that is not optimized for hardware inference but runs on a wide variety of machines. |
-| [TensorFlow](https://www.tensorflow.org/) | Nvidia GPU | Linux (Jetson) | A full framework that is made for more production-ready systems. |
-| [PyTorch](https://pytorch.org/) | Nvidia GPU | Linux (Jetson) | A full framework that was built primarily for research. Because of this, it is much faster to do iterative development with (model doesn’t have to be predefined) but it is not as “production ready” as TensorFlow. It is the most common framework for OSS models because it is the go-to framework for ML researchers. |
+| Model Framework | Deploy Service | Hardware Support | System Architecture | Description |
+| --------------- | --------------- | ---------------- | ------------------- | ----------- |
+| [TensorFlow Lite](https://www.tensorflow.org/lite) | [`tflite_cpu`](/ml/deploy/) | Any CPU <br> Nvidia GPU | Linux, Raspbian, MacOS, Android | Quantized version of TensorFlow that has reduced compatibility for models but supports more hardware. Uploaded models must adhere to the [model requirements](/ml/deploy/tflite_cpu/#model-requirements). |
+| [ONNX](https://onnx.ai/) | [`onnx_cpu`](https://github.com/viam-labs/onnx-cpu) | Any CPU <br> Nvidia GPU | Android, MacOS, Linux arm-64 | Universal format that is not optimized for hardware inference but runs on a wide variety of machines. |
+| [TensorFlow](https://www.tensorflow.org/) | [`triton`](https://github.com/viamrobotics/viam-mlmodelservice-triton) | Nvidia GPU | Linux (Jetson) | A full framework that is made for more production-ready systems. |
+| [PyTorch](https://pytorch.org/) | [`triton`](https://github.com/viamrobotics/viam-mlmodelservice-triton) | Nvidia GPU | Linux (Jetson) | A full framework that was built primarily for research. Because of this, it is much faster to do iterative development with (model doesn’t have to be predefined) but it is not as “production ready” as TensorFlow. It is the most common framework for OSS models because it is the go-to framework for ML researchers. |
 
 ## Upload a new model or new version
 

--- a/docs/ml/vision/_index.md
+++ b/docs/ml/vision/_index.md
@@ -97,7 +97,7 @@ For configuration information, click on the model name:
 <!-- prettier-ignore -->
 Model | Description <a name="model-table"></a>
 ----- | -----------
-[`mlmodel`](./mlmodel/) | A detector or classifier that uses a `tensorflow-lite` model available on the machine’s hard drive to draw bounding boxes around objects or returns a class label and confidence score.
+[`mlmodel`](./mlmodel/) | A detector or classifier that uses a model available on the machine’s hard drive to draw bounding boxes around objects or returns a class label and confidence score.
 [`color_detector`](./color_detector/) | A heuristic detector that draws boxes around objects according to their hue (does not detect black, gray, and white).
 [`obstacles_pointcloud`](./obstacles_pointcloud/) | A segmenter that identifies well-separated objects above a flat plane.
 [`detector_3d_segmenter`](./detector_3d_segmenter/) | A segmenter that takes 2D bounding boxes from an object detector and projects the pixels in the bounding box to points in 3D space.


### PR DESCRIPTION
a very long pr title

A combo of two related tickets.

Feedback: 
- A rough overview of ML and what Viam supports in the platform–Focusing on Computer Vision but more specifically Detection and Classification. Also, discuss the ML “Frameworks” that Viam supports
- Call out the Computer Vision service vs the ML Model Service and what the difference is or when you should use one vs the other
- The three ways to run an ML model on the Viam platform (really kind of four so I ended up editing that all around)

Deploy new model frameworks:
- Map framework types to services
- Make more clear in `tflite_cpu` that models at top of dropdown are models you've trained yourself and that they will only be tflite models

+ some small fixes across these docs 

Does not include best practices tips (will be covered in another ticket)