### PR TITLE
DOCS-2488: Add param, return override support

### DIFF
--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -1445,8 +1445,20 @@ def format_method_usage(parsed_usage_string, go_method_name, resource, path_to_m
             return_string += f"- `{type_name}` [({param_type})]({param_type_link}): A Context carries a deadline, a cancellation signal, and other values across API boundaries."
         elif type_name == "extra":
             return_string += f"- `{type_name}` [({param_type})]({param_type_link}): Extra options to pass to the underlying RPC call."
-        elif type_name == "cmd":
+        elif go_method_name == "DoCommand" and type_name == "cmd":
             return_string += f"- `{type_name}` [({param_type})]({param_type_link}): The command to execute."
+        elif go_method_name == "Reconfigure" and type_name == "deps":
+            return_string += f"- `{type_name}` [({param_type})]({param_type_link}): The resource dependencies."
+        elif go_method_name == "Reconfigure" and type_name == "conf":
+            return_string += f"- `{type_name}` [({param_type})]({param_type_link}): The resource configuration."
+        elif go_method_name == "DoCommand" and param_type == "map[string]interface{}":
+            return_string += f"- [({param_type})]({param_type_link}): The command response."
+        elif go_method_name == "Geometries" and param_type == "[]spatialmath.Geometry":
+            return_string += f"- [({param_type})]({param_type_link}): The geometries associated with this resource, in any order."
+        elif go_method_name == "IsMoving" and param_type == "bool":
+            return_string += f"- [({param_type})]({param_type_link}): Whether this resource is moving (`true`) or not (`false`)."
+        elif go_method_name == "Readings" and param_type == "map[string]interface{}":
+            return_string += f"- [({param_type})]({param_type_link}): A map containing the measurements from the sensor. Contents depend on sensor model and can be of any type."
         elif param_type == "error":
             return_string += f"- [({param_type})]({param_type_link}): An error, if one occurred."
         else:
@@ -1474,7 +1486,7 @@ def format_method_usage(parsed_usage_string, go_method_name, resource, path_to_m
             if os.path.exists(param_desc_override_file):
                 for line in open(param_desc_override_file, 'r', encoding='utf-8'):
                     param_or_return_description = param_or_return_description + line.replace('\n', ' ')
-                param_or_return_description.rstrip()
+                param_or_return_description = param_or_return_description.rstrip()
 
             ## If we have a param description override, use that. If not, skip:
             if param_or_return_description != '':

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -1483,7 +1483,7 @@ def format_method_usage(parsed_usage_string, go_method_name, resource, path_to_m
                 param_desc_override_file = path_to_methods_override + '/go.' + resource + '.' + go_method_name + '.' + return_type_short + '.return.md'
 
             ## NOTE: To help when populating override files, uncomment this line, run this script, and use printed paths as filepaths:
-            #print('         ' + param_desc_override_file.split('/')[-1])
+            #print(param_desc_override_file)
 
             if os.path.exists(param_desc_override_file):
                 for line in open(param_desc_override_file, 'r', encoding='utf-8'):
@@ -1700,7 +1700,7 @@ def write_markdown(type, names, methods):
                                     param_desc_override_file = path_to_methods_override + '/python.' + resource + '.' + py_method_name + '.' + parameter + '.md'
 
                                     ## NOTE: To help when populating param override files, uncomment this line, run this script, and use printed paths as filepaths:
-                                    #print('         ' + param_desc_override_file.split('/')[-1])
+                                    #print(param_desc_override_file)
 
                                     if os.path.exists(param_desc_override_file):
                                         for line in open(param_desc_override_file, 'r', encoding='utf-8'):
@@ -1745,7 +1745,7 @@ def write_markdown(type, names, methods):
                                 return_desc_override_file = path_to_methods_override + '/python.' + resource + '.' + py_method_name + '.return.md'
 
                                 ## NOTE: To help when populating return override files, uncomment this line, run this script, and use printed paths as filepaths:
-                                #print('         ' + return_desc_override_file.split('/')[-1])
+                                #print(return_desc_override_file)
 
                                 if os.path.exists(return_desc_override_file):
                                     for line in open(return_desc_override_file, 'r', encoding='utf-8'):
@@ -1917,7 +1917,7 @@ def write_markdown(type, names, methods):
                                     param_desc_override_file = path_to_methods_override + '/flutter.' + resource + '.' + flutter_method_name + '.' + parameter + '.md'
 
                                     ## NOTE: To help when populating param override files, uncomment this line, run this script, and use printed paths as filepaths:
-                                    #print('         ' + param_desc_override_file.split('/')[-1])
+                                    #print(param_desc_override_file)
 
                                     if os.path.exists(param_desc_override_file):
                                         for line in open(param_desc_override_file, 'r', encoding='utf-8'):
@@ -1983,7 +1983,7 @@ def write_markdown(type, names, methods):
                                     return_desc_override_file = path_to_methods_override + '/flutter.' + resource + '.' + flutter_method_name + '.' + return_name + '.md'
 
                                     ## NOTE: To help when populating return override files, uncomment this line, run this script, and use printed paths as filepaths:
-                                    #print('         ' + return_desc_override_file.split('/')[-1])
+                                    #print(return_desc_override_file)
 
                                     if os.path.exists(return_desc_override_file):
                                         for line in open(return_desc_override_file, 'r', encoding='utf-8'):

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -1469,7 +1469,7 @@ def format_method_usage(parsed_usage_string, go_method_name, resource, path_to_m
                 param_desc_override_file = path_to_methods_override + '/go.' + resource + '.' + go_method_name + '.' + return_type_short + '.return.md'
 
             ## NOTE: To help when populating override files, uncomment this line, run this script, and use printed paths as filepaths:
-            #print(param_desc_override_file)
+            #print('         ' + param_desc_override_file.split('/')[-1])
 
             if os.path.exists(param_desc_override_file):
                 for line in open(param_desc_override_file, 'r', encoding='utf-8'):
@@ -1680,7 +1680,7 @@ def write_markdown(type, names, methods):
                                     param_desc_override_file = path_to_methods_override + '/python.' + resource + '.' + py_method_name + '.' + parameter + '.md'
 
                                     ## NOTE: To help when populating param override files, uncomment this line, run this script, and use printed paths as filepaths:
-                                    #print(param_desc_override_file)
+                                    #print('         ' + param_desc_override_file.split('/')[-1])
 
                                     if os.path.exists(param_desc_override_file):
                                         for line in open(param_desc_override_file, 'r', encoding='utf-8'):
@@ -1720,7 +1720,7 @@ def write_markdown(type, names, methods):
                                 return_desc_override_file = path_to_methods_override + '/python.' + resource + '.' + py_method_name + '.return.md'
 
                                 ## NOTE: To help when populating return override files, uncomment this line, run this script, and use printed paths as filepaths:
-                                #print(return_desc_override_file)
+                                #print('         ' + return_desc_override_file.split('/')[-1])
 
                                 if os.path.exists(return_desc_override_file):
                                     for line in open(return_desc_override_file, 'r', encoding='utf-8'):
@@ -1887,7 +1887,7 @@ def write_markdown(type, names, methods):
                                     param_desc_override_file = path_to_methods_override + '/flutter.' + resource + '.' + flutter_method_name + '.' + parameter + '.md'
 
                                     ## NOTE: To help when populating param override files, uncomment this line, run this script, and use printed paths as filepaths:
-                                    #print(param_desc_override_file)
+                                    #print('         ' + param_desc_override_file.split('/')[-1])
 
                                     if os.path.exists(param_desc_override_file):
                                         for line in open(param_desc_override_file, 'r', encoding='utf-8'):
@@ -1947,7 +1947,7 @@ def write_markdown(type, names, methods):
                                     return_desc_override_file = path_to_methods_override + '/flutter.' + resource + '.' + flutter_method_name + '.' + return_name + '.md'
 
                                     ## NOTE: To help when populating return override files, uncomment this line, run this script, and use printed paths as filepaths:
-                                    #print(return_desc_override_file)
+                                    #print('         ' + return_desc_override_file.split('/')[-1])
 
                                     if os.path.exists(return_desc_override_file):
                                         for line in open(return_desc_override_file, 'r', encoding='utf-8'):

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -1472,12 +1472,12 @@ def format_method_usage(parsed_usage_string, go_method_name, resource, path_to_m
             else:
                 if 'map[string]interface{}' in param_type:
                     return_type_short = 'string'
-                elif param_type.startswith('[]'):
-                    return_type_short = param_type.removeprefix('[]')
                 elif '.' in param_type:
                     return_type_short = param_type.split('.')[-1]
                 else:
                     return_type_short = param_type
+
+                return_type_short = return_type_short.removeprefix('[]').removeprefix('*')
 
                 ## .../overrides/methods/{sdk}.{resource}.{go_method_name}.{return_data_type_last_part}.return.md
                 param_desc_override_file = path_to_methods_override + '/go.' + resource + '.' + go_method_name + '.' + return_type_short + '.return.md'
@@ -1682,7 +1682,7 @@ def write_markdown(type, names, methods):
 
                             ## If we detected a 'before' method override file, write it out here:
                             if os.path.exists(before_method_override_filepath):
-                                for line in open(before_method_override_file_path, 'r', encoding='utf-8'):
+                                for line in open(before_method_override_filepath, 'r', encoding='utf-8'):
                                     output_file.write(line)
 
                             output_file.write('**Parameters:**\n\n')
@@ -1782,7 +1782,7 @@ def write_markdown(type, names, methods):
                             if os.path.exists(after_method_override_filepath):
 
                                 output_file.write('\n')
-                                for line in open(after_method_override_file_path, 'r', encoding='utf-8'):
+                                for line in open(after_method_override_filepath, 'r', encoding='utf-8'):
                                     output_file.write(line)
 
                             # Output the method link
@@ -1806,7 +1806,7 @@ def write_markdown(type, names, methods):
 
                             ## If we detected a 'before' method override file, write it out here:
                             if os.path.exists(before_method_override_filepath):
-                                for line in open(before_method_override_file_path, 'r', encoding='utf-8'):
+                                for line in open(before_method_override_filepath, 'r', encoding='utf-8'):
                                     output_file.write(line)
 
                                 output_file.write('\n')
@@ -1875,7 +1875,7 @@ def write_markdown(type, names, methods):
                             if os.path.exists(after_method_override_filepath):
 
                                 output_file.write('\n')
-                                for line in open(after_method_override_file_path, 'r', encoding='utf-8'):
+                                for line in open(after_method_override_filepath, 'r', encoding='utf-8'):
                                     output_file.write(line)
 
                             # Output the method link
@@ -1898,7 +1898,7 @@ def write_markdown(type, names, methods):
 
                             ## If we detected a 'before' method override file, write it out here:
                             if os.path.exists(before_method_override_filepath):
-                                for line in open(before_method_override_file_path, 'r', encoding='utf-8'):
+                                for line in open(before_method_override_filepath, 'r', encoding='utf-8'):
                                     output_file.write(line)
 
                             output_file.write('**Parameters:**\n\n')
@@ -2034,7 +2034,7 @@ def write_markdown(type, names, methods):
                             if os.path.exists(after_method_override_filepath):
 
                                 output_file.write('\n')
-                                for line in open(after_method_override_file_path, 'r', encoding='utf-8'):
+                                for line in open(after_method_override_filepath, 'r', encoding='utf-8'):
                                     output_file.write(line)
 
                             # Output the method link

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -1471,7 +1471,9 @@ def format_method_usage(parsed_usage_string, go_method_name, resource, path_to_m
             ## Return override:
             else:
                 if 'map[string]interface{}' in param_type:
-                    return_type_short = 'string' 
+                    return_type_short = 'string'
+                elif param_type.startswith('[]'):
+                    return_type_short = param_type.removeprefix('[]')
                 elif '.' in param_type:
                     return_type_short = param_type.split('.')[-1]
                 else:

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -1478,6 +1478,11 @@ def format_method_usage(parsed_usage_string, go_method_name, resource, path_to_m
 
             ## If we have a param description override, use that. If not, skip:
             if param_or_return_description != '':
+
+                ## Add a trailing period if it is missing, either from upstream or from override file:
+                if not param_or_return_description.endswith('.'):
+                    param_or_return_description = param_or_return_description + '.'
+
                 ## Format returns:
                 if type_name == '':
                    return_string += f"- [({param_type})]({param_type_link}): {param_or_return_description}"
@@ -1700,6 +1705,11 @@ def write_markdown(type, names, methods):
                                         output_file.write(' (required)')
 
                                     if param_description:
+
+                                        ## Add a trailing period if it is missing, either from upstream or from override file:
+                                        if not param_description.endswith('.'):
+                                            param_description = param_description + '.'
+
                                         output_file.write(f": {param_description}")
 
                                     # line break for parameters list
@@ -1734,6 +1744,11 @@ def write_markdown(type, names, methods):
                                     output_file.write(f"- ({return_type})")
 
                                     if return_description:
+
+                                        ## Add a trailing period if it is missing, either from upstream or from override file:
+                                        if not return_description.endswith('.'):
+                                            return_description = return_description + '.'
+
                                         output_file.write(f": {return_description}\n")
                                     else:
                                         output_file.write("\n")
@@ -1924,6 +1939,11 @@ def write_markdown(type, names, methods):
                                         output_file.write(' (required)')
 
                                     if param_description:
+
+                                        ## Add a trailing period if it is missing, either from upstream or from override file:
+                                        if not param_description.endswith('.'):
+                                            param_description = param_description + '.'
+
                                         output_file.write(f": {param_description}")
 
                                     # line break for parameters list
@@ -1976,6 +1996,11 @@ def write_markdown(type, names, methods):
                                             pass
 
                                         if return_description:
+
+                                            ## Add a trailing period if it is missing, either from upstream or from override file:
+                                            if not return_description.endswith('.'):
+                                                return_description = return_description + '.'
+
                                             output_file.write(f": {return_description}\n")
                                         else:
                                             output_file.write("\n")

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -1473,7 +1473,8 @@ def format_method_usage(parsed_usage_string, go_method_name, resource, path_to_m
 
             if os.path.exists(param_desc_override_file):
                 for line in open(param_desc_override_file, 'r', encoding='utf-8'):
-                    param_or_return_description = param_or_return_description + line.rstrip()
+                    param_or_return_description = param_or_return_description + line.replace('\n', ' ')
+                param_or_return_description.rstrip()
 
             ## If we have a param description override, use that. If not, skip:
             if param_or_return_description != '':
@@ -1491,7 +1492,7 @@ def format_method_usage(parsed_usage_string, go_method_name, resource, path_to_m
                 else:
                    return_string += f"- `{type_name}` [({param_type})]({param_type_link})"
 
-        formatted_output.append(return_string)
+        formatted_output.append(return_string.rstrip())
 
     return formatted_output
 
@@ -1684,7 +1685,7 @@ def write_markdown(type, names, methods):
 
                                     if os.path.exists(param_desc_override_file):
                                         for line in open(param_desc_override_file, 'r', encoding='utf-8'):
-                                            param_description = param_description + line
+                                            param_description = param_description + line.replace('\n', ' ')
                                         param_description = param_description.rstrip()
                                     else:
                                         param_description = param_data.get("param_description")
@@ -1724,7 +1725,7 @@ def write_markdown(type, names, methods):
 
                                 if os.path.exists(return_desc_override_file):
                                     for line in open(return_desc_override_file, 'r', encoding='utf-8'):
-                                        return_description = return_description + line
+                                        return_description = return_description + line.replace('\n', ' ')
                                     return_description = return_description.rstrip()
                                 else:
                                     return_description = return_data.get("return_description")
@@ -1891,7 +1892,8 @@ def write_markdown(type, names, methods):
 
                                     if os.path.exists(param_desc_override_file):
                                         for line in open(param_desc_override_file, 'r', encoding='utf-8'):
-                                            param_description = param_description + line.rstrip()
+                                            param_description = param_description + line.replace('\n', ' ')
+                                        param_description = param_description.rstrip()
                                     else:
                                         param_description = param_data.get("param_description")
 
@@ -1951,7 +1953,8 @@ def write_markdown(type, names, methods):
 
                                     if os.path.exists(return_desc_override_file):
                                         for line in open(return_desc_override_file, 'r', encoding='utf-8'):
-                                            return_description = return_description + line.rstrip()
+                                            return_description = return_description + line.replace('\n', ' ')
+                                        return_description = return_description.rstrip()
                                     else:
                                         return_description = return_data.get("return_description")
 

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -39,6 +39,9 @@ parser.add_argument('sdk_languages', type=str, nargs='?', help="A comma-separate
                      Can be one of: go, python, flutter. Omit to run against all sdks.")
 parser.add_argument('target_resources', type=str, nargs='?', help="A comma-separated list of the resources to run against. \
                      Must be all within the same resource type, like component or service. Omit to run against all resources.")
+parser.add_argument('-o', '--overrides', action='store_true', help="Print out the full expected parameter | return description \
+                     override filepath to STDOUT. Use with something like:\n \
+                     for filename in `python3 .github/workflows/update_sdk_methods.py -o go motion`; do touch $filename; done")
 parser.add_argument('-m', '--map', action='store_true', help="Generate initial mapping CSV file from upstream protos. \
                      In this mode, only the initial mapping file is output, no markdown.")
 parser.add_argument('-v', '--verbose', action='store_true', help="Run in verbose mode. Writes a debug file containing \
@@ -125,6 +128,13 @@ if sdk_list and args.verbose:
     print('SDKS OVERRIDE: Only running against ' + str(sdks) + '\n')
 if resource_list and args.verbose:
     print('RESOURCE OVERRIDE: Only running against ' + str(resource_list) + '\n')
+if args.overrides and args.verbose:
+    print("ERROR: You cannot use verbose mode with print overrides mode.")
+    print("       If you want this script to print the overrides filepaths it needs")
+    print("       for param | return description overrides, rerun this script with")
+    print("       the -o flag but WITHOUT the -v flag.")
+    print("Exiting ...")
+    exit(1)
 
 ## This script must be run within the 'docs' git repo. Here we check
 ## to make sure this is the case, and get the root of our git-managed
@@ -1482,8 +1492,8 @@ def format_method_usage(parsed_usage_string, go_method_name, resource, path_to_m
                 ## .../overrides/methods/{sdk}.{resource}.{go_method_name}.{return_data_type_last_part}.return.md
                 param_desc_override_file = path_to_methods_override + '/go.' + resource + '.' + go_method_name + '.' + return_type_short + '.return.md'
 
-            ## NOTE: To help when populating override files, uncomment this line, run this script, and use printed paths as filepaths:
-            #print(param_desc_override_file)
+            if args.overrides:
+                print(param_desc_override_file)
 
             if os.path.exists(param_desc_override_file):
                 for line in open(param_desc_override_file, 'r', encoding='utf-8'):
@@ -1699,8 +1709,8 @@ def write_markdown(type, names, methods):
                                     ## .../overrides/methods/{sdk}.{resource}.{py_method_name}.{param_name}.md
                                     param_desc_override_file = path_to_methods_override + '/python.' + resource + '.' + py_method_name + '.' + parameter + '.md'
 
-                                    ## NOTE: To help when populating param override files, uncomment this line, run this script, and use printed paths as filepaths:
-                                    #print(param_desc_override_file)
+                                    if args.overrides:
+                                        print(param_desc_override_file)
 
                                     if os.path.exists(param_desc_override_file):
                                         for line in open(param_desc_override_file, 'r', encoding='utf-8'):
@@ -1744,8 +1754,8 @@ def write_markdown(type, names, methods):
                                 ## .../overrides/methods/{sdk}.{resource}.{py_method_name}.return.md
                                 return_desc_override_file = path_to_methods_override + '/python.' + resource + '.' + py_method_name + '.return.md'
 
-                                ## NOTE: To help when populating return override files, uncomment this line, run this script, and use printed paths as filepaths:
-                                #print(return_desc_override_file)
+                                if args.overrides:
+                                    print(return_desc_override_file)
 
                                 if os.path.exists(return_desc_override_file):
                                     for line in open(return_desc_override_file, 'r', encoding='utf-8'):
@@ -1916,8 +1926,8 @@ def write_markdown(type, names, methods):
                                     param_description = ''
                                     param_desc_override_file = path_to_methods_override + '/flutter.' + resource + '.' + flutter_method_name + '.' + parameter + '.md'
 
-                                    ## NOTE: To help when populating param override files, uncomment this line, run this script, and use printed paths as filepaths:
-                                    #print(param_desc_override_file)
+                                    if args.overrides:
+                                        print(param_desc_override_file)
 
                                     if os.path.exists(param_desc_override_file):
                                         for line in open(param_desc_override_file, 'r', encoding='utf-8'):
@@ -1982,8 +1992,8 @@ def write_markdown(type, names, methods):
                                     return_description = ''
                                     return_desc_override_file = path_to_methods_override + '/flutter.' + resource + '.' + flutter_method_name + '.' + return_name + '.md'
 
-                                    ## NOTE: To help when populating return override files, uncomment this line, run this script, and use printed paths as filepaths:
-                                    #print(return_desc_override_file)
+                                    if args.overrides:
+                                        print(return_desc_override_file)
 
                                     if os.path.exists(return_desc_override_file):
                                         for line in open(return_desc_override_file, 'r', encoding='utf-8'):


### PR DESCRIPTION
Add ability to override parameter descriptions and/or return descriptions, using (param|return) override files.
- Each SDK requires slightly-different override logic, see script comments.
- Also cleans up override file detection logic for `before` and `after` overrides: simpler, shorter, less filesystem traversal.
	- Important: no longer supporting omitting literal string `before` for `before`-type overrides, we need this explicitness to support new param|return override filepath detection.

Note:
- If you are seeking to populate a bunch of param|return override files, see the notes in the script: you can uncomment print statements to get the full expected override path for each param|return to make populating these much easier.
	- Even better, you can now use something like the following to create all necessary param | return override files for you:
		```
		## Uncomment relevant print(param|return_desc_override_file) line for the SDK you want. Then run:
		for filename in `python3 .github/workflows/update_sdk_methods.py -o go motion`; do touch $filename; done
		## All Go > Motion override files will be created for you. Copy and paste your content into them.
		```
- Not 100% sure we're matching all possible Go return data types. Will fix during `arm`, `robot`, and `app` re-generation shortly if so.