### PR TITLE
DOCS-2301: Add Go code sample scraping

### DIFF
--- a/.github/workflows/sdk_protos_map.csv
+++ b/.github/workflows/sdk_protos_map.csv
@@ -38,7 +38,7 @@ board,PWMFrequency,get_pwm_frequency,PWMFreq,pWMFrequency
 board,SetPWMFrequency,set_pwm_frequency,SetPWMFreq,setPWMFrequency
 board,ReadAnalogReader,analog_by_name,AnalogByName,readAnalogReader
 ## HACK: Omitting PySDK: write_analog, currently borked: https://python.viam.dev/autoapi/viam/components/board/client/index.html#viam.components.board.client.BoardClient.write_analog
-board,WriteAnalog,,WriteAnalog,writeAnalog
+board,WriteAnalog,,Write,writeAnalog
 board,GetDigitalInterruptValue,digital_interrupt_by_name,DigitalInterruptByName,,
 board,StreamTicks,,StreamTicks,streamTicks
 board,SetPowerMode,set_power_mode,SetPowerMode,setPowerMode

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -696,12 +696,12 @@ def parse(type, names):
                                 ## Not possible to link to the specific functions, so we link to the parent resource instead:
                                 this_method_dict["method_link"] = url + '#' + interface_name
 
-
+                                ## Check for code sample for this method.
+                                ## If we detected that a local instance of the Go SDK docs is available, use that.
+                                ## Otherwise, use the existing scraped 'soup' object from the live Go SDK docs instead.
                                 if is_go_sdk_staging_available:
 
                                     staging_url = regex.sub('https://pkg.go.dev', 'http://localhost:8080', url)
-
-                                    #staging_url = 'https://pkg.go.dev', 'http://localhost:8080'
                                     staging_soup = make_soup(staging_url)
 
                                     ## Get a raw dump of all go methods by interface for each resource:


### PR DESCRIPTION
Add Go code sample scraping to `update_sdk_methods.py`:
- Scrape code samples from the live Go SDK documentation by default, or
- Scrape code samples from a locally-staged Go SDK docs site if detected.
	- All other data objects are still populated from live site, even if staging link is found. This is only for code samples. Can be changed if desired.
	- Script now checks to see which port `pkgsite` is using locally, and uses that (`8080` by default): thanks for the report, Sky!
- Sierra already handled the code needed for `write_markdown()` to display scraped Go code samples (🎉 ), so this PR just needed to update `parse()`
- Replaces tab characters with double-whitespace for scraped `usage` content as well, noticed while handling tab characters in code samples (which must be converted).
- Also update SDK mapping for recent Go > board > `Write` method rename (from `WriteAnalog`)