### PR TITLE
DOCS-2471: Remove SDK links from proto descriptions

### DIFF
--- a/static/include/app/apis/overrides/protos/data.AddBinaryDataToDatasetByIds.md
+++ b/static/include/app/apis/overrides/protos/data.AddBinaryDataToDatasetByIds.md
@@ -1,2 +1,2 @@
-Add the [BinaryData](https://python.viam.dev/autoapi/viam/proto/app/data/index.html#viam.proto.app.data.BinaryData) to the provided dataset.
+Add the `BinaryData` to the provided dataset.
 This BinaryData will be tagged with the VIAM_DATASET\_{id} label.

--- a/static/include/app/apis/overrides/protos/data.BinaryDataByIDs.md
+++ b/static/include/app/apis/overrides/protos/data.BinaryDataByIDs.md
@@ -1,2 +1,2 @@
-Retrieve binary data from the [Viam app](https://app.viam.com) by [`BinaryID`](https://python.viam.dev/autoapi/viam/proto/app/data/index.html#viam.proto.app.data.BinaryID).
+Retrieve binary data from the [Viam app](https://app.viam.com) by `BinaryID`.
 You can also find your binary data under the **Images**, **Point clouds**, or **Files** subtab of the app's [**Data** tab](https://app.viam.com/data), depending on the type of data that you have uploaded.

--- a/static/include/components/apis/overrides/protos/arm.GetEndPosition.md
+++ b/static/include/components/apis/overrides/protos/arm.GetEndPosition.md
@@ -1,1 +1,1 @@
-Get the current position of the arm as a [Pose](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.Pose).
+Get the current position of the arm as a [pose](/internals/orientation-vector/).

--- a/static/include/components/apis/overrides/protos/arm.MoveToPosition.md
+++ b/static/include/components/apis/overrides/protos/arm.MoveToPosition.md
@@ -1,1 +1,1 @@
-Move the end of the arm to the desired [Pose](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.Pose), relative to the base of the arm.
+Move the end of the arm to the desired [pose](/internals/orientation-vector/), relative to the base of the arm.

--- a/static/include/services/apis/overrides/protos/motion.MoveOnMap.md
+++ b/static/include/services/apis/overrides/protos/motion.MoveOnMap.md
@@ -1,6 +1,6 @@
-Move a [base](/components/base/) component to a destination [`Pose`](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.Pose) on a {{< glossary_tooltip term_id="slam" text="SLAM" >}} map.
+Move a [base](/components/base/) component to a destination [pose](/internals/orientation-vector/) on a {{< glossary_tooltip term_id="slam" text="SLAM" >}} map.
 
-`MoveOnMap()` is non blocking, meaning the motion service will move the component to the destination [`Pose`](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.Pose) after `MoveOnMap()` returns.
+`MoveOnMap()` is non blocking, meaning the motion service will move the component to the destination [pose](/internals/orientation-vector/) after `MoveOnMap()` returns.
 
 Each successful `MoveOnMap()` call returns a unique `ExecutionID` which you can use to identify all plans generated during the `MoveOnMap()` call.
 


### PR DESCRIPTION
Remove SDK links from proto descriptions.
- Converted `Pose` to use docs-side link target, matching other uses sitewide (like [this one](https://docs.viam.com/internals/kinematic-chain-config/#kinematic-parameters))
- Unlinked `BinaryData` entirely.