### PR TITLE
DOCS-2593: Fix how-to formatting

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1798,6 +1798,7 @@ div .filterable > p {
 .tablestep {
   clear: both;
   padding: 1rem;
+  overflow: auto;
 }
 
 .usecase-table .tablestep:nth-of-type(odd) {


### PR DESCRIPTION
Tablestep divs were sizing to the text, so if the image was bigger than the text, the grey background of the tablestep div would end above the bottom of the image.
