### PR TITLE
DOCS-2010: Add `part_online` type of webhook

### DIFF
--- a/docs/build/configure/_index.md
+++ b/docs/build/configure/_index.md
@@ -238,7 +238,6 @@ Viam provides two webhook types depending on the event you want to trigger on:
 - `"part_data_ingested"`: trigger when a sensor on the machine part collects a new reading
 - `"part_online"`: trigger when the machine part is online
 
-
 To configure a webhook:
 
 {{< tabs name="Types of Webhooks" >}}

--- a/docs/build/configure/_index.md
+++ b/docs/build/configure/_index.md
@@ -232,13 +232,12 @@ Find more information in the [processes documentation](/build/configure/processe
 ## Webhooks
 
 Webhooks allow you to trigger actions when certain types of data are sent from your machine to the cloud, or when the internet connectivity of your machine changes.
+For example, you can configure a webhook to send you a notification when your robot's sensor collects a new reading.
 Viam provides two webhook types depending on the event you want to trigger on:
 
 - `"part_data_ingested"`: trigger when a sensor on the machine part collects a new reading
 - `"part_online"`: trigger when the machine part is online
 
-One action you can trigger is sending a notification.
-For example, you can use the `"part_data_ingested"` type to configure a webhook to send you a notification when your robot's sensor collects a new reading, or use the `"part_online"` type to notify you when your machine part comes online.
 
 To configure a webhook:
 

--- a/docs/build/configure/_index.md
+++ b/docs/build/configure/_index.md
@@ -232,15 +232,26 @@ Find more information in the [processes documentation](/build/configure/processe
 ## Webhooks
 
 Webhooks allow you to trigger actions when certain types of data are sent from your machine to the cloud.
-For example, you can configure a webhook to send you a notification when your robot's sensor collects a new reading.
 
-Switch to **Raw JSON** mode to configure webhooks as follows:
+Viam offers different types of webhooks depending on the type of data you want to serve as a trigger.
+For example, you can use the `"part_data_ingested"` type to configure a webhook to send you a notification when your robot's sensor collects a new reading, or use the `"part_online"` type to notify you when your machine part comes online.
+
+To configure a webhook:
+
+{{< tabs name="Types of Webhooks" >}}
+
+1. Go to the **Config** tab of your machine on the [Viam app](https://app.viam.com).
+   Select **Raw JSON** mode.
+
+2. Follow the instructions depending on the type of webhook you want to implement:
+
+{{% tab name="part_data_ingested" %}}
 
 1. Paste the following JSON template into your raw JSON config.
    `"webhooks"` is a top-level section like `"components"`, `"services"`, or any of the other config sections.
 
-   {{< tabs >}}
-   {{% tab name="JSON Template" %}}
+{{< tabs >}}
+{{% tab name="JSON Template" %}}
 
 ```json {class="line-numbers linkable-line-numbers"}
   "webhooks": [
@@ -264,7 +275,7 @@ Switch to **Raw JSON** mode to configure webhooks as follows:
   "components": [
     {
       "name": "local",
-      "model": "rdk:builtin:pi",
+      "model": "pi",
       "type": "board",
       "namespace": "rdk",
       "attributes": {},
@@ -272,7 +283,7 @@ Switch to **Raw JSON** mode to configure webhooks as follows:
     },
     {
       "name": "my_temp_sensor",
-      "model": "rdk:builtin:bme280",
+      "model": "bme280",
       "type": "sensor",
       "namespace": "rdk",
       "attributes": {},
@@ -298,7 +309,7 @@ Switch to **Raw JSON** mode to configure webhooks as follows:
       "url": "https://1abcde2ab3cd4efg5abcdefgh10zyxwv.lambda-url.us-east-1.on.aws",
       "event": {
         "attributes": {
-          "data_types": ["binary", "tabular"]
+          "data_types": ["binary", "tabular", "file"]
         },
         "type": "part_data_ingested"
       }
@@ -343,6 +354,103 @@ Switch to **Raw JSON** mode to configure webhooks as follows:
      return 'Sent request to {}'.format(slack_url)
 
    ```
+
+{{% /tab %}}
+{{% tab name="part_online" %}}
+
+1. Paste the following JSON template into your raw JSON config.
+   `"webhooks"` is a top-level section like `"components"`, `"services"`, or any of the other config sections.
+
+   {{< tabs >}}
+   {{% tab name="JSON Template" %}}
+
+```json {class="line-numbers linkable-line-numbers"}
+  "webhooks": [
+    {
+      "url": "<Insert your own cloud function or lambda URL for sending the event>",
+      "event": {
+        "type": "part_online",
+        "attributes": {
+          "seconds_between_notifications": 10
+        }
+      }
+    }
+  ]
+```
+
+{{% /tab %}}
+{{% tab name="JSON Example" %}}
+
+```json {class="line-numbers linkable-line-numbers"}
+{
+  "components": [
+    {
+      "name": "local",
+      "model": "pi",
+      "type": "board",
+      "namespace": "rdk",
+      "attributes": {},
+      "depends_on": []
+    },
+    {
+      "name": "my_temp_sensor",
+      "model": "bme280",
+      "type": "sensor",
+      "namespace": "rdk",
+      "attributes": {},
+      "depends_on": [],
+      "service_configs": []
+    }
+  ],
+  "webhooks": [
+    {
+      "url": "https://1abcde2ab3cd4efg5abcdefgh10zyxwv.lambda-url.us-east-1.on.aws",
+      "event": {
+        "type": "part_online",
+        "attributes": {
+          "seconds_between_notifications": 10
+        }
+    }
+  ]
+}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+2. Replace the URL value with the URL of your cloud/lambda function.
+3. Adjust the `seconds_between_notifications` attribute to your desired duration between actions being triggered when the `part_online` condition is met.
+4. Write your cloud/lambda function to process the request from `viam-server`.
+   The following example function sends a Slack message with a machine's details, such as robot and location IDs, when it receives a request:
+
+   ```python {class="line-numbers linkable-line-numbers"}
+   import functions_framework
+   import requests
+   import time
+
+   @functions_framework.http
+   def hello_http(request):
+     payload = {
+       "Org-ID": request.headers['org-id'] if 'org-id' in request.headers else 'no value',
+       "Location-ID": request.headers['location-id'] if 'location-id' in request.headers else 'no value',
+       "Part-ID": request.headers['part-id'] if 'part-id' in request.headers else 'no value',
+       "Robot-ID": request.headers['robot-id'] if 'robot-id' in request.headers else 'no value'
+     }
+
+     slack_url = "<paste in your own Slack URL>"
+     headers = {}
+
+     response = requests.post(slack_url, json=payload, headers=headers)
+
+     request_json = request.get_json(silent=True)
+     request_args = request.args
+
+     return 'Sent request to {}'.format(slack_url)
+
+   ```
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Fragments
 

--- a/docs/build/configure/_index.md
+++ b/docs/build/configure/_index.md
@@ -231,9 +231,9 @@ Find more information in the [processes documentation](/build/configure/processe
 
 ## Webhooks
 
-Webhooks allow you to trigger actions when certain types of data are sent from your machine to the cloud.
+Webhooks allow you to trigger actions when certain types of data are sent from your machine to the cloud, or when your machines come online.
 
-Viam offers different types of webhooks depending on the type of data you want to serve as a trigger.
+Viam provides two webhook types depending on the event you want to trigger an action on.
 For example, you can use the `"part_data_ingested"` type to configure a webhook to send you a notification when your robot's sensor collects a new reading, or use the `"part_online"` type to notify you when your machine part comes online.
 
 To configure a webhook:
@@ -361,8 +361,8 @@ To configure a webhook:
 1. Paste the following JSON template into your raw JSON config.
    `"webhooks"` is a top-level section like `"components"`, `"services"`, or any of the other config sections.
 
-   {{< tabs >}}
-   {{% tab name="JSON Template" %}}
+{{< tabs >}}
+{{% tab name="JSON Template" %}}
 
 ```json {class="line-numbers linkable-line-numbers"}
   "webhooks": [
@@ -419,7 +419,8 @@ To configure a webhook:
 {{< /tabs >}}
 
 2. Replace the URL value with the URL of your cloud/lambda function.
-3. Adjust the `seconds_between_notifications` attribute to your desired duration between actions being triggered when the `part_online` condition is met.
+3. While your part is online, the webhook action triggers at a specified interval.
+   Edit the `seconds_between_notifications` attribute to set this interval according to your preferences.
 4. Write your cloud/lambda function to process the request from `viam-server`.
    The following example function sends a Slack message with a machine's details, such as robot and location IDs, when it receives a request:
 

--- a/docs/build/configure/_index.md
+++ b/docs/build/configure/_index.md
@@ -231,9 +231,13 @@ Find more information in the [processes documentation](/build/configure/processe
 
 ## Webhooks
 
-Webhooks allow you to trigger actions when certain types of data are sent from your machine to the cloud, or when your machines come online.
+Webhooks allow you to trigger actions when certain types of data are sent from your machine to the cloud, or when the internet connectivity of your machine changes.
+Viam provides two webhook types depending on the event you want to trigger on:
 
-Viam provides two webhook types depending on the event you want to trigger an action on.
+- `"part_data_ingested"`: trigger when a sensor on the machine part collects a new reading
+- `"part_online"`: trigger when the machine part is online
+
+One action you can trigger is sending a notification.
 For example, you can use the `"part_data_ingested"` type to configure a webhook to send you a notification when your robot's sensor collects a new reading, or use the `"part_online"` type to notify you when your machine part comes online.
 
 To configure a webhook:
@@ -410,6 +414,7 @@ To configure a webhook:
         "attributes": {
           "seconds_between_notifications": 10
         }
+      }
     }
   ]
 }

--- a/docs/build/configure/_index.md
+++ b/docs/build/configure/_index.md
@@ -309,7 +309,7 @@ To configure a webhook:
       "url": "https://1abcde2ab3cd4efg5abcdefgh10zyxwv.lambda-url.us-east-1.on.aws",
       "event": {
         "attributes": {
-          "data_types": ["binary", "tabular", "file"]
+          "data_types": ["binary", "tabular"]
         },
         "type": "part_data_ingested"
       }


### PR DESCRIPTION
* Refactor docs webhooks section to account for different types 
* Add `part_online` example config 