### PR TITLE
DOCS-1574: Fix use case page nits

### DIFF
--- a/docs/use-cases/configure.md
+++ b/docs/use-cases/configure.md
@@ -45,6 +45,9 @@ For example, if you have a DC motor, follow the [corresponding configuration ins
 {{< /tablestep >}}
 {{< tablestep >}}
 {{<gif webm_src="/manage/control.webm" mp4_src="/manage/control.mp4" alt="The Viam app Control tab with a control panel for each component. The panel for a DC motor is clicked, expanding to show power controls." max-width="400px" class="fill alignleft">}}
+
+<!-- markdownlint-disable MD036 -->
+
 **4. Test your components**
 
 When you configure a component, a remote control panel is generated for it in the **Control** tab of the Viam app.

--- a/docs/use-cases/deploy-code.md
+++ b/docs/use-cases/deploy-code.md
@@ -34,8 +34,9 @@ Or, you can [create your own module](/registry/create/) to add support for new h
 {{< tablestep >}}
 
 {{<imgproc src="/registry/upload-module.svg" class="fill alignleft" style="max-width: 150px" declaredimensions=true alt="Deploy your module">}}
+**3. Deploy your module**
 
-If your machine is offline when you deploy a module, it will deploy once your machine comes back online.
+Once you have created your new module, you can deploy it to your machine in one of two ways:
 
 - You can [upload your module](/registry/upload/) to the Viam registry using the Viam CLI. Modules available from the Viam registry can be deployed directly to a machine or fleet of machines from the Viam app. When you upload your module to the registry, you can choose to make it **public** to make your module available to all or **private** to make your module only visible to members of your [organization](/fleet/organizations/).
 - You can deploy your module directly to your machine as a [local module](/registry/configure/#local-modules). Local modules are not uploaded to the Viam registry, and must be manually added to your machine.


### PR DESCRIPTION
The double asterisks appear for "Test your components", and adding a line break fixed that problem but makes the linter mad about emphasis used instead of a heading, so this disables that MD rule for that section.

For Deploy, this fixes a copy pasta error.