### PR TITLE
Reorder services and tweak descriptions

### DIFF
--- a/docs/services/_index.md
+++ b/docs/services/_index.md
@@ -35,12 +35,12 @@ You can also add support for additional service types using [{{< glossary_toolti
 
 {{< cards >}}
 {{% card link="/services/data/" %}}
+{{% card link="/services/vision/" %}}
+{{% card link="/services/ml/deploy/" customTitle="Machine Learning" %}}
 {{% card link="/services/motion/" %}}
 {{% card link="/services/frame-system/" %}}
-{{% card link="/services/base-rc/" %}}
-{{% card link="/services/ml/deploy/" customTitle="Machine Learning" %}}
 {{% card link="/services/navigation/" %}}
 {{% card link="/services/slam/" %}}
-{{% card link="/services/vision/" %}}
+{{% card link="/services/base-rc/" %}}
 {{% card link="/services/generic/" %}}
 {{< /cards >}}

--- a/docs/services/base-rc/_index.md
+++ b/docs/services/base-rc/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Base Remote Control Service"
 linkTitle: "Base Remote Control"
-weight: 60
+weight: 70
 type: "docs"
 description: "The base remote control service allows you to remotely control a base with an input controller like a gamepad."
 tags: ["base", "services", "rover", "input controller", "remote control"]

--- a/docs/services/data/_index.md
+++ b/docs/services/data/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Data Management"
 linkTitle: "Data Management"
-weight: 440
+weight: 10
 no_list: true
 type: "docs"
 tags: ["data management", "data", "services"]

--- a/docs/services/frame-system/_index.md
+++ b/docs/services/frame-system/_index.md
@@ -3,7 +3,7 @@ title: "The Robot Frame System"
 linkTitle: "Frame System"
 description: "The frame system holds reference frame information for the relative position of components in space."
 type: docs
-weight: 10
+weight: 50
 no_list: true
 icon: true
 images: ["/services/icons/frame-system.svg"]
@@ -15,12 +15,12 @@ no_service: true
 # SMEs: Peter L, Gautham, Bijan
 ---
 
-Any machine configured in Viam comes with the frame system service: an internally managed and mostly static system for storing the "reference frame" of each component of a machine within a coordinate system configured by the user.
-
-![Visualization of a wheeled base configured with motors and a mounted camera in the frame system tab of the Viam app UI](/services/frame-system/frame_system_wheeled_base.png)
-
 The frame system is the basis for some of Viam's other services, like [motion](/services/motion/) and [vision](/services/vision/).
 It stores the required contextual information to use the position and orientation readings returned by some components.
+
+It is a mostly static system for storing the "reference frame" of each component of a machine within a coordinate system configured by the user.
+
+![Visualization of a wheeled base configured with motors and a mounted camera in the frame system tab of the Viam app UI](/services/frame-system/frame_system_wheeled_base.png)
 
 ## Used with
 

--- a/docs/services/generic/_index.md
+++ b/docs/services/generic/_index.md
@@ -2,7 +2,7 @@
 title: "Generic Service"
 linkTitle: "Generic Service"
 childTitleEndOverwrite: "Generic Service"
-weight: 55
+weight: 500
 type: "docs"
 description: "A service that does not fit any of the other APIs."
 tags: ["generic", "services"]

--- a/docs/services/ml/_index.md
+++ b/docs/services/ml/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Machine Learning"
 linkTitle: "Machine Learning"
-weight: 450
+weight: 30
 type: "docs"
 tags: ["data management", "data", "services"]
 no_list: true

--- a/docs/services/motion/_index.md
+++ b/docs/services/motion/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Motion Service"
 linkTitle: "Motion"
-weight: 20
+weight: 40
 type: "docs"
 description: "The motion service enables your machine to plan and move its components relative to itself, other machines, and the world."
 tags: ["motion", "motion planning", "services"]

--- a/docs/services/navigation/_index.md
+++ b/docs/services/navigation/_index.md
@@ -1,9 +1,9 @@
 ---
 title: "Navigation Service"
 linkTitle: "Navigation"
-description: "The navigation service uses GPS to autonomously navigate a rover to user-defined endpoints."
+description: "The navigation service uses GPS to autonomously navigate a rover to user-defined waypoints."
 type: docs
-weight: 40
+weight: 50
 no_list: true
 icon: true
 images: ["/services/icons/navigation.svg"]
@@ -16,7 +16,8 @@ no_service: true
 ---
 
 The navigation service is the stateful definition of Viam's [motion service](/services/motion/).
-It uses GPS to autonomously navigate a rover [base](/components/base/) to user-defined endpoints called waypoints.
+It uses GPS to autonomously navigate a rover [base](/components/base/) to user-defined waypoints.
+
 Configure your base with a navigation service, add waypoints, and set the mode of the service to [**Waypoint**](/services/navigation/#setmode) to move your rover along a defined path at your desired motion configuration.
 
 ## Used with

--- a/docs/services/slam/_index.md
+++ b/docs/services/slam/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "SLAM Service"
 linkTitle: "SLAM"
-weight: 30
+weight: 60
 type: "docs"
 description: "Simultaneous localization and mapping (SLAM) allows your machine to create a map of its surroundings and find its location within that map."
 tags: ["slam", "services"]

--- a/docs/services/vision/_index.md
+++ b/docs/services/vision/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Vision Service"
 linkTitle: "Computer Vision"
-weight: 90
+weight: 20
 type: "docs"
 description: "The vision service enables your machine to use its on-board cameras to intelligently see and interpret the world around it."
 icon: true


### PR DESCRIPTION
- Un-bury vision, and put it by ML
- Put ML before mobility to match viam.com
- Make service page order match left nav
- Put the human-readable part of the frame system description first :D 