### PR TITLE
DOCS-2063: Add GetProperties API

### DIFF
--- a/.github/workflows/sdk_protos_map.csv
+++ b/.github/workflows/sdk_protos_map.csv
@@ -297,6 +297,7 @@ vision,Reconfigure,,Reconfigure,
 vision,DoCommand,do_command,DoCommand,doCommand
 vision,FromRobot,,,fromRobot
 vision,Name,,,getResourceName
+vision,GetProperties,get_properties,GetProperties,
 vision,Close,close,Close,
 
 ## App

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -422,7 +422,8 @@ python_datatype_links = {
     "viam.proto.common.ResponseMetadata": "https://python.viam.dev/autoapi/viam/gen/common/v1/common_pb2/index.html#viam.gen.common.v1.common_pb2.ResponseMetadata",
     "viam.proto.component.encoder.PositionType.ValueType": "https://python.viam.dev/autoapi/viam/gen/component/encoder/v1/encoder_pb2/index.html#viam.gen.component.encoder.v1.encoder_pb2.PositionType",
     "typing_extensions.Self": "https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient",
-    "viam.components.movement_sensor.movement_sensor.MovementSensor.Accuracy": "https://python.viam.dev/autoapi/viam/components/movement_sensor/movement_sensor/index.html#viam.components.movement_sensor.movement_sensor.MovementSensor.Accuracy"
+    "viam.components.movement_sensor.movement_sensor.MovementSensor.Accuracy": "https://python.viam.dev/autoapi/viam/components/movement_sensor/movement_sensor/index.html#viam.components.movement_sensor.movement_sensor.MovementSensor.Accuracy",
+    "viam.services.vision.vision.Vision.Properties": "https://python.viam.dev/autoapi/viam/components/audio_input/audio_input/index.html#viam.components.audio_input.audio_input.AudioInput.Properties"
 }
 
 ## Inject these URLs, relative to 'docs', into param/return/raises descriptions that contain exact matching key text.

--- a/static/include/services/apis/generated/vision-table.md
+++ b/static/include/services/apis/generated/vision-table.md
@@ -10,4 +10,5 @@
 | [`DoCommand`](/services/vision/#docommand) | Execute model-specific commands that are not otherwise defined by the service API. |
 | [`FromRobot`](/services/vision/#fromrobot) | Get the resource from the provided robot with the given name. |
 | [`Name`](/services/vision/#name) | Get the `ResourceName` for this instance of the Vision service with the given name. |
+| [`GetProperties`](/services/vision/#getproperties) | Get info about what vision methods the vision service provides. |
 | [`Close`](/services/vision/#close) | Safely shut down the resource and prevent further use. |

--- a/static/include/services/apis/generated/vision-table.md
+++ b/static/include/services/apis/generated/vision-table.md
@@ -10,5 +10,5 @@
 | [`DoCommand`](/services/vision/#docommand) | Execute model-specific commands that are not otherwise defined by the service API. |
 | [`FromRobot`](/services/vision/#fromrobot) | Get the resource from the provided robot with the given name. |
 | [`Name`](/services/vision/#name) | Get the `ResourceName` for this instance of the Vision service with the given name. |
-| [`GetProperties`](/services/vision/#getproperties) | Fetch information about what vision methods the vision service provides. |
+| [`GetProperties`](/services/vision/#getproperties) | Fetch information about which vision methods a given vision service supports. |
 | [`Close`](/services/vision/#close) | Safely shut down the resource and prevent further use. |

--- a/static/include/services/apis/generated/vision-table.md
+++ b/static/include/services/apis/generated/vision-table.md
@@ -10,5 +10,5 @@
 | [`DoCommand`](/services/vision/#docommand) | Execute model-specific commands that are not otherwise defined by the service API. |
 | [`FromRobot`](/services/vision/#fromrobot) | Get the resource from the provided robot with the given name. |
 | [`Name`](/services/vision/#name) | Get the `ResourceName` for this instance of the Vision service with the given name. |
-| [`GetProperties`](/services/vision/#getproperties) | Get info about what vision methods the vision service provides. |
+| [`GetProperties`](/services/vision/#getproperties) | Fetch information about what vision methods the vision service provides. |
 | [`Close`](/services/vision/#close) | Safely shut down the resource and prevent further use. |

--- a/static/include/services/apis/generated/vision.md
+++ b/static/include/services/apis/generated/vision.md
@@ -615,6 +615,52 @@ For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_s
 {{% /tab %}}
 {{< /tabs >}}
 
+### GetProperties
+
+Fetch information about what vision methods the vision service provides.
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `extra` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (optional): Extra options to pass to the underlying RPC call.
+- `timeout` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
+
+**Returns:**
+
+- ([Vision.Properties](https://python.viam.dev/autoapi/viam/components/audio_input/audio_input/index.html#viam.components.audio_input.audio_input.AudioInput.Properties)): The properties of the vision service.
+
+**Example:**
+
+```python {class="line-numbers linkable-line-numbers"}
+# Grab the detector you configured on your machine
+my_detector = VisionClient.from_robot(robot, "my_detector")
+properties = await my_detector.get_properties()
+properties.detections_supported      # returns True
+properties.classifications_supported # returns False
+```
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/services/vision/client/index.html#viam.services.vision.client.VisionClient.get_properties).
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+**Parameters:**
+
+- `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
+- `extra` [(map[string]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
+
+**Returns:**
+
+- [(*Properties)](https://pkg.go.dev/go.viam.com/rdk/services/vision#Properties)
+- [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
+
+For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/vision#Service).
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ### Close
 
 Safely shut down the resource and prevent further use.

--- a/static/include/services/apis/generated/vision.md
+++ b/static/include/services/apis/generated/vision.md
@@ -617,7 +617,7 @@ For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_s
 
 ### GetProperties
 
-Fetch information about what vision methods the vision service provides.
+Fetch information about which vision methods a given vision service supports.
 
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/static/include/services/apis/overrides/protos/vision.GetProperties.md
+++ b/static/include/services/apis/overrides/protos/vision.GetProperties.md
@@ -1,0 +1,1 @@
+Fetch information about what vision methods the vision service provides.

--- a/static/include/services/apis/overrides/protos/vision.GetProperties.md
+++ b/static/include/services/apis/overrides/protos/vision.GetProperties.md
@@ -1,1 +1,1 @@
-Fetch information about what vision methods the vision service provides.
+Fetch information about which vision methods a given vision service supports.


### PR DESCRIPTION
Add `GetProperties` Go and PySDK API methods. Flutter not implemented upstream yet.
- Add new data type to Python link array for `Properties`