### PR TITLE
DOCS-2370: Add more information for other Python methods

### DIFF
--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -1323,7 +1323,7 @@ Follow [these instructions](/cli/#using-the-build-subcommand) to automatically b
 {{% tab name="Python: venv" %}}
 
 Create a `run.sh` shell script that creates a new Python virtual environment, ensures that the package dependencies your module requires are installed, and runs your module.
-This is recommended approach for modules written in Python:
+This is the recommended approach for modules written in Python:
 
 1. Create a `requirements.txt` file containing a list of all the dependencies your module requires.
    For example, a `requirements.txt` file with the following contents ensures that the Viam Python SDK (`viam-sdk`) is installed:

--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -65,10 +65,6 @@ If you want to write a module to extend support to a new type of component or se
 Most module use cases, however, benefit from extending an existing API, as covered below.
 {{% /alert %}}
 
-{{% alert title="Tip" color="tip" %}}
-If you would like to test your module locally against its intended target platform before uploading it, you can follow the steps for [Iterative module development](/registry/advanced/iterative-development/) to verify that any code changes you have made work as expected on your target platform.
-{{% /alert %}}
-
 ### (Optional) Use a module template
 
 If you are using Golang, use the [Golang Module templates](https://github.com/viam-labs/module-templates-golang) which contain detailed instructions for creating your module.

--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -1410,7 +1410,8 @@ Compiling your Python module in this fashion ensures that your module has access
 If you intend to share your module with other users, or to deploy it to a fleet of machines, this approach "bundles" your module code together with its required dependencies, making your module highly-portable across like architectures.
 
 However, used in this manner, Nuitka does not support relative imports (imports starting with `.`).
-In addition, Nuitka does not support cross-compiling: you must compile your module on the target architecture you wish to support.
+In addition, Nuitka does not support cross-compiling: you can only compile your module on the target architecture you wish to support if using the Nutika approach.
+If you want to cross-compile your module, consider using a different local compilation method, or the [`module build start` command](/cli/#using-the-build-subcommand) to build your module on a cloud build host, which supports building for multiple platforms.
 For example, you cannot run a module on a Linux `arm64` system if you compiled it using Nuitka on a Linux `amd64` system.
 
 {{% /tab %}}

--- a/docs/registry/create/_index.md
+++ b/docs/registry/create/_index.md
@@ -65,6 +65,10 @@ If you want to write a module to extend support to a new type of component or se
 Most module use cases, however, benefit from extending an existing API, as covered below.
 {{% /alert %}}
 
+{{% alert title="Tip" color="tip" %}}
+If you would like to test your module locally against its intended target platform before uploading it, you can follow the steps for [Iterative module development](/registry/advanced/iterative-development/) to verify that any code changes you have made work as expected on your target platform.
+{{% /alert %}}
+
 ### (Optional) Use a module template
 
 If you are using Golang, use the [Golang Module templates](https://github.com/viam-labs/module-templates-golang) which contain detailed instructions for creating your module.
@@ -1244,7 +1248,7 @@ This executable file:
 Depending on the language you are using to code your module, you may have options for how you create your executable file:
 
 {{% tabs %}}
-{{% tab name="Python" %}}
+{{% tab name="Python: pyinstaller (recommended)" %}}
 
 The recommended approach for Python is to use [`PyInstaller`](https://pypi.org/project/pyinstaller/) to compile your module into a packaged executable: a standalone file containing your program, the Python interpreter, and all of its dependencies.
 When packaged in this fashion, you can run the resulting executable on your desired target platform or platforms without needing to install additional software or manage dependencies manually.
@@ -1318,6 +1322,96 @@ Viam makes this easy to manage by providing a build system for modules.
 Follow [these instructions](/cli/#using-the-build-subcommand) to automatically build for each system your module can support using Viam's [CLI](/cli/).
 
 {{% /alert %}}
+
+{{% /tab %}}
+{{% tab name="Python: venv" %}}
+
+Create a `run.sh` shell script that creates a new Python virtual environment, ensures that the package dependencies your module requires are installed, and runs your module.
+This is recommended approach for modules written in Python:
+
+1. Create a `requirements.txt` file containing a list of all the dependencies your module requires.
+   For example, a `requirements.txt` file with the following contents ensures that the Viam Python SDK (`viam-sdk`) is installed:
+
+   ```sh { class="command-line" data-prompt="$"}
+   viam-sdk
+   ```
+
+   Add additional dependencies for your module as needed.
+   See the [pip `requirements.txt` file documentation](https://pip.pypa.io/en/stable/reference/requirements-file-format/) for more information.
+
+1. Add a shell script that creates a new virtual environment, installs the dependencies listed in `requirements.txt`, and runs the module entry point file `main.py`:
+
+   ```sh { class="command-line" data-prompt="$"}
+   #!/bin/sh
+   cd `dirname $0`
+
+   # Create a virtual environment to run our code
+   VENV_NAME="venv"
+   PYTHON="$VENV_NAME/bin/python"
+
+   python3 -m venv $VENV_NAME
+   $PYTHON -m pip install -r requirements.txt -U # remove -U if viam-sdk should not be upgraded whenever possible
+
+   # Be sure to use `exec` so that termination signals reach the python process,
+   # or handle forwarding termination signals manually
+   exec $PYTHON <your-src-dir-if-inside>/main.py $@
+   ```
+
+1. Make your shell script executable by running the following command in your terminal:
+
+   ```sh { class="command-line" data-prompt="$"}
+   sudo chmod +x <your-file-path-to>/run.sh
+   ```
+
+Using a virtual environment together with a `requirements.txt` file and a `run.sh` file that references it ensures that your module has access to any packages it requires during runtime.
+If you intend to share your module with other users, or to deploy it to a fleet of machines, this approach handles dependency resolution for each deployment automatically, meaning that there is no need to explicitly determine and install the Python packages your module requires to run on each machine that installs your module.
+See [prepare a Python virtual environment](/build/program/python-venv/) for more information.
+
+{{% /tab %}}
+{{% tab name="Python: nuitka" %}}
+
+Use the [`nuitka` Python compiler](https://pypi.org/project/Nuitka/) to compile your module into a single executable file:
+
+1. In order to use Nuitka, you must install a [supported C compiler](https://github.com/Nuitka/Nuitka#c-compiler) on your machine.
+
+1. Then, [create a Python virtual environment](/build/program/python-venv/) in your module's directory to ensure your module has access to any required libraries.
+   Be sure you are within your Python virtual environment for the rest of these steps: your terminal prompt should include the name of your virtual environment in parenthesis.
+
+1. Create a `requirements.txt` file containing a list of all the dependencies your module requires.
+   For example, a `requirements.txt` file with the following contents ensures that the Viam Python SDK (`viam-sdk`) and Nuitka (`nuitka`) are installed:
+
+   ```sh { class="command-line" data-prompt="$"}
+   viam-sdk
+   nuitka
+   ```
+
+   Add additional dependencies for your module as needed.
+   See the [pip `requirements.txt` file documentation](https://pip.pypa.io/en/stable/reference/requirements-file-format/) for more information.
+
+1. Install the dependencies listed in your `requirements.txt` file within your Python virtual environment using the following command:
+
+   ```sh { class="command-line" data-prompt="$"}
+   python -m pip install -r requirements.txt -U
+   ```
+
+1. Then, compile your module using Nuitka with the following command:
+
+   ```sh { class="command-line" data-prompt="$"}
+   python -m nuitka --onefile src/main.py
+   ```
+
+   If you need to include any additional data files to support your module, specify them using the `--include-data-files` flag:
+
+   ```sh { class="command-line" data-prompt="$"}
+   python -m nuitka --onefile --include-data-files=src/arm/my_arm_kinematics.json src/main.py
+   ```
+
+Compiling your Python module in this fashion ensures that your module has access to any packages it requires during runtime.
+If you intend to share your module with other users, or to deploy it to a fleet of machines, this approach "bundles" your module code together with its required dependencies, making your module highly-portable across like architectures.
+
+However, used in this manner, Nuitka does not support relative imports (imports starting with `.`).
+In addition, Nuitka does not support cross-compiling: you must compile your module on the target architecture you wish to support.
+For example, you cannot run a module on a Linux `arm64` system if you compiled it using Nuitka on a Linux `amd64` system.
 
 {{% /tab %}}
 {{% tab name="Go" %}}

--- a/docs/registry/upload/_index.md
+++ b/docs/registry/upload/_index.md
@@ -206,7 +206,7 @@ For a Python module built using the `venv` approach, the command might look like
  tar -czf module.tar.gz run.sh requirements.txt src
 ```
 
-Where `run.sh` is your [entrypoint file](/registry/create/#compile-or-package-your-module), `requirements.txt` is your [pip dependency list file](/registry/create/#compile-or-package-your-module), and `src` is the source directory of your module.
+Where `run.sh` is your [entrypoint file](/registry/create/#compile-or-package-your-module), `requirements.txt` is your [pip dependency list file](/registry/create/#compile-or-package-your-module), and `src` is the directory that contains the source code of your module.
 
 Supply the path to the resulting archive file in the next step.
 

--- a/docs/registry/upload/_index.md
+++ b/docs/registry/upload/_index.md
@@ -133,6 +133,8 @@ If you later wish to make your module public, you can use the [`viam module upda
 
     For example, the following represents the configuration of an example `my-module` public module in the `acme` namespace:
 
+    {{%expand "Click to view example meta.json with build object" %}}
+
     ```json {class="line-numbers linkable-line-numbers"}
     {
       "module_id": "acme:my-module",
@@ -150,9 +152,31 @@ If you later wish to make your module public, you can use the [`viam module upda
         "build": "./build.sh", // command that will build your module
         "arch": ["linux/amd64", "linux/arm64"] // architecture(s) to build for
       },
-      "entrypoint": "<PATH-TO-EXECUTABLE>"
+      "entrypoint": "dist/main" // path to executable
     }
     ```
+
+    {{% /expand%}}
+
+    {{%expand "Click to view example meta.json without build object" %}}
+
+    ```json {class="line-numbers linkable-line-numbers"}
+    {
+      "module_id": "acme:my-module",
+      "visibility": "public",
+      "url": "https://github.com/<my-repo-name>/my-module",
+      "description": "An example custom module.",
+      "models": [
+        {
+          "api": "rdk:component:generic",
+          "model": "acme:demo:my-model"
+        }
+      ],
+      "entrypoint": "my-module.sh" // path to executable
+    }
+    ```
+
+    {{% /expand%}}
 
     {{% alert title="Important" color="note" %}}
 
@@ -174,6 +198,15 @@ For more information, see [Naming your model](/registry/#naming-your-model-names
    ```
 
 Where `<PATH-TO-EXECUTABLE>` is the [packaged executable](/registry/create/#compile-or-package-your-module) that runs the module at the [entry point](/registry/create/#write-an-entry-point-main-program-file).
+If using PyInstaller, by default this would be `dist/main`.
+
+For a Python module built using the `venv` approach, the command might look like this:
+
+```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+ tar -czf module.tar.gz run.sh requirements.txt src
+```
+
+Where `run.sh` is your [entrypoint file](/registry/create/#compile-or-package-your-module), `requirements.txt` is your [pip dependency list file](/registry/create/#compile-or-package-your-module), and `src` is the source directory of your module.
 
 Supply the path to the resulting archive file in the next step.
 


### PR DESCRIPTION
From feedback: 
- re-add how things work on other installation methods to packaged executable section 
- highlight testing and iterating doc before it is highlighted in uploading and deployment
- change bullet points on upload re. [this feedback](https://viam.atlassian.net/browse/DOCS-2370?focusedCommentId=30571)