### PR TITLE
Improve MD link stripping

### DIFF
--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -1569,7 +1569,7 @@ def write_markdown(type, names, methods):
                             search_result = file_contents.split('.\n', 1)[0].strip().replace("\n", " ")
 
                             ## If the proto description contains any MD links, strip them out:
-                            search_result = regex.sub(r"\[(.+?)\]\(.+?\)", r"\1", search_result)
+                            search_result = regex.sub(r'\[([A-Za-z0-9\.\(\)\-\_\`\s]*)\]\([A-Za-z0-9\.\:\/\-\_\#]*\)', r'\1', search_result)
 
                             ## If the proto description is missing a trailing period, or we stripped it off during the above matching, append
                             ## (restore) the period character:

--- a/static/include/components/apis/overrides/protos/movement_sensor.GetCompassHeading.md
+++ b/static/include/components/apis/overrides/protos/movement_sensor.GetCompassHeading.md
@@ -1,3 +1,3 @@
-Report the current [compass heading](<https://en.wikipedia.org/wiki/Heading_(navigation)>) in degrees.
+Report the current [compass heading](https://en.wikipedia.org/wiki/Heading_(navigation)) in degrees.
 
 Supported by GPS models.


### PR DESCRIPTION
Improve the stripping of MD links from proto override files to handle links with title text that includes parens, skip square bracket pairs that aren't part of MD links (like text ```a float [`0.0`, `1.0`]```, and catch a few other misses from my first iteration.
- Also update override file with malformed link.