### PR TITLE
DOCS-2340: Clarify example link

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -684,7 +684,7 @@ For example, the following represents the configuration of an example `my-module
 {
   "module_id": "acme:my-module",
   "visibility": "public",
-  "url": "https://github.com/acme-co-example/my-module",
+  "url": "https://github.com/<my-repo-name>/my-module",
   "description": "An example custom module.",
   "models": [
     {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -852,7 +852,7 @@ For example, the following extends the `my-module` <file>meta.json</file> file f
 {
   "module_id": "acme:my-module",
   "visibility": "public",
-  "url": "https://github.com/acme-co-example/my-module",
+  "url": "https://github.com/<my-repo-name>/my-module",
   "description": "An example custom module.",
   "models": [
     {

--- a/docs/registry/upload/_index.md
+++ b/docs/registry/upload/_index.md
@@ -137,7 +137,7 @@ If you later wish to make your module public, you can use the [`viam module upda
     {
       "module_id": "acme:my-module",
       "visibility": "public",
-      "url": "https://github.com/{my-repo-name}/my-module",
+      "url": "https://github.com/<my-repo-name>/my-module",
       "description": "An example custom module.",
       "models": [
         {

--- a/docs/registry/upload/_index.md
+++ b/docs/registry/upload/_index.md
@@ -137,7 +137,7 @@ If you later wish to make your module public, you can use the [`viam module upda
     {
       "module_id": "acme:my-module",
       "visibility": "public",
-      "url": "https://github.com/acme-co-example/my-module",
+      "url": "https://github.com/{my-repo-name}/my-module",
       "description": "An example custom module.",
       "models": [
         {


### PR DESCRIPTION
More clearly indicate that example URL is example, using placeholder syntax.