### PR TITLE
DOCS-2346: Add non-interface funcs for SLAM

### DIFF
--- a/.github/workflows/sdk_protos_map.csv
+++ b/.github/workflows/sdk_protos_map.csv
@@ -248,9 +248,14 @@ navigation,Close,close,Close,
 
 ## SLAM
 slam,GetPosition,get_position,Position,getPosition
-slam,GetPointCloudMap,get_point_cloud_map,PointCloudMap,getPointCloudMap
-slam,GetInternalState,get_internal_state,InternalState,getInternalState
+## HACK: SLAM (Go) implements proto GetPointCloudMap in user-facing helper PointCloudMapFull instead:
+slam,GetPointCloudMap,get_point_cloud_map,,getPointCloudMap
+## HACK: SLAM (Go) implements proto GetInternalState in user-facing helper InternalStateFull instead:
+slam,GetInternalState,get_internal_state,,getInternalState
 slam,GetProperties,get_properties,Properties,getProperties
+## HACK: SLAM (Go) provides 2 additional helper functions, adding 2 pseudo-entries:
+slam,InternalStateFull,,InternalStateFull,
+slam,PointCloudMapFull,,PointCloudMapFull,
 ## HACK: No proto for these (and/or inherited in Go SDK), manually mapping:
 slam,Reconfigure,,Reconfigure,
 slam,DoCommand,do_command,DoCommand,doCommand

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -776,6 +776,33 @@ def parse(type, names):
                                 'usage': 'Readings(ctx <a href="/context">context</a>.<a href="/context#Context">Context</a>, extra map[<a href="/builtin#string">string</a>]interface{}) (map[<a href="/builtin#string">string</a>]interface{}, <a href="/builtin#error">error</a>)', \
                                 'method_link': 'https://pkg.go.dev/go.viam.com/rdk/resource#Sensor'}
 
+                ## For SLAM service only, additionally fetch data for two helper methods defined outside of the resource's interface:
+                if resource == 'slam':
+
+                    ## Fetch PointCloudMapFull:
+                    pointcloudmapfull_method_raw = soup.find_all(
+                        lambda tag: tag.name == 'div'
+                        and tag.get('class') == ['Documentation-declaration']
+                        and "PointCloudMapFull" in tag.pre.text)
+
+                    go_methods[type][resource]['PointCloudMapFull'] = {}
+                    go_methods[type][resource]['PointCloudMapFull']['proto'] = 'PointCloudMapFull'
+                    go_methods[type][resource]['PointCloudMapFull']['description'] = pointcloudmapfull_method_raw[0].pre.find_next('p').text
+                    go_methods[type][resource]['PointCloudMapFull']['usage'] = pointcloudmapfull_method_raw[0].pre.text.removeprefix('func ')
+                    go_methods[type][resource]['PointCloudMapFull']['method_link'] = 'https://pkg.go.dev/go.viam.com/rdk@v0.27.1/services/slam#PointCloudMapFull'
+
+                    ## Fetch InternalStateFull:
+                    internalstatefull_method_raw = soup.find_all(
+                        lambda tag: tag.name == 'div'
+                        and tag.get('class') == ['Documentation-declaration']
+                        and "InternalStateFull" in tag.pre.text)
+
+                    go_methods[type][resource]['InternalStateFull'] = {}
+                    go_methods[type][resource]['InternalStateFull']['proto'] = 'InternalStateFull'
+                    go_methods[type][resource]['InternalStateFull']['description'] = internalstatefull_method_raw[0].pre.find_next('p').text
+                    go_methods[type][resource]['InternalStateFull']['usage'] = internalstatefull_method_raw[0].pre.text.removeprefix('func ')
+                    go_methods[type][resource]['InternalStateFull']['method_link'] = 'https://pkg.go.dev/go.viam.com/rdk@v0.27.1/services/slam#InternalStateFull'
+
                 ## We have finished looping through all scraped Go methods. Write the go_methods dictionary
                 ## in its entirety to the all_methods dictionary using "go" as the key:
                 all_methods["go"] = go_methods

--- a/static/include/services/apis/generated/slam.md
+++ b/static/include/services/apis/generated/slam.md
@@ -1,0 +1,357 @@
+### GetPosition
+
+Get the current position of the component the SLAM service is configured to source point cloud data from in the SLAM map as a [`Pose`](/internals/orientation-vector/).
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `timeout` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
+
+**Returns:**
+
+- ([viam.services.slam.Pose](https://python.viam.dev/autoapi/viam/index.html#viam.services.slam.Pose)): The current position of the specified component
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/services/slam/client/index.html#viam.services.slam.client.SLAMClient.get_position).
+
+```python {class="line-numbers linkable-line-numbers"}
+slam_svc = SLAMClient.from_robot(robot=robot, name="my_slam_service")
+
+# Get the current position of the specified source component in the SLAM map as a Pose.
+pose = await slam.get_position()
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+**Parameters:**
+
+- `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
+
+**Returns:**
+
+- `spatialmath` [(Pose)](https://pkg.go.dev/go.viam.com/rdk@v0.27.1/spatialmath#Pose):
+- [(string)](https://pkg.go.dev/builtin#string):
+- [(error)](https://pkg.go.dev/builtin#error):
+
+For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/slam#Service).
+
+{{% /tab %}}
+{{% tab name="Flutter" %}}
+
+**Parameters:**
+
+- `name` [(String)](https://api.flutter.dev/flutter/dart-core/String-class.html) (required):
+
+**Returns:**
+
+- None.
+
+For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_protos.service.slam/SLAMServiceClient/getPosition.html).
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### GetPointCloudMap
+
+Get the point cloud map.
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `return_edited_map` ([bool](https://docs.python.org/3/library/stdtypes.html#boolean-type-bool)) (required): signal to the SLAM service to return an edited map, if the map package contains one and if the SLAM service supports the feature
+- `timeout` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
+
+**Returns:**
+
+- (List[[bytes](https://docs.python.org/3/library/stdtypes.html#bytes-objects)]): Complete pointcloud in standard PCD format. Chunks of the PointCloud, concatenating all GetPointCloudMapResponse.point_cloud_pcd_chunk values.
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/services/slam/client/index.html#viam.services.slam.client.SLAMClient.get_point_cloud_map).
+
+```python {class="line-numbers linkable-line-numbers"}
+slam_svc = SLAMClient.from_robot(robot=robot, name="my_slam_service")
+
+# Get the point cloud map in standard PCD format.
+pcd_map = await slam_svc.get_point_cloud_map()
+```
+
+{{% /tab %}}
+{{% tab name="Flutter" %}}
+
+**Parameters:**
+
+- `name` [(String)](https://api.flutter.dev/flutter/dart-core/String-class.html) (required):
+- `returnEditedMap` [(bool)](https://api.flutter.dev/flutter/dart-core/bool-class.html) (required):
+
+**Returns:**
+
+- None.
+
+For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_protos.service.slam/SLAMServiceClient/getPointCloudMap.html).
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### GetInternalState
+
+Get the internal state of the SLAM algorithm required to continue mapping/localization.
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `timeout` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
+
+**Returns:**
+
+- (List[[bytes](https://docs.python.org/3/library/stdtypes.html#bytes-objects)]): Chunks of the internal state of the SLAM algorithm
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/services/slam/client/index.html#viam.services.slam.client.SLAMClient.get_internal_state).
+
+```python {class="line-numbers linkable-line-numbers"}
+slam = SLAMClient.from_robot(robot=robot, name="my_slam_service")
+
+# Get the internal state of the SLAM algorithm required to continue mapping/localization.
+internal_state = await slam.get_internal_state()
+```
+
+{{% /tab %}}
+{{% tab name="Flutter" %}}
+
+**Parameters:**
+
+- `name` [(String)](https://api.flutter.dev/flutter/dart-core/String-class.html) (required):
+
+**Returns:**
+
+- None.
+
+For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_protos.service.slam/SLAMServiceClient/getInternalState.html).
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### GetProperties
+
+Get information about the current SLAM session.
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `timeout` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
+
+**Returns:**
+
+- (viam.services.slam.slam.SLAM.Properties): The properties of SLAM
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/services/slam/client/index.html#viam.services.slam.client.SLAMClient.get_properties).
+
+```python {class="line-numbers linkable-line-numbers"}
+slam_svc = SLAMClient.from_robot(robot=robot, name="my_slam_service")
+
+# Get the properties of your current SLAM session.
+slam_properties = await slam_svc.get_properties()
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+**Parameters:**
+
+- `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
+
+**Returns:**
+
+- [(Properties)](https://pkg.go.dev#Properties):
+- [(error)](https://pkg.go.dev/builtin#error):
+
+For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/slam#Service).
+
+{{% /tab %}}
+{{% tab name="Flutter" %}}
+
+**Parameters:**
+
+- `name` [(String)](https://api.flutter.dev/flutter/dart-core/String-class.html) (required):
+
+**Returns:**
+
+- None.
+
+For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_protos.service.slam/SLAMServiceClient/getProperties.html).
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### InternalStateFull
+
+`InternalStateFull` concatenates the streaming responses from `InternalState` into the internal serialized state of the SLAM algorithm.
+
+{{< tabs >}}
+{{% tab name="Go" %}}
+
+**Parameters:**
+
+- `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
+- [(Service))](<INSERT PARAM TYPE LINK>):
+
+**Returns:**
+
+- [([]byte)](<INSERT PARAM TYPE LINK>):
+- [(error))](<INSERT PARAM TYPE LINK>):
+
+For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk@v0.27.1/services/slam#InternalStateFull).
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### PointCloudMapFull
+
+`PointCloudMapFull` concatenates the streaming responses from `PointCloudMap` into a full point cloud.
+
+{{< tabs >}}
+{{% tab name="Go" %}}
+
+**Parameters:**
+
+- `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
+- [(Service)](<INSERT PARAM TYPE LINK>):
+- [(bool))](<INSERT PARAM TYPE LINK>):
+
+**Returns:**
+
+- [([]byte)](<INSERT PARAM TYPE LINK>):
+- [(error))](<INSERT PARAM TYPE LINK>):
+
+For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk@v0.27.1/services/slam#PointCloudMapFull).
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### Reconfigure
+
+
+{{< tabs >}}
+{{% tab name="Go" %}}
+
+**Parameters:**
+
+- `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
+- `deps` [(Dependencies)](https://pkg.go.dev#Dependencies):
+- `conf` [(Config)](https://pkg.go.dev#Config):
+
+**Returns:**
+
+- [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
+
+For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### DoCommand
+
+Execute model-specific commands that are not otherwise defined by the service API.
+For built-in service models, any model-specific commands available are covered with each model's documentation.
+If you are implementing your own SLAM service and add features that have no built-in API method, you can access them with `DoCommand`.
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `command` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), ValueTypes]) (required): The command to execute
+- `timeout` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
+
+**Returns:**
+
+- (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), viam.utils.ValueTypes]): Result of the executed command
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/services/slam/client/index.html#viam.services.slam.client.SLAMClient.do_command).
+
+```python {class="line-numbers linkable-line-numbers"}
+motion = MotionClient.from_robot(robot, "builtin")
+
+my_command = {
+  "cmnd": "dosomething",
+  "someparameter": 52
+}
+
+# Can be used with any resource, using the motion service as an example
+await motion.do_command(command=my_command)
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+**Parameters:**
+
+- `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
+- [(string)](https://pkg.go.dev/builtin#string):
+
+**Returns:**
+
+- [(string)](https://pkg.go.dev/builtin#string):
+- [(error)](https://pkg.go.dev/builtin#error):
+
+For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).
+
+{{% /tab %}}
+{{% tab name="Flutter" %}}
+
+**Parameters:**
+
+- `command` [(Struct)](<INSERT PARAM TYPE LINK>) (required):
+- `name` [(String)](https://api.flutter.dev/flutter/dart-core/String-class.html) (required):
+
+**Returns:**
+
+- None.
+
+For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_protos.service.slam/SLAMServiceClient/doCommand.html).
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### Close
+
+Safely shut down the resource and prevent further use.
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- None.
+
+**Returns:**
+
+- None.
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/services/slam/client/index.html#viam.services.slam.client.SLAMClient.close).
+
+```python {class="line-numbers linkable-line-numbers"}
+await component.close()
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+**Parameters:**
+
+- `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
+
+**Returns:**
+
+- [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
+
+For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).
+
+{{% /tab %}}
+{{< /tabs >}}

--- a/static/include/services/apis/overrides/protos/slam.InternalStateFull.md
+++ b/static/include/services/apis/overrides/protos/slam.InternalStateFull.md
@@ -1,0 +1,1 @@
+`InternalStateFull` concatenates the streaming responses from `InternalState` into the internal serialized state of the SLAM algorithm.

--- a/static/include/services/apis/overrides/protos/slam.PointCloudMapFull.md
+++ b/static/include/services/apis/overrides/protos/slam.PointCloudMapFull.md
@@ -1,0 +1,1 @@
+`PointCloudMapFull` concatenates the streaming responses from `PointCloudMap` into a full point cloud.


### PR DESCRIPTION
Add the ability to scrape methods that are defined outside of a resource's interface.  This applies only to the SLAM service for the Go SDK.
- Removed interface methods `GetPointCloudMap` and `GetInternalState` from mapping file for Go SDK.
	- Added proto override files for both (to provide method descriptions, copied from Go SDK docs)
- Added non-interface methods `PointCloudMapFull` and `InternalStateFull` to mapping file for Go SDK.
- Added non-interface scraping for Go SDK > SLAM only to `update_sdk_methods.py`.

Note:
- Included `static/include/services/apis/generated/slam.md` file for verification, but will remove from this PR before merging.
- Ignore missing parameter name and parameter types for some of these Go methods, that's a separate issue / ticket.