### PR TITLE
DOCS-2564: Add Grafana to viz howto

### DIFF
--- a/docs/use-cases/collect-sensor-data.md
+++ b/docs/use-cases/collect-sensor-data.md
@@ -45,7 +45,7 @@ If you're not sure which sensor model to choose, start with the [`viam:viam-sens
 Viam's [data management service](/services/data/) lets you capture data locally from sensors and then sync it to the cloud where you can access all data across different {{< glossary_tooltip term_id="machine" text="machines" >}} or {{< glossary_tooltip term_id="location" text="locations" >}}.
 
 {{< table >}}
-{{< tablestep link="/services/data/">}}
+{{% tablestep link="/services/data/"%}}
 {{<imgproc src="/services/icons/data-management.svg" class="fill alignleft" style="max-width: 150px" declaredimensions=true alt="Configure the data management service">}}
 **1. Add the data management service**
 
@@ -55,8 +55,8 @@ Then add the **data management** service.
 
 Enable **Syncing** to ensure captured data is synced to the cloud and set the sync interval, for example to `0.05` minutes to sync every 3 seconds.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 {{<imgproc src="/icons/components/sensor.svg" class="fill alignleft" style="max-width: 150px" declaredimensions=true alt="configure a camera component">}}
 **2. Capture data from sensor**
 
@@ -64,15 +64,15 @@ On the **CONFIGURE** tab, go to the **sensor**'s card and find the **Data captur
 Add a new method, `Readings`, to capture data for and set the frequency.
 For example, setting a frequency of `0.1` will capture data once every ten seconds.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 {{<imgproc src="/services/ml/configure.svg" class="fill alignleft" style="max-width: 150px"  declaredimensions=true alt="Train models">}}
 **3. Save to start capturing**
 
 Save the config.
 With cloud sync enabled, captured data is automatically uploaded to the Viam app after a short delay.
 
-{{< /tablestep >}}
+{{% /tablestep %}}
 {{< /table >}}
 
 {{< alert title="Tip" color="tip" >}}
@@ -82,7 +82,7 @@ If you need to sync data conditionally, for example at a certain time, see [Trig
 ## View sensor data
 
 {{< table >}}
-{{< tablestep link="/services/data/view/">}}
+{{% tablestep link="/services/data/view/"%}}
 {{<imgproc src="/services/icons/data-capture.svg" class="fill alignleft" style="max-width: 150px" declaredimensions=true alt="Capture tabular data from a sensor">}}
 **1. View data in the Viam app**
 
@@ -91,7 +91,7 @@ Confirm that you are seeing data appear.
 
 {{<gif webm_src="/services/data/monitor.webm" mp4_src="/services/data/monitor.mp4" alt="sensor control tab">}}
 
-{{< /tablestep >}}
+{{% /tablestep %}}
 {{< /table >}}
 
 ## Next steps

--- a/docs/use-cases/configure.md
+++ b/docs/use-cases/configure.md
@@ -13,7 +13,7 @@ You can get a smart machine running with Viam in just a few steps.
 Viam's modular system of {{< glossary_tooltip term_id="component" text="components" >}} and {{< glossary_tooltip term_id="service" text="services" >}} means that you can start doing interesting things with your machine without writing much or any code.
 
 {{< table >}}
-{{< tablestep >}}
+{{% tablestep %}}
 
 {{<imgproc src="/use-cases/signup-narrow.png" class="fill alignleft" resize="500x" style="max-width: 200px" declaredimensions=true alt="Viam app login screen.">}}
 **1. Create a machine in the Viam app**
@@ -24,15 +24,15 @@ Then create a machine by typing in a name and clicking **Add machine**.
 
 {{<imgproc src="/use-cases/new-machine.png" class="fill aligncenter" resize="400x" style="max-width: 250px" declaredimensions=true alt="Viam app login screen.">}}
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 {{<imgproc src="/services/icons/data-capture.svg" class="fill alignright" style="max-width: 150px" declaredimensions=true alt="Installation icon">}}
 **2. Install Viam on your machine**
 
 All of the software that runs your smart machine is packaged into a binary called `viam-server`. Install it on the computer controlling your smart machine by following the {{< glossary_tooltip term_id="setup" text="setup instructions" >}} in the [Viam app](https://app.viam.com/).
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 
 {{<imgproc src="/icons/components.png" class="fill alignleft" resize="400x" style="max-width: 220px" declaredimensions=true alt="An assortment of components.">}}
 **3. Configure your components**
@@ -43,8 +43,8 @@ You need to [_configure_](/build/configure/) your machine so that `viam-server` 
 Use the configuration builder tool in the Viam app to create a file that describes what hardware you are using and how it is connected.
 For example, if you have a DC motor, follow the [corresponding configuration instructions](/components/motor/gpio/) to tell the software which pins it is connected to.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 {{<gif webm_src="/fleet/control.webm" mp4_src="/fleet/control.mp4" alt="The Viam app Control tab with a control panel for each component. The panel for a DC motor is clicked, expanding to show power controls." max-width="400px" class="fill alignleft">}}
 
 <!-- markdownlint-disable MD036 -->
@@ -54,8 +54,8 @@ For example, if you have a DC motor, follow the [corresponding configuration ins
 When you configure a component, a remote control panel is generated for it in the **CONTROL** tab of the Viam app.
 With the panels, you can drive motors at different speeds, view your camera feeds, see sensor readings, and generally test the basic functionality of your machine before you've even written any code.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 
 {{<imgproc src="/services/ml/collect.svg" class="fill alignright" style="max-width: 220px"  declaredimensions=true alt="Services">}}
 **5. Configure services**
@@ -64,8 +64,8 @@ Services are built-in Viam software packages that add high-level functionality t
 If you want to use any services, see their [documentation](/services/) for configuration and usage information.
 If you are making a simple machine that doesn't use services, you can skip this step!
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 
 {{<imgproc src="/services/ml/configure.svg" class="fill alignleft" style="max-width: 210px"  declaredimensions=true alt="Services">}}
 **6. Do more with code**
@@ -76,7 +76,7 @@ Viam has [SDKs](/sdks/) for Python, Golang, C++, TypeScript and Flutter.
 The easiest way to get started is to copy the auto-generated boilerplate code from the **Code sample** page of the **CONNECT** tab on your machine's page in the Viam app.
 You can run this code directly on the machine or from a separate computer; it then connects to the machine using API keys.
 
-{{< /tablestep >}}
+{{% /tablestep %}}
 {{< /table >}}
 
 ## Next steps

--- a/docs/use-cases/deploy-code.md
+++ b/docs/use-cases/deploy-code.md
@@ -17,22 +17,22 @@ Further, you can determine the accessibility of your module when you upload it -
 When you deploy a module, whether its one you've written yourself or added from the registry, you maintain complete control over how that module's code is deployed to your machine when new updates to the module are available.
 
 {{< table >}}
-{{< tablestep >}}
+{{% tablestep %}}
 {{<imgproc src="/registry/module-icon.svg" class="fill alignleft" style="max-width: 150px" alt="Search modules">}}
 **1. Search modules**
 
 Once you [have created a machine in the Viam app](/cloud/machines/#add-a-new-machine), [search for modules in the Viam registry](/registry/configure/) that fit your machine's requirements, and then [add a module](/registry/configure/#add-a-modular-resource-from-the-viam-registry) from your machine's configuration page in the Viam app.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 
 {{<imgproc src="/registry/create-module.svg" class="fill alignleft" style="max-width: 150px" declaredimensions=true alt="Create your own module">}}
 **2. Create your own module**
 
 Or, you can [create your own module](/registry/create/) to add support for new hardware, or to extend an existing software service.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 
 {{<imgproc src="/registry/upload-module.svg" class="fill alignleft" style="max-width: 150px" declaredimensions=true alt="Deploy your module">}}
 **3. Deploy your module**
@@ -44,8 +44,8 @@ Once you have created your new module, you can deploy it to your machine in one 
 
 If your machine is offline when you deploy a module, it will deploy once your machine comes back online.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 {{<imgproc src="/registry/create-module.svg" class="fill alignleft" style="max-width: 150px" declaredimensions=true alt="Configure your module">}}
 **4. Configure your module**
 
@@ -53,8 +53,8 @@ Once you've deployed a module to your machine or fleet, [configure the module](/
 
 You can also configure [how a deployed module updates itself](/registry/configure/#configure-version-update-management-for-a-registry-module) when new versions of that module become available from the Viam registry. You can choose to always update to the latest version as soon as it becomes available, pin to a specific code revision and never update it, or upgrade only within a specified major or minor version.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 {{<imgproc src="/registry/upload-module.svg" class="fill alignleft" style="max-width: 150px" declaredimensions=true alt="Update your module">}}
 **5. Update your module**
 
@@ -63,5 +63,5 @@ You can also use a [GitHub action to automate module releases](/registry/upload/
 
 These options make it easy to push changes to a fleet of machines.
 
-{{< /tablestep >}}
+{{% /tablestep %}}
 {{< /table >}}

--- a/docs/use-cases/deploy-ml.md
+++ b/docs/use-cases/deploy-ml.md
@@ -29,15 +29,15 @@ You will not need to write any code.
 ## Create a dataset and label data
 
 {{< table >}}
-{{< tablestep >}}
+{{% tablestep %}}
 {{<imgproc src="/services/icons/data-capture.svg" class="fill alignleft" style="max-width: 150px" declaredimensions=true alt="Collect data">}}
 **1. Collect images**
 
 Start by collecting images from your cameras and syncing it to the [Viam app](https://app.viam.com).
 See [Collect image data and sync it to the cloud](/use-cases/image-data/#collect-image-data-and-sync-it-to-the-cloud) for instructions.
 
-{{< /tablestep >}}
-{{< tablestep link="/services/data/dataset/">}}
+{{% /tablestep %}}
+{{% tablestep link="/services/data/dataset/" %}}
 {{<imgproc src="/services/ml/collect.svg" class="fill alignleft" style="max-width: 150px" declaredimensions=true alt="Label data">}}
 **2. Label your images**
 
@@ -45,14 +45,14 @@ Once you have enough images of the objects you'd like to classify, use the inter
 If you want to train an image classifier, use image tags.
 For an object detector, use bounding boxes.
 
-{{< /tablestep >}}
-{{< tablestep link="/services/data/dataset/">}}
+{{% /tablestep %}}
+{{% tablestep link="/services/data/dataset/"%}}
 {{<imgproc src="/services/ml/label.svg" class="fill alignleft" style="max-width: 150px" declaredimensions=true alt="Label data">}}
 **2. Create a dataset**
 
 Use the interface on the **DATA** tab (or the [`viam data dataset add` command](/cli/#data)) to add all images you want to train the model on to a dataset.
 
-{{< /tablestep >}}
+{{% /tablestep %}}
 {{< /table >}}
 
 {{% alert title="Tip" color="tip" %}}
@@ -66,15 +66,15 @@ This is not required, since you can use other filters like time or machine ID in
 ## Train and test a machine learning (ML) model
 
 {{< table >}}
-{{< tablestep link="/services/ml/train-model/">}}
+{{% tablestep link="/services/ml/train-model/"%}}
 {{<imgproc src="/services/ml/train.svg" class="fill alignleft" style="max-width: 150px" declaredimensions=true alt="Train models">}}
 **1. Train an ML model**
 
 In the Viam app, navigate to your list of [**DATASETS**](https://app.viam.com/data/datasets) and select the one you want to train on.
 Click **Train model** and follow the prompts.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 {{<imgproc src="/registry/upload-module.svg" class="fill alignleft" style="max-width: 150px" declaredimensions=true alt="Train models">}}
 **2. Deploy your ML model**
 
@@ -82,8 +82,8 @@ On the **Configure** page add the built-in [ML model service](/services/ml/deplo
 The service will to deploy and run the model.
 Once you've added the ML model service to your machine, choose your newly-trained model from the dropdown menu in the ML model service's configuration card.
 
-{{< /tablestep >}}
-{{< tablestep link="/services/vision/">}}
+{{% /tablestep %}}
+{{% tablestep link="/services/vision/" %}}
 {{<imgproc src="/services/icons/vision.svg" class="fill alignleft" style="max-width: 150px" declaredimensions=true alt="Configure a service">}}
 **3. Configure an <code>mlmodel</code> vision service**
 
@@ -92,14 +92,14 @@ The vision service takes the the ML model and applies it to the stream of images
 Add the `vision / ML model` service to your machine.
 Then, from the **Select model** dropdown, select the name of the ML model service you configured in the last step (for example, `mlmodel-1`).
 
-{{< /tablestep >}}
-{{< tablestep link="/services/vision/mlmodel/#test-your-detector-or-classifier">}}
+{{% /tablestep %}}
+{{% tablestep link="/services/vision/mlmodel/#test-your-detector-or-classifier" %}}
 {{<imgproc src="/services/ml/deploy.svg" class="fill alignleft" style="max-width: 150px" declaredimensions=true alt="Deploy your model">}}
 **4. Test your classifier**
 
 Test your ML model classifier with [existing images in the Viam app](/services/vision/mlmodel/#existing-images-in-the-cloud), [live camera footage,](/services/vision/mlmodel/#live-camera-footage) or [existing images on a computer](/services/vision/mlmodel/#existing-images-on-your-machine).
 
-{{< /tablestep >}}
+{{% /tablestep %}}
 {{< /table >}}
 
 ## Next steps

--- a/docs/use-cases/image-data.md
+++ b/docs/use-cases/image-data.md
@@ -38,14 +38,14 @@ In the next how-to guide you can use the images you collect here to [train compu
 ## Collect image data and sync it to the cloud
 
 {{< table >}}
-{{< tablestep link="/components/camera/">}}
+{{% tablestep link="/components/camera/"%}}
 {{<imgproc src="/icons/components/camera.svg" class="fill alignleft" style="max-width: 150px" declaredimensions=true alt="configure a camera component">}}
 **1. Configure a camera**
 
 Configure a camera component, such as a [webcam](/components/camera/webcam/), on your machine.
 
-{{< /tablestep >}}
-{{< tablestep link="/services/data/">}}
+{{% /tablestep %}}
+{{% tablestep link="/services/data/"%}}
 {{<imgproc src="/services/icons/data-management.svg" class="fill alignleft" style="max-width: 150px" declaredimensions=true alt="Collect data">}}
 **2. Enable the data management service**
 
@@ -53,16 +53,16 @@ In your camera component configuration panel, find the **Data capture** section.
 Click **Add method** and follow the prompt to **Create a data management service**.
 You can leave the default data manager settings.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 {{<imgproc src="/services/icons/data-capture.svg" class="fill alignleft" style="max-width: 150px" declaredimensions=true alt="Collect data">}}
 **3. Capture data**
 
 With the data management service configured on your machine, you can continue configuring how the camera component itself captures data.
 In the **Data capture** panel of your camera's config, select **Read image** from the method selector, and set your desired capture frequency.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 {{<imgproc src="/services/ml/collect.svg" class="fill alignleft" style="max-width: 150px"  declaredimensions=true alt="Train models">}}
 **4. View data in the Viam app**
 
@@ -70,7 +70,7 @@ Once you have synced images, you can [view those images in the Viam app](/servic
 
 You can also [export your data from the Viam app](/services/data/export/) to a deployed machine, or to any computer.
 
-{{< /tablestep >}}
+{{% /tablestep %}}
 {{< /table >}}
 
 ## Use filtering to collect and sync only certain images
@@ -81,7 +81,7 @@ Contributors have written several filtering {{< glossary_tooltip term_id="module
 The following steps use the [`filtered_camera`](https://github.com/erh/filtered_camera) module:
 
 {{< table >}}
-{{< tablestep link="/services/ml/deploy/">}}
+{{% tablestep link="/services/ml/deploy/"%}}
 {{<imgproc src="/services/ml/train.svg" class="fill alignleft" style="max-width: 150px"  declaredimensions=true alt="Train models">}}
 **1. Add an ML model to your machine**
 
@@ -89,8 +89,8 @@ Configure an ML model service on your machine that is compatible with the ML mod
 
 From the **Model** dropdown, select the preexisting model you want to use, or click **Add new model** to upload your own.
 
-{{< /tablestep >}}
-{{< tablestep link="/services/vision/">}}
+{{% /tablestep %}}
+{{% tablestep link="/services/vision/"%}}
 {{<imgproc src="/services/icons/vision.svg" class="fill alignleft" style="max-width: 150px"  declaredimensions=true alt="Train models">}}
 **2. Add a vision service to use with the ML model**
 
@@ -99,8 +99,8 @@ You can think of the vision service as the bridge between the ML model service a
 Configure the `vision / ML model` service on your machine.
 From the **Select model** dropdown, select the name of your ML model service (for example, `mlmodel-1`).
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 {{<imgproc src="/services/icons/modular-registry.svg" class="fill alignleft" style="max-width: 150px"  declaredimensions=true alt="Train models">}}
 **3. Configure the filtered camera**
 
@@ -108,8 +108,8 @@ The `filtered-camera` {{< glossary_tooltip term_id="modular-resource" text="modu
 
 Configure a `filtered-camera` component on your machine, following the [attribute guide in the README](https://github.com/erh/filtered_camera?tab=readme-ov-file#configure-your-filtered-camera) to specify the names of your webcam and vision service, and add classification and object detection filters.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 {{<imgproc src="/services/icons/data-capture.svg" class="fill alignleft" style="max-width: 150px"  declaredimensions=true alt="Train models">}}
 **4. Configure data capture and sync on the filtered camera**
 
@@ -118,15 +118,15 @@ The filtered camera will only capture image data that passes the filters you con
 
 Turn off data capture on your webcam if you haven't already, so that you don't capture duplicate or unfiltered images.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 {{<imgproc src="/services/ml/configure.svg" class="fill alignleft" style="max-width: 150px"  declaredimensions=true alt="Train models">}}
 **5. (Optional) Trigger sync with custom logic**
 
 By default, the captured data syncs at the regular interval you specified in the data capture config.
 If you need to trigger sync in a different way, see [Trigger cloud sync conditionally](/services/data/trigger-sync/) for a documented example of syncing data only at certain times of day.
 
-{{< /tablestep >}}
+{{% /tablestep %}}
 {{< /table >}}
 
 ## Next steps

--- a/docs/use-cases/manage-fleet.md
+++ b/docs/use-cases/manage-fleet.md
@@ -18,29 +18,29 @@ You can monitor and teleoperate all of the robots from one online dashboard, and
 You can grant users different levels of access to individual machines or to groups of machines.
 
 {{< table >}}
-{{< tablestep >}}
+{{% tablestep %}}
 {{<imgproc src="/use-cases/signup.png" class="fill alignright" resize="600x" style="max-width: 350px" declaredimensions=true alt="Viam app signup screen">}}
 **1. Create an account**
 
 Go to the [Viam app](https://app.viam.com) and sign up with Google, GitHub, Apple, or an email address.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 {{<imgproc src="/fleet/fleet.svg" class="fill alignleft" resize="600x" style="max-width: 400px" declaredimensions=true alt="Two locations within an organization">}}
 **2. Create organizations and locations**
 
 Use [organizations](/cloud/organizations/), and [locations](/cloud/locations/) within them, to organize your machines into groups and manage user access.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 {{<imgproc src="/fleet/app-usage/limit-access.png" class="fill alignright" resize="600x" style="max-width: 350px" declaredimensions=true alt="Limit user access">}}
 **3. Invite other users and assign permissions**
 
 Invite other users to an organization or a location to [share access](/fleet/#use-viam-for-collaboration) to the machines within it.
 Assign each user a role (owner or operator) to manage permissions.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 {{<imgproc src="/fleet/app-usage/create-machine.png" class="fill alignleft" resize="600x" style="max-width: 450px" declaredimensions=true alt="Create a new machine in the Viam app">}}
 **4. Connect machines to the cloud**
 
@@ -49,8 +49,8 @@ When you [install `viam-server`](/get-started/installation/) on each machine, un
 Use the config builder interface to configure {{< glossary_tooltip term_id="component" text="components" >}} and {{< glossary_tooltip term_id="service" text="services" >}} for new or existing smart machines.
 You can use {{< glossary_tooltip term_id="fragment" text="fragments" >}} to streamline the process of configuring multiple similar machines.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 {{<imgproc src="/use-cases/last-online.png" class="fill alignright" resize="600x" style="max-width: 100px" declaredimensions=true alt="Machine last online status indicator in the Viam app.">}}
 **5. Monitor your fleet**
 
@@ -62,7 +62,7 @@ Using the [Viam app](https://app.viam.com), you can:
 
 Use [modules](/registry/) to deploy code to your fleet and manage versioning.
 
-{{< /tablestep >}}
+{{% /tablestep %}}
 {{< /table >}}
 
 ## Next steps

--- a/docs/use-cases/navigate.md
+++ b/docs/use-cases/navigate.md
@@ -13,7 +13,7 @@ If you have a rover base, you can use Viam to teleoperate it and to navigate aut
 Once you have configured your machine, you can remotely control your machine on the app's **CONTROL** tab, and set up autonomous navigation with the [navigation service](/services/navigation/).
 
 {{< table >}}
-{{< tablestep >}}
+{{% tablestep %}}
 {{<imgproc src="/use-cases/base-control.png" class="fill alignright" resize="200x" style="max-width: 200px" declaredimensions=true alt="Base control card">}}
 **1. Teleoperate**
 
@@ -22,16 +22,16 @@ Create an account and add a machine, [install `viam-server`](/get-started/instal
 Then, go to the **CONTROL** tab and access a remote control card for your base, with an interface for controlling speed, direction, and power.
 You can also view live feeds from any cameras you configure.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 {{<imgproc src="/services/icons/base-rc.svg" class="fill alignleft" resize="200x" style="max-width: 200px" declaredimensions=true alt="Base remote control service icon.">}}
 **2. Program to move**
 
 Remotely control your rover base programmatically with a [Viam SDK](/sdks/) by making calls to the [base API](/components/base/#api).
 Or, [configure the base remote control service](/services/base-rc/) to teleoperate your base with an [input controller.](/components/input-controller/)
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 {{<imgproc src="/services/icons/navigation.svg" class="fill alignright" resize="200x" style="max-width: 200px" declaredimensions=true alt="Navigation icon.">}}
 **3. Prepare your base to navigate**
 
@@ -39,14 +39,14 @@ Or, [configure the base remote control service](/services/base-rc/) to teleopera
 Additionally, [configure and calibrate](/services/navigation/#configure-and-calibrate-the-frame-system-service-for-gps-navigation) the frame system for GPS navigation.
 Then, [configure the navigation service](/services/navigation/) on your machine.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 {{<imgproc src="/use-cases/navigation-card.png" class="fill alignleft" resize="200x" style="max-width: 300px" declaredimensions=true alt="Navigation map card">}}
 **4. Navigate autonomously**
 
 Define a path for your rover to navigate with waypoints and obstacles. Then, start and stop your machine's motion along the path and view your machine's current location. You can use the map interface on the **CONTROL** tab or the [navigation API](/services/navigation/#api).
 
-{{< /tablestep >}}
+{{% /tablestep %}}
 {{< /table >}}
 
 ## Next steps

--- a/docs/use-cases/sensor-data-query-sdk.md
+++ b/docs/use-cases/sensor-data-query-sdk.md
@@ -44,7 +44,7 @@ Follow the guide to [capture sensor data](/use-cases/collect-sensor-data/).
 ## Set up the Python SDK
 
 {{< table >}}
-{{< tablestep link="/build/program/#requirements">}}
+{{% tablestep link="/build/program/#requirements"%}}
 **1. Install the Python SDK**
 
 For macOS (both Intel x86_64 and Apple Silicon) or Linux (x86, aarch64, armv6l), run the following commands:
@@ -55,13 +55,13 @@ source .venv/bin/activate
 pip install viam-sdk
 ```
 
-{{< /tablestep >}}
+{{% /tablestep %}}
 {{< /table >}}
 
 ## Query data with the Python SDK
 
 {{< table >}}
-{{< tablestep link="/cli/#organizations">}}
+{{% tablestep link="/cli/#organizations"%}}
 **1. Create an API key**
 
 To access your machines using the Python SDK, you must use an API key:
@@ -70,8 +70,8 @@ To access your machines using the Python SDK, you must use an API key:
 viam organizations api-key create --org-id <org-id> --name my-api-key
 ```
 
-{{< /tablestep >}}
-{{< tablestep link="/appendix/apis/data-client/">}}
+{{% /tablestep %}}
+{{% tablestep link="/appendix/apis/data-client/"%}}
 **2. Use the API key with the `data_client`**
 
 Use the API key and [`TabularDataByFilter()`](/appendix/apis/data-client/#tabulardatabyfilter), [`TabularDataBySQL()`](/appendix/apis/data-client/#tabulardatabysql), [`TabularDataByMQL()`](/appendix/apis/data-client/#tabulardatabymql), and[`DeleteTabularData()`](/appendix/apis/data-client/#deletetabulardata) to query data:
@@ -134,7 +134,7 @@ if __name__ == '__main__':
     asyncio.run(main())
 ```
 
-{{< /tablestep >}}
+{{% /tablestep %}}
 {{< /table >}}
 
 Adjust the Python script to uery your data further.

--- a/docs/use-cases/sensor-data-query.md
+++ b/docs/use-cases/sensor-data-query.md
@@ -53,14 +53,14 @@ Once your data has synced, you can query your data from within the Viam app usin
 You must have the [owner role](/cloud/rbac/) in order to query data in the Viam app.
 
 {{< table >}}
-{{< tablestep >}}
+{{% tablestep %}}
 **1. Query with SQL or MQL**
 
 Navigate to the [**Query** page](https://app.viam.com/data/query).
 Then, select either **SQL** or **MQL** from the **Query mode** dropdown menu on the right-hand side.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 **2. Run your query**
 
 This example query returns 5 readings from a component called `my-sensor`:
@@ -81,8 +81,8 @@ SELECT * FROM readings WHERE component_name = 'my-sensor' LIMIT 5
 
 {{% /tab %}}
 {{< /tabs >}}
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 **3. Review results**
 
 Click **Run query** when ready to perform your query and get matching results.
@@ -102,7 +102,7 @@ For more information on MQL syntax, see the [MQL (MongoDB Query Language)](https
 
 {{% /expand%}}
 
-{{< /tablestep >}}
+{{% /tablestep %}}
 {{< /table >}}
 
 ## Configure data query
@@ -116,7 +116,7 @@ If you want to query data from third party tools, you have to configure data que
 You can use third-party tools, such as the [`mongosh` shell](https://www.mongodb.com/docs/mongodb-shell/), [MongoDB Compass](https://www.mongodb.com/docs/compass/current/), to query against captured sensor data.
 
 {{< table >}}
-{{< tablestep link="/use-cases/sensor-data-query/#configure-data-query">}}
+{{% tablestep link="/use-cases/sensor-data-query/#configure-data-query"%}}
 **1. Connect to your Viam organization's data**
 
 Run the following command to connect to your Viam organization's MongoDB Atlas instance from `mongosh` using the connection URI you obtained during query configuration:
@@ -125,8 +125,8 @@ Run the following command to connect to your Viam organization's MongoDB Atlas i
 mongosh "<YOUR-DB-CONNECTION-URI>"
 ```
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 **2. Query data from a compatible client**
 
 Once connected, you can run SQL or MQL statements to query captured data directly.
@@ -173,7 +173,7 @@ db.readings.aggregate(
 {{% /tab %}}
 {{< /tabs >}}
 
-{{< /tablestep >}}
+{{% /tablestep %}}
 {{< /table >}}
 
 {{< alert title="Tip" color="tip" >}}

--- a/docs/use-cases/sensor-data-visualize.md
+++ b/docs/use-cases/sensor-data-visualize.md
@@ -170,6 +170,8 @@ db-user-<YOUR-ORG-ID>
 
 Substitute your organization ID for `<YOUR-ORG-ID>`.
 
+{{% /tabs %}}
+
 {{< /tablestep >}}
 {{< tablestep >}}
 **3. Use visualization tools for dashboards**
@@ -185,7 +187,7 @@ See the [guide on querying sensor data](/use-cases/sensor-data-query/) for more 
 {{< /tablestep >}}
 {{< /table >}}
 
-{{< /tabs >}}
+{{< /tab >}}
 {{< /tabs >}}
 
 ## Next steps

--- a/docs/use-cases/sensor-data-visualize.md
+++ b/docs/use-cases/sensor-data-visualize.md
@@ -50,12 +50,79 @@ If you want to query data from third party tools, you have to configure data que
 When you sync captured data to Viam, that data is stored in the Viam organization’s MongoDB Atlas Data Federation instance.
 Your chosen third-party visualization tool must be able to connect to a [MongoDB Atlas Data Federation](https://www.mongodb.com/docs/atlas/data-federation/query/sql/connect/) instance as its data store.
 
+Select a tab below to learn how to configure your visualization tool for use with Viam:
+
+{{< tabs >}}
+{{% tab name="Grafana" %}}
+
+{{< table >}}
+{{< tablestep >}}
+**1. Choose Grafana instance**
+
+Install or set up Grafana. You can use either a local instance of Grafana or Grafana Cloud, and can use the free trial version of Grafana if desired.
+
+{{< /tablestep >}}
+{{< tablestep >}}
+**2. Install connector to MongoDB data source**
+
+Navigate to your Grafana web UI, and add the [Grafana MongoDB data source](https://grafana.com/grafana/plugins/grafana-mongodb-datasource/) plugin to your Grafana instance.
+
+{{<imgproc src="/tutorials/visualize-data-grafana/search-grafana-plugins.png" resize="800x" declaredimensions=true alt="The Grafana plugin search interface showing the results for a search for mongodb">}}
+
+{{< /tablestep >}}
+{{< tablestep >}}
+**3. Configure a data connection**
+
+Navigate to the Grafana data source management page, and select the Grafana MongoDB data source that you just added.
+
+Enter the following information in the configuration UI for that plugin:
+
+- **Connection string**: Enter the following connection string, and replace `<MONGODB-ATLAS-DF-HOSTNAME>` with your database hostname as configured with the `viam data database configure` command, and replace `<DATABASE-NAME>` with the desired database name to query:
+
+  ```sh
+  mongodb://<MONGODB-ATLAS-DF-HOSTNAME>/<DATABASE-NAME>?directConnection=true&authSource=admin&tls=true
+  ```
+
+- **Credentials: User**: Enter the following username, substituting your organization ID as determined earlier, for `<YOUR-ORG-ID>`:
+
+  ```sh
+  db-user-<YOUR-ORG-ID>
+  ```
+
+- **Credentials: Password**: Enter the password you provided earlier.
+
+{{<imgproc src="/tutorials/visualize-data-grafana/configure-grafana-mongodb-datasource.png" resize="800x" declaredimensions=true alt="The Grafana data source plugin configuration page, showing the connection string and username filled in with the configuration determined from the previous steps">}}
+
+{{% /tab %}}
+{{< /tabs >}}
+
+{{< /tablestep >}}
+{{< tablestep >}}
+**4. Use visualization tools for dashboards**
+
+Some third-party visualization tools support the ability to directly query your data within their platform to generate more granular visualizations of specific data.
+You might use this functionality to visualize only a single day's metrics, limit the visualization to a select machine or component, or to isolate an outlier in your reported data, for example.
+
+While every third-party tool is different, you would generally query your data using either {{< glossary_tooltip term_id="sql" text="SQL" >}} or {{< glossary_tooltip term_id="mql" text="MQL" >}}.
+See the [guide on querying sensor data](/use-cases/sensor-data-query/) for more information.
+
+<!-- markdownlint-disable-file MD034 -->
+
+{{< /tablestep >}}
+{{< /table >}}
+
+{{% /tab %}}
+{{% tab name="Other visualization tools" %}}
+
 {{< table >}}
 {{< tablestep >}}
 **1. Install connector to MongoDB data source**
 
-For example, if you are using [Grafana](https://grafana.com/), you must install and configure the [Grafana MongoDB data source](https://grafana.com/grafana/plugins/grafana-mongodb-datasource/) plugin.
-See the [Visualize Data Using Grafana](/tutorials/services/visualize-data-grafana/) tutorial for a detailed walkthrough for Grafana.
+Some visualization clients are able to connect to the Viam MongoDB Atlas Data Federation instance natively, while others require that you install and configure an additional plugin or connector.
+For example, Tableau requires both the [Atlas SQL JDBC Driver](https://www.mongodb.com/try/download/jdbc-driver) as well as the the [Tableau Connector](https://www.mongodb.com/try/download/tableau-connector) in order to successfully connect and access data.
+
+Check with the documentation for your third-party visualization tool to be sure you have the required additional software installed to connect to a MongoDB Atlas Data Federation instance.
+
 {{< /tablestep >}}
 {{< tablestep >}}
 **2. Configure a data connection**
@@ -67,7 +134,7 @@ This is what they look like:
 {{< tabs >}}
 {{% tab name="Connection URI and credentials" %}}
 
-If your client supports a connection URI, use the following format and repolace `YOUR-PASSWORD-HERE` with your database password as configured with the `viam data database configure` command:
+If your client supports a connection URI, use the following format and replace `YOUR-PASSWORD-HERE` with your database password as configured with the `viam data database configure` command:
 
 ```sh {class="command-line" data-prompt="$"}
 mongodb://db-user-abcdef12-abcd-abcd-abcd-abcdef123456:YOUR-PASSWORD-HERE@data-federation-abcdef12-abcd-abcd-abcd-abcdef123456-e4irv.a.query.mongodb.net/?ssl=true&authSource=admin
@@ -124,9 +191,11 @@ See the [guide on querying sensor data](/use-cases/sensor-data-query/) for more 
 {{< /tablestep >}}
 {{< /table >}}
 
+{{< /tabs >}}
+
 ## Next steps
 
-For a walkthrough of visualizing data with a specific tool, see [visualizing data with Grafana](/tutorials/services/visualize-data-grafana/).
+For more detailed instructions on using Grafana, including a full step-by-step configuration walkthrough, see [visualizing data with Grafana](/tutorials/services/visualize-data-grafana/).
 
 On top of visualizing sensor data with third-party tools, you can also [query it with the Python SDK](/use-cases/sensor-data-query-sdk/) or [query it with the Viam app](/use-cases/sensor-data-query/).
 

--- a/docs/use-cases/sensor-data-visualize.md
+++ b/docs/use-cases/sensor-data-visualize.md
@@ -93,9 +93,6 @@ Enter the following information in the configuration UI for that plugin:
 
 {{<imgproc src="/tutorials/visualize-data-grafana/configure-grafana-mongodb-datasource.png" resize="800x" declaredimensions=true alt="The Grafana data source plugin configuration page, showing the connection string and username filled in with the configuration determined from the previous steps">}}
 
-{{% /tab %}}
-{{< /tabs >}}
-
 {{< /tablestep >}}
 {{< tablestep >}}
 **4. Use visualization tools for dashboards**
@@ -173,9 +170,6 @@ db-user-<YOUR-ORG-ID>
 
 Substitute your organization ID for `<YOUR-ORG-ID>`.
 
-{{% /tab %}}
-{{< /tabs >}}
-
 {{< /tablestep >}}
 {{< tablestep >}}
 **3. Use visualization tools for dashboards**
@@ -191,6 +185,7 @@ See the [guide on querying sensor data](/use-cases/sensor-data-query/) for more 
 {{< /tablestep >}}
 {{< /table >}}
 
+{{< /tabs >}}
 {{< /tabs >}}
 
 ## Next steps

--- a/docs/use-cases/sensor-data-visualize.md
+++ b/docs/use-cases/sensor-data-visualize.md
@@ -53,7 +53,7 @@ Your chosen third-party visualization tool must be able to connect to a [MongoDB
 Select a tab below to learn how to configure your visualization tool for use with Viam:
 
 {{< tabs >}}
-{{% tab name="Grafana" %}}
+{{< tab name="Grafana" >}}
 
 {{< table >}}
 {{% tablestep %}}
@@ -91,9 +91,9 @@ Enter the following information in the configuration UI for that plugin:
 
 - **Password**: Enter the password you provided earlier.
 
-{{<imgproc src="/tutorials/visualize-data-grafana/configure-grafana-mongodb-datasource.png" resize="800x" declaredimensions=true alt="The Grafana data source plugin configuration page, showing the connection string and username filled in with the configuration determined from the previous steps">}}
+  {{<imgproc src="/tutorials/visualize-data-grafana/configure-grafana-mongodb-datasource.png" resize="800x" declaredimensions=true alt="The Grafana data source plugin configuration page, showing the connection string and username filled in with the configuration determined from the previous steps">}}
 
-{{% /tablestep %}}
+{{< /tablestep >}}
 {{% tablestep %}}
 
 **4. Use visualization tools for dashboards**
@@ -110,7 +110,7 @@ See the [guide on querying sensor data](/use-cases/sensor-data-query/) for more 
 {{< /table >}}
 
 {{% /tab %}}
-{{% tab name="Other visualization tools" %}}
+{{< tab name="Other visualization tools" >}}
 
 {{< table >}}
 {{% tablestep %}}
@@ -171,7 +171,7 @@ db-user-<YOUR-ORG-ID>
 
 Substitute your organization ID for `<YOUR-ORG-ID>`.
 
-{{% /tab %}}
+{{< /tab >}}
 {{% /tabs %}}
 
 {{% /tablestep %}}

--- a/docs/use-cases/sensor-data-visualize.md
+++ b/docs/use-cases/sensor-data-visualize.md
@@ -83,13 +83,13 @@ Enter the following information in the configuration UI for that plugin:
   mongodb://<MONGODB-ATLAS-DF-HOSTNAME>/<DATABASE-NAME>?directConnection=true&authSource=admin&tls=true
   ```
 
-- **Credentials: User**: Enter the following username, substituting your organization ID as determined earlier, for `<YOUR-ORG-ID>`:
+- **User**: Enter the following username, substituting your organization ID as determined earlier, for `<YOUR-ORG-ID>`:
 
   ```sh
   db-user-<YOUR-ORG-ID>
   ```
 
-- **Credentials: Password**: Enter the password you provided earlier.
+- **Password**: Enter the password you provided earlier.
 
 {{<imgproc src="/tutorials/visualize-data-grafana/configure-grafana-mongodb-datasource.png" resize="800x" declaredimensions=true alt="The Grafana data source plugin configuration page, showing the connection string and username filled in with the configuration determined from the previous steps">}}
 
@@ -169,7 +169,6 @@ db-user-<YOUR-ORG-ID>
 ```
 
 Substitute your organization ID for `<YOUR-ORG-ID>`.
-
 
 {{% /tab %}}
 {{% /tabs %}}

--- a/docs/use-cases/sensor-data-visualize.md
+++ b/docs/use-cases/sensor-data-visualize.md
@@ -99,11 +99,11 @@ Enter the following information in the configuration UI for that plugin:
 
 With your data connection established, you can then build dashboards that provide insight into your data.
 
-You can query your captured data within a Grafana dashboard using either {{< glossary_tooltip term_id="sql" text="SQL" >}} or {{< glossary_tooltip term_id="mql" text="MQL" >}}.
-See the [guide on querying sensor data](/use-cases/sensor-data-query/) for more information.
-
 Grafana additionally supports the ability to directly [query and transform your data](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/) within a dashboard to generate more granular visualizations of specific data.
 You might use this functionality to visualize only a single day's metrics, limit the visualization to a select machine or component, or to isolate an outlier in your reported data, for example.
+
+You can query your captured data within a Grafana dashboard using either {{< glossary_tooltip term_id="sql" text="SQL" >}} or {{< glossary_tooltip term_id="mql" text="MQL" >}}.
+See the [guide on querying sensor data](/use-cases/sensor-data-query/) for more information.
 
 <!-- markdownlint-disable-file MD034 -->
 

--- a/docs/use-cases/sensor-data-visualize.md
+++ b/docs/use-cases/sensor-data-visualize.md
@@ -170,6 +170,8 @@ db-user-<YOUR-ORG-ID>
 
 Substitute your organization ID for `<YOUR-ORG-ID>`.
 
+
+{{% /tab %}}
 {{% /tabs %}}
 
 {{< /tablestep >}}

--- a/docs/use-cases/sensor-data-visualize.md
+++ b/docs/use-cases/sensor-data-visualize.md
@@ -95,14 +95,15 @@ Enter the following information in the configuration UI for that plugin:
 
 {{< /tablestep >}}
 {{% tablestep %}}
+**4. Use Grafana for dashboards**
 
-**4. Use visualization tools for dashboards**
+With your data connection established, you can then build dashboards that provide insight into your data.
 
-Some third-party visualization tools support the ability to directly query your data within their platform to generate more granular visualizations of specific data.
-You might use this functionality to visualize only a single day's metrics, limit the visualization to a select machine or component, or to isolate an outlier in your reported data, for example.
-
-While every third-party tool is different, you would generally query your data using either {{< glossary_tooltip term_id="sql" text="SQL" >}} or {{< glossary_tooltip term_id="mql" text="MQL" >}}.
+You can query your captured data within a Grafana dashboard using either {{< glossary_tooltip term_id="sql" text="SQL" >}} or {{< glossary_tooltip term_id="mql" text="MQL" >}}.
 See the [guide on querying sensor data](/use-cases/sensor-data-query/) for more information.
+
+Grafana additionally supports the ability to directly [query and transform your data](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/) within a dashboard to generate more granular visualizations of specific data.
+You might use this functionality to visualize only a single day's metrics, limit the visualization to a select machine or component, or to isolate an outlier in your reported data, for example.
 
 <!-- markdownlint-disable-file MD034 -->
 

--- a/docs/use-cases/sensor-data-visualize.md
+++ b/docs/use-cases/sensor-data-visualize.md
@@ -56,21 +56,21 @@ Select a tab below to learn how to configure your visualization tool for use wit
 {{% tab name="Grafana" %}}
 
 {{< table >}}
-{{< tablestep >}}
+{{% tablestep %}}
 **1. Choose Grafana instance**
 
 Install or set up Grafana. You can use either a local instance of Grafana or Grafana Cloud, and can use the free trial version of Grafana if desired.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 **2. Install connector to MongoDB data source**
 
 Navigate to your Grafana web UI, and add the [Grafana MongoDB data source](https://grafana.com/grafana/plugins/grafana-mongodb-datasource/) plugin to your Grafana instance.
 
 {{<imgproc src="/tutorials/visualize-data-grafana/search-grafana-plugins.png" resize="800x" declaredimensions=true alt="The Grafana plugin search interface showing the results for a search for mongodb">}}
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 **3. Configure a data connection**
 
 Navigate to the Grafana data source management page, and select the Grafana MongoDB data source that you just added.
@@ -93,8 +93,9 @@ Enter the following information in the configuration UI for that plugin:
 
 {{<imgproc src="/tutorials/visualize-data-grafana/configure-grafana-mongodb-datasource.png" resize="800x" declaredimensions=true alt="The Grafana data source plugin configuration page, showing the connection string and username filled in with the configuration determined from the previous steps">}}
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
+
 **4. Use visualization tools for dashboards**
 
 Some third-party visualization tools support the ability to directly query your data within their platform to generate more granular visualizations of specific data.
@@ -105,14 +106,14 @@ See the [guide on querying sensor data](/use-cases/sensor-data-query/) for more 
 
 <!-- markdownlint-disable-file MD034 -->
 
-{{< /tablestep >}}
+{{% /tablestep %}}
 {{< /table >}}
 
 {{% /tab %}}
 {{% tab name="Other visualization tools" %}}
 
 {{< table >}}
-{{< tablestep >}}
+{{% tablestep %}}
 **1. Install connector to MongoDB data source**
 
 Some visualization clients are able to connect to the Viam MongoDB Atlas Data Federation instance natively, while others require that you install and configure an additional plugin or connector.
@@ -120,8 +121,8 @@ For example, Tableau requires both the [Atlas SQL JDBC Driver](https://www.mongo
 
 Check with the documentation for your third-party visualization tool to be sure you have the required additional software installed to connect to a MongoDB Atlas Data Federation instance.
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 **2. Configure a data connection**
 
 Most third-party visualization tools require the _connection URI_ (also called the connection string) to that database server, and the _credentials_ to authenticate to that server in order to visualize your data.
@@ -173,8 +174,8 @@ Substitute your organization ID for `<YOUR-ORG-ID>`.
 {{% /tab %}}
 {{% /tabs %}}
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 **3. Use visualization tools for dashboards**
 
 Some third-party visualization tools support the ability to directly query your data within their platform to generate more granular visualizations of specific data.
@@ -185,7 +186,7 @@ See the [guide on querying sensor data](/use-cases/sensor-data-query/) for more 
 
 <!-- markdownlint-disable-file MD034 -->
 
-{{< /tablestep >}}
+{{% /tablestep %}}
 {{< /table >}}
 
 {{< /tab >}}

--- a/layouts/shortcodes/tablestep.html
+++ b/layouts/shortcodes/tablestep.html
@@ -5,7 +5,7 @@
   {{ end }}
   {{ with $.Inner }}
       {{ if eq $.Page.File.Ext "md" }}
-        {{ $.Inner | markdownify }}
+        {{ $.Inner }}
       {{ else }}
         {{ $.Inner | htmlUnescape | safeHTML }}
       {{ end }}

--- a/static/include/how-to/query-data.md
+++ b/static/include/how-to/query-data.md
@@ -1,5 +1,5 @@
 {{< table >}}
-{{< tablestep link="/cli/#authenticate">}}
+{{% tablestep link="/cli/#authenticate"%}}
 **1. Authenticate with the CLI**
 
 Authenticate using a personal access token:
@@ -8,8 +8,8 @@ Authenticate using a personal access token:
 viam login
 ```
 
-{{< /tablestep >}}
-{{< tablestep link="/cli/#organizations">}}
+{{% /tablestep %}}
+{{% tablestep link="/cli/#organizations"%}}
 **2. Find your organization ID**
 
 To create a database user allowing you to access your data, find your organization ID:
@@ -18,17 +18,17 @@ To create a database user allowing you to access your data, find your organizati
 viam organizations list
 ```
 
-{{< /tablestep >}}
-{{< tablestep >}}
+{{% /tablestep %}}
+{{% tablestep %}}
 **3. Configure a new database user**
 
 Configure a new database user for the Viam organization's MongoDB [Atlas Data Federation](https://www.mongodb.com/docs/atlas/data-federation/overview/) instance, which is where your machine's synced data is stored.
 
-{{< alert title="Warning" color="warning" >}}
+{{% alert title="Warning" color="warning" %}}
 The command will create a user with your organization ID as the username.
 If you or someone else in your organization have already created this user, the following steps update the password for that user instead.
 Dashboards or other integrations relying on this password will then need to be updated.
-{{< /alert >}}
+{{% /alert %}}
 
 Provide your organization's `org-id` from step 2, and a password for your database user.
 Your password must be at least 8 characters long, and include at least one uppercase, one number, and one special character (such as `$` or `%`):
@@ -40,8 +40,8 @@ viam data database configure --org-id=<YOUR-ORGANIZATION-ID> --password=<NEW-DBU
 This command configures a database user for your organization for use with data query, and sets the password.
 If you have run this command before, this command instead updates the password to the new value you set.
 
-{{< /tablestep >}}
-{{< tablestep link="/cli/#data" >}}
+{{% /tablestep %}}
+{{% tablestep link="/cli/#data" %}}
 **4. Determine the connection URI**
 
 Determine the connection URI (also known as a connection string) for your organization's MongoDB Atlas Data Federation instance by running the following command with the organization's `org-id` from step 2:
@@ -59,5 +59,5 @@ This command returns both the _connection URI_ to your organization's MongoDB At
 
 You will need this information to query your data in the next section.
 
-{{< /tablestep >}}
+{{% /tablestep %}}
 {{< /table >}}


### PR DESCRIPTION
Add Grafana tab to visualize data how-to guide, and convert existing steps to be all-others in separate tab.
- Opted for simple (how-to), so omitting example forms of various URIs and connection strings. Can re-add (from `docs/tutorials/services/visualize-data-grafana.md` if helpful)

NOTICED: `tablestep` and `tabs` seem to require a specific order, perhaps tabs with tablesteps within them are not permitted, but tablesteps with tabs in them is? If so I can try switching around, but more than one tablestep is specific to the grafana tab. I could see a solution where I declare the tabset in each tablestep, if there is no way to include tablesteps within tabs. Hoping I just did something wrong.