### PR TITLE
DOCS-2647: Merge more flutter code samples

### DIFF
--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -977,9 +977,9 @@ def parse(type, names):
 
                     if not id.endswith(".from_robot") and not id.endswith(".get_resource_name") \
                     and not id.endswith(".get_operation") and not id.endswith(".from_proto") \
-                    and not id.endswith(".from_string") and not id.endswith("__") \
-                    and not id.endswith("HasField") and not id.endswith("WhichOneof") \
-                    and not id in python_ignore_apis:
+                    and not id.endswith(".to_proto") and not id.endswith(".from_string") \
+                    and not id.endswith("__") and not id.endswith("HasField") \
+                    and not id.endswith("WhichOneof") and not id in python_ignore_apis:
 
                         ## Determine method name, but don't save to dictionary as value; we use it as a key instead:
                         method_name = id.rsplit('.',1)[1]
@@ -992,8 +992,9 @@ def parse(type, names):
                                 and row.split(',')[2] == method_name:
                                     this_method_dict["proto"] = row.split(',')[1]
 
-                        ## Determine method description, stripping newlines:
-                        this_method_dict["description"] = tag.find('dd').p.text.replace("\n", " ")
+                        ## Determine method description, stripping newlines. If not present, skip:
+                        if tag.find('dd').p:
+                            this_method_dict["description"] = tag.find('dd').p.text.replace("\n", " ") 
 
                         ## Determine method direct link, no need to parse for it, it's inferrable.
                         ## If we are scraping from a local staging instance, replace host and port with upstream link target URL:

--- a/static/include/components/apis/generated/motor.md
+++ b/static/include/components/apis/generated/motor.md
@@ -64,6 +64,13 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 - [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+// Set the power to  40% forwards.
+await myMotor.setPower(0.4);
+```
+
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/Motor/setPower.html).
 
 {{% /tab %}}
@@ -84,6 +91,13 @@ Spin the motor indefinitely at the specified speed, in revolutions per minute. I
 **Returns:**
 
 - [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
+
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+// Set the motor to turn backwards at 120.5 RPM.
+await myMotor.setRPM(-120.5);
+```
 
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/Motor/setRPM.html).
 
@@ -158,6 +172,13 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 - [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+// Turn the motor 7.2 revolutions forward at 60 RPM.
+await myMotor.goFor(60, 7.2);
+```
+
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/Motor/goFor.html).
 
 {{% /tab %}}
@@ -230,6 +251,13 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 - [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+// Turn the motor to 8.3 revolutions from home at 75 RPM.
+await myMotor.goTo(75, 8.3);
+```
+
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/Motor/goTo.html).
 
 {{% /tab %}}
@@ -296,6 +324,13 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Returns:**
 
 - [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
+
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+// Set the current position as the new home position with no offset.
+await myMotor.resetZeroPosition(0.0);
+```
 
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/Motor/resetZeroPosition.html).
 
@@ -367,6 +402,13 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Returns:**
 
 - [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[double](https://api.flutter.dev/flutter/dart-core/double-class.html)>
+
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+// Get the current position of an encoded motor.
+var position = await myMotor.position();
+```
 
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/Motor/position.html).
 
@@ -441,6 +483,13 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 - [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[MotorProperties](https://flutter.viam.dev/viam_sdk/MotorProperties.html)>
 
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+// Return whether the motor supports certain optional features
+var properties = await myMotor.properties();
+```
+
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/Motor/properties.html).
 
 {{% /tab %}}
@@ -514,6 +563,16 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Returns:**
 
 - [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[PowerState](https://flutter.viam.dev/viam_sdk/PowerState-class.html)>
+
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+// Check whether the motor is currently powered and
+// check the percentage of max power to the motor.
+var powerState = await myMotor.powerState();
+var powered = powerState.isOn;
+var pct = powerState.powerPct;
+```
 
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/Motor/powerState.html).
 
@@ -618,6 +677,13 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 - [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[bool](https://api.flutter.dev/flutter/dart-core/bool-class.html)>
 
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+// Check whether the motor is moving.
+var moving = await myMotor.isMoving();
+```
+
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/Motor/isMoving.html).
 
 {{% /tab %}}
@@ -684,6 +750,13 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Returns:**
 
 - [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
+
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+// Stop the motor.
+await myMotor.stop();
+```
 
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/Motor/stop.html).
 
@@ -828,6 +901,12 @@ Get the `ResourceName` for this motor with the given name.
 **Returns:**
 
 - [ResourceName](https://flutter.viam.dev/viam_sdk/ResourceName-class.html)
+
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+var name = Motor.getResourceName('myMotor');
+```
 
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/Motor/getResourceName.html).
 

--- a/static/include/components/apis/generated/power_sensor.md
+++ b/static/include/components/apis/generated/power_sensor.md
@@ -63,9 +63,9 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```dart {class="line-numbers linkable-line-numbers"}
-var voltageObject = await myPowerSensor.readings();
-double voltageInVolts = voltageObject['volts'];
-bool isItAC = voltageObject['isAc'];
+var voltageObject = await myPowerSensor.voltage();
+double voltageInVolts = voltageObject.volts;
+bool isItAC = voltageObject.isAc;
 ```
 
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/PowerSensor/voltage.html).
@@ -138,9 +138,9 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```dart {class="line-numbers linkable-line-numbers"}
-var currentObject = await myPowerSensor.readings();
-double amps = voltageObject['amperes'];
-bool isItAC = voltageObject['isAc'];
+var currentObject = await myPowerSensor.current();
+double amps = currentObject.amperes;
+bool isItAC = currentObject.isAc;
 ```
 
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/PowerSensor/current.html).

--- a/static/include/components/apis/generated/servo.md
+++ b/static/include/components/apis/generated/servo.md
@@ -159,6 +159,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 - [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)>
 
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+var angle = await myServo.position();
+```
+
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/Servo/position.html).
 
 {{% /tab %}}
@@ -260,6 +266,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 - [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[bool](https://api.flutter.dev/flutter/dart-core/bool-class.html)>
 
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+var isItMoving = await myServo.isMoving();
+```
+
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/Servo/isMoving.html).
 
 {{% /tab %}}
@@ -329,6 +341,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Returns:**
 
 - [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
+
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+await myServo.stop();
+```
 
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/Servo/stop.html).
 
@@ -473,6 +491,13 @@ Get the `ResourceName` for this servo with the given name.
 **Returns:**
 
 - [ResourceName](https://flutter.viam.dev/viam_sdk/ResourceName-class.html)
+
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+// Example:
+var name = Servo.getResourceName('myServo');
+```
 
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/Servo/getResourceName.html).
 

--- a/static/include/robot/apis/generated/robot.md
+++ b/static/include/robot/apis/generated/robot.md
@@ -710,7 +710,7 @@ Any machines created using this method will NOT automatically close the channel 
 
 **Parameters:**
 
-- `channel` ([grpclib.client.Channel | viam.rpc.dial.ViamChannel](https://python.viam.dev/autoapi/viam/rpc/dial/index.html#viam.rpc.dial.ViamChannel)) (required): The channel that is connected to a robot, obtained by viam.rpc.dial.
+- `channel` ([grpclib.client.Channel | viam.rpc.dial.ViamChannel](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.ViamChannel)) (required): The channel that is connected to a robot, obtained by viam.rpc.dial.
 - `options` ([Options](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient.Options)) (required): Options for refreshing. Any connection options will be ignored.
 
 **Returns:**

--- a/static/include/robot/apis/generated/robot.md
+++ b/static/include/robot/apis/generated/robot.md
@@ -577,6 +577,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 - [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[CloudMetadata](https://flutter.viam.dev/viam_sdk/CloudMetadata.html)>
 
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+var metadata = await machine.getCloudMetadata();
+```
+
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/RobotClient/getCloudMetadata.html).
 
 {{% /tab %}}
@@ -670,6 +676,25 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 - [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[RobotClient](https://flutter.viam.dev/viam_sdk/RobotClient-class.html)>
 
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+// Example usage; see your machine's CONNECT tab for your machine's address and API key.
+
+Future<void> connectToViam() async {
+  const host = '<YOUR ROBOT ADDRESS>.viam.cloud';
+  // Replace "<API-KEY-ID>" (including brackets) with your machine's API key ID
+  const apiKeyID = '<API-KEY-ID>';
+  // Replace "<API-KEY>" (including brackets) with your machine's API key
+  const apiKey = '<API-KEY>';
+
+  final machine = await RobotClient.atAddress(
+    host,
+    RobotClientOptions.withApiKey(apiKeyID, apiKey),
+  );
+}
+```
+
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/RobotClient/atAddress.html).
 
 {{% /tab %}}
@@ -685,7 +710,7 @@ Any machines created using this method will NOT automatically close the channel 
 
 **Parameters:**
 
-- `channel` ([grpclib.client.Channel | viam.rpc.dial.ViamChannel](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.ViamChannel)) (required): The channel that is connected to a robot, obtained by viam.rpc.dial.
+- `channel` ([grpclib.client.Channel | viam.rpc.dial.ViamChannel](https://python.viam.dev/autoapi/viam/rpc/dial/index.html#viam.rpc.dial.ViamChannel)) (required): The channel that is connected to a robot, obtained by viam.rpc.dial.
 - `options` ([Options](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient.Options)) (required): Options for refreshing. Any connection options will be ignored.
 
 **Returns:**
@@ -744,6 +769,12 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Returns:**
 
 - [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
+
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+await machine.refresh();
+```
 
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/RobotClient/refresh.html).
 
@@ -847,6 +878,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Returns:**
 
 - [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
+
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+await machine.close();
+```
 
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/RobotClient/close.html).
 


### PR DESCRIPTION
Add servo, motor, robot client Flutter code samples
- Add updated power sensor Flutter code samples
- Include new omit API for Python: `to_proto`
- Include better handling for missing description in PySDK, like with above.