### PR TITLE
DOCS-2410: Enhance staged docs site scraping

### DIFF
--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -438,7 +438,7 @@ for pid in http_server_process_pids:
     ## Mediocre guess: Flutter build process likely to have string 'flutter' in cwd, either 'viam-flutter-sdk' as cloned directly, or 'flutter' as renamed by operator.
     ## TODO: If operators run into instances where this script misses a valid Flutter staging URL because the path to that staged HTML artifacts dir has been
     ## renamed in a fashion that does not include the string 'flutter', then change this to just always pick up any instances of http.server that aren't already matched to 
-    ## Flutter, above. This would mean that operators cannot run an unrelated http.server instance on this workstation, which they currently can do with present config.
+    ## Go, above. This would mean that operators cannot run an unrelated http.server instance on this workstation, which they currently can do with present config.
     if 'flutter' in http_server_pwd_result:
         flutter_process_port = subprocess.run(["lsof -Pp " + pid + " | grep LISTEN | awk {'print $9'} | sed 's%.*:%%g'"], shell=True, text = True, capture_output=True).stdout.rstrip()
         flutter_staging_url = 'http://localhost:' + flutter_process_port + '/doc/api'

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -402,8 +402,8 @@ code_fence_fmt = {
 
 ## Check to see if we have a locally-staged version of any of the supported SDK docs sites.
 ## If any are detected here, they will be used for all content in parse(), and the live
-## version for that SDK docs site will not be scraped at all!
-
+## version for that SDK docs site will not be scraped at all! First, set empty staging URLs
+## to allow us to later action on whether they are empty or not:
 python_staging_url = ''
 go_staging_url = ''
 flutter_staging_url = ''

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -579,8 +579,6 @@ def parse(type, names):
         sdk_url = sdk_url_mapping[sdk]
         scrape_url = sdk_url
 
-        print('SDK URL: ' + sdk_url)
-
         ## Build empty dict to house methods:
         if sdk == "go":
             go_methods = {}
@@ -599,8 +597,6 @@ def parse(type, names):
                 scrape_url = flutter_staging_url
         else:
             print("unsupported language!")
-
-        print('SCRAPE URL: ' + scrape_url)
 
         ## Iterate through each resource (like 'arm') in type (like 'components') array:
         for resource in names:
@@ -645,7 +641,6 @@ def parse(type, names):
             ## If an invalid language was provided:
             else:
                 pass
-                #print("unsupported language!")
 
             ## Scrape each parent method tag and all contained child tags for Go by resource:
             if sdk == "go" and type != "app":
@@ -664,7 +659,6 @@ def parse(type, names):
 
                     ## Determine the interface name, which we need for the method_link:
                     interface_name = resource_interface.find('pre').text.splitlines()[0].removeprefix('type ').removesuffix(' interface {')
-                    #print(interface_name)
 
                     ## Exclude unwanted Go interfaces:
                     check_interface_name = 'interface.' + interface_name

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -409,7 +409,6 @@ go_staging_url = ''
 flutter_staging_url = ''
 
 ## Check for GO SDK docs staging on local workstation:
-go_process_pid = ''
 go_process_pid = subprocess.run(["ps -ef | grep pkgsite | grep -v grep | awk {'print $2'}"], shell=True, text=True, capture_output=True).stdout.rstrip()
 
 ## If we found a staged local instance of the GO SDK docs, determine which port it is using, and build the staging URL to scrape against:
@@ -424,7 +423,7 @@ if go_process_pid != '':
 ## Both use http.server with a user-selected port. This command fetches all possible matches:
 http_server_process_pids = subprocess.run(["ps -ef | grep http.server | grep -v grep | awk '{print $2}'"], shell=True, text=True, capture_output=True).stdout.rstrip().split('\n')
 
-## For each http.server processes detected, make educated guesses about which is which:
+## For each http.server processes detected, make educated guesses about which is which, determine the port used, and build the staging URL to scrape against:
 for pid in http_server_process_pids:
     http_server_pwd_result = subprocess.run(["lsof -Pp " + pid + " | grep cwd | awk {'print $9'}"], shell=True, text = True, capture_output=True).stdout.rstrip()
     
@@ -579,7 +578,8 @@ def parse(type, names):
         sdk_url = sdk_url_mapping[sdk]
         scrape_url = sdk_url
 
-        ## Build empty dict to house methods:
+        ## Build empty dict to house methods, and update scrape_url
+        ## with staging link if we detected one earlier:
         if sdk == "go":
             go_methods = {}
             go_methods[type] = {}


### PR DESCRIPTION
Enhance `update_sdk_methods.py` to be able to scrape more locally-staged content:
- Now supports scraping all content from a staged Go docs instance, rather than only code samples
- Now supports scraping all content from a staged Python docs instance.
- Now supports scraping all content from a staged Flutter docs instance.

NOTE:
- Check out the new Wiki page in the Dev Content section for how to stage each of the three SDK docs sites locally.