### PR TITLE
DOCS-2302: Improve data type linking

### DIFF
--- a/.github/workflows/sdk_protos_map.csv
+++ b/.github/workflows/sdk_protos_map.csv
@@ -386,15 +386,15 @@ dataset,ListDatasetsByOrganizationID,list_datasets_by_organization_id,,listDatas
 dataset,ListDatasetsByIDs,list_dataset_by_ids,,listDatasetsByIDs
 
 ## Datasync
-datasync,DataCaptureUpload,,,dataCaptureUpload
+data_sync,DataCaptureUpload,,,dataCaptureUpload
 ## HACK: DataCaptureUpload instead implemented in binary_data_capture_upload (python), adding pseudo-entry:
-datasync,BinaryDataCaptureUpload,binary_data_capture_upload,,
+data_sync,BinaryDataCaptureUpload,binary_data_capture_upload,,
 ## HACK: DataCaptureUpload instead implemented in tabular_data_capture_upload (python), adding pseudo-entry:
-datasync,TabularDataCaptureUpload,tabular_data_capture_upload,,
-datasync,FileUpload,file_upload,,fileUpload
+data_sync,TabularDataCaptureUpload,tabular_data_capture_upload,,
+data_sync,FileUpload,file_upload,,fileUpload
 ## HACK: FileUpload also implemented in file_upload_from_path (python), adding pseudo-entry:
-datasync,FileUploadFromPath,file_upload_from_path,,
-datasync,StreamingDataCaptureUpload,streaming_data_capture_upload,,streamingDataCaptureUpload
+data_sync,FileUploadFromPath,file_upload_from_path,,
+data_sync,StreamingDataCaptureUpload,streaming_data_capture_upload,,streamingDataCaptureUpload
 
 ## MLTraining
 ## TODO: Something wrong with parsing: submit_training_job in PySDK (??):

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -1342,30 +1342,10 @@ def write_markdown(type, names, methods):
                                     param_data = methods['python'][type][resource][py_method_name]['parameters'][parameter]
 
                                     param_type = param_data.get("param_type")
-                                    #param_subtype = param_data.get("param_subtype")
-                                    #param_type_link = param_data.get("param_type_link")
-                                    #param_subtype_link = param_data.get("param_subtype_link")
                                     param_description = param_data.get("param_description")
                                     optional = param_data.get("optional")
 
                                     output_file.write(f'- `{parameter}` ({param_type})')
-
-                                    # Ideally we could update at least Python SDK with type links?
-                                    #if param_type_link:
-                                    #    # Check for subtype
-                                    #    if param_subtype:
-                                    #        output_file.write(f"({param_type_link})")
-                                    #        if param_subtype_link:
-                                    #            output_file.write(f"<[{param_subtype}]")
-                                    #            output_file.write(f"({param_subtype_link})>")
-                                    #        else:
-                                    #            output_file.write(f"<{param_subtype}>")
-                                    #    else:
-                                    #        output_file.write(f"({param_type_link})")
-                                    # SG: Haven't found any sub-types without param type links-- they are all in flutter SDK--
-                                    # could expand this logic if popped up or grabbing more subtypes?
-                                    #else:
-                                    #    output_file.write('(<INSERT PARAM TYPE LINK>)')
 
                                     if optional:
                                         output_file.write(' (optional)')
@@ -1392,28 +1372,10 @@ def write_markdown(type, names, methods):
 
                                 return_data = methods['python'][type][resource][py_method_name]["return"]
                                 return_type = return_data.get("return_type")
-                                #return_subtype = return_data.get("return_subtype")
-                                #return_type_link = return_data.get("return_type_link")
-                                #return_link = return_data.get("return_type_link") # TODO: handle this
-                                #return_subtype_link = return_data.get("return_subtype_link")
                                 return_description = return_data.get("return_description")
 
                                 if return_type:
                                     output_file.write(f"- ({return_type})")
-
-                                    #if return_type_link:
-                                    #    output_file.write(f"({return_type_link})")
-                                    #else:
-                                    #    output_file.write("(INSERT RETURN TYPE LINK)")
-
-                                    #if return_subtype:
-                                    #    output_file.write(f"<[{return_subtype}]")
-                                    #    if return_subtype_link:
-                                    #        output_file.write(f"({return_subtype_link})>")
-                                    #    else:
-                                    #        output_file.write("(<INSERT RETURN SUBTYPE LINK>)")
-                                    #else:
-                                    #    pass
 
                                     if return_description:
                                         output_file.write(f": {return_description}\n")

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -875,11 +875,8 @@ def parse(type, names):
                                                 ## Parameter type link is an anchor link:
                                                 if param_type_link_raw.startswith('#'):
                                                     this_method_parameters_dict["param_type"] = '[' + param_type + '](' + url + param_type_link_raw + ')'
-                                                ## Parameter type link is a relative link, in one of three forms:
-                                                elif param_type_link_raw.startswith('../../../'):
-                                                    this_method_parameters_dict["param_type"] = '[' + param_type + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../../', '')+ ')'
-                                                elif param_type_link_raw.startswith('../../'):
-                                                    this_method_parameters_dict["param_type"] = '[' + param_type + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../', '')+ ')'
+                                                ## Parameter type link is a relative link, starting 1 - 3 instances of '../'
+                                                ## Convert to an absolute link:
                                                 elif param_type_link_raw.startswith('../'):
                                                     this_method_parameters_dict["param_type"] = '[' + param_type + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../', '')+ ')'
 
@@ -921,12 +918,9 @@ def parse(type, names):
 
                                 ## Return type link is an anchor link:
                                 if return_type_link_raw.startswith('#'):
-                                    this_method_dict["return"]["return_type"] = '[' + return_type + '](' + url + param_type_link_raw + ')'
-                                ## Return type link is a relative link, in one of three forms:
-                                elif return_type_link_raw.startswith('../../../'):
-                                    this_method_dict["return"]["return_type"] = '[' + return_type + '](' + sdk_url + "/autoapi/viam/" + return_type_link_raw.replace('../../../', '')+ ')'
-                                elif return_type_link_raw.startswith('../../'):
-                                    this_method_dict["return"]["return_type"] = '[' + return_type + '](' + sdk_url + "/autoapi/viam/" + return_type_link_raw.replace('../../', '')+ ')'
+                                    this_method_dict["return"]["return_type"] = '[' + return_type + '](' + url + return_type_link_raw + ')'
+                                ## Return type link is a relative link, starting 1 - 3 instances of '../'
+                                ## Convert to an absolute link:
                                 elif return_type_link_raw.startswith('../'):
                                     this_method_dict["return"]["return_type"] = '[' + return_type + '](' + sdk_url + "/autoapi/viam/" + return_type_link_raw.replace('../', '')+ ')'
 

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -329,9 +329,9 @@ python_ignore_apis = [
     'viam.components.board.client.BoardClient.write_analog' # Currently borked: https://python.viam.dev/autoapi/viam/components/board/client/index.html#viam.components.board.client.BoardClient.write_analog
 ]
 
-## Use these URLs for data types that are not otherwise captured by parse():
+## Use these URLs for data types that are not otherwise captured by parse().
+## Data type links defined here will be used instead of scraped links if found:
 python_datatype_links = {
-    ## Standard data types:
     "str": "https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str",
     "int": "https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex",
     "float": "https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex",
@@ -339,46 +339,7 @@ python_datatype_links = {
     "bool": "https://docs.python.org/3/library/stdtypes.html#boolean-type-bool",
     "datetime": "https://docs.python.org/3/library/datetime.html",
     "datetime.datetime": "https://docs.python.org/3/library/datetime.html",
-    "datetime.timedelta": "https://docs.python.org/3/library/datetime.html#timedelta-objects",
-
-    ## Viam data types:
-    "RobotPart": "https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.RobotPart",
-    "Fragment": "https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.Fragment",
-    "List[LogEntry]": "https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.LogEntry",
-    "viam.proto.app.Robot": "https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Robot",
-    "viam.proto.app.Module": "https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Module",
-    
-    "viam.proto.app.Location": "https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Location",
-    "viam.proto.app.LocationAuth": "https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.LocationAuth",
-    "viam.proto.app.Organization": "https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Organization",
-
-    "List[RobotPartHistoryEntry]": "https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.RobotPartHistoryEntry",
-    "List[viam.proto.app.Authorization]": "https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Authorization",
-    "List[viam.proto.app.APIKeyWithAuthorizations]": "https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.APIKeyWithAuthorizations",
-    "Literal[owner] | Literal[operator]": "https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str",
-    "Literal[organization] | Literal[location] | Literal[robot]": "https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str",
-    "List[viam.proto.app.AuthorizedPermissions]": "https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.AuthorizedPermissions",
-    "viam.components.arm.Pose": "https://python.viam.dev/autoapi/viam/components/arm/index.html#viam.components.arm.Pose",
-    #"viam.proto.component.arm.JointPositions": "https://python.viam.dev/autoapi/viam/proto/component/arm/index.html#viam.proto.component.arm.JointPositions",
-    "viam.components.arm.KinematicsFileFormat.ValueType": "https://python.viam.dev/autoapi/viam/components/arm/index.html#viam.components.arm.KinematicsFileFormat",
-    "viam.components.base.Vector3": "https://python.viam.dev/autoapi/viam/components/base/index.html#viam.components.base.Vector3",
-    "viam.components.board.board.Board.GPIOPin": "https://python.viam.dev/autoapi/viam/components/board/board/index.html#viam.components.board.board.Board.GPIOPin",
-    "viam.components.board.board.Board.Analog": "https://python.viam.dev/autoapi/viam/components/board/board/index.html#viam.components.board.board.Board.Analog",
-    "viam.components.board.board.Board.DigitalInterrupt": "https://python.viam.dev/autoapi/viam/components/board/board/index.html#viam.components.board.board.Board.DigitalInterrupt",
-    "viam.media.video.NamedImage": "https://python.viam.dev/autoapi/viam/media/video/index.html#viam.media.video.NamedImage",
-    "viam.proto.common.ResponseMetadata": "https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.ResponseMetadata",
-    "viam.components.camera.Camera.Properties": "https://python.viam.dev/autoapi/viam/components/audio_input/audio_input/index.html#viam.components.audio_input.audio_input.AudioInput.Properties",
-    "viam.proto.common.Geometry": "https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.Geometry",
-    "viam.proto.component.encoder.PositionType.ValueType": "https://python.viam.dev/autoapi/viam/gen/component/encoder/v1/encoder_pb2/index.html#viam.gen.component.encoder.v1.encoder_pb2.PositionType"
-    #"viam.components.input.input.Control": "https://python.viam.dev/autoapi/viam/components/input/input/index.html#viam.components.input.input.Control",
-    #"viam.components.input.input.EventType": "https://python.viam.dev/autoapi/viam/components/input/input/index.html#viam.components.input.input.EventType",
-    #"viam.components.input.input.Event": "https://python.viam.dev/autoapi/viam/components/input/input/index.html#viam.components.input.input.Event"
-
-
-    #"Tuple[List[viam.proto.app.OrganizationMember], List[viam.proto.app.OrganizationInvite]]"
-
-    #"Control": "https://python.viam.dev/autoapi/viam/components/input/index.html#viam.components.input.Control",
-    #"EventType": "https://python.viam.dev/autoapi/viam/components/input/index.html#viam.components.input.EventType"
+    "datetime.timedelta": "https://docs.python.org/3/library/datetime.html#timedelta-objects"
 }
 
 ## Inject these URLs, relative to 'docs', into param/return/raises descriptions that contain exact matching key text.
@@ -486,7 +447,7 @@ def make_soup(url):
 ## multiple data types (and therefore requires multiple data type links), such as
 ## ListOrganizationMembers: Tuple[List[viam.proto.app.OrganizationMember], List[viam.proto.app.OrganizationInvite]
 ## DESIGN DECISION: Ignore well-known, usually leading (containing) data types like List, Tuple, Dict.
-## NOTE: Only used in PySDK parsing, for now:
+## NOTE: Only used in PySDK parsing, for now (but should work for all with minor tweak to support per-language links array):
 def link_data_types(sdk, data_type_string):
 
     linked_data_type_string = ""
@@ -509,7 +470,7 @@ def link_data_types(sdk, data_type_string):
             for data_type_found in matching_data_types:
 
                 ## Discard string matches that are substrings of other data type strings:
-                if not regex.search('[A-Za-z0-9]' + data_type_found, data_type_string) and not regex.search(data_type_found + '[A-Za-z0-9]', data_type_string):
+                if not regex.search(r'[A-Za-z0-9]' + data_type_found, data_type_string) and not regex.search(data_type_found + r'[A-Za-z0-9]', data_type_string):
 
                     data_type_linked = '[' + data_type_found + '](' + python_datatype_links[data_type_found] + ')'
                     linked_data_type_string = regex.sub(data_type_found, data_type_linked, linked_data_type_string)
@@ -517,7 +478,13 @@ def link_data_types(sdk, data_type_string):
                     ## If we get here, this data_type is actually a substring of another data type. Take no action:
                     pass
 
-    return linked_data_type_string
+    ## If we didn't find any matching links, return an empty string so we can know to look elsewhere,
+    ## otherwise return linked data type string:
+    if linked_data_type_string == data_type_string:
+        return ""
+    else:
+        return linked_data_type_string
+
 
 ## Link matching text, used in write_markdown():
 ## NOTE: Currently does not support formatting for link titles
@@ -813,11 +780,6 @@ def parse(type, names):
                                 ## Determine parameter type:
                                 param_type = parameter_tag.find_all('span', class_='n')[1].text
 
-                                if method_name == 'move_to_joint_positions':
-                                    print('PARAM: ' + param_name + '    TYPE: ' + param_type)
-
-                                #this_method_parameters_dict["param_type"] = param_type
-
                                 ## Determine if this parameter is optional, and strip off ' | None' syntax if so:
                                 if param_type.endswith(' | None'):
                                     this_method_parameters_dict["optional"] = True
@@ -825,17 +787,6 @@ def parse(type, names):
                                     #this_method_parameters_dict["param_type"] = param_type
                                 else:
                                     this_method_parameters_dict["optional"] = False
-
-                                if method_name == 'move_to_joint_positions':
-                                    print('PARAM: ' + param_name + '    TYPE2: ' + param_type)
-
-                                ## Determine if this parameter data type has a data type link. Include if so, otherwise omit:
-                                #if param_type in python_datatype_links.keys():
-                                #    this_method_parameters_dict["param_type_link"] = python_datatype_links[param_type]
-
-                                #matching_data_types2 = list(key for key in python_datatype_links if key in param_type)
-                                #if len(matching_data_types2) > 0:
-                                #    print('METHOD: ' + method_name + '    PARAM NAME: ' + param_name + '         PARAM TYPE: ' + param_type + ' RESULT MAYBE: ' + str(matching_data_types2))
 
                                 ## 'Extra' params do not appear in "Parameters" section (Except for PySDK > Motion Service),
                                 ## so we must populate this param's content manually:
@@ -862,78 +813,71 @@ def parse(type, names):
                                     this_method_parameters_dict["param_type"] = "Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), ValueTypes]"
 
                                 else:
+
+                                    ## First, check python_datatype_links array for manually-mapped data type links.
+                                    ## These will override all other ways of determining data type links:
                                     linked_param_type = ""
                                     linked_param_type = link_data_types('python', param_type)
 
-                                    if method_name == 'move_to_joint_positions':
-                                        print('PARAM: ' + param_name + '    LINKED PARAM TYPE: ' + linked_param_type)
-
+                                    ## If link_data_types() returns a linked data type string, use that.
+                                    ## Otherwise, check the scraped parameter_tag for the link:
                                     if linked_param_type != "":
                                         this_method_parameters_dict["param_type"] = linked_param_type
                                     elif parameter_tag.find('a', class_="reference internal"):
                                         param_type_link_raw = parameter_tag.find('a', class_="reference internal").get("href")
 
-
-                                        ## WE ARE SOMEHOW NOT GETTING HERE, DESPITE DEFINITELY HAVING A LINK UPSTREAM:
-                                        if method_name == 'move_to_joint_positions':
-                                            print('PARAM: ' + param_name + '    TYPE LINK RAW: ' + param_type_link_raw)
-
                                         ## Parameter type link is an anchor link:
                                         if param_type_link_raw.startswith('#'):
                                             this_method_parameters_dict["param_type"] = '[' + param_name + '](' + url + param_type_link_raw + ')'
-                                        ## Parameter type link is a relative link, in one of two forms:
+                                        ## Parameter type link is a relative link, in one of three forms:
                                         elif param_type_link_raw.startswith('../../../'):
                                             this_method_parameters_dict["param_type"] = '[' + param_name + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../../', '')+ ')'
                                         elif param_type_link_raw.startswith('../../'):
                                             this_method_parameters_dict["param_type"] = '[' + param_name + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../', '')+ ')'
+                                        elif param_type_link_raw.startswith('../'):
+                                            this_method_parameters_dict["param_type"] = '[' + param_name + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../', '')+ ')'
 
-                                    ## Get parameter usage and description, if method contains a "Parameters" section. Otherwise omit.
-                                    ## NOTE: We can't just use the initial param content as found above, because it does not contain descriptions,
-                                    ## and we can't just use this "Parameters" section, because it does not (usually) contain things like `extra` and `timeout`.
-                                    ## METHODOLOGY: Find parent <p> tag around matching <strong>param_name</strong> tag which contains this data.
-                                    ##   Determining by <strong> tags allows matching parameters regardless whether they are
-                                    ##   presented in <p> tags (single param) or <li> tags (multiple params):
-                                    for strong_tag in tag.find_all('strong'):
-                                        ## We have to explicitly exclude extra and timeout from this loop also,
-                                        ## because Python Motion service includes them explicitly as well:
-                                        if param_name != 'extra' and \
-                                            param_name != 'timeout' and \
-                                            strong_tag.text == param_name:
+                                        ## Get parameter usage and description, if method contains a "Parameters" section. Otherwise omit.
+                                        ## NOTE: We can't just use the initial param content as found above, because it does not contain descriptions,
+                                        ## and we can't just use this "Parameters" section, because it does not (usually) contain things like `extra` and `timeout`.
+                                        ## METHODOLOGY: Find parent <p> tag around matching <strong>param_name</strong> tag which contains this data.
+                                        ##   Determining by <strong> tags allows matching parameters regardless whether they are
+                                        ##   presented in <p> tags (single param) or <li> tags (multiple params):
+                                        for strong_tag in tag.find_all('strong'):
+                                            ## We have to explicitly exclude extra and timeout from this loop also,
+                                            ## because Python Motion service includes them explicitly as well:
+                                            if param_name != 'extra' and \
+                                                param_name != 'timeout' and \
+                                                strong_tag.text == param_name:
 
-                                            ## OPTION: Get just the parameter description, stripping all newlines:
-                                            this_method_parameters_dict["param_description"] = regex.split(r" – ", strong_tag.parent.text)[1].replace("\n", " ")
+                                                ## OPTION: Get just the parameter description, stripping all newlines:
+                                                this_method_parameters_dict["param_description"] = regex.split(r" – ", strong_tag.parent.text)[1].replace("\n", " ")
 
-                                            ## OPTION: Get full parameter usage string, stripping all newlines:
-                                            ## NOTE: Currently unused.
-                                            this_method_parameters_dict['param_usage'] = strong_tag.parent.text.replace("\n", " ")
+                                                ## OPTION: Get full parameter usage string, stripping all newlines:
+                                                ## NOTE: Currently unused.
+                                                this_method_parameters_dict['param_usage'] = strong_tag.parent.text.replace("\n", " ")
 
-                                            ## Some params provide data type links in Parameters section only, not initial usage.
-                                            ## Get that here if so:
-                                            if strong_tag.parent.find('a', class_="reference internal"):
-                                                param_type_link_raw = strong_tag.parent.find('a', class_="reference internal").get("href")
-                                                ## Parameter type link is an anchor link:
-                                                if param_type_link_raw.startswith('#'):
-                                                    this_method_parameters_dict["param_type"] = '[' + param_name + '](' + url + param_type_link_raw + ')'
-                                                ## Parameter type link is a relative link, in one of two forms:
-                                                elif param_type_link_raw.startswith('../../../'):
-                                                    this_method_parameters_dict["param_type"] = '[' + param_name + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../../', '')+ ')'
-                                                elif param_type_link_raw.startswith('../../'):
-                                                    this_method_parameters_dict["param_type"] = '[' + param_name + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../', '')+ ')'
+                                                ## Some params provide data type links in Parameters section only, not initial usage.
+                                                ## Get that here if soL
+                                                if strong_tag.parent.find('a', class_="reference internal"):
+                                                    param_type_link_raw = strong_tag.parent.find('a', class_="reference internal").get("href")
+                                                    ## Parameter type link is an anchor link:
+                                                    if param_type_link_raw.startswith('#'):
+                                                        this_method_parameters_dict["param_type"] = '[' + param_name + '](' + url + param_type_link_raw + ')'
+                                                    ## Parameter type link is a relative link, in one of three forms:
+                                                    elif param_type_link_raw.startswith('../../../'):
+                                                        this_method_parameters_dict["param_type"] = '[' + param_name + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../../', '')+ ')'
+                                                    elif param_type_link_raw.startswith('../../'):
+                                                        this_method_parameters_dict["param_type"] = '[' + param_name + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../', '')+ ')'
+                                                    elif param_type_link_raw.startswith('../'):
+                                                        this_method_parameters_dict["param_type"] = '[' + param_name + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../', '')+ ')'
 
-                                        ## Unable to determine parameter description, neither timeout or extra, nor matching to any
-                                        ## param in initial method usage string. Usually this means a non-param (like error raised),
-                                        ## but if we are missing expected param descriptions, expand this section to catch them.
-                                        else:
-                                            ## No-op:
-                                            pass
-
-                                    #else:
-                                        ## Unable to find any links.
-                                        ## We will try again when looping params in the Parameters section.
-                                        ## Sometimes the param links are there instead. No-op here:
-                                        #pass
-                                    #    this_method_parameters_dict["param_type"] = "INSERT DATA TYPE LINK"
-                                    #    print('ERROR: ' + 'M: ' + method_name + '  LPT: ' + linked_param_type)
+                                            ## Unable to determine parameter description, neither timeout or extra, nor matching to any
+                                            ## param in initial method usage string. Usually this means a non-param (like error raised),
+                                            ## but if we are missing expected param descriptions, expand this section to catch them.
+                                            else:
+                                                ## No-op:
+                                                pass
 
                                 this_method_dict["parameters"][param_name] = this_method_parameters_dict
 
@@ -952,22 +896,29 @@ def parse(type, names):
                             return_type = return_tag.find('span', class_="sig-return-typehint").text
                             this_method_dict["return"]["return_type"] = return_type
 
-                            ## Determine if the return data type has a data type link. Include if so, otherwise omit:
-                            #if return_type in python_datatype_links.keys():
-                            #    this_method_dict["return"]["return_type_link"] = python_datatype_links[return_type]
-                            #else:
-                            #    ## No matching type link found in python_datatype_links[] array, omit link:
-                            #    pass
-
                             linked_return_type = ""
                             linked_return_type = link_data_types('python', return_type)
 
                             if linked_return_type != "":
                                 this_method_dict["return"]["return_type"] = linked_return_type
-                            else:
-                                ## Unable to find any links.
-                                #pass
-                                this_method_dict["return"]["return_type"] = "INSERT DATA TYPE LINK"
+                            elif return_tag.find('a', class_="reference internal"):
+
+                                return_type_link_raw = return_tag.find('a', class_="reference internal").get("href")
+
+                                ## Return type link is an anchor link:
+                                if return_type_link_raw.startswith('#'):
+                                    this_method_dict["return"]["return_type"] = '[' + return_type + '](' + url + param_type_link_raw + ')'
+                                ## Return type link is a relative link, in one of three forms:
+                                elif return_type_link_raw.startswith('../../../'):
+                                    this_method_dict["return"]["return_type"] = '[' + return_type + '](' + sdk_url + "/autoapi/viam/" + return_type_link_raw.replace('../../../', '')+ ')'
+                                elif return_type_link_raw.startswith('../../'):
+                                    this_method_dict["return"]["return_type"] = '[' + return_type + '](' + sdk_url + "/autoapi/viam/" + return_type_link_raw.replace('../../', '')+ ')'
+                                elif return_type_link_raw.startswith('../'):
+                                    this_method_dict["return"]["return_type"] = '[' + return_type + '](' + sdk_url + "/autoapi/viam/" + return_type_link_raw.replace('../', '')+ ')'
+
+                                else:
+                                    ## Unable to find any links.
+                                    pass
 
                             ## OPTION: Get full return usage, including type info and html links if present, stripping all newlines:
                             ## NOTE: Currently unused.

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -329,9 +329,13 @@ python_ignore_apis = [
     'viam.components.board.client.BoardClient.write_analog' # Currently borked: https://python.viam.dev/autoapi/viam/components/board/client/index.html#viam.components.board.client.BoardClient.write_analog
 ]
 
-## Use these URLs for data types that are not otherwise captured by parse().
-## Data type links defined here will be used instead of scraped links if found:
+## Use these URLs for data types that are not otherwise captured by parse(), such as:
+## - Well-known built-in data types that are not scrapable (like 'int')
+## - Viam-specific data types, even if scrapeable, that are part of a multiple-data-type return
+##   (like list_organization_members : Tuple[List[viam.proto.app.OrganizationMember], List[viam.proto.app.OrganizationInvite]]
+## Data type links defined here will be used instead of scraped links if both exist:
 python_datatype_links = {
+    ## Built-in data types:
     "str": "https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str",
     "int": "https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex",
     "float": "https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex",
@@ -339,7 +343,14 @@ python_datatype_links = {
     "bool": "https://docs.python.org/3/library/stdtypes.html#boolean-type-bool",
     "datetime": "https://docs.python.org/3/library/datetime.html",
     "datetime.datetime": "https://docs.python.org/3/library/datetime.html",
-    "datetime.timedelta": "https://docs.python.org/3/library/datetime.html#timedelta-objects"
+    "datetime.timedelta": "https://docs.python.org/3/library/datetime.html#timedelta-objects",
+    ## Viam-specific data types:
+    "viam.proto.app.OrganizationMember": "https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.OrganizationMember",
+    "viam.proto.app.OrganizationInvite": "https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.OrganizationInvite",
+    "viam.components.arm.KinematicsFileFormat.ValueType": "https://python.viam.dev/autoapi/viam/components/arm/index.html#viam.components.arm.KinematicsFileFormat",
+    "viam.media.video.NamedImage": "https://python.viam.dev/autoapi/viam/media/video/index.html#viam.media.video.NamedImage",
+    "viam.proto.common.ResponseMetadata": "https://python.viam.dev/autoapi/viam/gen/common/v1/common_pb2/index.html#viam.gen.common.v1.common_pb2.ResponseMetadata",
+    "viam.proto.component.encoder.PositionType.ValueType": "https://python.viam.dev/autoapi/viam/gen/component/encoder/v1/encoder_pb2/index.html#viam.gen.component.encoder.v1.encoder_pb2.PositionType"
 }
 
 ## Inject these URLs, relative to 'docs', into param/return/raises descriptions that contain exact matching key text.
@@ -903,6 +914,9 @@ def parse(type, names):
                                 this_method_dict["return"]["return_type"] = linked_return_type
                             elif return_tag.find('a', class_="reference internal"):
 
+                                ## TODO: Only grabbing the first link encountered, but a few methods return a tuple of two data linked data types.
+                                ## Handling those via link_data_types() with manual entries in python_datatype_links for now,
+                                ## But there's room for a more elegant solution:
                                 return_type_link_raw = return_tag.find('a', class_="reference internal").get("href")
 
                                 ## Return type link is an anchor link:

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -329,20 +329,56 @@ python_ignore_apis = [
     'viam.components.board.client.BoardClient.write_analog' # Currently borked: https://python.viam.dev/autoapi/viam/components/board/client/index.html#viam.components.board.client.BoardClient.write_analog
 ]
 
-## Use these URLs for data types that are built-in to the language:
+## Use these URLs for data types that are not otherwise captured by parse():
 python_datatype_links = {
+    ## Standard data types:
     "str": "https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str",
     "int": "https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex",
     "float": "https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex",
     "bytes": "https://docs.python.org/3/library/stdtypes.html#bytes-objects",
     "bool": "https://docs.python.org/3/library/stdtypes.html#boolean-type-bool",
-    "list": "https://docs.python.org/3/library/stdtypes.html#typesseq-list",
-    "tuple": "https://docs.python.org/3/library/stdtypes.html#tuples",
     "datetime": "https://docs.python.org/3/library/datetime.html",
     "datetime.datetime": "https://docs.python.org/3/library/datetime.html",
-    ## We could also choose to be explicit about Viam data types, like so:
-    "Control": "https://python.viam.dev/autoapi/viam/components/input/index.html#viam.components.input.Control",
-    "EventType": "https://python.viam.dev/autoapi/viam/components/input/index.html#viam.components.input.EventType"
+    "datetime.timedelta": "https://docs.python.org/3/library/datetime.html#timedelta-objects",
+
+    ## Viam data types:
+    "RobotPart": "https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.RobotPart",
+    "Fragment": "https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.Fragment",
+    "List[LogEntry]": "https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.LogEntry",
+    "viam.proto.app.Robot": "https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Robot",
+    "viam.proto.app.Module": "https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Module",
+    
+    "viam.proto.app.Location": "https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Location",
+    "viam.proto.app.LocationAuth": "https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.LocationAuth",
+    "viam.proto.app.Organization": "https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Organization",
+
+    "List[RobotPartHistoryEntry]": "https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.RobotPartHistoryEntry",
+    "List[viam.proto.app.Authorization]": "https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Authorization",
+    "List[viam.proto.app.APIKeyWithAuthorizations]": "https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.APIKeyWithAuthorizations",
+    "Literal[owner] | Literal[operator]": "https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str",
+    "Literal[organization] | Literal[location] | Literal[robot]": "https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str",
+    "List[viam.proto.app.AuthorizedPermissions]": "https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.AuthorizedPermissions",
+    "viam.components.arm.Pose": "https://python.viam.dev/autoapi/viam/components/arm/index.html#viam.components.arm.Pose",
+    #"viam.proto.component.arm.JointPositions": "https://python.viam.dev/autoapi/viam/proto/component/arm/index.html#viam.proto.component.arm.JointPositions",
+    "viam.components.arm.KinematicsFileFormat.ValueType": "https://python.viam.dev/autoapi/viam/components/arm/index.html#viam.components.arm.KinematicsFileFormat",
+    "viam.components.base.Vector3": "https://python.viam.dev/autoapi/viam/components/base/index.html#viam.components.base.Vector3",
+    "viam.components.board.board.Board.GPIOPin": "https://python.viam.dev/autoapi/viam/components/board/board/index.html#viam.components.board.board.Board.GPIOPin",
+    "viam.components.board.board.Board.Analog": "https://python.viam.dev/autoapi/viam/components/board/board/index.html#viam.components.board.board.Board.Analog",
+    "viam.components.board.board.Board.DigitalInterrupt": "https://python.viam.dev/autoapi/viam/components/board/board/index.html#viam.components.board.board.Board.DigitalInterrupt",
+    "viam.media.video.NamedImage": "https://python.viam.dev/autoapi/viam/media/video/index.html#viam.media.video.NamedImage",
+    "viam.proto.common.ResponseMetadata": "https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.ResponseMetadata",
+    "viam.components.camera.Camera.Properties": "https://python.viam.dev/autoapi/viam/components/audio_input/audio_input/index.html#viam.components.audio_input.audio_input.AudioInput.Properties",
+    "viam.proto.common.Geometry": "https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.Geometry",
+    "viam.proto.component.encoder.PositionType.ValueType": "https://python.viam.dev/autoapi/viam/gen/component/encoder/v1/encoder_pb2/index.html#viam.gen.component.encoder.v1.encoder_pb2.PositionType"
+    #"viam.components.input.input.Control": "https://python.viam.dev/autoapi/viam/components/input/input/index.html#viam.components.input.input.Control",
+    #"viam.components.input.input.EventType": "https://python.viam.dev/autoapi/viam/components/input/input/index.html#viam.components.input.input.EventType",
+    #"viam.components.input.input.Event": "https://python.viam.dev/autoapi/viam/components/input/input/index.html#viam.components.input.input.Event"
+
+
+    #"Tuple[List[viam.proto.app.OrganizationMember], List[viam.proto.app.OrganizationInvite]]"
+
+    #"Control": "https://python.viam.dev/autoapi/viam/components/input/index.html#viam.components.input.Control",
+    #"EventType": "https://python.viam.dev/autoapi/viam/components/input/index.html#viam.components.input.EventType"
 }
 
 ## Inject these URLs, relative to 'docs', into param/return/raises descriptions that contain exact matching key text.
@@ -445,6 +481,51 @@ def make_soup(url):
    except urllib.error.HTTPError as err:
        print(f'An HTTPError was thrown: {err.code} {err.reason} for URL: {url}')
 
+## Link any matching data types to their reference links, based on {sdk}_datatype_links[] array,
+## used in parse() for both param and return data types. Handles data types syntax that includes
+## multiple data types (and therefore requires multiple data type links), such as
+## ListOrganizationMembers: Tuple[List[viam.proto.app.OrganizationMember], List[viam.proto.app.OrganizationInvite]
+## DESIGN DECISION: Ignore well-known, usually leading (containing) data types like List, Tuple, Dict.
+## NOTE: Only used in PySDK parsing, for now:
+def link_data_types(sdk, data_type_string):
+
+    linked_data_type_string = ""
+
+    ## If the passed data_type_string matches exactly to a data type defined in python_datatype_links, use that:
+    if data_type_string in python_datatype_links.keys():
+       linked_data_type_string = '[' + data_type_string + '](' + python_datatype_links[data_type_string] + ')'
+    else:
+
+        ## Assemble all encountered data types that match to python_datatype_links keys into array.
+        ## This match is a little too greedy, and will match, say, 'int' to 'JointPositions'. To counter
+        ## this, we additionally check for leading and trailing alphanumeric characters further in:
+        matching_data_types = list(key for key in python_datatype_links if key in data_type_string)
+
+        if len(matching_data_types) > 0:
+
+            ## Ugly hack to allow us to append within the for loop below, sorry:
+            linked_data_type_string = data_type_string
+
+            for data_type_found in matching_data_types:
+
+                ## Build two regexes to handle leading and trailing alphanumeric matches
+                ## (which indicate that a match to a data type is in fact a string match to
+                ## a different data type that _contains_ this data type string!)
+                data_type_regex1 = "r'[A-Za-z0-9]" + data_type_found + "'"
+                data_type_regex2 = "r'" + data_type_found + "[A-Za-z0-9]'"
+
+                ## Discard string matches that are substrings of other data type strings:
+                if not regex.search(data_type_regex1, data_type_string) and not regex.search(data_type_regex2, data_type_string):
+ 
+                    data_type_linked = '[' + data_type_found + '](' + python_datatype_links[data_type_found] + ')'
+                    linked_data_type_string = regex.sub(data_type_found, data_type_linked, linked_data_type_string)
+                else:
+                    ## Not entirely sure I'm fully omitting bad matches here, but it seems to be working?
+                    #print('SKIPPING: ' + data_type_found + ' for ' + data_type_string)
+                    pass
+
+    return linked_data_type_string
+
 ## Link matching text, used in write_markdown():
 ## NOTE: Currently does not support formatting for link titles
 ## (EXAMPLE: bolded DATA tab here: https://docs.viam.com/build/program/apis/data-client/#binarydatabyfilter)
@@ -461,7 +542,7 @@ def link_description(format_type, full_description, link_text, link_url):
 
     return linked_description
 
-## Fetch sdk documentations for each language in sdks array, by language, by type, by resource, by method.
+## Fetch SDK documentation for each language in sdks array, by language, by type, by resource, by method.
 def parse(type, names):
 
 ## TODO:
@@ -739,32 +820,29 @@ def parse(type, names):
                                 ## Determine parameter type:
                                 param_type = parameter_tag.find_all('span', class_='n')[1].text
 
-                                this_method_parameters_dict["param_type"] = param_type
+                                if method_name == 'move_to_joint_positions':
+                                    print('PARAM: ' + param_name + '    TYPE: ' + param_type)
+
+                                #this_method_parameters_dict["param_type"] = param_type
 
                                 ## Determine if this parameter is optional, and strip off ' | None' syntax if so:
                                 if param_type.endswith(' | None'):
                                     this_method_parameters_dict["optional"] = True
-                                    this_method_parameters_dict["param_type"] = param_type.replace(' | None', "")
+                                    param_type = param_type.replace(' | None', "")
+                                    #this_method_parameters_dict["param_type"] = param_type
                                 else:
                                     this_method_parameters_dict["optional"] = False
 
-                                ## Determine if this parameter has a parameter type link. Include if so, otherwise omit:
-                                if param_type in python_datatype_links.keys():
-                                    this_method_parameters_dict["param_type_link"] = python_datatype_links[param_type]
-                                elif parameter_tag.find('a', class_="reference internal"):
-                                    param_type_link_raw = parameter_tag.find('a', class_="reference internal").get("href")
-                                    ## Parameter type link is an anchor link:
-                                    if param_type_link_raw.startswith('#'):
-                                        this_method_parameters_dict["param_type_link"] = url + param_type_link_raw
-                                    ## Parameter type link is a relative link:
-                                    elif param_type_link_raw.startswith('../../'):
-                                        this_method_parameters_dict["param_type_link"] = sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../', '')
+                                if method_name == 'move_to_joint_positions':
+                                    print('PARAM: ' + param_name + '    TYPE2: ' + param_type)
 
-                                else:
-                                    ## Unable to find any links.
-                                    ## We will try again when looping params in the Parameters section.
-                                    ## Sometimes the param links are there instead. No-op here:
-                                    pass
+                                ## Determine if this parameter data type has a data type link. Include if so, otherwise omit:
+                                #if param_type in python_datatype_links.keys():
+                                #    this_method_parameters_dict["param_type_link"] = python_datatype_links[param_type]
+
+                                #matching_data_types2 = list(key for key in python_datatype_links if key in param_type)
+                                #if len(matching_data_types2) > 0:
+                                #    print('METHOD: ' + method_name + '    PARAM NAME: ' + param_name + '         PARAM TYPE: ' + param_type + ' RESULT MAYBE: ' + str(matching_data_types2))
 
                                 ## 'Extra' params do not appear in "Parameters" section (Except for PySDK > Motion Service),
                                 ## so we must populate this param's content manually:
@@ -772,7 +850,7 @@ def parse(type, names):
 
                                     this_method_parameters_dict["param_description"] = "Extra options to pass to the underlying RPC call."
                                     this_method_parameters_dict["param_usage"] = "extra (Mapping[str, Any]) - Extra options to pass to the underlying RPC call."
-                                    this_method_parameters_dict["param_type"] = "Mapping[str, Any]"
+                                    this_method_parameters_dict["param_type"] = "Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]"
 
                                 ## 'Timeout' params do not appear in "Parameters" section (Except for PySDK > Motion Service),
                                 ## so we must populate this param's content manually:
@@ -780,7 +858,7 @@ def parse(type, names):
 
                                     this_method_parameters_dict["param_description"] = "An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call."
                                     this_method_parameters_dict["param_usage"] = "timeout (float) - An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call."
-                                    this_method_parameters_dict["param_type"] = "float"
+                                    this_method_parameters_dict["param_type"] = "[float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)"
 
                                 ## Initial method usage syntax and Parameters section do not agree on param_type for do_command.
                                 ## Manually override with correct values, for param 'command' only:
@@ -788,9 +866,34 @@ def parse(type, names):
 
                                     this_method_parameters_dict["param_description"] = "The command to execute"
                                     this_method_parameters_dict["param_usage"] = "command (Mapping[str, ValueTypes]) – The command to execute"
-                                    this_method_parameters_dict["param_type"] = "Mapping[str, ValueTypes]"
+                                    this_method_parameters_dict["param_type"] = "Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), ValueTypes]"
 
                                 else:
+                                    linked_param_type = ""
+                                    linked_param_type = link_data_types('python', param_type)
+
+                                    if method_name == 'move_to_joint_positions':
+                                        print('PARAM: ' + param_name + '    LINKED PARAM TYPE: ' + linked_param_type)
+
+                                    if linked_param_type != "":
+                                        this_method_parameters_dict["param_type"] = linked_param_type
+                                    elif parameter_tag.find('a', class_="reference internal"):
+                                        param_type_link_raw = parameter_tag.find('a', class_="reference internal").get("href")
+
+
+                                        ## WE ARE SOMEHOW NOT GETTING HERE, DESPITE DEFINITELY HAVING A LINK UPSTREAM:
+                                        if method_name == 'move_to_joint_positions':
+                                            print('PARAM: ' + param_name + '    TYPE LINK RAW: ' + param_type_link_raw)
+
+                                        ## Parameter type link is an anchor link:
+                                        if param_type_link_raw.startswith('#'):
+                                            this_method_parameters_dict["param_type"] = '[' + param_name + '](' + url + param_type_link_raw + ')'
+                                        ## Parameter type link is a relative link, in one of two forms:
+                                        elif param_type_link_raw.startswith('../../../'):
+                                            this_method_parameters_dict["param_type"] = '[' + param_name + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../../', '')+ ')'
+                                        elif param_type_link_raw.startswith('../../'):
+                                            this_method_parameters_dict["param_type"] = '[' + param_name + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../', '')+ ')'
+
                                     ## Get parameter usage and description, if method contains a "Parameters" section. Otherwise omit.
                                     ## NOTE: We can't just use the initial param content as found above, because it does not contain descriptions,
                                     ## and we can't just use this "Parameters" section, because it does not (usually) contain things like `extra` and `timeout`.
@@ -808,19 +911,21 @@ def parse(type, names):
                                             this_method_parameters_dict["param_description"] = regex.split(r" – ", strong_tag.parent.text)[1].replace("\n", " ")
 
                                             ## OPTION: Get full parameter usage string, stripping all newlines:
+                                            ## NOTE: Currently unused.
                                             this_method_parameters_dict['param_usage'] = strong_tag.parent.text.replace("\n", " ")
 
                                             ## Some params provide data type links in Parameters section only, not initial usage.
                                             ## Get that here if so:
-                                            ## TODO: Only finding the first link, a few have more than one.
                                             if strong_tag.parent.find('a', class_="reference internal"):
                                                 param_type_link_raw = strong_tag.parent.find('a', class_="reference internal").get("href")
                                                 ## Parameter type link is an anchor link:
                                                 if param_type_link_raw.startswith('#'):
-                                                    this_method_parameters_dict["param_type_link"] = url + param_type_link_raw
-                                                ## Parameter type link is a relative link:
+                                                    this_method_parameters_dict["param_type"] = '[' + param_name + '](' + url + param_type_link_raw + ')'
+                                                ## Parameter type link is a relative link, in one of two forms:
+                                                elif param_type_link_raw.startswith('../../../'):
+                                                    this_method_parameters_dict["param_type"] = '[' + param_name + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../../', '')+ ')'
                                                 elif param_type_link_raw.startswith('../../'):
-                                                    this_method_parameters_dict["param_type_link"] = sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../', '')
+                                                    this_method_parameters_dict["param_type"] = '[' + param_name + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../', '')+ ')'
 
                                         ## Unable to determine parameter description, neither timeout or extra, nor matching to any
                                         ## param in initial method usage string. Usually this means a non-param (like error raised),
@@ -828,6 +933,14 @@ def parse(type, names):
                                         else:
                                             ## No-op:
                                             pass
+
+                                    #else:
+                                        ## Unable to find any links.
+                                        ## We will try again when looping params in the Parameters section.
+                                        ## Sometimes the param links are there instead. No-op here:
+                                        #pass
+                                    #    this_method_parameters_dict["param_type"] = "INSERT DATA TYPE LINK"
+                                    #    print('ERROR: ' + 'M: ' + method_name + '  LPT: ' + linked_param_type)
 
                                 this_method_dict["parameters"][param_name] = this_method_parameters_dict
 
@@ -843,9 +956,28 @@ def parse(type, names):
                             this_method_dict["return"] = {}
 
                             ## OPTION: Get return_type by explicit key name:
-                            this_method_dict["return"]["return_type"] = return_tag.find('span', class_="sig-return-typehint").text
+                            return_type = return_tag.find('span', class_="sig-return-typehint").text
+                            this_method_dict["return"]["return_type"] = return_type
+
+                            ## Determine if the return data type has a data type link. Include if so, otherwise omit:
+                            #if return_type in python_datatype_links.keys():
+                            #    this_method_dict["return"]["return_type_link"] = python_datatype_links[return_type]
+                            #else:
+                            #    ## No matching type link found in python_datatype_links[] array, omit link:
+                            #    pass
+
+                            linked_return_type = ""
+                            linked_return_type = link_data_types('python', return_type)
+
+                            if linked_return_type != "":
+                                this_method_dict["return"]["return_type"] = linked_return_type
+                            else:
+                                ## Unable to find any links.
+                                #pass
+                                this_method_dict["return"]["return_type"] = "INSERT DATA TYPE LINK"
 
                             ## OPTION: Get full return usage, including type info and html links if present, stripping all newlines:
+                            ## NOTE: Currently unused.
                             this_method_dict["return"]["return_usage"] = str(return_tag.find('span', class_="sig-return-typehint")).replace("\n", " ")
 
                             ## Get return description from "Returns" section if present:
@@ -884,6 +1016,7 @@ def parse(type, names):
 
                                     ## OPTION: Get full error raised usage, including type info and html links if present.
                                     ## NOTE: Errors raised (py) don't seem to have any links, just some monospace formatting:
+                                    ## NOTE: Currently unused.
                                     this_method_raises_dict["raises_usage"] = str(strong_tag.parent).replace("\n", " ")
 
                                     ## OPTION: Determine error raised description, stripping any newlines:
@@ -1048,13 +1181,17 @@ def parse_method_usage(usage_string):
     parsed_usage_string = []
 
     for param in parameters:
-        # HACKY: Hardcoding extra and error bc they are all the same and parsing from usage string
+        # HACKY: Hardcoding ctx, extra, and error bc they are all the same and parsing from usage string
         # has proven difficult
 
         # Splitting each parameter by space to separate parameter name and type
         parts = param.split()
 
-        if 'extra' in param:
+        if 'ctx' in param:
+            type_name = "ctx"
+            param_type = "Context"
+            param_type_link = "https://pkg.go.dev/context#Context"
+        elif 'extra' in param:
             type_name = "extra"
             param_type = "map[string]interface\{\}"
             param_type_link = "https://go.dev/blog/maps"
@@ -1084,7 +1221,10 @@ def format_method_usage(parsed_usage_string):
 
         return_string = ""
 
-        if type_name == "extra":
+        if type_name == "ctx":
+            return_string += f"- `{type_name}` [({param_type})]({param_type_link}): A Context carries a deadline, a cancellation signal, and other values across API boundaries."
+            formatted_output.append(return_string)
+        elif type_name == "extra":
             return_string += f"- `{type_name}` [({param_type})]({param_type_link}): Extra options to pass to the underlying RPC call."
             formatted_output.append(return_string)
         elif param_type == "error":
@@ -1255,30 +1395,30 @@ def write_markdown(type, names, methods):
                                     param_data = methods['python'][type][resource][py_method_name]['parameters'][parameter]
 
                                     param_type = param_data.get("param_type")
-                                    param_subtype = param_data.get("param_subtype")
-                                    param_type_link = param_data.get("param_type_link")
-                                    param_subtype_link = param_data.get("param_subtype_link")
+                                    #param_subtype = param_data.get("param_subtype")
+                                    #param_type_link = param_data.get("param_type_link")
+                                    #param_subtype_link = param_data.get("param_subtype_link")
                                     param_description = param_data.get("param_description")
                                     optional = param_data.get("optional")
 
-                                    output_file.write(f'- `{parameter}` [({param_type})]')
+                                    output_file.write(f'- `{parameter}` ({param_type})')
 
                                     # Ideally we could update at least Python SDK with type links?
-                                    if param_type_link:
-                                        # Check for subtype
-                                        if param_subtype:
-                                            output_file.write(f"({param_type_link})")
-                                            if param_subtype_link:
-                                                output_file.write(f"<[{param_subtype}]")
-                                                output_file.write(f"({param_subtype_link})>")
-                                            else:
-                                                output_file.write(f"<{param_subtype}>")
-                                        else:
-                                            output_file.write(f"({param_type_link})")
+                                    #if param_type_link:
+                                    #    # Check for subtype
+                                    #    if param_subtype:
+                                    #        output_file.write(f"({param_type_link})")
+                                    #        if param_subtype_link:
+                                    #            output_file.write(f"<[{param_subtype}]")
+                                    #            output_file.write(f"({param_subtype_link})>")
+                                    #        else:
+                                    #            output_file.write(f"<{param_subtype}>")
+                                    #    else:
+                                    #        output_file.write(f"({param_type_link})")
                                     # SG: Haven't found any sub-types without param type links-- they are all in flutter SDK--
                                     # could expand this logic if popped up or grabbing more subtypes?
-                                    else:
-                                        output_file.write('(<INSERT PARAM TYPE LINK>)')
+                                    #else:
+                                    #    output_file.write('(<INSERT PARAM TYPE LINK>)')
 
                                     if optional:
                                         output_file.write(' (optional)')
@@ -1303,28 +1443,28 @@ def write_markdown(type, names, methods):
 
                                 return_data = methods['python'][type][resource][py_method_name]["return"]
                                 return_type = return_data.get("return_type")
-                                return_subtype = return_data.get("return_subtype")
-                                return_type_link = return_data.get("return_type_link")
-                                return_link = return_data.get("return_type_link") # TODO: handle this
-                                return_subtype_link = return_data.get("return_subtype_link")
+                                #return_subtype = return_data.get("return_subtype")
+                                #return_type_link = return_data.get("return_type_link")
+                                #return_link = return_data.get("return_type_link") # TODO: handle this
+                                #return_subtype_link = return_data.get("return_subtype_link")
                                 return_description = return_data.get("return_description")
 
                                 if return_type:
-                                    output_file.write(f"- [({return_type})]")
+                                    output_file.write(f"- ({return_type})")
 
-                                    if return_type_link:
-                                        output_file.write(f"({return_type_link})")
-                                    else:
-                                        output_file.write("(INSERT RETURN TYPE LINK)")
+                                    #if return_type_link:
+                                    #    output_file.write(f"({return_type_link})")
+                                    #else:
+                                    #    output_file.write("(INSERT RETURN TYPE LINK)")
 
-                                    if return_subtype:
-                                        output_file.write(f"<[{return_subtype}]")
-                                        if return_subtype_link:
-                                            output_file.write(f"({return_subtype_link})>")
-                                        else:
-                                            output_file.write("(<INSERT RETURN SUBTYPE LINK>)")
-                                    else:
-                                        pass
+                                    #if return_subtype:
+                                    #    output_file.write(f"<[{return_subtype}]")
+                                    #    if return_subtype_link:
+                                    #        output_file.write(f"({return_subtype_link})>")
+                                    #    else:
+                                    #        output_file.write("(<INSERT RETURN SUBTYPE LINK>)")
+                                    #else:
+                                    #    pass
 
                                     if return_description:
                                         output_file.write(f": {return_description}\n")

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -508,20 +508,13 @@ def link_data_types(sdk, data_type_string):
 
             for data_type_found in matching_data_types:
 
-                ## Build two regexes to handle leading and trailing alphanumeric matches
-                ## (which indicate that a match to a data type is in fact a string match to
-                ## a different data type that _contains_ this data type string!)
-                data_type_regex1 = "r'[A-Za-z0-9]" + data_type_found + "'"
-                data_type_regex2 = "r'" + data_type_found + "[A-Za-z0-9]'"
-
                 ## Discard string matches that are substrings of other data type strings:
-                if not regex.search(data_type_regex1, data_type_string) and not regex.search(data_type_regex2, data_type_string):
- 
+                if not regex.search('[A-Za-z0-9]' + data_type_found, data_type_string) and not regex.search(data_type_found + '[A-Za-z0-9]', data_type_string):
+
                     data_type_linked = '[' + data_type_found + '](' + python_datatype_links[data_type_found] + ')'
                     linked_data_type_string = regex.sub(data_type_found, data_type_linked, linked_data_type_string)
                 else:
-                    ## Not entirely sure I'm fully omitting bad matches here, but it seems to be working?
-                    #print('SKIPPING: ' + data_type_found + ' for ' + data_type_string)
+                    ## If we get here, this data_type is actually a substring of another data type. Take no action:
                     pass
 
     return linked_data_type_string

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -839,14 +839,14 @@ def parse(type, names):
 
                                         ## Parameter type link is an anchor link:
                                         if param_type_link_raw.startswith('#'):
-                                            this_method_parameters_dict["param_type"] = '[' + param_name + '](' + url + param_type_link_raw + ')'
+                                            this_method_parameters_dict["param_type"] = '[' + param_type + '](' + url + param_type_link_raw + ')'
                                         ## Parameter type link is a relative link, in one of three forms:
                                         elif param_type_link_raw.startswith('../../../'):
-                                            this_method_parameters_dict["param_type"] = '[' + param_name + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../../', '')+ ')'
+                                            this_method_parameters_dict["param_type"] = '[' + param_type + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../../', '')+ ')'
                                         elif param_type_link_raw.startswith('../../'):
-                                            this_method_parameters_dict["param_type"] = '[' + param_name + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../', '')+ ')'
+                                            this_method_parameters_dict["param_type"] = '[' + param_type + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../', '')+ ')'
                                         elif param_type_link_raw.startswith('../'):
-                                            this_method_parameters_dict["param_type"] = '[' + param_name + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../', '')+ ')'
+                                            this_method_parameters_dict["param_type"] = '[' + param_type + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../', '')+ ')'
 
                                         ## Get parameter usage and description, if method contains a "Parameters" section. Otherwise omit.
                                         ## NOTE: We can't just use the initial param content as found above, because it does not contain descriptions,
@@ -874,14 +874,14 @@ def parse(type, names):
                                                     param_type_link_raw = strong_tag.parent.find('a', class_="reference internal").get("href")
                                                     ## Parameter type link is an anchor link:
                                                     if param_type_link_raw.startswith('#'):
-                                                        this_method_parameters_dict["param_type"] = '[' + param_name + '](' + url + param_type_link_raw + ')'
+                                                        this_method_parameters_dict["param_type"] = '[' + param_type + '](' + url + param_type_link_raw + ')'
                                                     ## Parameter type link is a relative link, in one of three forms:
                                                     elif param_type_link_raw.startswith('../../../'):
-                                                        this_method_parameters_dict["param_type"] = '[' + param_name + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../../', '')+ ')'
+                                                        this_method_parameters_dict["param_type"] = '[' + param_type + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../../', '')+ ')'
                                                     elif param_type_link_raw.startswith('../../'):
-                                                        this_method_parameters_dict["param_type"] = '[' + param_name + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../', '')+ ')'
+                                                        this_method_parameters_dict["param_type"] = '[' + param_type + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../', '')+ ')'
                                                     elif param_type_link_raw.startswith('../'):
-                                                        this_method_parameters_dict["param_type"] = '[' + param_name + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../', '')+ ')'
+                                                        this_method_parameters_dict["param_type"] = '[' + param_type + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../', '')+ ')'
 
                                             ## Unable to determine parameter description, neither timeout or extra, nor matching to any
                                             ## param in initial method usage string. Usually this means a non-param (like error raised),

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -848,40 +848,40 @@ def parse(type, names):
                                         elif param_type_link_raw.startswith('../'):
                                             this_method_parameters_dict["param_type"] = '[' + param_type + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../', '')+ ')'
 
-                                        ## Get parameter usage and description, if method contains a "Parameters" section. Otherwise omit.
-                                        ## NOTE: We can't just use the initial param content as found above, because it does not contain descriptions,
-                                        ## and we can't just use this "Parameters" section, because it does not (usually) contain things like `extra` and `timeout`.
-                                        ## METHODOLOGY: Find parent <p> tag around matching <strong>param_name</strong> tag which contains this data.
-                                        ##   Determining by <strong> tags allows matching parameters regardless whether they are
-                                        ##   presented in <p> tags (single param) or <li> tags (multiple params):
-                                        for strong_tag in tag.find_all('strong'):
-                                            ## We have to explicitly exclude extra and timeout from this loop also,
-                                            ## because Python Motion service includes them explicitly as well:
-                                            if param_name != 'extra' and \
-                                                param_name != 'timeout' and \
-                                                strong_tag.text == param_name:
+                                    ## Get parameter usage and description, if method contains a "Parameters" section. Otherwise omit.
+                                    ## NOTE: We can't just use the initial param content as found above, because it does not contain descriptions,
+                                    ## and we can't just use this "Parameters" section, because it does not (usually) contain things like `extra` and `timeout`.
+                                    ## METHODOLOGY: Find parent <p> tag around matching <strong>param_name</strong> tag which contains this data.
+                                    ##   Determining by <strong> tags allows matching parameters regardless whether they are
+                                    ##   presented in <p> tags (single param) or <li> tags (multiple params):
+                                    for strong_tag in tag.find_all('strong'):
+                                        ## We have to explicitly exclude extra and timeout from this loop also,
+                                        ## because Python Motion service includes them explicitly as well:
+                                        if param_name != 'extra' and \
+                                            param_name != 'timeout' and \
+                                            strong_tag.text == param_name:
 
-                                                ## OPTION: Get just the parameter description, stripping all newlines:
-                                                this_method_parameters_dict["param_description"] = regex.split(r" – ", strong_tag.parent.text)[1].replace("\n", " ")
+                                            ## OPTION: Get just the parameter description, stripping all newlines:
+                                            this_method_parameters_dict["param_description"] = regex.split(r" – ", strong_tag.parent.text)[1].replace("\n", " ")
 
-                                                ## OPTION: Get full parameter usage string, stripping all newlines:
-                                                ## NOTE: Currently unused.
-                                                this_method_parameters_dict['param_usage'] = strong_tag.parent.text.replace("\n", " ")
+                                            ## OPTION: Get full parameter usage string, stripping all newlines:
+                                            ## NOTE: Currently unused.
+                                            this_method_parameters_dict['param_usage'] = strong_tag.parent.text.replace("\n", " ")
 
-                                                ## Some params provide data type links in Parameters section only, not initial usage.
-                                                ## Get that here if soL
-                                                if strong_tag.parent.find('a', class_="reference internal"):
-                                                    param_type_link_raw = strong_tag.parent.find('a', class_="reference internal").get("href")
-                                                    ## Parameter type link is an anchor link:
-                                                    if param_type_link_raw.startswith('#'):
-                                                        this_method_parameters_dict["param_type"] = '[' + param_type + '](' + url + param_type_link_raw + ')'
-                                                    ## Parameter type link is a relative link, in one of three forms:
-                                                    elif param_type_link_raw.startswith('../../../'):
-                                                        this_method_parameters_dict["param_type"] = '[' + param_type + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../../', '')+ ')'
-                                                    elif param_type_link_raw.startswith('../../'):
-                                                        this_method_parameters_dict["param_type"] = '[' + param_type + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../', '')+ ')'
-                                                    elif param_type_link_raw.startswith('../'):
-                                                        this_method_parameters_dict["param_type"] = '[' + param_type + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../', '')+ ')'
+                                            ## Some params provide data type links in Parameters section only, not initial usage.
+                                            ## Get that here if soL
+                                            if strong_tag.parent.find('a', class_="reference internal"):
+                                                param_type_link_raw = strong_tag.parent.find('a', class_="reference internal").get("href")
+                                                ## Parameter type link is an anchor link:
+                                                if param_type_link_raw.startswith('#'):
+                                                    this_method_parameters_dict["param_type"] = '[' + param_type + '](' + url + param_type_link_raw + ')'
+                                                ## Parameter type link is a relative link, in one of three forms:
+                                                elif param_type_link_raw.startswith('../../../'):
+                                                    this_method_parameters_dict["param_type"] = '[' + param_type + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../../', '')+ ')'
+                                                elif param_type_link_raw.startswith('../../'):
+                                                    this_method_parameters_dict["param_type"] = '[' + param_type + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../../', '')+ ')'
+                                                elif param_type_link_raw.startswith('../'):
+                                                    this_method_parameters_dict["param_type"] = '[' + param_type + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../', '')+ ')'
 
                                             ## Unable to determine parameter description, neither timeout or extra, nor matching to any
                                             ## param in initial method usage string. Usually this means a non-param (like error raised),
@@ -914,7 +914,7 @@ def parse(type, names):
                                 this_method_dict["return"]["return_type"] = linked_return_type
                             elif return_tag.find('a', class_="reference internal"):
 
-                                ## TODO: Only grabbing the first link encountered, but a few methods return a tuple of two data linked data types.
+                                ## TODO: Only grabbing the first link encountered, but a few methods return a tuple of two linked data types.
                                 ## Handling those via link_data_types() with manual entries in python_datatype_links for now,
                                 ## But there's room for a more elegant solution:
                                 return_type_link_raw = return_tag.find('a', class_="reference internal").get("href")

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -1387,6 +1387,8 @@ def write_markdown(type, names, methods):
 
                                     if param_description:
                                         output_file.write(f" {param_description}")
+                                    else:
+                                        output_file.write(": <INSERT PARAM DESCRIPTION>\n")
 
                                     # line break for parameters list
                                     output_file.write('\n')

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -341,7 +341,6 @@ python_datatype_links = {
     "float": "https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex",
     "bytes": "https://docs.python.org/3/library/stdtypes.html#bytes-objects",
     "bool": "https://docs.python.org/3/library/stdtypes.html#boolean-type-bool",
-    "datetime": "https://docs.python.org/3/library/datetime.html",
     "datetime.datetime": "https://docs.python.org/3/library/datetime.html",
     "datetime.timedelta": "https://docs.python.org/3/library/datetime.html#timedelta-objects",
     ## Viam-specific data types:
@@ -875,7 +874,7 @@ def parse(type, names):
                                                 ## Parameter type link is an anchor link:
                                                 if param_type_link_raw.startswith('#'):
                                                     this_method_parameters_dict["param_type"] = '[' + param_type + '](' + url + param_type_link_raw + ')'
-                                                ## Parameter type link is a relative link, starting 1 - 3 instances of '../'
+                                                ## Parameter type link is a relative link, beginning with 1 - 3 instances of '../'
                                                 ## Convert to an absolute link:
                                                 elif param_type_link_raw.startswith('../'):
                                                     this_method_parameters_dict["param_type"] = '[' + param_type + '](' + sdk_url + "/autoapi/viam/" + param_type_link_raw.replace('../', '')+ ')'
@@ -919,14 +918,10 @@ def parse(type, names):
                                 ## Return type link is an anchor link:
                                 if return_type_link_raw.startswith('#'):
                                     this_method_dict["return"]["return_type"] = '[' + return_type + '](' + url + return_type_link_raw + ')'
-                                ## Return type link is a relative link, starting 1 - 3 instances of '../'
+                                ## Return type link is a relative link, beginning with 1 - 3 instances of '../'
                                 ## Convert to an absolute link:
                                 elif return_type_link_raw.startswith('../'):
                                     this_method_dict["return"]["return_type"] = '[' + return_type + '](' + sdk_url + "/autoapi/viam/" + return_type_link_raw.replace('../', '')+ ')'
-
-                                else:
-                                    ## Unable to find any links.
-                                    pass
 
                             ## OPTION: Get full return usage, including type info and html links if present, stripping all newlines:
                             ## NOTE: Currently unused.


### PR DESCRIPTION
Improve determination of upstream data type links.
- Should fix all remaining Python SDK data type issues.
- Adds Go SDK data type link and description for `ctx`

To support the above: 
- Reduce reliance on manually populating `python_datatype_links` array, by improving scrape logic.
	- Now much more reliably getting the upstream data type links, no matter where they are defined.
	- Exception: returns with multiple return data types, where at least one is a Viam data type still require manual override via `python_datatype_links` array.
- Add new `link_data_types()` function to help with linking built-in data types, and any override links from `python_datatype_links` array.
	- I think there is still an edge cases where we might match a built-in data type to a multiple data-type return and stop looking through the return for other data types. Haven't tripped it in my testing (I think?) but a future method might.

Change to `write_markdown()`:
- No longer tracking and writing param data type and param data type link separately: Now `parse()` returns a unified `data_type` field that already includes the link(s) (for Python SDK, no changes to Go or Flutter).
- Commenting out some subtype logic for PySDK that are only necessary for Flutter. Leaving in as-commented for now though in case we want to unify code across all three, etc.

Not covered in this PR:
- Go data types other than `ctx`
- Go descriptions
- Flutter anything.
