### PR TITLE
DOCS-2085: Review motor and servo snippets

### DIFF
--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -206,7 +206,7 @@ await my_motor.go_for(rpm=60, revolutions=7.2)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotorComponent, err := motor.FromRobot(robot, "my_motor")
+myMotorComponent, err := motor.FromRobot(machine, "my_motor")
 
 // Turn the motor 7.2 revolutions at 60 RPM.
 myMotorComponent.GoFor(context.Background(), 60, 7.2, nil)
@@ -259,7 +259,7 @@ await my_motor.go_to(rpm=75, revolutions=8.3)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotorComponent, err := motor.FromRobot(robot, "my_motor")
+myMotorComponent, err := motor.FromRobot(machine, "my_motor")
 
 // Turn the motor to 8.3 revolutions from home at 75 RPM.
 myMotorComponent.GoTo(context.Background(), 75, 8.3, nil)
@@ -308,7 +308,7 @@ await my_motor.reset_zero_position(offset=0.0)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotorComponent, err := motor.FromRobot(robot, "my_motor")
+myMotorComponent, err := motor.FromRobot(machine, "my_motor")
 
 // Set the current position as the new home position with no offset.
 myMotorComponent.ResetZeroPosition(context.Background(), 0.0, nil)
@@ -359,7 +359,7 @@ position = await my_motor.get_position()
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotorComponent, err := motor.FromRobot(robot, "my_motor")
+myMotorComponent, err := motor.FromRobot(machine, "my_motor")
 
 // Get the current position of the motor.
 position, err := myMotorComponent.Position(context.Background(), nil)
@@ -416,7 +416,7 @@ print(f'Properties: {properties}')
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotorComponent, err := motor.FromRobot(robot, "my_motor")
+myMotorComponent, err := motor.FromRobot(machine, "my_motor")
 
 // Return whether or not the motor supports certain optional features.
 properties, err := myMotorComponent.Properties(context.Background(), nil)
@@ -474,7 +474,7 @@ print('Powered: ', powered)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotorComponent, err := motor.FromRobot(robot, "my_motor")
+myMotorComponent, err := motor.FromRobot(machine, "my_motor")
 
 // Check whether the motor is currently running.
 powered, pct, err := myMotorComponent.IsPowered(context.Background(), nil)
@@ -528,7 +528,7 @@ print('Moving: ', moving)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/resource#MovingCheckable).
 
 ```go
-myMotorComponent, err := motor.FromRobot(robot, "my_motor")
+myMotorComponent, err := motor.FromRobot(machine, "my_motor")
 
 // Check whether the motor is currently moving.
 moving, err := myMotorComponent.IsMoving(context.Background())
@@ -579,7 +579,7 @@ await my_motor.stop()
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotorComponent, err := motor.FromRobot(robot, "my_motor")
+myMotorComponent, err := motor.FromRobot(machine, "my_motor")
 
 // Stop the motor.
 myMotorComponent.Stop(context.Background(), nil)
@@ -633,7 +633,7 @@ if geometries:
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Shaped).
 
 ```go {class="line-numbers linkable-line-numbers"}
-myMotorComponent, err := motor.FromRobot(robot, "my_motor")
+myMotorComponent, err := motor.FromRobot(machine, "my_motor")
 
 geometries, err := myMotorComponent.Geometries(context.Background(), nil)
 
@@ -692,7 +692,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-myMotorComponent, err := motor.FromRobot(robot, "my_motor")
+myMotorComponent, err := motor.FromRobot(machine, "my_motor")
 
 resp, err := myMotorComponent.DoCommand(ctx, map[string]interface{}{"command": "jog", "raw_input": "home"})
 ```
@@ -737,9 +737,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - [(error)](https://pkg.go.dev/builtin#error) : An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-myMotorComponent, err := motor.FromRobot(robot, "my_motor")
+myMotorComponent, err := motor.FromRobot(machine, "my_motor")
 
-err := myMotorComponent.Close(ctx)
+err = myMotorComponent.Close(ctx)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -150,7 +150,7 @@ await my_motor.set_power(power=0.4)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotor, err := motor.FromRobot(robot, "my_motor")
+myMotor, err := motor.FromRobot(machine, "my_motor")
 
 // Set the motor power to 40% forwards.
 myMotor.SetPower(context.Background(), 0.4, nil)
@@ -206,7 +206,7 @@ await my_motor.go_for(rpm=60, revolutions=7.2)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotor, err := motor.FromRobot(robot, "my_motor")
+myMotor, err := motor.FromRobot(machine, "my_motor")
 
 // Turn the motor 7.2 revolutions at 60 RPM.
 myMotor.GoFor(context.Background(), 60, 7.2, nil)
@@ -259,7 +259,7 @@ await my_motor.go_to(rpm=75, revolutions=8.3)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotor, err := motor.FromRobot(robot, "my_motor")
+myMotor, err := motor.FromRobot(machine, "my_motor")
 
 // Turn the motor to 8.3 revolutions from home at 75 RPM.
 myMotor.GoTo(context.Background(), 75, 8.3, nil)
@@ -308,7 +308,7 @@ await my_motor.reset_zero_position(offset=0.0)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotor, err := motor.FromRobot(robot, "my_motor")
+myMotor, err := motor.FromRobot(machine, "my_motor")
 
 // Set the current position as the new home position with no offset.
 myMotor.ResetZeroPosition(context.Background(), 0.0, nil)
@@ -359,7 +359,7 @@ position = await my_motor.get_position()
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotor, err := motor.FromRobot(robot, "my_motor")
+myMotor, err := motor.FromRobot(machine, "my_motor")
 
 // Get the current position of the motor.
 position, err := myMotor.Position(context.Background(), nil)
@@ -412,7 +412,7 @@ print(f'Properties: {properties}')
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotor, err := motor.FromRobot(robot, "my_motor")
+myMotor, err := motor.FromRobot(machine, "my_motor")
 
 // Return whether or not the motor supports certain optional features.
 properties, err := myMotor.Properties(context.Background(), nil)
@@ -470,7 +470,7 @@ print('Powered: ', powered)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotor, err := motor.FromRobot(robot, "my_motor")
+myMotor, err := motor.FromRobot(machine, "my_motor")
 
 // Check whether the motor is currently running.
 powered, pct, err := myMotor.IsPowered(context.Background(), nil)
@@ -524,7 +524,7 @@ print('Moving: ', moving)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/resource#MovingCheckable).
 
 ```go
-myMotor, err := motor.FromRobot(robot, "my_motor")
+myMotor, err := motor.FromRobot(machine, "my_motor")
 
 // Check whether the motor is currently moving.
 moving, err := myMotor.IsMoving(context.Background())
@@ -575,7 +575,7 @@ await my_motor.stop()
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotor, err := motor.FromRobot(robot, "my_motor")
+myMotor, err := motor.FromRobot(machine, "my_motor")
 
 // Stop the motor.
 myMotor.Stop(context.Background(), nil)
@@ -629,7 +629,7 @@ if geometries:
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Shaped).
 
 ```go {class="line-numbers linkable-line-numbers"}
-myMotor, err := motor.FromRobot(robot, "my_motor")
+myMotor, err := motor.FromRobot(machine, "my_motor")
 
 geometries, err := myMotor.Geometries(context.Background(), nil)
 
@@ -688,7 +688,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-myMotor, err := motor.FromRobot(robot, "my_motor")
+myMotor, err := motor.FromRobot(machine, "my_motor")
 
 resp, err := myMotor.DoCommand(ctx, map[string]interface{}{"command": "jog", "raw_input": "home"})
 ```
@@ -733,7 +733,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - [(error)](https://pkg.go.dev/builtin#error) : An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-myMotor, err := motor.FromRobot(robot, "my_motor")
+myMotor, err := motor.FromRobot(machine, "my_motor")
 
 err := myMotor.Close(ctx)
 ```

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -150,7 +150,7 @@ await my_motor.set_power(power=0.4)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotorComponent, err := motor.FromRobot(robot, "my_motor")
+myMotorComponent, err := motor.FromRobot(machine, "my_motor")
 
 // Set the motor power to 40% forwards.
 myMotorComponent.SetPower(context.Background(), 0.4, nil)

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -150,11 +150,8 @@ await my_motor.set_power(power=0.4)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotorComponent, err := motor.FromRobot(machine, "my_motor")
-
 // Set the motor power to 40% forwards.
 myMotorComponent.SetPower(context.Background(), 0.4, nil)
-
 ```
 
 {{% /tab %}}
@@ -206,8 +203,6 @@ await my_motor.go_for(rpm=60, revolutions=7.2)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotorComponent, err := motor.FromRobot(machine, "my_motor")
-
 // Turn the motor 7.2 revolutions at 60 RPM.
 myMotorComponent.GoFor(context.Background(), 60, 7.2, nil)
 ```
@@ -259,8 +254,6 @@ await my_motor.go_to(rpm=75, revolutions=8.3)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotorComponent, err := motor.FromRobot(machine, "my_motor")
-
 // Turn the motor to 8.3 revolutions from home at 75 RPM.
 myMotorComponent.GoTo(context.Background(), 75, 8.3, nil)
 ```
@@ -308,8 +301,6 @@ await my_motor.reset_zero_position(offset=0.0)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotorComponent, err := motor.FromRobot(machine, "my_motor")
-
 // Set the current position as the new home position with no offset.
 myMotorComponent.ResetZeroPosition(context.Background(), 0.0, nil)
 ```
@@ -359,8 +350,6 @@ position = await my_motor.get_position()
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotorComponent, err := motor.FromRobot(machine, "my_motor")
-
 // Get the current position of the motor.
 position, err := myMotorComponent.Position(context.Background(), nil)
 
@@ -416,8 +405,6 @@ print(f'Properties: {properties}')
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotorComponent, err := motor.FromRobot(machine, "my_motor")
-
 // Return whether or not the motor supports certain optional features.
 properties, err := myMotorComponent.Properties(context.Background(), nil)
 
@@ -474,8 +461,6 @@ print('Powered: ', powered)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotorComponent, err := motor.FromRobot(machine, "my_motor")
-
 // Check whether the motor is currently running.
 powered, pct, err := myMotorComponent.IsPowered(context.Background(), nil)
 
@@ -528,8 +513,6 @@ print('Moving: ', moving)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/resource#MovingCheckable).
 
 ```go
-myMotorComponent, err := motor.FromRobot(machine, "my_motor")
-
 // Check whether the motor is currently moving.
 moving, err := myMotorComponent.IsMoving(context.Background())
 
@@ -579,8 +562,6 @@ await my_motor.stop()
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotorComponent, err := motor.FromRobot(machine, "my_motor")
-
 // Stop the motor.
 myMotorComponent.Stop(context.Background(), nil)
 ```
@@ -633,8 +614,6 @@ if geometries:
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Shaped).
 
 ```go {class="line-numbers linkable-line-numbers"}
-myMotorComponent, err := motor.FromRobot(machine, "my_motor")
-
 geometries, err := myMotorComponent.Geometries(context.Background(), nil)
 
 if len(geometries) > 0 {
@@ -692,8 +671,6 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-myMotorComponent, err := motor.FromRobot(machine, "my_motor")
-
 resp, err := myMotorComponent.DoCommand(ctx, map[string]interface{}{"command": "jog", "raw_input": "home"})
 ```
 
@@ -737,8 +714,6 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - [(error)](https://pkg.go.dev/builtin#error) : An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-myMotorComponent, err := motor.FromRobot(machine, "my_motor")
-
 err = myMotorComponent.Close(ctx)
 ```
 

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -150,10 +150,10 @@ await my_motor.set_power(power=0.4)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotor, err := motor.FromRobot(machine, "my_motor")
+myMotorComponent, err := motor.FromRobot(robot, "my_motor")
 
 // Set the motor power to 40% forwards.
-myMotor.SetPower(context.Background(), 0.4, nil)
+myMotorComponent.SetPower(context.Background(), 0.4, nil)
 
 ```
 
@@ -206,10 +206,10 @@ await my_motor.go_for(rpm=60, revolutions=7.2)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotor, err := motor.FromRobot(machine, "my_motor")
+myMotorComponent, err := motor.FromRobot(robot, "my_motor")
 
 // Turn the motor 7.2 revolutions at 60 RPM.
-myMotor.GoFor(context.Background(), 60, 7.2, nil)
+myMotorComponent.GoFor(context.Background(), 60, 7.2, nil)
 ```
 
 {{% /tab %}}
@@ -259,10 +259,10 @@ await my_motor.go_to(rpm=75, revolutions=8.3)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotor, err := motor.FromRobot(machine, "my_motor")
+myMotorComponent, err := motor.FromRobot(robot, "my_motor")
 
 // Turn the motor to 8.3 revolutions from home at 75 RPM.
-myMotor.GoTo(context.Background(), 75, 8.3, nil)
+myMotorComponent.GoTo(context.Background(), 75, 8.3, nil)
 ```
 
 {{% /tab %}}
@@ -308,10 +308,10 @@ await my_motor.reset_zero_position(offset=0.0)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotor, err := motor.FromRobot(machine, "my_motor")
+myMotorComponent, err := motor.FromRobot(robot, "my_motor")
 
 // Set the current position as the new home position with no offset.
-myMotor.ResetZeroPosition(context.Background(), 0.0, nil)
+myMotorComponent.ResetZeroPosition(context.Background(), 0.0, nil)
 ```
 
 {{% /tab %}}
@@ -359,10 +359,14 @@ position = await my_motor.get_position()
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotor, err := motor.FromRobot(machine, "my_motor")
+myMotorComponent, err := motor.FromRobot(robot, "my_motor")
 
 // Get the current position of the motor.
-position, err := myMotor.Position(context.Background(), nil)
+position, err := myMotorComponent.Position(context.Background(), nil)
+
+// Log the position.
+logger.Info("Position:")
+logger.Info(position)
 ```
 
 {{% /tab %}}
@@ -412,10 +416,10 @@ print(f'Properties: {properties}')
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotor, err := motor.FromRobot(machine, "my_motor")
+myMotorComponent, err := motor.FromRobot(robot, "my_motor")
 
 // Return whether or not the motor supports certain optional features.
-properties, err := myMotor.Properties(context.Background(), nil)
+properties, err := myMotorComponent.Properties(context.Background(), nil)
 
 // Log the properties.
 logger.Info("Properties:")
@@ -470,10 +474,10 @@ print('Powered: ', powered)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotor, err := motor.FromRobot(machine, "my_motor")
+myMotorComponent, err := motor.FromRobot(robot, "my_motor")
 
 // Check whether the motor is currently running.
-powered, pct, err := myMotor.IsPowered(context.Background(), nil)
+powered, pct, err := myMotorComponent.IsPowered(context.Background(), nil)
 
 logger.Info("Is powered?")
 logger.Info(powered)
@@ -524,10 +528,10 @@ print('Moving: ', moving)
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/resource#MovingCheckable).
 
 ```go
-myMotor, err := motor.FromRobot(machine, "my_motor")
+myMotorComponent, err := motor.FromRobot(robot, "my_motor")
 
 // Check whether the motor is currently moving.
-moving, err := myMotor.IsMoving(context.Background())
+moving, err := myMotorComponent.IsMoving(context.Background())
 
 logger.Info("Is moving?")
 logger.Info(moving)
@@ -575,10 +579,10 @@ await my_motor.stop()
 For more information, see the [Go SDK docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 ```go
-myMotor, err := motor.FromRobot(machine, "my_motor")
+myMotorComponent, err := motor.FromRobot(robot, "my_motor")
 
 // Stop the motor.
-myMotor.Stop(context.Background(), nil)
+myMotorComponent.Stop(context.Background(), nil)
 ```
 
 {{% /tab %}}
@@ -629,9 +633,9 @@ if geometries:
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Shaped).
 
 ```go {class="line-numbers linkable-line-numbers"}
-myMotor, err := motor.FromRobot(machine, "my_motor")
+myMotorComponent, err := motor.FromRobot(robot, "my_motor")
 
-geometries, err := myMotor.Geometries(context.Background(), nil)
+geometries, err := myMotorComponent.Geometries(context.Background(), nil)
 
 if len(geometries) > 0 {
     // Get the center of the first geometry
@@ -688,9 +692,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-myMotor, err := motor.FromRobot(machine, "my_motor")
+myMotorComponent, err := motor.FromRobot(robot, "my_motor")
 
-resp, err := myMotor.DoCommand(ctx, map[string]interface{}{"command": "jog", "raw_input": "home"})
+resp, err := myMotorComponent.DoCommand(ctx, map[string]interface{}{"command": "jog", "raw_input": "home"})
 ```
 
 For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/blob/main/resource/resource.go).
@@ -733,9 +737,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - [(error)](https://pkg.go.dev/builtin#error) : An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-myMotor, err := motor.FromRobot(machine, "my_motor")
+myMotorComponent, err := motor.FromRobot(robot, "my_motor")
 
-err := myMotor.Close(ctx)
+err := myMotorComponent.Close(ctx)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).

--- a/docs/components/motor/_index.md
+++ b/docs/components/motor/_index.md
@@ -270,7 +270,7 @@ myMotorComponent.GoTo(context.Background(), 75, 8.3, nil)
 
 ### ResetZeroPosition
 
-Set the current position (modified by `offset`) to be the new zero (home) position.
+Set the current position (modified by `offset`) of an [encoded motor](/components/motor/gpio/encoded-motor/) to be the new zero (home) position.
 
 {{< tabs >}}
 {{% tab name="Python" %}}
@@ -319,7 +319,7 @@ myMotorComponent.ResetZeroPosition(context.Background(), 0.0, nil)
 
 ### GetPosition
 
-Report the position of the motor based on its encoder.
+Report the position of an [encoded motor](/components/motor/gpio/encoded-motor/) based on its encoder.
 The value returned is the number of revolutions relative to its zero position.
 This method raises an exception if position reporting is not supported by the motor.
 

--- a/docs/components/motor/dmc4000.md
+++ b/docs/components/motor/dmc4000.md
@@ -130,13 +130,13 @@ Run the DMC homing routine.
 For more information on `do_command`, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/component_base/index.html#viam.components.component_base.ComponentBase.do_command).
 
 ```python
-myMotor = Motor.from_robot(robot=robot, name='my_motor')
+my_motor = Motor.from_robot(robot=robot, name='my_motor')
 
 # Home the motor
 home_dict = {
   "command": "home"
 }
-await myMotorComponent.do_command(home_dict)
+await my_motor.do_command(home_dict)
 ```
 
 {{% /tab %}}
@@ -180,14 +180,14 @@ Move the motor indefinitely at the specified RPM.
 For more information on `do_command`, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/component_base/index.html#viam.components.component_base.ComponentBase.do_command).
 
 ```python
-myMotor = Motor.from_robot(robot=robot, name='my_motor')
+my_motor = Motor.from_robot(robot=robot, name='my_motor')
 
 # Run the motor indefinitely at 70 rpm
 jog_dict = {
   "command": "jog",
   "rpm": 70
 }
-await myMotorComponent.do_command(jog_dict)
+await my_motor.do_command(jog_dict)
 ```
 
 {{% /tab %}}
@@ -232,13 +232,13 @@ Send [raw string commands](https://www.galil.com/downloads/manuals-and-data-shee
 For more information on `do_command`, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/component_base/index.html#viam.components.component_base.ComponentBase.do_command).
 
 ```python
-myMotor = Motor.from_robot(robot=robot, name='my_motor')
+my_motor = Motor.from_robot(robot=robot, name='my_motor')
 
 raw_dict = {
   "command": "raw",
   "raw_input": "home"
 }
-await myMotorComponent.do_command(raw_dict)
+await my_motor.do_command(raw_dict)
 ```
 
 {{% /tab %}}

--- a/docs/components/motor/dmc4000.md
+++ b/docs/components/motor/dmc4000.md
@@ -153,7 +153,7 @@ await myMotor.do_command(home_dict)
 For more information, see the Go SDK docs on [`Home`](https://pkg.go.dev/go.viam.com/rdk/components/motor/dmc4000#Motor.Home) and on [`DoCommand`](https://pkg.go.dev/go.viam.com/rdk/components/motor/dmc4000#Motor.DoCommand).
 
 ```go
-myMotor, err := motor.FromRobot(robot, "motor1")
+myMotor, err := motor.FromRobot(machine, "motor1")
 
 // Home the motor
 resp, err := myMotor.DoCommand(ctx, map[string]interface{}{"command": "home"})
@@ -205,7 +205,7 @@ await myMotor.do_command(jog_dict)
 For more information, see the Go SDK Docs on [`Jog`](https://pkg.go.dev/go.viam.com/rdk/components/motor/dmc4000#Motor.Jog) and on [`DoCommand`](https://pkg.go.dev/go.viam.com/rdk/components/motor/dmc4000#Motor.DoCommand).
 
 ```go
-myMotor, err := motor.FromRobot(robot, "motor1")
+myMotor, err := motor.FromRobot(machine, "motor1")
 
 // Run the motor indefinitely at 70 rpm
 resp, err := myMotor.DoCommand(ctx, map[string]interface{}{"command": "jog", "rpm": 70})
@@ -256,7 +256,7 @@ await myMotor.do_command(raw_dict)
 For more information, see the Go SDK Docs on [`Raw`](https://pkg.go.dev/go.viam.com/rdk/components/motor/dmc4000#Motor.Raw) and on [`DoCommand`](https://pkg.go.dev/go.viam.com/rdk/components/motor/dmc4000#Motor.DoCommand).
 
 ```go
-myMotor, err := motor.FromRobot(robot, "motor1")
+myMotor, err := motor.FromRobot(machine, "motor1")
 
 resp, err := myMotor.DoCommand(ctx, map[string]interface{}{"command": "jog", "raw_input": "home"})
 ```

--- a/docs/components/motor/dmc4000.md
+++ b/docs/components/motor/dmc4000.md
@@ -153,8 +153,6 @@ await my_motor.do_command(home_dict)
 For more information, see the Go SDK docs on [`Home`](https://pkg.go.dev/go.viam.com/rdk/components/motor/dmc4000#Motor.Home) and on [`DoCommand`](https://pkg.go.dev/go.viam.com/rdk/components/motor/dmc4000#Motor.DoCommand).
 
 ```go
-myMotorComponent, err := motor.FromRobot(machine, "motor1")
-
 // Home the motor
 resp, err := myMotorComponent.DoCommand(ctx, map[string]interface{}{"command": "home"})
 ```
@@ -205,8 +203,6 @@ await my_motor.do_command(jog_dict)
 For more information, see the Go SDK Docs on [`Jog`](https://pkg.go.dev/go.viam.com/rdk/components/motor/dmc4000#Motor.Jog) and on [`DoCommand`](https://pkg.go.dev/go.viam.com/rdk/components/motor/dmc4000#Motor.DoCommand).
 
 ```go
-myMotorComponent, err := motor.FromRobot(machine, "motor1")
-
 // Run the motor indefinitely at 70 rpm
 resp, err := myMotorComponent.DoCommand(ctx, map[string]interface{}{"command": "jog", "rpm": 70})
 ```
@@ -256,8 +252,6 @@ await my_motor.do_command(raw_dict)
 For more information, see the Go SDK Docs on [`Raw`](https://pkg.go.dev/go.viam.com/rdk/components/motor/dmc4000#Motor.Raw) and on [`DoCommand`](https://pkg.go.dev/go.viam.com/rdk/components/motor/dmc4000#Motor.DoCommand).
 
 ```go
-myMotorComponent, err := motor.FromRobot(machine, "motor1")
-
 resp, err := myMotorComponent.DoCommand(ctx, map[string]interface{}{"command": "jog", "raw_input": "home"})
 ```
 

--- a/docs/components/motor/dmc4000.md
+++ b/docs/components/motor/dmc4000.md
@@ -136,7 +136,7 @@ myMotor = Motor.from_robot(robot=robot, name='my_motor')
 home_dict = {
   "command": "home"
 }
-await myMotor.do_command(home_dict)
+await myMotorComponent.do_command(home_dict)
 ```
 
 {{% /tab %}}
@@ -153,10 +153,10 @@ await myMotor.do_command(home_dict)
 For more information, see the Go SDK docs on [`Home`](https://pkg.go.dev/go.viam.com/rdk/components/motor/dmc4000#Motor.Home) and on [`DoCommand`](https://pkg.go.dev/go.viam.com/rdk/components/motor/dmc4000#Motor.DoCommand).
 
 ```go
-myMotor, err := motor.FromRobot(machine, "motor1")
+myMotorComponent, err := motor.FromRobot(machine, "motor1")
 
 // Home the motor
-resp, err := myMotor.DoCommand(ctx, map[string]interface{}{"command": "home"})
+resp, err := myMotorComponent.DoCommand(ctx, map[string]interface{}{"command": "home"})
 ```
 
 {{% /tab %}}
@@ -187,7 +187,7 @@ jog_dict = {
   "command": "jog",
   "rpm": 70
 }
-await myMotor.do_command(jog_dict)
+await myMotorComponent.do_command(jog_dict)
 ```
 
 {{% /tab %}}
@@ -205,10 +205,10 @@ await myMotor.do_command(jog_dict)
 For more information, see the Go SDK Docs on [`Jog`](https://pkg.go.dev/go.viam.com/rdk/components/motor/dmc4000#Motor.Jog) and on [`DoCommand`](https://pkg.go.dev/go.viam.com/rdk/components/motor/dmc4000#Motor.DoCommand).
 
 ```go
-myMotor, err := motor.FromRobot(machine, "motor1")
+myMotorComponent, err := motor.FromRobot(machine, "motor1")
 
 // Run the motor indefinitely at 70 rpm
-resp, err := myMotor.DoCommand(ctx, map[string]interface{}{"command": "jog", "rpm": 70})
+resp, err := myMotorComponent.DoCommand(ctx, map[string]interface{}{"command": "jog", "rpm": 70})
 ```
 
 {{% /tab %}}
@@ -238,7 +238,7 @@ raw_dict = {
   "command": "raw",
   "raw_input": "home"
 }
-await myMotor.do_command(raw_dict)
+await myMotorComponent.do_command(raw_dict)
 ```
 
 {{% /tab %}}
@@ -256,9 +256,9 @@ await myMotor.do_command(raw_dict)
 For more information, see the Go SDK Docs on [`Raw`](https://pkg.go.dev/go.viam.com/rdk/components/motor/dmc4000#Motor.Raw) and on [`DoCommand`](https://pkg.go.dev/go.viam.com/rdk/components/motor/dmc4000#Motor.DoCommand).
 
 ```go
-myMotor, err := motor.FromRobot(machine, "motor1")
+myMotorComponent, err := motor.FromRobot(machine, "motor1")
 
-resp, err := myMotor.DoCommand(ctx, map[string]interface{}{"command": "jog", "raw_input": "home"})
+resp, err := myMotorComponent.DoCommand(ctx, map[string]interface{}{"command": "jog", "raw_input": "home"})
 ```
 
 {{% /tab %}}

--- a/docs/components/motor/tmc5072.md
+++ b/docs/components/motor/tmc5072.md
@@ -139,13 +139,13 @@ Home the motor using [TMC's StallGuard<sup>TM</sup>](https://www.trinamic.com/te
 For more information on `do_command`, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/component_base/index.html#viam.components.component_base.ComponentBase.do_command).
 
 ```python
-myMotor = Motor.from_robot(robot=robot, name='my_motor')
+my_motor = Motor.from_robot(robot=robot, name='my_motor')
 
 # Home the motor
 home_dict = {
   "command": "home"
 }
-await myMotorComponent.do_command(home_dict)
+await my_motor.do_command(home_dict)
 ```
 
 {{% /tab %}}
@@ -189,14 +189,14 @@ Move the motor indefinitely at the specified RPM.
 For more information on `do_command`, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/component_base/index.html#viam.components.component_base.ComponentBase.do_command).
 
 ```python
-myMotor = Motor.from_robot(robot=robot, name='my_motor')
+my_motor = Motor.from_robot(robot=robot, name='my_motor')
 
 # Run the motor indefinitely at 70 rpm
 jog_dict = {
   "command": "jog",
   "rpm": 70
 }
-await myMotorComponent.do_command(jog_dict)
+await my_motor.do_command(jog_dict)
 ```
 
 {{% /tab %}}

--- a/docs/components/motor/tmc5072.md
+++ b/docs/components/motor/tmc5072.md
@@ -145,7 +145,7 @@ myMotor = Motor.from_robot(robot=robot, name='my_motor')
 home_dict = {
   "command": "home"
 }
-await myMotor.do_command(home_dict)
+await myMotorComponent.do_command(home_dict)
 ```
 
 {{% /tab %}}
@@ -162,10 +162,10 @@ await myMotor.do_command(home_dict)
 For more information, see the Go SDK docs on [Home()](https://pkg.go.dev/go.viam.com/rdk/components/motor/tmcstepper#Motor.Home) and on [DoCommand()](https://pkg.go.dev/go.viam.com/rdk/components/motor/tmcstepper#Motor.DoCommand).
 
 ```go
-myMotor, err := motor.FromRobot(machine, "motor1")
+myMotorComponent, err := motor.FromRobot(machine, "motor1")
 
 // Home the motor
-resp, err := myMotor.DoCommand(ctx, map[string]interface{}{"command": "home"})
+resp, err := myMotorComponent.DoCommand(ctx, map[string]interface{}{"command": "home"})
 ```
 
 {{% /tab %}}
@@ -196,7 +196,7 @@ jog_dict = {
   "command": "jog",
   "rpm": 70
 }
-await myMotor.do_command(jog_dict)
+await myMotorComponent.do_command(jog_dict)
 ```
 
 {{% /tab %}}
@@ -214,10 +214,10 @@ await myMotor.do_command(jog_dict)
 For more information, see the Go SDK Docs on [`Jog`](https://pkg.go.dev/go.viam.com/rdk/components/motor/tmcstepper#Motor.Jog) and on [`DoCommand`](https://pkg.go.dev/go.viam.com/rdk/components/motor/tmcstepper#Motor.DoCommand).
 
 ```go
-myMotor, err := motor.FromRobot(machine, "motor1")
+myMotorComponent, err := motor.FromRobot(machine, "motor1")
 
 // Run the motor indefinitely at 70 rpm
-resp, err := myMotor.DoCommand(ctx, map[string]interface{}{"command": "jog", "rpm": 70})
+resp, err := myMotorComponent.DoCommand(ctx, map[string]interface{}{"command": "jog", "rpm": 70})
 ```
 
 {{% /tab %}}

--- a/docs/components/motor/tmc5072.md
+++ b/docs/components/motor/tmc5072.md
@@ -162,8 +162,6 @@ await my_motor.do_command(home_dict)
 For more information, see the Go SDK docs on [Home()](https://pkg.go.dev/go.viam.com/rdk/components/motor/tmcstepper#Motor.Home) and on [DoCommand()](https://pkg.go.dev/go.viam.com/rdk/components/motor/tmcstepper#Motor.DoCommand).
 
 ```go
-myMotorComponent, err := motor.FromRobot(machine, "motor1")
-
 // Home the motor
 resp, err := myMotorComponent.DoCommand(ctx, map[string]interface{}{"command": "home"})
 ```
@@ -214,8 +212,6 @@ await my_motor.do_command(jog_dict)
 For more information, see the Go SDK Docs on [`Jog`](https://pkg.go.dev/go.viam.com/rdk/components/motor/tmcstepper#Motor.Jog) and on [`DoCommand`](https://pkg.go.dev/go.viam.com/rdk/components/motor/tmcstepper#Motor.DoCommand).
 
 ```go
-myMotorComponent, err := motor.FromRobot(machine, "motor1")
-
 // Run the motor indefinitely at 70 rpm
 resp, err := myMotorComponent.DoCommand(ctx, map[string]interface{}{"command": "jog", "rpm": 70})
 ```

--- a/docs/components/motor/tmc5072.md
+++ b/docs/components/motor/tmc5072.md
@@ -162,7 +162,7 @@ await myMotor.do_command(home_dict)
 For more information, see the Go SDK docs on [Home()](https://pkg.go.dev/go.viam.com/rdk/components/motor/tmcstepper#Motor.Home) and on [DoCommand()](https://pkg.go.dev/go.viam.com/rdk/components/motor/tmcstepper#Motor.DoCommand).
 
 ```go
-myMotor, err := motor.FromRobot(robot, "motor1")
+myMotor, err := motor.FromRobot(machine, "motor1")
 
 // Home the motor
 resp, err := myMotor.DoCommand(ctx, map[string]interface{}{"command": "home"})
@@ -214,7 +214,7 @@ await myMotor.do_command(jog_dict)
 For more information, see the Go SDK Docs on [`Jog`](https://pkg.go.dev/go.viam.com/rdk/components/motor/tmcstepper#Motor.Jog) and on [`DoCommand`](https://pkg.go.dev/go.viam.com/rdk/components/motor/tmcstepper#Motor.DoCommand).
 
 ```go
-myMotor, err := motor.FromRobot(robot, "motor1")
+myMotor, err := motor.FromRobot(machine, "motor1")
 
 // Run the motor indefinitely at 70 rpm
 resp, err := myMotor.DoCommand(ctx, map[string]interface{}{"command": "jog", "rpm": 70})

--- a/docs/components/servo/_index.md
+++ b/docs/components/servo/_index.md
@@ -165,7 +165,7 @@ await my_servo.move(30)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/servo#Servo).
 
 ```go {class="line-numbers linkable-line-numbers"}
-myServoComponent, err := servo.FromRobot(robot, "my_servo")
+myServoComponent, err := servo.FromRobot(machine, "my_servo")
 
 // Move the servo from its origin to the desired angle of 30 degrees.
 myServoComponent.Move(context.Background(), 30, nil)
@@ -221,7 +221,7 @@ pos2 = await my_servo.get_position()
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/servo#Servo).
 
 ```go {class="line-numbers linkable-line-numbers"}
-myServoComponent, err := servo.FromRobot(robot, "my_servo")
+myServoComponent, err := servo.FromRobot(machine, "my_servo")
 
 // Get the current set angle of the servo.
 pos1, err = myServoComponent.Position(context.Background(), nil)
@@ -282,7 +282,7 @@ await my_servo.stop()
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/servo#Servo).
 
 ```go {class="line-numbers linkable-line-numbers"}
-myServoComponent, err := servo.FromRobot(robot, "my_servo")
+myServoComponent, err := servo.FromRobot(machine, "my_servo")
 
 // Move the servo from its origin to the desired angle of 10 degrees.
 myServoComponent.Move(context.Background(), 10, nil)
@@ -339,7 +339,7 @@ if geometries:
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Shaped).
 
 ```go {class="line-numbers linkable-line-numbers"}
-myServoComponent, err := servo.FromRobot(robot, "my_servo")
+myServoComponent, err := servo.FromRobot(machine, "my_servo")
 
 geometries, err := myServoComponent.Geometries(context.Background(), nil)
 
@@ -394,7 +394,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-myServoComponent, err := servo.FromRobot(robot, "my_servo")
+myServoComponent, err := servo.FromRobot(machine, "my_servo")
 
 command := map[string]interface{}{"cmd": "test", "data1": 500}
 result, err := myServoComponent.DoCommand(context.Background(), command)
@@ -440,9 +440,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - [(error)](https://pkg.go.dev/builtin#error) : An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-myServoComponent, err := servo.FromRobot(robot, "my_servo")
+myServoComponent, err := servo.FromRobot(machine, "my_servo")
 
-err := myServoComponent.Close(ctx)
+err = myServoComponent.Close(ctx)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).

--- a/docs/components/servo/_index.md
+++ b/docs/components/servo/_index.md
@@ -145,11 +145,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 ```python {class="line-numbers linkable-line-numbers"}
 my_servo = Servo.from_robot(robot=robot, name="my_servo")
 
-# Move the servo from its origin to the desired angle of 10 degrees.
-await my_servo.move(10)
-
-# Move the servo from its origin to the desired angle of 90 degrees.
-await my_servo.move(90)
+# Move the servo from its origin to the desired angle of 30 degrees.
+await my_servo.move(30)
 ```
 
 {{% /tab %}}
@@ -168,13 +165,10 @@ await my_servo.move(90)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/servo#Servo).
 
 ```go {class="line-numbers linkable-line-numbers"}
-myServo, err := servo.FromRobot(robot, "my_servo")
+myServoComponent, err := servo.FromRobot(robot, "my_servo")
 
-// Move the servo from its origin to the desired angle of 10 degrees.
-myServo.Move(context.Background(), 10, nil)
-
-// Move the servo from its origin to the desired angle of 90 degrees.
-myServo.Move(context.Background(), 90, nil)
+// Move the servo from its origin to the desired angle of 30 degrees.
+myServoComponent.Move(context.Background(), 30, nil)
 ```
 
 {{% /tab %}}
@@ -200,9 +194,6 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```python {class="line-numbers linkable-line-numbers"}
 my_servo = Servo.from_robot(robot=robot, name="my_servo")
-
-# Move the servo from its origin to the desired angle of 10 degrees.
-await my_servo.move(10)
 
 # Get the current set angle of the servo.
 pos1 = await my_servo.get_position()
@@ -230,19 +221,19 @@ pos2 = await my_servo.get_position()
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/servo#Servo).
 
 ```go {class="line-numbers linkable-line-numbers"}
-myServo, err := servo.FromRobot(robot, "my_servo")
-
-// Move the servo from its origin to the desired angle of 10 degrees.
-myServo.Move(context.Background(), 10, nil)
+myServoComponent, err := servo.FromRobot(robot, "my_servo")
 
 // Get the current set angle of the servo.
-pos1, err = myServo.Position(context.Background(), nil)
+pos1, err = myServoComponent.Position(context.Background(), nil)
 
 // Move the servo from its origin to the desired angle of 20 degrees.
-myServo.Move(context.Background(), 20, nil)
+myServoComponent.Move(context.Background(), 20, nil)
 
 // Get the current set angle of the servo.
-pos2, err = myServo.Position(context.Background(), nil)
+pos2, err = myServoComponent.Position(context.Background(), nil)
+
+logger.Info("Position 1: ", pos1)
+logger.Info("Position 2: ", pos2)
 ```
 
 {{% /tab %}}
@@ -291,13 +282,13 @@ await my_servo.stop()
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/servo#Servo).
 
 ```go {class="line-numbers linkable-line-numbers"}
-myServo, err := servo.FromRobot(robot, "my_servo")
+myServoComponent, err := servo.FromRobot(robot, "my_servo")
 
 // Move the servo from its origin to the desired angle of 10 degrees.
-myServo.Move(context.Background(), 10, nil)
+myServoComponent.Move(context.Background(), 10, nil)
 
 // Stop the servo. It is assumed that the servo stops moving immediately.
-myServo.Stop(context.Background(), nil)
+myServoComponent.Stop(context.Background(), nil)
 ```
 
 {{% /tab %}}
@@ -348,9 +339,9 @@ if geometries:
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Shaped).
 
 ```go {class="line-numbers linkable-line-numbers"}
-myServo, err := servo.FromRobot(robot, "my_servo")
+myServoComponent, err := servo.FromRobot(robot, "my_servo")
 
-geometries, err := myServo.Geometries(context.Background(), nil)
+geometries, err := myServoComponent.Geometries(context.Background(), nil)
 
 if len(geometries) > 0 {
     // Get the center of the first geometry
@@ -403,10 +394,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-myServo, err := servo.FromRobot(robot, "my_servo")
+myServoComponent, err := servo.FromRobot(robot, "my_servo")
 
 command := map[string]interface{}{"cmd": "test", "data1": 500}
-result, err := myServo.DoCommand(context.Background(), command)
+result, err := myServoComponent.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Code](https://github.com/viamrobotics/rdk/blob/main/resource/resource.go).
@@ -449,9 +440,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - [(error)](https://pkg.go.dev/builtin#error) : An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-myServo, err := servo.FromRobot(robot, "my_servo")
+myServoComponent, err := servo.FromRobot(robot, "my_servo")
 
-err := myServo.Close(ctx)
+err := myServoComponent.Close(ctx)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).

--- a/docs/components/servo/_index.md
+++ b/docs/components/servo/_index.md
@@ -165,8 +165,6 @@ await my_servo.move(30)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/servo#Servo).
 
 ```go {class="line-numbers linkable-line-numbers"}
-myServoComponent, err := servo.FromRobot(machine, "my_servo")
-
 // Move the servo from its origin to the desired angle of 30 degrees.
 myServoComponent.Move(context.Background(), 30, nil)
 ```
@@ -221,16 +219,14 @@ pos2 = await my_servo.get_position()
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/servo#Servo).
 
 ```go {class="line-numbers linkable-line-numbers"}
-myServoComponent, err := servo.FromRobot(machine, "my_servo")
-
 // Get the current set angle of the servo.
-pos1, err = myServoComponent.Position(context.Background(), nil)
+pos1, err := myServoComponent.Position(context.Background(), nil)
 
 // Move the servo from its origin to the desired angle of 20 degrees.
 myServoComponent.Move(context.Background(), 20, nil)
 
 // Get the current set angle of the servo.
-pos2, err = myServoComponent.Position(context.Background(), nil)
+pos2, err := myServoComponent.Position(context.Background(), nil)
 
 logger.Info("Position 1: ", pos1)
 logger.Info("Position 2: ", pos2)
@@ -282,8 +278,6 @@ await my_servo.stop()
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/servo#Servo).
 
 ```go {class="line-numbers linkable-line-numbers"}
-myServoComponent, err := servo.FromRobot(machine, "my_servo")
-
 // Move the servo from its origin to the desired angle of 10 degrees.
 myServoComponent.Move(context.Background(), 10, nil)
 
@@ -339,8 +333,6 @@ if geometries:
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Shaped).
 
 ```go {class="line-numbers linkable-line-numbers"}
-myServoComponent, err := servo.FromRobot(machine, "my_servo")
-
 geometries, err := myServoComponent.Geometries(context.Background(), nil)
 
 if len(geometries) > 0 {
@@ -394,8 +386,6 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-myServoComponent, err := servo.FromRobot(machine, "my_servo")
-
 command := map[string]interface{}{"cmd": "test", "data1": 500}
 result, err := myServoComponent.DoCommand(context.Background(), command)
 ```
@@ -440,9 +430,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - [(error)](https://pkg.go.dev/builtin#error) : An error, if one occurred.
 
 ```go {class="line-numbers linkable-line-numbers"}
-myServoComponent, err := servo.FromRobot(machine, "my_servo")
-
-err = myServoComponent.Close(ctx)
+err := myServoComponent.Close(ctx)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).


### PR DESCRIPTION
- Add "Component" to the end of "myMotor" because the code sample code appends it.
- Change TMC and DMC Python examples to use "my_motor" because that's how the code sample code does it.
- Clarify that two methods are for encoded motors.
- Print servo positions, and trim out a couple of excess servo example lines for concision.
