### PR TITLE
DOCS-2439: Fix Go versioned links

### DIFF
--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -714,7 +714,10 @@ def parse(type, names):
 
                                 ## Get full method usage string, by omitting all comment spans:
                                 method_usage_raw = regex.sub(r'<span class="comment">.*</span>', '', this_method_raw2)
-                                this_method_dict["usage"] = regex.sub(r'</span>', '', method_usage_raw).replace("\t", "  ").lstrip().rstrip()
+                                method_usage_raw2 = regex.sub(r'</span>', '', method_usage_raw).replace("\t", "  ").lstrip().rstrip()
+                                ## Some Go params use versioned links, some omit the version (to use latest).
+                                ## Standardize on using latest for all cases. This handles parameters and returns:
+                                this_method_dict["usage"] = regex.sub(r'/rdk@v[0-9\.]*/', '/rdk/', method_usage_raw2, flags=regex.DOTALL)
 
                                 ## Not possible to link to the specific functions, so we link to the parent resource instead:
                                 this_method_dict["method_link"] = url + '#' + interface_name


### PR DESCRIPTION
Fix scraped Go parameter and return links that contain GO SDK versions to use latest instead.
- Some upstream param and return type links use versioned SDK url, some use latest. This standardizes on latest for all case, regardless of upstream.

NOTE:
- It is possible that there are times where we might actually want a version in the URL, like for legacy support of a method that has since been deleted from current versions, but exists in archived versions, for example. If this becomes the case, we can revert this. Nearer-term: leaving versions in is instead more likely to result in users finding themselves on upstream docs pages that contain outdated information.