### PR TITLE
DOCS-2050: Remove links to C++ example module broken by base image rollback

### DIFF
--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -1525,7 +1525,7 @@ Browse additional example modules by language:
 | Module | Repository | Description |
 | ------ | ---------- | ----------- |
 | [csi-cam](https://app.viam.com/module/viam/csi-cam) | [viamrobotics/csi-camera](https://github.com/viamrobotics/csi-camera/) | Extends the built-in [camera API](https://docs.viam.com/components/camera/#api) to support the Intel CSI camera. |
-| [module-example-cpp](https://app.viam.com/module/viam/module-example-cpp) | [viamrobotics/module-example-cpp](https://github.com/viamrobotics/module-example-cpp) | Extends the built-in [sensor API](https://docs.viam.com/components/sensor/#api) to report wifi statistics. |
+<!-- | [module-example-cpp](https://app.viam.com/module/viam/module-example-cpp) | [viamrobotics/module-example-cpp](https://github.com/viamrobotics/module-example-cpp) | Extends the built-in [sensor API](https://docs.viam.com/components/sensor/#api) to report wifi statistics. | -->
 
 {{% /tab %}}
 {{% /tabs %}}

--- a/docs/registry/upload/_index.md
+++ b/docs/registry/upload/_index.md
@@ -340,8 +340,8 @@ For more details, see the [`build-action` GitHub Action documentation](https://g
 
 - [Golang CI yaml](https://github.com/viam-labs/wifi-sensor/blob/main/.github/workflows/build.yml)
 - [Golang Example CI meta.json](https://github.com/viam-labs/wifi-sensor/blob/main/meta.json)
-- [C++ Example CI yaml](https://github.com/viamrobotics/module-example-cpp/blob/main/.github/workflows/build2.yml)
-- [C++ Example CI meta.json](https://github.com/viamrobotics/module-example-cpp/blob/main/meta.json)
+<!-- - [C++ Example CI yaml](https://github.com/viamrobotics/module-example-cpp/blob/main/.github/workflows/build2.yml)
+- [C++ Example CI meta.json](https://github.com/viamrobotics/module-example-cpp/blob/main/meta.json) -->
 
 {{% /tab %}}
 {{% tab name="CI with upload-action" %}}


### PR DESCRIPTION
Re. [this ticket](https://viam.atlassian.net/jira/software/c/projects/DOCS/boards/31?quickFilter=40&selectedIssue=DOCS-2050), this should be only docs change needed for base image rollback Abe made 

- Comment out links to broken module

(Asking Abe about associated ticket: will track work to fix to uncomment when needed) 