### PR TITLE
DOCS-2418: Fix file path to enable PWM on pi5

### DIFF
--- a/docs/components/board/pi5.md
+++ b/docs/components/board/pi5.md
@@ -21,7 +21,7 @@ To configure a Raspberry Pi 4 or earlier, see [Configure a Raspberry Pi 4, 3, or
 
 ### Enable hardware PWM
 
-_(Optional)_ If you want to use hardware PWM on {{< glossary_tooltip term_id="pin-number" text="pins" >}} 12 and 35, edit <file>/boot/config.txt</file> on your Pi, adding the following line:
+_(Optional)_ If you want to use hardware PWM on {{< glossary_tooltip term_id="pin-number" text="pins" >}} 12 and 35, edit <file>/boot/firmare/config.txt</file> on your Pi, adding the following line:
 
 ```sh {class="line-numbers linkable-line-numbers"}
 dtoverlay=pwm-2chan

--- a/docs/components/board/pi5.md
+++ b/docs/components/board/pi5.md
@@ -21,7 +21,7 @@ To configure a Raspberry Pi 4 or earlier, see [Configure a Raspberry Pi 4, 3, or
 
 ### Enable hardware PWM
 
-_(Optional)_ If you want to use hardware PWM on {{< glossary_tooltip term_id="pin-number" text="pins" >}} 12 and 35, edit <file>/boot/firmare/config.txt</file> on your Pi, adding the following line:
+_(Optional)_ If you want to use hardware PWM on {{< glossary_tooltip term_id="pin-number" text="pins" >}} 12 and 35, edit <file>/boot/firmware/config.txt</file> on your Pi, adding the following line:
 
 ```sh {class="line-numbers linkable-line-numbers"}
 dtoverlay=pwm-2chan


### PR DESCRIPTION
* Fix with suggestion from @oliviamiller 

Olivia: need to confirm with you that this is `firmware` and not `firmare`? Googling ([this forum](https://forums.raspberrypi.com/viewtopic.php?t=367971)) seems  to suggest firmware so I figured it might be a typo but not sure, don't have access to pi5