### PR TITLE
Fix python method and heading name on AnalogByName

### DIFF
--- a/docs/build/micro-rdk/board/_index.md
+++ b/docs/build/micro-rdk/board/_index.md
@@ -46,7 +46,7 @@ See [PWM signals on `esp32` pins](/build/micro-rdk/board/esp32/#pwm-signals-on-e
 
 For `Analog`s:
 
-- [`Read()`](/components/board/#read)
+- [`ReadAnalogReader()`](/components/board/#readanalogreader)
 
 For `DigitalInterrupt`s:
 

--- a/docs/components/board/_index.md
+++ b/docs/components/board/_index.md
@@ -1135,7 +1135,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 ## `Analog` API
 
-### Read
+### ReadAnalogReader
 
 Read the current integer value of the digital signal output by the [ADC](#analogs).
 

--- a/docs/components/board/_index.md
+++ b/docs/components/board/_index.md
@@ -140,7 +140,7 @@ Additionally, the nested `GPIOPin`, `Analog`, and `DigitalInterrupt` interfaces 
 
 {{< readfile "/static/include/components/apis/digitalinterrupt.md" >}}
 
-### ReadAnalog
+### AnalogByName
 
 Get an [`Analog`](#analogs) pin by `name`.
 
@@ -161,7 +161,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 my_board = Board.from_robot(robot=robot, name="my_board")
 
 # Get the Analog "my_example_analog_pin".
-analog = await my_board.analog_by_name(name="my_example_analog")
+analog = await my_board.analog_reader_by_name(name="my_example_analog")
 ```
 
 {{% /tab %}}

--- a/static/include/components/apis/analogreader.md
+++ b/static/include/components/apis/analogreader.md
@@ -1,4 +1,4 @@
 | Method Name                         | Description                                                             |
 | ----------------------------------- | ----------------------------------------------------------------------- |
-| [`Read`](/components/board/#read)   | Read the current integer value of the digital signal output by the ADC. |
+| [`ReadAnalogReader`](/components/board/#readanalogreader)   | Read the current integer value of the digital signal output by the ADC. |
 | [`Close`](/components/board/#close) | Safely shut down the resource and prevent further use.                  |

--- a/static/include/components/apis/board.md
+++ b/static/include/components/apis/board.md
@@ -1,7 +1,7 @@
 <!-- prettier-ignore -->
 Method Name | Description
 ----------- | -----------
-[`ReadAnalog`](/components/board/#readanalog) | Get an [`Analog`](/components/board/#analogs) by `name`.
+[`AnalogByName`](/components/board/#analogbyname) | Get an [`Analog`](/components/board/#analogs) by `name`.
 [`GetDigitalInterruptValue`](/components/board/#getdigitalinterruptvalue) | Get a [`DigitalInterrupt`](/components/board/#digital_interrupts) by `name`.
 [`GetGPIO`](/components/board/#getgpio) | Get a `GPIOPin` by its {{< glossary_tooltip term_id="pin-number" text="pin number" >}}.
 [`SetGPIO`](/components/board/#setgpio) | Set a `GPIOPin` by its {{< glossary_tooltip term_id="pin-number" text="pin number" >}}.


### PR DESCRIPTION
Noticed this while working on automation-- heading was confusing and python method name was incorrect 

AFAIK there is not a proto for this? [ReadAnalogReader](https://github.com/viamrobotics/api/blob/b39c74b5a2d320fa459ef0ec4fac6a3b36a690e3/proto/viam/component/board/v1/board.proto#L66) is what we call `Read` within the analog reader endpoints