### PR TITLE
DOCS-2417: Add SetRPM API

### DIFF
--- a/.github/workflows/sdk_protos_map.csv
+++ b/.github/workflows/sdk_protos_map.csv
@@ -139,7 +139,7 @@ input_controller,Close,close,Close,
 
 ## Motor
 motor,SetPower,set_power,SetPower,setPower
-motor,SetRPM,,,setRPM
+motor,SetRPM,set_rpm,SetRPM,setRPM
 motor,GoFor,go_for,GoFor,goFor
 motor,GoTo,go_to,GoTo,goTo
 motor,ResetZeroPosition,reset_zero_position,ResetZeroPosition,resetZeroPosition

--- a/static/include/components/apis/generated/motor.md
+++ b/static/include/components/apis/generated/motor.md
@@ -74,6 +74,45 @@ For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_s
 Spin the motor indefinitely at the specified speed, in revolutions per minute. If `rpm` is positive, the motor will spin forwards, and if `rpm` is negative, the motor will spin backwards.
 
 {{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `rpm` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (required): Speed at which the motor should rotate.
+- `extra` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (optional): Extra options to pass to the underlying RPC call.
+- `timeout` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
+
+**Returns:**
+
+- None.
+
+**Example:**
+
+```python {class="line-numbers linkable-line-numbers"}
+my_motor = Motor.from_robot(robot=robot, name="my_motor")
+
+# Spin the motor at 75 RPM.
+await my_motor.set_rpm(rpm=75)
+```
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/motor/client/index.html#viam.components.motor.client.MotorClient.set_rpm).
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+**Parameters:**
+
+- `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
+- `rpm` [(float64)](https://pkg.go.dev/builtin#float64): The speed in RPM for the motor to move at.
+- `extra` [(map[string]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
+
+**Returns:**
+
+- [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
+
+For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**

--- a/static/include/components/apis/overrides/methods/go.motor.SetRPM.rpm.md
+++ b/static/include/components/apis/overrides/methods/go.motor.SetRPM.rpm.md
@@ -1,0 +1,1 @@
+The speed in RPM for the motor to move at.


### PR DESCRIPTION
Add `SetRPM` API for Go, PySDK.
- Flutter had been added previously, but its code sample is over in https://github.com/viamrobotics/docs/pull/3121
- No Go code sample for `SetRPM` upstream, creating other ticket to invent one, separately.