### PR TITLE
Add link to Espressif's documentation for PWM limitations

### DIFF
--- a/docs/build/micro-rdk/board/esp32.md
+++ b/docs/build/micro-rdk/board/esp32.md
@@ -136,7 +136,7 @@ The following properties are available for `digital_interrupts`:
 
 ### PWM signals on `esp32` pins
 
-You can set PWM frequencies with Viam through the [`GPIOPin` API](/build/micro-rdk/board/#api).
+You can set PWM frequencies with Viam through the [`GPIOPin` API](/build/micro-rdk/board/#api). Make sure to check [the supported range of frequencies and duty resolutions](https://docs.espressif.com/projects/esp-idf/en/v4.4/esp32/api-reference/peripherals/ledc.html?highlight=pwm#supported-range-of-frequency-and-duty-resolutions) before proceeding. 
 A configured `esp32` board can support a maximum of four different PWM frequencies simultaneously, as the boards only have four available timers.
 
 For example:

--- a/docs/build/micro-rdk/board/esp32.md
+++ b/docs/build/micro-rdk/board/esp32.md
@@ -136,7 +136,7 @@ The following properties are available for `digital_interrupts`:
 
 ### PWM signals on `esp32` pins
 
-You can set PWM frequencies with Viam through the [`GPIOPin` API](/build/micro-rdk/board/#api). Make sure to check [the supported range of frequencies and duty resolutions](https://docs.espressif.com/projects/esp-idf/en/v4.4/esp32/api-reference/peripherals/ledc.html?highlight=pwm#supported-range-of-frequency-and-duty-resolutions) before proceeding. 
+You can set PWM frequencies with Viam through the [`GPIOPin` API](/build/micro-rdk/board/#api). Make sure to check [the supported range of frequencies and duty resolutions](https://docs.espressif.com/projects/esp-idf/en/v4.4/esp32/api-reference/peripherals/ledc.html?#supported-range-of-frequency-and-duty-resolutions) before proceeding.
 A configured `esp32` board can support a maximum of four different PWM frequencies simultaneously, as the boards only have four available timers.
 
 For example:

--- a/docs/build/micro-rdk/board/esp32.md
+++ b/docs/build/micro-rdk/board/esp32.md
@@ -136,7 +136,8 @@ The following properties are available for `digital_interrupts`:
 
 ### PWM signals on `esp32` pins
 
-You can set PWM frequencies with Viam through the [`GPIOPin` API](/build/micro-rdk/board/#api). Make sure to check [the supported range of frequencies and duty resolutions](https://docs.espressif.com/projects/esp-idf/en/v4.4/esp32/api-reference/peripherals/ledc.html?#supported-range-of-frequency-and-duty-resolutions) before proceeding.
+You can set PWM frequencies with Viam through the [`GPIOPin` API](/build/micro-rdk/board/#api).
+Refer to the [Espressif documentation for valid frequencies and duty resolutions](https://docs.espressif.com/projects/esp-idf/en/v4.4/esp32/api-reference/peripherals/ledc.html?#supported-range-of-frequency-and-duty-resolutions).
 A configured `esp32` board can support a maximum of four different PWM frequencies simultaneously, as the boards only have four available timers.
 
 For example:


### PR DESCRIPTION
To head off confusion, it would be nice to direct users to Espressif's documentation regarding the allowable range of PWM frequencies and duty cycles on the ESP32
