### PR TITLE
Remove more Py APIs

### DIFF
--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -393,7 +393,10 @@ python_ignore_apis = [
     'viam.robot.client.RobotClient.transform_point_cloud', # unimplemented
     'viam.robot.client.RobotClient.get_component', # GUESS ?
     'viam.robot.client.RobotClient.get_service', # GUESS ?
-    'viam.components.board.client.BoardClient.write_analog' # Currently borked: https://python.viam.dev/autoapi/viam/components/board/client/index.html#viam.components.board.client.BoardClient.write_analog
+    'viam.components.board.client.BoardClient.write_analog', # Currently borked: https://python.viam.dev/autoapi/viam/components/board/client/index.html#viam.components.board.client.BoardClient.write_analog
+    'viam.components.board.client.StreamWithIterator.next', # No content upstream
+    'viam.robot.client.ViamChannel.close', # channel-specific close
+    'viam.robot.client.SessionsClient.reset'  # session-specific reset
 ]
 
 ## Use these URLs for data types that are not otherwise captured by parse(), such as:


### PR DESCRIPTION
Remove three more PySDK API methods that were preventing parsing in some cases.
- I will investigate these later, but they do not seem user-facing. If so, will re-add with proper parsing fix if needed.