### PR TITLE
DOCS-2300: Restructure generated includes

### DIFF
--- a/.github/workflows/sdk_protos_map.csv
+++ b/.github/workflows/sdk_protos_map.csv
@@ -36,8 +36,9 @@ board,GetPWM,get_pwm,PWM,pWM
 board,SetPWM,set_pwm,SetPWM,setPWM
 board,PWMFrequency,get_pwm_frequency,PWMFreq,pWMFrequency
 board,SetPWMFrequency,set_pwm_frequency,SetPWMFreq,setPWMFrequency
-board,ReadAnalogReader,analog_reader_by_name,AnalogByName,readAnalogReader
-board,WriteAnalog,write_analog,WriteAnalog,writeAnalog
+board,ReadAnalogReader,analog_by_name,AnalogByName,readAnalogReader
+## HACK: Omitting PySDK: write_analog, currently borked: https://python.viam.dev/autoapi/viam/components/board/client/index.html#viam.components.board.client.BoardClient.write_analog
+board,WriteAnalog,,WriteAnalog,writeAnalog
 board,GetDigitalInterruptValue,digital_interrupt_by_name,DigitalInterruptByName,,
 board,StreamTicks,,StreamTicks,streamTicks
 board,SetPowerMode,set_power_mode,SetPowerMode,setPowerMode
@@ -45,7 +46,7 @@ board,GetGeometries,get_geometries,,getGeometries
 ## HACK: Board (python, go) provides additional helper functions, adding 5 pseudo-entries:
 board,Read,read,Read,
 board,Value,value,Value,getDigitalInterruptValue
-board,AnalogReaderNames,analog_reader_names,AnalogNames,
+board,AnalogReaderNames,analog_names,AnalogNames,
 board,DigitalInterruptNames,digital_interrupt_names,DigitalInterruptNames,
 board,GPIOPinByName,gpio_pin_by_name,GPIOPinByName,
 ## HACK: No proto for these (and/or inherited in Go SDK), manually mapping:

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -1158,10 +1158,6 @@ def write_markdown(type, names, methods):
     ## scope limited to 'type', so we don't have to loop by type:
     for resource in names:
 
-        ## Create by-resource directory structure if not already present:
-        #path_to_resource = os.path.join(path_to_generated, resource)
-        #Path(path_to_resource).mkdir(parents=True, exist_ok=True)
-
         ## Determine where to write output:
         filename = resource + '.md'
         full_path_to_file = os.path.join(path_to_generated, filename)
@@ -1170,7 +1166,7 @@ def write_markdown(type, names, methods):
         ## Switch to identify the first method encountered for each resource, to help with
         ## knowing when we are at the top of the include file, or whether to to double newline
         ## between protos:
-        is_first_method_in_this_resource = 1
+        is_first_method_in_this_resource = True
 
         ## Loop through mapping file, and determine which sdk methods to document for each proto:
         with open(proto_map_file, 'r') as f:
@@ -1617,7 +1613,7 @@ def write_markdown(type, names, methods):
                     ## After this loop, we will be working with additional methods appended to the same {resource}.md include file.
                     ## This switch tells us at the start of the loop for this same resource that we should double-newline the next
                     ## proto encountered:
-                    is_first_method_in_this_resource = 0
+                    is_first_method_in_this_resource = False
 
 ## Main run function:
 ## - proto_map()        Fetch canonical proto methods from upstream, used for Flutter mapping in `parse()`

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -325,7 +325,8 @@ python_ignore_apis = [
     'viam.robot.client.RobotClient.transform_point_cloud', # unimplemented
     'viam.robot.client.RobotClient.get_component', # GUESS ?
     'viam.robot.client.RobotClient.get_service', # GUESS ?
-    'viam.app.app_client.AppClient.create_organization_invite' # Currently borked: https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_organization_invite
+    'viam.app.app_client.AppClient.create_organization_invite', # Currently borked: https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_organization_invite
+    'viam.components.board.client.BoardClient.write_analog' # Currently borked: https://python.viam.dev/autoapi/viam/components/board/client/index.html#viam.components.board.client.BoardClient.write_analog
 ]
 
 ## Use these URLs for data types that are built-in to the language:
@@ -1158,8 +1159,18 @@ def write_markdown(type, names, methods):
     for resource in names:
 
         ## Create by-resource directory structure if not already present:
-        path_to_resource = os.path.join(path_to_generated, resource)
-        Path(path_to_resource).mkdir(parents=True, exist_ok=True)
+        #path_to_resource = os.path.join(path_to_generated, resource)
+        #Path(path_to_resource).mkdir(parents=True, exist_ok=True)
+
+        ## Determine where to write output:
+        filename = resource + '.md'
+        full_path_to_file = os.path.join(path_to_generated, filename)
+        output_file = open('%s' % full_path_to_file, "w")
+
+        ## Switch to identify the first method encountered for each resource, to help with
+        ## knowing when we are at the top of the include file, or whether to to double newline
+        ## between protos:
+        is_first_method_in_this_resource = 1
 
         ## Loop through mapping file, and determine which sdk methods to document for each proto:
         with open(proto_map_file, 'r') as f:
@@ -1175,14 +1186,11 @@ def write_markdown(type, names, methods):
                     ## for specific protos as needed, if needed:
                     if py_method_name or go_method_name or flutter_method_name:
 
-                        ## About to change this to by-resource filenames, instead of by-proto filenames. Stay tuned!
-                        filename = proto + '.md'
-
-                        full_path_to_file = os.path.join(path_to_resource, filename)
-                        output_file = open('%s' % full_path_to_file, "w")
-
-                        ## Write proto as H3:
-                        output_file.write('### ' + proto + '\n\n')
+                        ## Write proto as H3, with leading newlines if appending to ongoing {resource}.md file:
+                        if is_first_method_in_this_resource:
+                            output_file.write('### ' + proto + '\n\n')
+                        else:
+                            output_file.write('\n### ' + proto + '\n\n')
 
                         ## NOTE: This is where proto descriptions could go if we scraped them. However:
                         ## - Some protos do not have descriptions.
@@ -1336,16 +1344,17 @@ def write_markdown(type, names, methods):
                             ## If the method has a code sample, print it here:
                             if 'code_sample' in methods['python'][type][resource][py_method_name]:
 
-                                output_file.write('``` ' + code_fence_fmt['python'] + ' {class="line-numbers linkable-line-numbers"}\n')
+                                output_file.write('```' + code_fence_fmt['python'] + ' {class="line-numbers linkable-line-numbers"}\n')
                                 output_file.write(methods['python'][type][resource][py_method_name]['code_sample'])
                                 output_file.write('```\n\n')
 
                             ## If we detected an 'after' method override file earlier, write it out here:
                             if has_after_override:
-                                output_file.write('\n')
 
                                 for line in open(method_override_file_path, 'r', encoding='utf-8'):
                                     output_file.write(line)
+
+                                output_file.write('\n')
 
                             # Close tabs
                             output_file.write("{{% /tab %}}\n")
@@ -1445,16 +1454,17 @@ def write_markdown(type, names, methods):
                             ## If the method has a code sample, print it here:
                             if 'code_sample' in methods['go'][type][resource][go_method_name]:
 
-                                output_file.write('``` ' + code_fence_fmt['go'] + ' {class="line-numbers linkable-line-numbers"}\n')
+                                output_file.write('```' + code_fence_fmt['go'] + ' {class="line-numbers linkable-line-numbers"}\n')
                                 output_file.write(methods['go'][type][resource][go_method_name]['code_sample'])
                                 output_file.write('```\n\n')
 
                             ## If we detected an 'after' method override file earlier, write it out here:
                             if has_after_override:
-                                output_file.write('\n')
 
                                 for line in open(method_override_file_path, 'r', encoding='utf-8'):
                                     output_file.write(line)
+
+                                output_file.write('\n')
 
                             output_file.write("{{% /tab %}}\n")
                             if not flutter_method_name:
@@ -1589,20 +1599,25 @@ def write_markdown(type, names, methods):
                             ## If the method has a code sample, print it here:
                             if 'code_sample' in methods['flutter'][type][resource][flutter_method_name]:
 
-                                output_file.write('``` ' + code_fence_fmt['flutter'] + ' {class="line-numbers linkable-line-numbers"}\n')
+                                output_file.write('```' + code_fence_fmt['flutter'] + ' {class="line-numbers linkable-line-numbers"}\n')
                                 output_file.write(methods['flutter'][type][resource][flutter_method_name]['code_sample'])
                                 output_file.write('```\n\n')
 
                             ## If we detected an 'after' method override file earlier, write it out here:
                             if has_after_override:
-                                output_file.write('\n')
 
                                 for line in open(method_override_file_path, 'r', encoding='utf-8'):
                                     output_file.write(line)
 
+                                output_file.write('\n')
+
                             output_file.write("{{% /tab %}}\n")
                             output_file.write("{{< /tabs >}}\n")
 
+                    ## After this loop, we will be working with additional methods appended to the same {resource}.md include file.
+                    ## This switch tells us at the start of the loop for this same resource that we should double-newline the next
+                    ## proto encountered:
+                    is_first_method_in_this_resource = 0
 
 ## Main run function:
 ## - proto_map()        Fetch canonical proto methods from upstream, used for Flutter mapping in `parse()`


### PR DESCRIPTION
Restructure generated include files to be by-resource instead of by-proto, cutting the number of includes down to 29 from 291. 👀 
- Also fixed some minor whitespace issues around code fences and `.after` override files.
- Also updated mapping file with recent board API changes to reader functions.
- Also omitting one more Py method until we can fix its upstream form: `write_analog`