### PR TITLE
[RSDK-7278] Update minimum hardware esp32

### DIFF
--- a/docs/build/micro-rdk/board/esp32.md
+++ b/docs/build/micro-rdk/board/esp32.md
@@ -17,12 +17,12 @@ Follow the [setup guide](/get-started/installation/prepare/microcontrollers/) to
 
 Viam recommends purchasing the ESP32 with a development board. The following ESP32 microcontrollers are supported:
 
-- ESP32-WROOM Series
+- ESP32-WROOM Series (until v0.1.7)
 - ESP-32-WROVER Series
 
-Your microcontroller should have the following resources available to work with the micro-RDK:
+Your microcontroller should have at least the following resources available to work with the micro-RDK:
 
-- 2 Cores + 384kB SRAM + 4MB Flash
+- 2 Cores + 384kB SRAM + 2MB PSRAM + 4MB Flash
 
 {{% /alert %}}
 

--- a/static/include/micro-rdk-hardware.md
+++ b/static/include/micro-rdk-hardware.md
@@ -4,12 +4,12 @@ You need an Espressif ESP32 microcontroller to use the micro-RDK.
 Viam recommends purchasing the ESP32 with a [development board](https://www.espressif.com/en/products/devkits).
 The following ESP32 microcontrollers are supported:
 
-- [ESP32-WROOM Series](https://www.espressif.com/en/products/modules/esp32)
+- [ESP32-WROOM Series](https://www.espressif.com/en/products/modules/esp32) (until v0.1.7)
 - [ESP32-WROVER Series](https://www.espressif.com/en/products/modules/esp32)
 
-Your microcontroller should have the following resources available to work with the micro-RDK:
+Your microcontroller should have at least the following resources available to work with the micro-RDK:
 
-- 2 Cores + 384kB SRAM + 4MB Flash
+- 2 Cores + 384kB SRAM + 2MB PSRAM + 4MB Flash
 
 {{< alert title="Tip" color="tip" >}}
 The main difference between the WROOM and WROVER is that the WROVER has additional RAM with the SPIRAM chip.


### PR DESCRIPTION
Since the latest release of micro-rdk we have dropped support of older models (ESP32-WROOM)  I have updated the minimum required hardware to reflect that.
