### PR TITLE
DOCS-2369: Add tarball as executable

### DIFF
--- a/docs/registry/advanced/iterative-development.md
+++ b/docs/registry/advanced/iterative-development.md
@@ -39,7 +39,7 @@ If you are developing a module for the same target architecture as your developm
    For the **Executable path** field, enter the absolute path on your machine's filesystem to either:
 
    - the module's [executable file](/registry/create/#compile-or-package-your-module), such as `run.sh` or a compiled binary.
-   - a packaged tarball of your module, ending in `.tar.gz` or `.tgz`.
+   - a [packaged tarball](https://www.cs.swarthmore.edu/~newhall/unixhelp/howto_tar.html) of your module, ending in `.tar.gz` or `.tgz`.
      If you are providing a tarball file in this field, be sure that your packaged tarball contains your module's [`meta.json` file](/cli/#the-metajson-file) within it.
 
    If you have previously added your module as a _registry module_, you will need to first remove the registry version of your module before then adding the local version.

--- a/docs/registry/advanced/iterative-development.md
+++ b/docs/registry/advanced/iterative-development.md
@@ -37,6 +37,7 @@ If you are developing a module for the same target architecture as your developm
 
 1. Navigate to the Viam app, select your machine, and [add your module as a local module](/registry/configure/#local-modules) to your machine.
    For the **Executable path** field, enter the absolute path on your machine's filesystem to either:
+
    - the module's [executable file](/registry/create/#compile-or-package-your-module), such as `run.sh` or a compiled binary.
    - a packaged tarball of your module, ending in `.tar.gz` or `.tgz`.
      If you are providing a tarball file in this field, be sure that your packaged tarball contains your module's [`meta.json` file](/cli/#the-metajson-file) within it.

--- a/docs/registry/advanced/iterative-development.md
+++ b/docs/registry/advanced/iterative-development.md
@@ -36,7 +36,11 @@ If you are developing a module for the same target architecture as your developm
    If you are using a programming language that does not require compilation, such as Python, you can skip this step.
 
 1. Navigate to the Viam app, select your machine, and [add your module as a local module](/registry/configure/#local-modules) to your machine.
-   Provide the **Executable path** in the configuration, pointing to the compiled or built binary, or the executable script, depending on your language.
+   For the **Executable path** field, enter the absolute path on your machine's filesystem to either:
+   - the module's [executable file](/registry/create/#compile-or-package-your-module), such as `run.sh` or a compiled binary.
+   - a packaged tarball of your module, ending in `.tar.gz` or `.tgz`.
+     If you are providing a tarball file in this field, be sure that your packaged tarball contains your module's [`meta.json` file](/cli/#the-metajson-file) within it.
+
    If you have previously added your module as a _registry module_, you will need to first remove the registry version of your module before then adding the local version.
 
 1. Click the **Save** button in the top right corner of the page.

--- a/docs/registry/configure.md
+++ b/docs/registry/configure.md
@@ -393,8 +393,11 @@ To add a local module on your machine, first add its module, then the component 
 1. Navigate to the **CONFIGURE** tab of your machine's page in [the Viam app](https://app.viam.com).
 2. Click the **+** (Create) icon next to your machine part in the left-hand menu and select **Local module**, then **Local module**.
 3. Enter a **Name** for this instance of your module.
-4. Enter the [module's executable path](/registry/create/#compile-or-package-your-module).
-   This path must be the absolute path to the executable on your machine's filesystem.
+4. Enter the module's **Executable path**.
+   This path must be the absolute path on your machine's filesystem to either:
+   - the module's [executable file](/registry/create/#compile-or-package-your-module), such as `run.sh` or a compiled binary.
+   - a packaged tarball of your module, ending in `.tar.gz` or `.tgz`.
+     If you are providing a tarball file in this field, be sure that your packaged tarball contains your module's [`meta.json` file](/cli/#the-metajson-file) within it.
 5. Then, click the **Create** button, and click **Save** in the upper right corner to save your config.
 
    {{<imgproc src="registry/configure/add-local-module-csi-cam.png" resize="300x" declaredimensions=true alt="The add a local module pane with name 'my-csi-cam' and executable path '/usr/local/bin/viam-csi'">}}

--- a/docs/registry/configure.md
+++ b/docs/registry/configure.md
@@ -396,7 +396,7 @@ To add a local module on your machine, first add its module, then the component 
 4. Enter the module's **Executable path**.
    This path must be the absolute path on your machine's filesystem to either:
    - the module's [executable file](/registry/create/#compile-or-package-your-module), such as `run.sh` or a compiled binary.
-   - a packaged tarball of your module, ending in `.tar.gz` or `.tgz`.
+   - a [packaged tarball](https://www.cs.swarthmore.edu/~newhall/unixhelp/howto_tar.html) of your module, ending in `.tar.gz` or `.tgz`.
      If you are providing a tarball file in this field, be sure that your packaged tarball contains your module's [`meta.json` file](/cli/#the-metajson-file) within it.
 5. Then, click the **Create** button, and click **Save** in the upper right corner to save your config.
 


### PR DESCRIPTION
Add notice that tarballs can be provided as **Executable path** to local modules, in addition to executable files / binaries.