### PR TITLE
Update Module readme template

### DIFF
--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -1099,10 +1099,13 @@ If you follow [the instructions to generate module scaffolding for a Python modu
 {{% tab name="Template" %}}
 
 ````md
-# <INSERT NAME> modular resource
+# [<INSERT MODULE NAME> module](<INSERT LINK TO MODULE REPO>)
 
-This module implements the <INSERT API NAMESPACE> <INSERT API NAME> API in a <INSERT MODEL> model.
+This module implements the <INSERT API TRIPLET> API in a <INSERT MODEL> model.
 With this model, you can...
+
+> [!NOTE]
+> For more information, see [Modular Resources].
 
 ## Requirements
 
@@ -1112,11 +1115,7 @@ _Add instructions here for any requirements._
 
 ```
 
-## Build and run
-
-To use this module, follow the instructions to [add a module from the Viam Registry](https://docs.viam.com/registry/configure/#add-a-modular-resource-from-the-viam-registry) and select the `<INSERT API NAMESPACE>:<INSERT API NAME>:<INSERT MODEL>` model from the [`<INSERT MODULE>` module](https://app.viam.com/module/<INSERT API NAMESPACE>/<INSERT MODULE>).
-
-## Configure your <INSERT API NAME>
+## Configure your <INSERT MODEL NAME> <INSERT API NAME>
 
 > [!NOTE]
 > Before configuring your <INSERT API NAME>, you must [create a machine](https://docs.viam.com/manage/fleet/machines/#add-a-new-machine).
@@ -1139,7 +1138,7 @@ On the new component panel, copy and paste the following attribute template into
 
 ### Attributes
 
-The following attributes are available for `<INSERT API NAMESPACE>:<INSERT API NAME>:<INSERT MODEL>` <INSERT API NAME>s:
+The following attributes are available for `<INSERT MODEL TRIPLET>` <INSERT API NAME>s:
 
 | Name    | Type   | Inclusion    | Description |
 | ------- | ------ | ------------ | ----------- |
@@ -1171,20 +1170,19 @@ _Add troubleshooting notes here._
 {{% tab name="Example" %}}
 
 ````md
-# AgileX LIMO Driver
+# [`agilex-limo` module](https://app.viam.com/module/viam/agilex-limo)
 
 This module implements the base driver for the [AgileX LIMO](https://global.agilex.ai/education/4) base to be used with [`viam-server`](https://docs.viam.com/). This driver supports differential, ackermann, and omni directional steering modes over the serial port.
 
-## Build and run
-
-To use this module, follow these instructions to [add a module from the Viam Registry](https://docs.viam.com/registry/configure/#add-a-modular-resource-from-the-viam-registry) and select the `viam:base:agilex-limo` model from the [`agilex-limo` module](https://app.viam.com/module/viam/agilex-limo).
+> [!NOTE]
+> For more information, see [Modular Resources].
 
 ## Configure your AgileX LIMO base
 
 > [!NOTE]
 > Before configuring your base, you must [create a machine](https://docs.viam.com/manage/fleet/robots/#add-a-new-robot).
 
-Navigate to the **Config** tab of your machine’s page in [the Viam app](https://app.viam.com/). Click on the **Components** subtab and click **Create component**. Select the `base` type, then select the `agilex-limo` model. Click **Add module**, then enter a name for your base and click **Create**.
+Navigate to the **Config** tab of your machine’s page in [the Viam app](https://app.viam.com/). Click on the **Components** subtab and click **Create component**. Select the `base` type, then search for and select the `agilex-limo` model. Click **Add module**, then enter a name for your base and click **Create**.
 
 On the new component panel, copy and paste the following attribute template into your base’s **Attributes** box.
 

--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -304,7 +304,7 @@ class MyBase(Base, Reconfigurable):
 {{< alert title="Note" color="note" >}}
 For an example featuring a sensor, see [MCP300x](https://github.com/viam-labs/mcp300x-adc-sensor).
 
-For additional examples use the [modular resources search](https://docs.viam.com/registry/#modular-resources) to examples of the model you are implementing, and click on the model's link to be able to browse its code.
+For additional examples use the [modular resources search](https://docs.viam.com/registry/#modular-resources) to search for examples of the model you are implementing, and click on the model's link to be able to browse its code.
 {{< /alert >}}
 
 When implementing built-in methods from the Viam Python SDK in your model, be sure your implementation of those methods returns any values designated in the built-in function's return signature, typed correctly.
@@ -554,7 +554,7 @@ func (b *myBase) Close(ctx context.Context) error {
 {{< alert title="Note" color="note" >}}
 For an example featuring a sensor, see [MCP3004-8](https://github.com/mestcihazal/mcp3004-8-go).
 
-For additional examples use the [modular resources search](https://docs.viam.com/registry/#modular-resources) to examples of the model you are implementing, and click on the model's link to be able to browse its code.
+For additional examples use the [modular resources search](https://docs.viam.com/registry/#modular-resources) to search for examples of the model you are implementing, and click on the model's link to be able to browse its code.
 {{< /alert >}}
 
 When implementing built-in methods from the Viam Go SDK in your model, be sure your implementation of those methods returns any values designated in the built-in method's return signature, typed correctly.

--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -304,7 +304,7 @@ class MyBase(Base, Reconfigurable):
 {{< alert title="Note" color="note" >}}
 For an example featuring a sensor, see [MCP300x](https://github.com/viam-labs/mcp300x-adc-sensor).
 
-For additional examples use the [modular resources search](https://docs.viam.com/registry/#modular-resources) to  examples of the model you are implementing, and click on the model's link to be able to browse its code.
+For additional examples use the [modular resources search](https://docs.viam.com/registry/#modular-resources) to examples of the model you are implementing, and click on the model's link to be able to browse its code.
 {{< /alert >}}
 
 When implementing built-in methods from the Viam Python SDK in your model, be sure your implementation of those methods returns any values designated in the built-in function's return signature, typed correctly.
@@ -554,7 +554,7 @@ func (b *myBase) Close(ctx context.Context) error {
 {{< alert title="Note" color="note" >}}
 For an example featuring a sensor, see [MCP3004-8](https://github.com/mestcihazal/mcp3004-8-go).
 
-For additional examples use the [modular resources search](https://docs.viam.com/registry/#modular-resources) to  examples of the model you are implementing, and click on the model's link to be able to browse its code.
+For additional examples use the [modular resources search](https://docs.viam.com/registry/#modular-resources) to examples of the model you are implementing, and click on the model's link to be able to browse its code.
 {{< /alert >}}
 
 When implementing built-in methods from the Viam Go SDK in your model, be sure your implementation of those methods returns any values designated in the built-in method's return signature, typed correctly.

--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -1105,7 +1105,7 @@ This module implements the <INSERT API TRIPLET> API in a <INSERT MODEL> model.
 With this model, you can...
 
 > [!NOTE]
-> For more information, see [Modular Resources].
+> For more information, see [Modular Resources](https://docs.viam.com/registry/#modular-resources).
 
 ## Requirements
 
@@ -1175,7 +1175,7 @@ _Add troubleshooting notes here._
 This module implements the base driver for the [AgileX LIMO](https://global.agilex.ai/education/4) base to be used with [`viam-server`](https://docs.viam.com/). This driver supports differential, ackermann, and omni directional steering modes over the serial port.
 
 > [!NOTE]
-> For more information, see [Modular Resources].
+> For more information, see [Modular Resources](https://docs.viam.com/registry/#modular-resources).
 
 ## Configure your AgileX LIMO base
 

--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -304,7 +304,7 @@ class MyBase(Base, Reconfigurable):
 {{< alert title="Note" color="note" >}}
 For an example featuring a sensor, see [MCP300x](https://github.com/viam-labs/mcp300x-adc-sensor).
 
-For additional examples use the [modular resources search](https://docs.viam.com/registry/#modular-resources) to search for examples of the model you are implementing, and click on the model's link to be able to browse its code.
+For additional examples use the [modular resources search](https://docs.viam.com/registry/#modular-resources) to  examples of the model you are implementing, and click on the model's link to be able to browse its code.
 {{< /alert >}}
 
 When implementing built-in methods from the Viam Python SDK in your model, be sure your implementation of those methods returns any values designated in the built-in function's return signature, typed correctly.
@@ -554,7 +554,7 @@ func (b *myBase) Close(ctx context.Context) error {
 {{< alert title="Note" color="note" >}}
 For an example featuring a sensor, see [MCP3004-8](https://github.com/mestcihazal/mcp3004-8-go).
 
-For additional examples use the [modular resources search](https://docs.viam.com/registry/#modular-resources) to search for examples of the model you are implementing, and click on the model's link to be able to browse its code.
+For additional examples use the [modular resources search](https://docs.viam.com/registry/#modular-resources) to  examples of the model you are implementing, and click on the model's link to be able to browse its code.
 {{< /alert >}}
 
 When implementing built-in methods from the Viam Go SDK in your model, be sure your implementation of those methods returns any values designated in the built-in method's return signature, typed correctly.
@@ -1101,7 +1101,7 @@ If you follow [the instructions to generate module scaffolding for a Python modu
 ````md
 # [<INSERT MODULE NAME> module](<INSERT LINK TO MODULE REPO>)
 
-This module implements the <INSERT API TRIPLET> API in a <INSERT MODEL> model.
+This module implements the [<INSERT API TRIPLET> API]<INSERT LINK TO DOCS (if applicable)> in an <INSERT MODEL> model.
 With this model, you can...
 
 > [!NOTE]
@@ -1172,12 +1172,12 @@ _Add troubleshooting notes here._
 ````md
 # [`agilex-limo` module](https://app.viam.com/module/viam/agilex-limo)
 
-This module implements the base driver for the [AgileX LIMO](https://global.agilex.ai/education/4) base to be used with [`viam-server`](https://docs.viam.com/). This driver supports differential, ackermann, and omni directional steering modes over the serial port.
+This module implements the ["rdk:component:base" API](https://docs.viam.com/components/base/#api) in an `agilex` model for the [AgileX LIMO](https://global.agilex.ai/education/4) base to be used with [`viam-server`](https://docs.viam.com/). This driver supports differential, ackermann, and omni directional steering modes over the serial port.
 
 > [!NOTE]
 > For more information, see [Modular Resources](https://docs.viam.com/registry/#modular-resources).
 
-## Configure your AgileX LIMO base
+## Configure your `agilex` base
 
 > [!NOTE]
 > Before configuring your base, you must [create a machine](https://docs.viam.com/manage/fleet/robots/#add-a-new-robot).


### PR DESCRIPTION
- Get rid of duplicative build and run sections
- Make substitution easier to understand by using API and Model triplet pairs as they appear in github (also was slightly inaccurate)
- Add note directing to modular resources docs 
- Update agilex-limo to match (can update real readme if this gets approved)
