### PR TITLE
DOCS-2501: Update autogen descriptions

### DIFF
--- a/static/include/components/apis/generated/arm.md
+++ b/static/include/components/apis/generated/arm.md
@@ -12,7 +12,7 @@ Get the current position of the arm as a [pose](/internals/orientation-vector/).
 
 **Returns:**
 
-- ([viam.components.arm.Pose](https://python.viam.dev/autoapi/viam/index.html#viam.components.arm.Pose)): The location and orientation of the arm described as a Pose.
+- ([viam.components.arm.Pose](https://python.viam.dev/autoapi/viam/index.html#viam.components.arm.Pose)): A representation of the arm’s current position as a 6 DOF (six degrees of freedom) pose. The Pose is composed of values for location and orientation with respect to the origin. Location is expressed as distance, which is represented by x, y, and z coordinate values. Orientation is expressed as an orientation vector, which is represented by o_x, o_y, o_z, and theta values.
 
 **Example:**
 
@@ -35,7 +35,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(spatialmath.Pose)](https://pkg.go.dev/go.viam.com/rdk/spatialmath#Pose)
+- [(spatialmath.Pose)](https://pkg.go.dev/go.viam.com/rdk/spatialmath#Pose): A representation of the arm's current position as a 6 DOF (six degrees of freedom) pose. The `Pose` is composed of values for location and orientation with respect to the origin. Location is expressed as distance, which is represented by x, y, and z coordinate values. Orientation is expressed as an orientation vector, which is represented by o_x, o_y, o_z, and theta values.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**
@@ -60,7 +60,7 @@ Move the end of the arm to the desired [pose](/internals/orientation-vector/), r
 
 **Parameters:**
 
-- `pose` ([viam.components.arm.Pose](https://python.viam.dev/autoapi/viam/index.html#viam.components.arm.Pose)) (required): The destination Pose for the arm.
+- `pose` ([viam.components.arm.Pose](https://python.viam.dev/autoapi/viam/index.html#viam.components.arm.Pose)) (required): The destination Pose for the arm. The Pose is composed of values for location and orientation with respect to the origin. Location is expressed as distance, which is represented by x, y, and z coordinate values. Orientation is expressed as an orientation vector, which is represented by o_x, o_y, o_z, and theta values.
 - `extra` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (optional): Extra options to pass to the underlying RPC call.
 - `timeout` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
 
@@ -88,7 +88,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Parameters:**
 
 - `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
-- `pose` [(spatialmath.Pose)](https://pkg.go.dev/go.viam.com/rdk/spatialmath#Pose)
+- `pose` [(spatialmath.Pose)](https://pkg.go.dev/go.viam.com/rdk/spatialmath#Pose): A representation of the arm's destination position as a 6 DOF (six degrees of freedom) pose. The `Pose` is composed of values for location and orientation with respect to the origin. Location is expressed as distance, which is represented by x, y, and z coordinate values. Orientation is expressed as an orientation vector, which is represented by o_x, o_y, o_z, and theta values.
 - `extra` [(map[string]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
 
 **Returns:**
@@ -162,7 +162,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Parameters:**
 
 - `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
-- `positionDegs` [(*pb.JointPositions)](https://pkg.go.dev/go.viam.com/api/component/arm/v1#JointPositions)
+- `positionDegs` [(*pb.JointPositions)](https://pkg.go.dev/go.viam.com/api/component/arm/v1#JointPositions): The desired position of each joint of the arm at the end of movement. JointPositions can have one attribute, `values`, a list of joint positions with rotational values (degrees) and translational values (mm).
 - `extra` [(map[string]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
 
 **Returns:**
@@ -204,7 +204,7 @@ Get the current position of each joint on the arm.
 
 **Returns:**
 
-- ([viam.proto.component.arm.JointPositions](https://python.viam.dev/autoapi/viam/proto/component/arm/index.html#viam.proto.component.arm.JointPositions)): The current JointPositions for the arm.
+- ([viam.proto.component.arm.JointPositions](https://python.viam.dev/autoapi/viam/proto/component/arm/index.html#viam.proto.component.arm.JointPositions)): The current JointPositions for the arm. JointPositions can have one attribute, values, a list of joint positions with rotational values (degrees) and translational values (mm).
 
 **Example:**
 
@@ -227,7 +227,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(*pb.JointPositions)](https://pkg.go.dev/go.viam.com/api/component/arm/v1#JointPositions)
+- [(*pb.JointPositions)](https://pkg.go.dev/go.viam.com/api/component/arm/v1#JointPositions): The desired position of each joint of the arm at the end of movement.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**
@@ -269,7 +269,7 @@ Get the kinematics information associated with the arm as the format and byte co
 
 **Returns:**
 
-- (Tuple[[viam.components.arm.KinematicsFileFormat.ValueType](https://python.viam.dev/autoapi/viam/components/arm/index.html#viam.components.arm.KinematicsFileFormat), [bytes](https://docs.python.org/3/library/stdtypes.html#bytes-objects)]):  A tuple containing two values; the first [0] value represents the format of thefile, either in URDF format or Viam’s kinematic parameter format (spatial vector algebra), and the second [1] value represents the byte contents of the file.   
+- (Tuple[[viam.components.arm.KinematicsFileFormat.ValueType](https://python.viam.dev/autoapi/viam/components/arm/index.html#viam.components.arm.KinematicsFileFormat), [bytes](https://docs.python.org/3/library/stdtypes.html#bytes-objects)]): A tuple containing two values; the first [0] value represents the format of the file, either in URDF format or Viam’s kinematic parameter format (spatial vector algebra), and the second [1] value represents the byte contents of the file.
 
 **Example:**
 
@@ -329,7 +329,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(bool)](https://pkg.go.dev/builtin#bool)
+- [(bool)](https://pkg.go.dev/builtin#bool): Whether this resource is moving (`true`) or not (`false`).
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**
@@ -444,7 +444,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [([]spatialmath.Geometry)](https://pkg.go.dev/go.viam.com/rdk/spatialmath#Geometry)
+- [([]spatialmath.Geometry)](https://pkg.go.dev/go.viam.com/rdk/spatialmath#Geometry): The geometries associated with this resource, in any order.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**
@@ -478,8 +478,8 @@ Reconfigure must reconfigure the resource atomically and in place.
 **Parameters:**
 
 - `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
-- `deps` [(Dependencies)](https://pkg.go.dev/go.viam.com/rdk/resource#Dependencies)
-- `conf` [(Config)](https://pkg.go.dev/go.viam.com/rdk/resource#Config)
+- `deps` [(Dependencies)](https://pkg.go.dev/go.viam.com/rdk/resource#Dependencies): The resource dependencies.
+- `conf` [(Config)](https://pkg.go.dev/go.viam.com/rdk/resource#Config): The resource configuration.
 
 **Returns:**
 
@@ -501,12 +501,12 @@ If you are implementing your own arm and add features that have no built-in API 
 
 **Parameters:**
 
-- `command` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), ValueTypes]) (required): The command to execute
+- `command` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), ValueTypes]) (required): The command to execute.
 - `timeout` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
 
 **Returns:**
 
-- (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), viam.utils.ValueTypes]): Result of the executed command
+- (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), viam.utils.ValueTypes]): Result of the executed command.
 
 **Example:**
 
@@ -527,7 +527,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(map[string]interface{})](https://pkg.go.dev/builtin#string)
+- [(map[string]interface{})](https://pkg.go.dev/builtin#string): The command response.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**

--- a/static/include/components/apis/generated/power_sensor-table.md
+++ b/static/include/components/apis/generated/power_sensor-table.md
@@ -1,11 +1,11 @@
 <!-- prettier-ignore -->
 | Method Name | Description |
 | ----------- | ----------- |
-| [`GetVoltage`](/components/power_sensor/#getvoltage) | Return the voltage reading of a specified device and whether it is AC or DC. |
-| [`GetCurrent`](/components/power_sensor/#getcurrent) | Return the current of a specified device and whether it is AC or DC. |
-| [`GetPower`](/components/power_sensor/#getpower) | Return the power reading in watts. |
-| [`GetReadings`](/components/power_sensor/#getreadings) | Get the measurements or readings that this power sensor provides. |
-| [`GetGeometries`](/components/power_sensor/#getgeometries) | Get all the geometries associated with the power sensor in its current configuration, in the frame of the power sensor. |
-| [`Reconfigure`](/components/power_sensor/#reconfigure) | Reconfigure this resource. |
-| [`DoCommand`](/components/power_sensor/#docommand) | Execute model-specific commands that are not otherwise defined by the component API. |
-| [`Close`](/components/power_sensor/#close) | Safely shut down the resource and prevent further use. |
+| [`GetVoltage`](/components/power-sensor/#getvoltage) | Return the voltage reading of a specified device and whether it is AC or DC. |
+| [`GetCurrent`](/components/power-sensor/#getcurrent) | Return the current of a specified device and whether it is AC or DC. |
+| [`GetPower`](/components/power-sensor/#getpower) | Return the power reading in watts. |
+| [`GetReadings`](/components/power-sensor/#getreadings) | Get the measurements or readings that this power sensor provides. |
+| [`GetGeometries`](/components/power-sensor/#getgeometries) | Get all the geometries associated with the power sensor in its current configuration, in the frame of the power sensor. |
+| [`Reconfigure`](/components/power-sensor/#reconfigure) | Reconfigure this resource. |
+| [`DoCommand`](/components/power-sensor/#docommand) | Execute model-specific commands that are not otherwise defined by the component API. |
+| [`Close`](/components/power-sensor/#close) | Safely shut down the resource and prevent further use. |

--- a/static/include/components/apis/generated/power_sensor-table.md
+++ b/static/include/components/apis/generated/power_sensor-table.md
@@ -1,11 +1,11 @@
 <!-- prettier-ignore -->
 | Method Name | Description |
 | ----------- | ----------- |
-| [`GetVoltage`](/components/power-sensor/#getvoltage) | Return the voltage reading of a specified device and whether it is AC or DC. |
-| [`GetCurrent`](/components/power-sensor/#getcurrent) | Return the current of a specified device and whether it is AC or DC. |
-| [`GetPower`](/components/power-sensor/#getpower) | Return the power reading in watts. |
-| [`GetReadings`](/components/power-sensor/#getreadings) | Get the measurements or readings that this power sensor provides. |
-| [`GetGeometries`](/components/power-sensor/#getgeometries) | Get all the geometries associated with the power sensor in its current configuration, in the frame of the power sensor. |
-| [`Reconfigure`](/components/power-sensor/#reconfigure) | Reconfigure this resource. |
-| [`DoCommand`](/components/power-sensor/#docommand) | Execute model-specific commands that are not otherwise defined by the component API. |
-| [`Close`](/components/power-sensor/#close) | Safely shut down the resource and prevent further use. |
+| [`GetVoltage`](/components/power_sensor/#getvoltage) | Return the voltage reading of a specified device and whether it is AC or DC. |
+| [`GetCurrent`](/components/power_sensor/#getcurrent) | Return the current of a specified device and whether it is AC or DC. |
+| [`GetPower`](/components/power_sensor/#getpower) | Return the power reading in watts. |
+| [`GetReadings`](/components/power_sensor/#getreadings) | Get the measurements or readings that this power sensor provides. |
+| [`GetGeometries`](/components/power_sensor/#getgeometries) | Get all the geometries associated with the power sensor in its current configuration, in the frame of the power sensor. |
+| [`Reconfigure`](/components/power_sensor/#reconfigure) | Reconfigure this resource. |
+| [`DoCommand`](/components/power_sensor/#docommand) | Execute model-specific commands that are not otherwise defined by the component API. |
+| [`Close`](/components/power_sensor/#close) | Safely shut down the resource and prevent further use. |

--- a/static/include/components/apis/generated/power_sensor.md
+++ b/static/include/components/apis/generated/power_sensor.md
@@ -36,8 +36,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(float64)](https://pkg.go.dev/builtin#float64)
-- [(bool)](https://pkg.go.dev/builtin#bool)
+- [(float64)](https://pkg.go.dev/builtin#float64): The measurement of the voltage, represented as a 64-bit float number.
+- [(bool)](https://pkg.go.dev/builtin#bool): Indicate whether voltage is AC (`true`) or DC (`false`).
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**
@@ -90,8 +90,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(float64)](https://pkg.go.dev/builtin#float64)
-- [(bool)](https://pkg.go.dev/builtin#bool)
+- [(float64)](https://pkg.go.dev/builtin#float64): The measurement of the current, represented as a 64-bit float number.
+- [(bool)](https://pkg.go.dev/builtin#bool): Indicate whether current is AC (`true`) or DC (`false`).
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**
@@ -120,7 +120,7 @@ Return the power reading in watts.
 
 **Returns:**
 
-- ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)): The measurement of the power, represented as a float.
+- ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)): The power reading in watts.
 
 **Example:**
 
@@ -144,7 +144,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(float64)](https://pkg.go.dev/builtin#float64)
+- [(float64)](https://pkg.go.dev/builtin#float64): The measurement of the power, represented as a 64-bit float number.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**
@@ -174,7 +174,7 @@ If a sensor is not configured to have a measurement or fails to read a piece of 
 
 **Returns:**
 
-- (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), viam.utils.SensorReading]): The measurements or readings that this power sensor provides.
+- (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), viam.utils.SensorReading]):  The readings for the PowerSensor. Can be of any type. Includes voltage in volts (float), current inamperes (float), is_ac (bool), and power in watts (float).   .
 
 **Example:**
 
@@ -197,7 +197,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(map[string]interface{})](https://pkg.go.dev/builtin#string)
+- [(map[string]interface{})](https://pkg.go.dev/builtin#string): A map containing the measurements from the sensor. Contents depend on sensor model and can be of any type.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**
@@ -255,8 +255,8 @@ Reconfigure must reconfigure the resource atomically and in place.
 **Parameters:**
 
 - `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
-- `deps` [(Dependencies)](https://pkg.go.dev/go.viam.com/rdk/resource#Dependencies)
-- `conf` [(Config)](https://pkg.go.dev/go.viam.com/rdk/resource#Config)
+- `deps` [(Dependencies)](https://pkg.go.dev/go.viam.com/rdk/resource#Dependencies): The resource dependencies.
+- `conf` [(Config)](https://pkg.go.dev/go.viam.com/rdk/resource#Config): The resource configuration.
 
 **Returns:**
 
@@ -277,12 +277,12 @@ If you are implementing your own power sensor and add features that have no buil
 
 **Parameters:**
 
-- `command` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), ValueTypes]) (required): The command to execute
+- `command` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), ValueTypes]) (required): The command to execute.
 - `timeout` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
 
 **Returns:**
 
-- (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), viam.utils.ValueTypes]): Result of the executed command
+- (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), viam.utils.ValueTypes]): Result of the executed command.
 
 **Example:**
 
@@ -303,7 +303,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(map[string]interface{})](https://pkg.go.dev/builtin#string)
+- [(map[string]interface{})](https://pkg.go.dev/builtin#string): The command response.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**

--- a/static/include/components/apis/generated/sensor.md
+++ b/static/include/components/apis/generated/sensor.md
@@ -35,7 +35,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(map[string]interface{})](https://pkg.go.dev/builtin#string)
+- [(map[string]interface{})](https://pkg.go.dev/builtin#string): A map containing the measurements from the sensor. Contents depend on sensor model and can be of any type.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**
@@ -93,8 +93,8 @@ Reconfigure must reconfigure the resource atomically and in place.
 **Parameters:**
 
 - `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
-- `deps` [(Dependencies)](https://pkg.go.dev/go.viam.com/rdk/resource#Dependencies)
-- `conf` [(Config)](https://pkg.go.dev/go.viam.com/rdk/resource#Config)
+- `deps` [(Dependencies)](https://pkg.go.dev/go.viam.com/rdk/resource#Dependencies): The resource dependencies.
+- `conf` [(Config)](https://pkg.go.dev/go.viam.com/rdk/resource#Config): The resource configuration.
 
 **Returns:**
 
@@ -116,12 +116,12 @@ If you are implementing your own sensor and add features that have no built-in A
 
 **Parameters:**
 
-- `command` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), ValueTypes]) (required): The command to execute
+- `command` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), ValueTypes]) (required): The command to execute.
 - `timeout` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
 
 **Returns:**
 
-- (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), viam.utils.ValueTypes]): Result of the executed command
+- (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), viam.utils.ValueTypes]): Result of the executed command.
 
 **Example:**
 
@@ -142,7 +142,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(map[string]interface{})](https://pkg.go.dev/builtin#string)
+- [(map[string]interface{})](https://pkg.go.dev/builtin#string): The command response.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**

--- a/static/include/components/apis/generated/servo.md
+++ b/static/include/components/apis/generated/servo.md
@@ -48,7 +48,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Parameters:**
 
 - `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
-- `angleDeg` [(uint32)](https://pkg.go.dev/builtin#uint32)
+- `angleDeg` [(uint32)](https://pkg.go.dev/builtin#uint32): The desired angle of the servo in degrees.
 - `extra` [(map[string]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
 
 **Returns:**
@@ -113,7 +113,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(uint32)](https://pkg.go.dev/builtin#uint32)
+- [(uint32)](https://pkg.go.dev/builtin#uint32): The current set angle of the servo in degrees.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**
@@ -203,7 +203,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(bool)](https://pkg.go.dev/builtin#bool)
+- [(bool)](https://pkg.go.dev/builtin#bool): Whether this resource is moving (`true`) or not (`false`).
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**
@@ -293,8 +293,8 @@ Reconfigure must reconfigure the resource atomically and in place.
 **Parameters:**
 
 - `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
-- `deps` [(Dependencies)](https://pkg.go.dev/go.viam.com/rdk/resource#Dependencies)
-- `conf` [(Config)](https://pkg.go.dev/go.viam.com/rdk/resource#Config)
+- `deps` [(Dependencies)](https://pkg.go.dev/go.viam.com/rdk/resource#Dependencies): The resource dependencies.
+- `conf` [(Config)](https://pkg.go.dev/go.viam.com/rdk/resource#Config): The resource configuration.
 
 **Returns:**
 
@@ -316,12 +316,12 @@ If you are implementing your own servo and add features that have no built-in AP
 
 **Parameters:**
 
-- `command` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), ValueTypes]) (required): The command to execute
+- `command` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), ValueTypes]) (required): The command to execute.
 - `timeout` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
 
 **Returns:**
 
-- (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), viam.utils.ValueTypes]): Result of the executed command
+- (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), viam.utils.ValueTypes]): Result of the executed command.
 
 **Example:**
 
@@ -342,7 +342,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(map[string]interface{})](https://pkg.go.dev/builtin#string)
+- [(map[string]interface{})](https://pkg.go.dev/builtin#string): The command response.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**

--- a/static/include/components/apis/overrides/methods/go.arm.EndPosition.Pose.return.md
+++ b/static/include/components/apis/overrides/methods/go.arm.EndPosition.Pose.return.md
@@ -1,0 +1,4 @@
+A representation of the arm's current position as a 6 DOF (six degrees of freedom) pose.
+The `Pose` is composed of values for location and orientation with respect to the origin.
+Location is expressed as distance, which is represented by x, y, and z coordinate values.
+Orientation is expressed as an orientation vector, which is represented by o_x, o_y, o_z, and theta values.

--- a/static/include/components/apis/overrides/methods/go.arm.JointPositions.JointPositions.return.md
+++ b/static/include/components/apis/overrides/methods/go.arm.JointPositions.JointPositions.return.md
@@ -1,0 +1,1 @@
+The desired position of each joint of the arm at the end of movement.

--- a/static/include/components/apis/overrides/methods/go.arm.MoveToJointPositions.positionDegs.md
+++ b/static/include/components/apis/overrides/methods/go.arm.MoveToJointPositions.positionDegs.md
@@ -1,0 +1,2 @@
+The desired position of each joint of the arm at the end of movement.
+JointPositions can have one attribute, `values`, a list of joint positions with rotational values (degrees) and translational values (mm).

--- a/static/include/components/apis/overrides/methods/go.arm.MoveToPosition.pose.md
+++ b/static/include/components/apis/overrides/methods/go.arm.MoveToPosition.pose.md
@@ -1,0 +1,4 @@
+A representation of the arm's destination position as a 6 DOF (six degrees of freedom) pose.
+The `Pose` is composed of values for location and orientation with respect to the origin.
+Location is expressed as distance, which is represented by x, y, and z coordinate values.
+Orientation is expressed as an orientation vector, which is represented by o_x, o_y, o_z, and theta values.

--- a/static/include/components/apis/overrides/methods/go.power_sensor.Current.bool.return.md
+++ b/static/include/components/apis/overrides/methods/go.power_sensor.Current.bool.return.md
@@ -1,0 +1,1 @@
+Indicate whether current is AC (`true`) or DC (`false`).

--- a/static/include/components/apis/overrides/methods/go.power_sensor.Current.float64.return.md
+++ b/static/include/components/apis/overrides/methods/go.power_sensor.Current.float64.return.md
@@ -1,0 +1,1 @@
+The measurement of the current, represented as a 64-bit float number.

--- a/static/include/components/apis/overrides/methods/go.power_sensor.Power.float64.return.md
+++ b/static/include/components/apis/overrides/methods/go.power_sensor.Power.float64.return.md
@@ -1,0 +1,1 @@
+The measurement of the power, represented as a 64-bit float number.

--- a/static/include/components/apis/overrides/methods/go.power_sensor.Voltage.bool.return.md
+++ b/static/include/components/apis/overrides/methods/go.power_sensor.Voltage.bool.return.md
@@ -1,0 +1,1 @@
+Indicate whether voltage is AC (`true`) or DC (`false`).

--- a/static/include/components/apis/overrides/methods/go.power_sensor.Voltage.float64.return.md
+++ b/static/include/components/apis/overrides/methods/go.power_sensor.Voltage.float64.return.md
@@ -1,0 +1,1 @@
+The measurement of the voltage, represented as a 64-bit float number.

--- a/static/include/components/apis/overrides/methods/go.servo.Move.angleDeg.md
+++ b/static/include/components/apis/overrides/methods/go.servo.Move.angleDeg.md
@@ -1,0 +1,1 @@
+The desired angle of the servo in degrees.

--- a/static/include/components/apis/overrides/methods/go.servo.Position.uint32.return.md
+++ b/static/include/components/apis/overrides/methods/go.servo.Position.uint32.return.md
@@ -1,0 +1,1 @@
+The current set angle of the servo in degrees.


### PR DESCRIPTION
Update already-merged autogen content (`arm`, `power sensor`, `sensor`, and `servo`) with new param and return descriptions overrides from https://github.com/viamrobotics/docs/pull/3019.
- Also includes the latest upstream Python descriptions.
- Script handles inherited method overriding for us, so this was actually pretty quick, only a dozen override files across all four merged components.