### PR TITLE
Update robot.md

### DIFF
--- a/static/include/robot/apis/generated/robot.md
+++ b/static/include/robot/apis/generated/robot.md
@@ -533,7 +533,7 @@ Get app-related information about the robot.
 **Example:**
 
 ```python {class="line-numbers linkable-line-numbers"}
-metadata = machine.get_cloud_metadata()
+metadata = await machine.get_cloud_metadata()
 print(metadata.machine_id)
 print(metadata.machine_part_id)
 print(metadata.primary_org_id)


### PR DESCRIPTION
Minor fix, which caused the error

AttributeError: 'coroutine' object has no attribute 'machine_part_id'
sys:1: RuntimeWarning: coroutine 'RobotClient.get_cloud_metadata' was never awaited

Please include a summary of the change and what is does. Please also include relevant motivation and context.
