### PR TITLE
Fix Board Analog API methods

### DIFF
--- a/docs/components/board/_index.md
+++ b/docs/components/board/_index.md
@@ -1060,7 +1060,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 ### Read
 
-Read the current value from the analog reader.
+Read the current value from an analog pin or analog reader capable of reading analog values.
 
 {{< tabs >}}
 {{% tab name="Python" %}}
@@ -1117,8 +1117,9 @@ myBoard, err := board.FromRobot(robot, "my_board")
 analog, err := myBoard.AnalogByName("my_example_analog")
 
 // Get the value of the digital signal "my_example_analog" has most recently measured.
-reading := analog.Read(context.Background(), nil)
-reading_value := reading.Value
+reading, err := analog.Read(context.Background(), nil)
+readingValue := reading.Value
+stepSize := reading.StepSize
 ```
 
 {{% /tab %}}
@@ -1126,7 +1127,7 @@ reading_value := reading.Value
 
 ### Write
 
-Write a value to the analog writer.
+Write an analog value to a pin or analog output on a board capable of doing so.
 
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/components/board/_index.md
+++ b/docs/components/board/_index.md
@@ -1072,7 +1072,7 @@ Read the current value from the analog reader.
 
 **Returns:**
 
-- [(int)](https://docs.python.org/3/library/functions.html#int): The value of the digital signal output by the analog pin.
+- [(Analog.Value)](https://python.viam.dev/autoapi/viam/components/board/index.html#viam.components.board.Board.Analog.Value): The current value, including the integer `value` of the digital signal output by the analog pin and the `min_range`, `max_range`, and `step_size` of the reader.
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/board/index.html#viam.components.board.Board.Analog.read).
 
@@ -1092,6 +1092,7 @@ analog = await my_board.analog_by_name(
 # Get the value of the digital signal "my_example_analog" has most
 # recently measured.
 reading = analog.read()
+reading_value = reading.value
 ```
 
 {{% /tab %}}
@@ -1104,10 +1105,10 @@ reading = analog.read()
 
 **Returns:**
 
-- [(int)](https://pkg.go.dev/builtin#int): The value of the digital signal output by the analog pin.
+- [(AnalogValue)](https://pkg.go.dev/go.viam.com/rdk/components/board#AnalogValue): The current value, including the integer `Value` of the digital signal output by the analog pin and the `Min`, `Max`, and `StepSize` of the reader.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
-For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/board#GPIOPin).
+For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/board#Analog).
 
 ```go
 myBoard, err := board.FromRobot(robot, "my_board")
@@ -1117,6 +1118,7 @@ analog, err := myBoard.AnalogByName("my_example_analog")
 
 // Get the value of the digital signal "my_example_analog" has most recently measured.
 reading := analog.Read(context.Background(), nil)
+reading_value := reading.Value
 ```
 
 {{% /tab %}}

--- a/docs/components/board/_index.md
+++ b/docs/components/board/_index.md
@@ -1142,7 +1142,7 @@ Write a value to the analog writer.
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/board/client/index.html#viam.components.board.client.AnalogClient.write).
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_board = Board.from_robot(robot=robot, name=”my_board”)
+my_board = Board.from_robot(robot=robot, name="my_board")
 
 # Get the AnalogWriter “my_example_analog_writer”.
 writer = await my_board.analog_by_name(name=”my_example_analog_writer”)

--- a/docs/components/board/_index.md
+++ b/docs/components/board/_index.md
@@ -1148,7 +1148,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 my_board = Board.from_robot(robot=robot, name="my_board")
 
 # Get the AnalogWriter “my_example_analog_writer”.
-writer = await my_board.analog_by_name(name=”my_example_analog_writer”)
+writer = await my_board.analog_by_name(name="my_example_analog_writer")
 
 await writer.write(42)
 ```

--- a/docs/components/board/_index.md
+++ b/docs/components/board/_index.md
@@ -1072,7 +1072,7 @@ Read the current value from the analog reader.
 
 **Returns:**
 
-- [(Analog.Value)](https://python.viam.dev/autoapi/viam/components/board/index.html#viam.components.board.Board.Analog.Value): The current value, including the integer `value` of the digital signal output by the analog pin and the `min_range`, `max_range`, and `step_size` of the reader.
+- [(Analog.Value)](https://python.viam.dev/autoapi/viam/components/board/index.html#viam.components.board.Board.Analog.Value): The result of reading an analog reader. It contains the raw data read as `value`, the reader’s minimum and maximum possible values as `min_range` and `max_range`, and its `step_size` (the minimum possible change between values it can read).
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/board/index.html#viam.components.board.Board.Analog.read).
 

--- a/docs/components/board/_index.md
+++ b/docs/components/board/_index.md
@@ -119,7 +119,7 @@ Additionally, the nested `GPIOPin`, `Analog`, and `DigitalInterrupt` interfaces 
 
 {{< readfile "/static/include/components/apis/digitalinterrupt.md" >}}
 
-### ReadAnalog
+### AnalogByName
 
 Get an [`Analog`](#analogs) pin by `name`.
 
@@ -153,7 +153,7 @@ analog = await my_board.analog_by_name(name="my_example_analog")
 **Returns:**
 
 - [(Analog)](https://pkg.go.dev/go.viam.com/rdk/components/board#AnalogReader): An interface representing an analog pin configured and residing on the board.
-- [(bool)](https://pkg.go.dev/builtin#bool): True if there was an analog pin of this `name` found on your board.
+- [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/board#Board).
 
@@ -162,9 +162,6 @@ myBoard, err := board.FromRobot(robot, "my_board")
 
 // Get the Analog pin "my_example_analog".
 analog, err := myBoard.AnalogByName("my_example_analog")
-
-// Read the value from the analog pin.
-val, err := analog.Read(context.Background, map[string]interface{})
 ```
 
 {{% /tab %}}
@@ -418,58 +415,6 @@ myBoard, err := board.FromRobot(robot, "my_board")
 
 // Set the power mode of the board to OFFLINE_DEEP.
 myBoard.SetPowerMode(context.Background(), boardpb.PowerMode_POWER_MODE_OFFLINE_DEEP, nil)
-```
-
-{{% /tab %}}
-{{< /tabs >}}
-
-### WriteAnalog
-
-Write an analog value to a pin on the board.
-
-{{< tabs >}}
-{{% tab name="Python" %}}
-
-**Parameters:**
-
-- `pin` [(string)](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str): Name of the pin ({{< glossary_tooltip term_id="pin-number" text="pin number" >}}).
-- `value` [(int)](https://docs.python.org/3/library/functions.html#int): Value to write to the pin.
-- `timeout` [(Optional\[float\])](https://docs.python.org/library/typing.html#typing.Optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
-
-**Returns:**
-
-- None
-
-```python {class="line-numbers linkable-line-numbers"}
-my_board = Board.from_robot(robot=robot, name="my_board")
-
-# Set pin 11 to value 48.
-await my_board.write_analog(pin="11", value=48)
-```
-
-For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/board/board/index.html#viam.components.board.board.Board.write_analog).
-
-{{% /tab %}}
-{{% tab name="Go" %}}
-
-**Parameters:**
-
-- `ctx` [(Context)](https://pkg.go.dev/context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
-- `pin` [(string)](https://pkg.go.dev/builtin#string): Name of the pin ({{< glossary_tooltip term_id="pin-number" text="pin number" >}}).
-- `value` [(int)](https://pkg.go.dev/builtin#int32): Value to write to the pin.
-- `extra` [(map\[string\]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
-
-**Returns:**
-
-- [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
-
-For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/board#Board).
-
-```go
-myBoard, err := board.FromRobot(robot, "my_board")
-
-// Set pin 11 to value 48.
-err := myBoard.WriteAnalog(context.Background(), "11", 48, nil)
 ```
 
 {{% /tab %}}
@@ -1115,7 +1060,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 ### Read
 
-Read the current integer value of the digital signal output by the [ADC](#analogs).
+Read the current value from the analog reader.
 
 {{< tabs >}}
 {{% tab name="Python" %}}
@@ -1129,7 +1074,7 @@ Read the current integer value of the digital signal output by the [ADC](#analog
 
 - [(int)](https://docs.python.org/3/library/functions.html#int): The value of the digital signal output by the analog pin.
 
-For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/board/index.html#viam.components.board.Board.AnalogReader.read).
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/board/index.html#viam.components.board.Board.Analog.read).
 
 ```python
 my_board = Board.from_robot(robot=robot, name="my_board")
@@ -1177,30 +1122,33 @@ reading := analog.Read(context.Background(), nil)
 {{% /tab %}}
 {{< /tabs >}}
 
-### Close
+### Write
 
-Safely shut down the resource and prevent further use.
+Write a value to the analog writer.
 
 {{< tabs >}}
 {{% tab name="Python" %}}
 
 **Parameters:**
 
-- None
+- `value` [(int)](https://docs.python.org/3/library/functions.html#int): Value to write to the pin.
+- `extra` [(Optional\[Dict\[str, Any\]\])](https://docs.python.org/library/typing.html#typing.Optional): Extra options to pass to the underlying RPC call.
+- `timeout` [(Optional\[float\])](https://docs.python.org/library/typing.html#typing.Optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
 
 **Returns:**
 
 - None
 
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/board/client/index.html#viam.components.board.client.AnalogClient.write).
+
 ```python {class="line-numbers linkable-line-numbers"}
-my_board = Board.from_robot(robot=robot, name="my_board")
+my_board = Board.from_robot(robot=robot, name=”my_board”)
 
-# Get the Analog pin "my_example_analog".
-analog = await my_board.analog_by_name(
-    name="my_example_analog")
+# Get the AnalogWriter “my_example_analog_writer”.
+writer = await my_board.analog_by_name(name=”my_example_analog_writer”)
+
+await writer.write(42)
 ```
-
-For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/board/client/index.html#viam.components.board.client.AnalogReaderClient.close).
 
 {{% /tab %}}
 {{% tab name="Go" %}}
@@ -1208,22 +1156,24 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Parameters:**
 
 - `ctx` [(Context)](https://pkg.go.dev/context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
+- `value` [(int)](https://pkg.go.dev/builtin#int32): Value to write to the pin.
+- `extra` [(map\[string\]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
 
 **Returns:**
 
-- [(error)](https://pkg.go.dev/builtin#error) : An error, if one occurred.
+- [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
-```go {class="line-numbers linkable-line-numbers"}
+For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/board#Board).
+
+```go
 myBoard, err := board.FromRobot(robot, "my_board")
 
-// Get the Analog "my_example_analog".
+// Get the Analog pin "my_example_analog".
 analog, err := myBoard.AnalogByName("my_example_analog")
 
-// Read the current value from the analog pin.
-value, err := analog.Read(context.Background(), map[string]interface{})
+// Set the pin to value 48.
+err := analog.Write(context.Background(), 48, nil)
 ```
-
-For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/static/include/components/apis/analogreader.md
+++ b/static/include/components/apis/analogreader.md
@@ -1,5 +1,5 @@
 <!-- prettier-ignore -->
 | Method Name | Description |
 | ----------- | ----------- |
-| [`Read`](/components/board/#read)   | Read the current integer value of the digital signal output by the ADC. |
-| [`Write`](/components/board/#write) | Write a value to the analog writer. |
+| [`Read`](/components/board/#read)   | Read the current integer value of the digital signal output by an analog pin or ADC. |
+| [`Write`](/components/board/#write) | Write an analog value using a pin on an SBC capable of doing so. |

--- a/static/include/components/apis/analogreader.md
+++ b/static/include/components/apis/analogreader.md
@@ -1,4 +1,5 @@
-| Method Name                         | Description                                                             |
-| ----------------------------------- | ----------------------------------------------------------------------- |
+<!-- prettier-ignore -->
+| Method Name | Description |
+| ----------- | ----------- |
 | [`Read`](/components/board/#read)   | Read the current integer value of the digital signal output by the ADC. |
-| [`Close`](/components/board/#close) | Safely shut down the resource and prevent further use.                  |
+| [`Write`](/components/board/#write) | Write a value to the analog writer. |

--- a/static/include/components/apis/board.md
+++ b/static/include/components/apis/board.md
@@ -1,14 +1,13 @@
 <!-- prettier-ignore -->
 Method Name | Description
 ----------- | -----------
-[`ReadAnalog`](/components/board/#readanalog) | Get an [`Analog`](/components/board/#analogs) by `name`.
+[`AnalogByName`](/components/board/#analogbyname) | Get an [`Analog`](/components/board/#analogs) by `name`.
 [`GetDigitalInterruptValue`](/components/board/#getdigitalinterruptvalue) | Get a [`DigitalInterrupt`](/components/board/#digital_interrupts) by `name`.
 [`GetGPIO`](/components/board/#getgpio) | Get a `GPIOPin` by its {{< glossary_tooltip term_id="pin-number" text="pin number" >}}.
 [`SetGPIO`](/components/board/#setgpio) | Set a `GPIOPin` by its {{< glossary_tooltip term_id="pin-number" text="pin number" >}}.
 [`AnalogNames`](/components/board/#analognames) | Get the `name` of every [`Analog`](/components/board/#analogs).
 [`DigitalInterruptNames`](/components/board/#digitalinterruptnames) | Get the `name` of every [`DigitalInterrupt`](/components/board/#digital_interrupts).
 [`SetPWM`](/components/board/#setpwm) | Set the board to the indicated power mode.
-[`WriteAnalog`](/components/board/#writeanalog) | Write an analog value to a pin on the board.
 [`StreamTicks`](/components/board/#streamticks) | Start a stream of [`DigitalInterrupt`](/components/board/#digital_interrupts) ticks.
 [`GetGeometries`](/components/board/#getgeometries) | Get all the geometries associated with the board in its current configuration, in the [frame](/services/frame-system/) of the board.
 [`DoCommand`](/components/board/#docommand) | Send or receive model-specific commands.


### PR DESCRIPTION
Try 2 

- Fix python method and heading name on AnalogByName (see [this PR](https://github.com/viamrobotics/docs/pull/2861))
- Fix Analog `Read` links 
- Add Analog `Write` method
- Remove `WriteAnalog` method from board (was moved to Analog interface)
- Remove Analog `Close` method (not there/no longer exists) 

As far as I can tell this doesn't cross with with other signaling APIs pr to fix the way they're displayed on the [main APIs page?](https://docs.viam.com/appendix/apis/) (which seems to have been moved into the appendix anyways)-- if we change the way they're displayed on the board page I think this would still need to be fixed 