### PR TITLE
DOCS-2279: Add connection URI reference

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -336,7 +336,7 @@ done
 | ----------- | ----------- | ----------- |
 | `export`      | export data in a specified format to a specified location  | - |
 | `database configure`      | create a new database user for the Viam organization's MongoDB Atlas Data Federation instance, or change the password of an existing user. See [Configure data query](/data/query/#configure-data-query)  | - |
-| `database hostname`      | get the MongoDB Atlas Data Federation instance hostname and database name. See [Configure data query](/data/query/#configure-data-query)  | - |
+| `database hostname`      | get the MongoDB Atlas Data Federation instance hostname and connection URI. See [Configure data query](/data/query/#configure-data-query)  | - |
 | `dataset add`      | add a new image to an existing dataset by its file id, or add a group of images by specifying a filter | `filter` |
 | `dataset remove`      | remove an existing image from a dataset by its file id, or remove a group of images by specifying a filter | `filter` |
 | `delete binary`      | delete binary data  | - |

--- a/docs/data/query.md
+++ b/docs/data/query.md
@@ -121,7 +121,7 @@ You do not need to perform any additional configuration when [querying data in t
 
    This command returns the hostname (including database name) and connection URI to use to connect to your data store on the Viam organization's MongoDB Atlas instance.
    The connection URI includes everything you need to connect to your organization's MongoDB Atlas Data Federation instance from a valid MQL-compatible client, except for your configured database password.
-   Replace the placeholder text `YOUR-PASSWORD-HERE` in the connection URI with your configured database password, as returned from the `viam data database configure` command.
+   Replace the placeholder text `YOUR-PASSWORD-HERE` in the connection URI with your configured database password, as set by the `viam data database configure` command.
    You will need this to query your data in the next section.
 
 For more information, see the documentation for the [Viam CLI `database` command](/cli/#data).

--- a/docs/data/query.md
+++ b/docs/data/query.md
@@ -110,7 +110,8 @@ You do not need to perform any additional configuration when [querying data in t
    viam data database configure --org-id=<YOUR-ORGANIZATION-ID> --password=<NEW-DBUSER-PASSWORD>
    ```
 
-   This command configures a new database user for your org for use with data query.
+   This command configures a new database user for your org for use with data query, and sets the password.
+   If you have already run this command before, this command instead updates the password to the new value you set.
 
 1. Determine the connection URI for your organization's MongoDB Atlas Data Federation instance by running the following command with the organization's `org-id` from step 2:
 
@@ -119,8 +120,8 @@ You do not need to perform any additional configuration when [querying data in t
    ```
 
    This command returns the hostname (including database name) and connection URI to use to connect to your data store on the Viam organization's MongoDB Atlas instance.
-   The connection URI includes everything you need to connect to your organization's MongoDB Atlas Data Federation instance from a valid MQL-compatible client, except your Viam account password.
-   Replace the placeholder text `YOUR-PASSWORD-HERE` in the connection URI with your Viam account password.
+   The connection URI includes everything you need to connect to your organization's MongoDB Atlas Data Federation instance from a valid MQL-compatible client, except configured database password.
+   Replace the placeholder text `YOUR-PASSWORD-HERE` in the connection URI with the configured database password, as returned from the `viam data database configure` command.
    You will need this to query your data in the next section.
 
 For more information, see the documentation for the [Viam CLI `database` command](/cli/#data).
@@ -143,7 +144,7 @@ For example, to use the `mongosh` shell to connect to your Viam organization's M
    Where:
 
    - `<YOUR-DB-CONNECTION-URI>` is your organization's assigned MongoDB Atlas connection URI, determined from the [`viam data database hostname` CLI command](/data/query/#configure-data-query).
-   - `YOUR-PASSWORD-HERE` (included in the connection URI) is your Viam account password, as set by the [`viam data database configure` CLI command](/data/query/#configure-data-query).
+   - `YOUR-PASSWORD-HERE` (included in the connection URI) is the configured database password, as set by the [`viam data database configure` CLI command](/data/query/#configure-data-query).
 
 1. Once connected, you can run SQL or MQL to query captured data directly. For example:
 

--- a/docs/data/query.md
+++ b/docs/data/query.md
@@ -112,33 +112,24 @@ You do not need to perform any additional configuration when [querying data in t
 
    This command configures a new database user for your org for use with data query.
 
-1. Determine the hostname for your organization's MongoDB Atlas Data Federation instance by running the following command with the organization's `org-id` from step 2:
+1. Determine the connection URI for your organization's MongoDB Atlas Data Federation instance by running the following command with the organization's `org-id` from step 2:
 
    ```sh {class="line-numbers linkable-line-numbers"}
    viam data database hostname --org-id=<YOUR-ORGANIZATION-ID>
    ```
 
-   This command returns the `hostname` (including database name) to use to connect to your data store on the Viam organization's MongoDB Atlas instance.
+   This command returns the hostname (including database name) and connection URI to use to connect to your data store on the Viam organization's MongoDB Atlas instance.
+   The connection URI includes everything you need to connect to your organization's MongoDB Atlas Data Federation instance from a valid MQL-compatible client, except your Viam account password.
+   Replace the placeholder text `YOUR-PASSWORD-HERE` in the connection URI with your Viam account password.
    You will need this to query your data in the next section.
 
 For more information, see the documentation for the [Viam CLI `database` command](/cli/#data).
 
 ### Query
 
-Once you have synced tabular data to the Viam app, you can directly query that data from an MQL-compatible client, such as [`mongosh`](https://www.mongodb.com/docs/mongodb-shell/) or [Compass](https://www.mongodb.com/docs/compass/current/).
+Once you have synced tabular data to the Viam app, you can directly query that data from an MQL-compatible client, such as the [`mongosh` shell](https://www.mongodb.com/docs/mongodb-shell/), [MongoDB Compass](https://www.mongodb.com/docs/compass/current/), or many third-party tools.
 
-1. Open your chosen MQL-compatible client an connect to the Viam organization's MongoDB Atlas instance.
-   You can use any client that is capable of connecting to a MongoDB Atlas instance, including the [`mongosh` shell](https://www.mongodb.com/docs/mongodb-shell/), [MongoDB Compass](https://www.mongodb.com/docs/compass/current/), and many third-party tools.
-   To connect, use the `hostname` you determined when you [configured direct data query](/data/query/#configure-data-query), and structure your username in the following format:
-
-   ```sh
-   db-user-<YOUR-ORG-ID>
-   ```
-
-   Where `<YOUR-ORG-ID>` is your organization ID, determined from the `viam organizations list` CLI command.
-   The full username you provide to your client should therefore resemble `db-user-abcdef12-abcd-abcd-abcd-abcdef123456`.
-
-For example, to connect to your Viam organization's MongoDB Atlas instance and query data using the `mongosh` shell:
+For example, to use the `mongosh` shell to connect to your Viam organization's MongoDB Atlas instance and query data:
 
 1. If you haven't already, [download the `mongosh` shell](https://www.mongodb.com/try/download/shell).
    See the [`mongosh` documentation](https://www.mongodb.com/docs/mongodb-shell/) for more information.
@@ -146,14 +137,13 @@ For example, to connect to your Viam organization's MongoDB Atlas instance and q
 1. Run the following command to connect to the Viam organization's MongoDB Atlas instance from `mongosh`:
 
    ```sh {class="command-line" data-prompt=">"}
-   mongosh "mongodb://<YOUR-DB-HOSTNAME>" --tls --authenticationDatabase admin --username db-user-<YOUR-ORG-ID>
+   mongosh "<YOUR-DB-CONNECTION-URI>"
    ```
 
    Where:
 
-   - `<YOUR-DB-HOSTNAME>` is your organization's assigned MongoDB Atlas instance hostname, determined from the [`viam data database hostname` CLI command](/data/query/#configure-data-query).
-   - `<YOUR-ORG-ID>` is your organization ID, determined from the `viam organizations list` CLI command.
-     The full username you provide to the `--username` flag should therefore resemble `db-user-abcdef12-abcd-abcd-abcd-abcdef123456`.
+   - `<YOUR-DB-CONNECTION-URI>` is your organization's assigned MongoDB Atlas connection URI, determined from the [`viam data database hostname` CLI command](/data/query/#configure-data-query).
+   - `YOUR-PASSWORD-HERE` (included in the connection URI) is your Viam account password, as set by the [`viam data database configure` CLI command](/data/query/#configure-data-query).
 
 1. Once connected, you can run SQL or MQL to query captured data directly. For example:
 

--- a/docs/data/query.md
+++ b/docs/data/query.md
@@ -98,7 +98,7 @@ You do not need to perform any additional configuration when [querying data in t
 1. Configure a new database user for the Viam organization's MongoDB [Atlas Data Federation](https://www.mongodb.com/docs/atlas/data-federation/overview/) instance, which is where your machine's synced data is stored.
 
    {{< alert title="Warning" color="warning" >}}
-   The command will create a user with your organisation id as the username.
+   The command will create a user with your organization ID as the username.
    If you or someone else in your organization have already created this user, the following steps update the password for that user instead.
    Dashboards or other integrations relying on this password will then need to be updated.
    {{< /alert >}}
@@ -110,25 +110,27 @@ You do not need to perform any additional configuration when [querying data in t
    viam data database configure --org-id=<YOUR-ORGANIZATION-ID> --password=<NEW-DBUSER-PASSWORD>
    ```
 
-   This command configures a new database user for your org for use with data query, and sets the password.
+   This command configures a new database user for your organization for use with data query, and sets the password.
    If you have already run this command before, this command instead updates the password to the new value you set.
 
-1. Determine the connection URI for your organization's MongoDB Atlas Data Federation instance by running the following command with the organization's `org-id` from step 2:
+1. Determine the connection URI (also known as a connection string) for your organization's MongoDB Atlas Data Federation instance by running the following command with the organization's `org-id` from step 2:
 
    ```sh {class="line-numbers linkable-line-numbers"}
    viam data database hostname --org-id=<YOUR-ORGANIZATION-ID>
    ```
 
-   This command returns the hostname (including database name) and connection URI to use to connect to your data store on the Viam organization's MongoDB Atlas instance.
-   The connection URI includes everything you need to connect to your organization's MongoDB Atlas Data Federation instance from a valid MQL-compatible client, except for your configured database password.
-   Replace the placeholder text `YOUR-PASSWORD-HERE` in the connection URI with your configured database password, as set by the `viam data database configure` command.
+   This command returns both the _connection URI_ to your organization's MongoDB Atlas Data Federation instance, as well as its _hostname_ and _database name_:
+
+   - Most MQL-compatible database clients require the _connection URI_, along with your user credentials, to connect to this server.
+   - Some MQL-compatible database client instead require a _hostname_ and _database name_, along with your user credentials, to connect to this server.
+
    You will need this to query your data in the next section.
 
 For more information, see the documentation for the [Viam CLI `database` command](/cli/#data).
 
 ### Query
 
-Once you have synced tabular data to the Viam app, you can directly query that data from an MQL-compatible client, such as the [`mongosh` shell](https://www.mongodb.com/docs/mongodb-shell/), [MongoDB Compass](https://www.mongodb.com/docs/compass/current/), or many third-party tools.
+Once you have synced tabular data to the Viam app and [configured a database user](#configure-data-query), you can directly query that data from an MQL-compatible database client, such as the [`mongosh` shell](https://www.mongodb.com/docs/mongodb-shell/), [MongoDB Compass](https://www.mongodb.com/docs/compass/current/), or one of many third-party tools.
 
 For example, to use the `mongosh` shell to connect to your Viam organization's MongoDB Atlas instance and query data:
 
@@ -145,6 +147,8 @@ For example, to use the `mongosh` shell to connect to your Viam organization's M
 
    - `<YOUR-DB-CONNECTION-URI>` is your organization's assigned MongoDB Atlas connection URI, determined from the [`viam data database hostname` CLI command](/data/query/#configure-data-query).
    - `YOUR-PASSWORD-HERE` (included in the connection URI) is your configured database password, as set by the [`viam data database configure` CLI command](/data/query/#configure-data-query).
+
+   If you are connecting from a database client that requires a server hostname and database name, provide those values from the [`viam data database hostname` CLI command](/data/query/#configure-data-query) instead.
 
 1. Once connected, you can run SQL or MQL to query captured data directly. For example:
 

--- a/docs/data/query.md
+++ b/docs/data/query.md
@@ -120,8 +120,8 @@ You do not need to perform any additional configuration when [querying data in t
    ```
 
    This command returns the hostname (including database name) and connection URI to use to connect to your data store on the Viam organization's MongoDB Atlas instance.
-   The connection URI includes everything you need to connect to your organization's MongoDB Atlas Data Federation instance from a valid MQL-compatible client, except configured database password.
-   Replace the placeholder text `YOUR-PASSWORD-HERE` in the connection URI with the configured database password, as returned from the `viam data database configure` command.
+   The connection URI includes everything you need to connect to your organization's MongoDB Atlas Data Federation instance from a valid MQL-compatible client, except for your configured database password.
+   Replace the placeholder text `YOUR-PASSWORD-HERE` in the connection URI with your configured database password, as returned from the `viam data database configure` command.
    You will need this to query your data in the next section.
 
 For more information, see the documentation for the [Viam CLI `database` command](/cli/#data).
@@ -144,7 +144,7 @@ For example, to use the `mongosh` shell to connect to your Viam organization's M
    Where:
 
    - `<YOUR-DB-CONNECTION-URI>` is your organization's assigned MongoDB Atlas connection URI, determined from the [`viam data database hostname` CLI command](/data/query/#configure-data-query).
-   - `YOUR-PASSWORD-HERE` (included in the connection URI) is the configured database password, as set by the [`viam data database configure` CLI command](/data/query/#configure-data-query).
+   - `YOUR-PASSWORD-HERE` (included in the connection URI) is your configured database password, as set by the [`viam data database configure` CLI command](/data/query/#configure-data-query).
 
 1. Once connected, you can run SQL or MQL to query captured data directly. For example:
 

--- a/docs/data/query.md
+++ b/docs/data/query.md
@@ -124,7 +124,7 @@ You do not need to perform any additional configuration when [querying data in t
    - Most MQL-compatible database clients require the _connection URI_, along with your user credentials, to connect to this server.
    - Some MQL-compatible database client instead require a _hostname_ and _database name_, along with your user credentials, to connect to this server.
 
-   You will need this to query your data in the next section.
+   You will need this information to query your data in the next section.
 
 For more information, see the documentation for the [Viam CLI `database` command](/cli/#data).
 

--- a/docs/data/visualize.md
+++ b/docs/data/visualize.md
@@ -60,7 +60,7 @@ When you [configured data query](/data/query/#configure-data-query), this inform
   ```
 
   Replace `YOUR-PASSWORD-HERE` with your database password as returned from the `viam data database configure` command.
-  
+
   You can also specify a desired database name in your connection URI, if desired.
   For example, to use the `sensorData` database, the default name for uploaded tabular data, your connection string would resemble:
 

--- a/docs/data/visualize.md
+++ b/docs/data/visualize.md
@@ -47,11 +47,26 @@ With data query configured, you can use a variety of popular third-party tools t
 
 When you sync captured data to Viam, that data is stored in the Viam organization’s MongoDB Atlas Data Federation instance.
 
-Most third-party visualization tools require the _connection string_ to that database server, and the _credentials_ to authenticate to that server in order to visualize your data.
+Most third-party visualization tools require the _connection URI_ (also called the connection string) to that database server, and the _credentials_ to authenticate to that server in order to visualize your data.
+Some third-party tools instead require a _hostname_ and _database name_ of the database server.
 
 When you [configured data query](/data/query/#configure-data-query), this information was provided to you:
 
-- **Connection string**: The connection string your visualization tool uses to connect to and query your data.
+- **Connection URI**: The connection URI your visualization tool uses to connect to and query your data.
+  You can find your connection URI by running the `viam data database hostname` command:
+
+  ```sh
+  mongodb://db-user-abcdef12-abcd-abcd-abcd-abcdef123456:ABab123=123@data-federation-abcdef12-abcd-abcd-abcd-abcdef123456-e4irv.a.query.mongodb.net/?ssl=true&authSource=admin
+  ```
+
+  You can also specify a desired database name in your connection URI, if desired.
+  For example, to use the `sensorData` database, the default name for uploaded tabular data, your connection string would resemble:
+
+  ```sh
+  mongodb://db-user-abcdef12-abcd-abcd-abcd-abcdef123456:ABab123=123@data-federation-abcdef12-abcd-abcd-abcd-abcdef123456-e4irv.a.query.mongodb.net/sensorData?ssl=true&authSource=admin
+  ```
+
+- **Hostname and Database name**: If you client doesn't use a connection URI, you can supply the hostname and database name of the database server instead.
   Substitute the hostname returned from the `viam data database hostname` command for `<MONGODB-ATLAS-DF-HOSTNAME>` and the desired database name to query for `<DATABASE-NAME>`:
 
   ```sh
@@ -64,19 +79,24 @@ When you [configured data query](/data/query/#configure-data-query), this inform
   mongodb://data-federation-abcdef12-abcd-abcd-abcd-abcdef123456-e4irv.a.query.mongodb.net/sensorData?directConnection=true&authSource=admin&tls=true
   ```
 
+  If you are using a connection URI, the hostname and database name are already included in the URI string.
+
 - **Username**: Your database user. Substitute your organization ID for `<YOUR-ORG-ID>`:
 
   ```sh
   db-user-<YOUR-ORG-ID>
   ```
 
-  For example, your connection string would resemble:
+  For example, your username would resemble:
 
   ```sh
   db-user-abcdef12-abcd-abcd-abcd-abcdef123456
   ```
 
+  If you are using a connection URI, your username is already included in the URI string.
+
 - **Password**: Your chosen password for your database user, configured with the `viam data database` command.
+  Your password must be at least 8 characters long, and include at least one uppercase, one number, and one special character (such as `$` or `%`):
 
 With your data connection configured, you can then follow the instructions for your specific third-party visualization tool to be able to visualize that data on your chosen platform.
 

--- a/docs/data/visualize.md
+++ b/docs/data/visualize.md
@@ -56,14 +56,16 @@ When you [configured data query](/data/query/#configure-data-query), this inform
   You can find your connection URI by running the `viam data database hostname` command:
 
   ```sh
-  mongodb://db-user-abcdef12-abcd-abcd-abcd-abcdef123456:ABab123=123@data-federation-abcdef12-abcd-abcd-abcd-abcdef123456-e4irv.a.query.mongodb.net/?ssl=true&authSource=admin
+  mongodb://db-user-abcdef12-abcd-abcd-abcd-abcdef123456:YOUR-PASSWORD-HERE@data-federation-abcdef12-abcd-abcd-abcd-abcdef123456-e4irv.a.query.mongodb.net/?ssl=true&authSource=admin
   ```
 
+  Replace `YOUR-PASSWORD-HERE` with your database password as returned from the `viam data database configure` command.
+  
   You can also specify a desired database name in your connection URI, if desired.
   For example, to use the `sensorData` database, the default name for uploaded tabular data, your connection string would resemble:
 
   ```sh
-  mongodb://db-user-abcdef12-abcd-abcd-abcd-abcdef123456:ABab123=123@data-federation-abcdef12-abcd-abcd-abcd-abcdef123456-e4irv.a.query.mongodb.net/sensorData?ssl=true&authSource=admin
+  mongodb://db-user-abcdef12-abcd-abcd-abcd-abcdef123456:YOUR-PASSWORD-HERE@data-federation-abcdef12-abcd-abcd-abcd-abcdef123456-e4irv.a.query.mongodb.net/sensorData?ssl=true&authSource=admin
   ```
 
 - **Hostname and Database name**: If you client doesn't use a connection URI, you can supply the hostname and database name of the database server instead.
@@ -95,7 +97,7 @@ When you [configured data query](/data/query/#configure-data-query), this inform
 
   If you are using a connection URI, your username is already included in the URI string.
 
-- **Password**: Your chosen password for your database user, configured with the `viam data database` command.
+- **Password**: Your chosen password for your database user, configured with the `viam data database configure` command.
   Your password must be at least 8 characters long, and include at least one uppercase, one number, and one special character (such as `$` or `%`):
 
 With your data connection configured, you can then follow the instructions for your specific third-party visualization tool to be able to visualize that data on your chosen platform.


### PR DESCRIPTION
Update `viam data database hostname` reference and usage docs to reflect new returned Connection URI value.
- Converted query and visualize guidance to use connection URI directly, simpler.
	- But retained mention of hostname and database name for visualize guidance, in case some third party tools use hostname / db name for connecting.
- Updated term "connection string" to "connection URI" to match command output.