### PR TITLE
Include note about installing ffmpeg 

### DIFF
--- a/docs/components/camera/ffmpeg.md
+++ b/docs/components/camera/ffmpeg.md
@@ -10,12 +10,16 @@ aliases:
   - "/components/camera/ffmpeg/"
 component_description: "Uses a camera, a video file, or a stream as a camera."
 toc_hide: true
-# SMEs: Bijan, vision team
+# SMEs: Sean Yu, audio/video team
 ---
 
 The `ffmpeg` camera model uses a camera device, a video file, or a stream as a camera.
 
 When used with a streaming camera, the `ffmpeg` camera model supports any streaming camera format that is supported by the [`ffmpeg` program](https://ffmpeg.org/), including MJPEG, H264, and MP4.
+
+{{< alert title="Note" color="note" >}}
+The [`ffmpeg` program](https://ffmpeg.org/) program must be installed separately from `viam-server` on your system for this driver to work.
+{{< /alert >}}
 
 {{< tabs name="Configure a ffmpeg camera" >}}
 {{% tab name="Config Builder" %}}


### PR DESCRIPTION
Add a note to the ffmpeg camera page to tell users they need to have ffmpeg installed on their system to use this camera model. MacOS users get ffmpeg through viam-server's brew installation, but that does not apply to linux users depending on the app image they install. We are not adding an ffmpeg build dependency to viam-server. My hope is that this could be a module one day and handle its own dependencies, but until then, we add this note. 

