### PR TITLE
Fix interrupt pin type and add example

### DIFF
--- a/docs/build/micro-rdk/board/esp32.md
+++ b/docs/build/micro-rdk/board/esp32.md
@@ -8,7 +8,7 @@ images: ["/icons/components/board.svg"]
 tags: ["board", "components"]
 aliases:
   - /micro-rdk/board/esp32/
-# SMEs: Gautham, Rand
+# SMEs: Gautham, Nico, Andrew
 ---
 
 {{% alert title="REQUIREMENTS" color="caution" %}}
@@ -54,6 +54,11 @@ Copy the following JSON template and paste it into your configuration inside the
         "pin": <int>,
         "name": "<your-analog-name>"
       }
+    ],
+    "digital_interrupts" : [
+        {
+         "pin": <int>
+        }
     ]
   },
   "depends_on": []
@@ -76,6 +81,11 @@ Copy the following JSON template and paste it into your configuration inside the
         "pin": "34",
         "name": "sensor"
       }
+    ],
+    "digital_interrupts" : [
+        {
+         "pin": 4
+        }
     ]
   },
   "depends_on": []
@@ -132,7 +142,7 @@ The following properties are available for `digital_interrupts`:
 <!-- prettier-ignore -->
 | Name | Type | Required? | Description |
 | ---- | ---- | --------- | ----------- |
-|`pin`| string | **Required** | The GPIO number of the board's GPIO pin that you wish to configure the digital interrupt for. |
+|`pin`| integer | **Required** | The GPIO number of the board's GPIO pin that you wish to configure the digital interrupt for. |
 
 ### PWM signals on `esp32` pins
 

--- a/docs/build/micro-rdk/board/esp32.md
+++ b/docs/build/micro-rdk/board/esp32.md
@@ -82,10 +82,10 @@ Copy the following JSON template and paste it into your configuration inside the
         "name": "sensor"
       }
     ],
-    "digital_interrupts" : [
-        {
-         "pin": 4
-        }
+    "digital_interrupts": [
+      {
+        "pin": 4
+      }
     ]
   },
   "depends_on": []


### PR DESCRIPTION
The interrupt pin is an int, not a string (https://github.com/viamrobotics/micro-rdk/blob/main/micro-rdk/src/common/digital_interrupt.rs#L5). Plus added an example.
Will probably follow up with an example pr for i2c.