### PR TITLE
DOCS-2822: Add provisioning guides

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -297,6 +297,13 @@ END MARKETING CSS
   width: 600px;
   height: auto;
 }
+
+.td-content > .video-shortcode.aligncenter, .video-shortcode.aligncenter {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 /* START VIDEO SHORTCODE STYLES https://roneo.org/en/hugo-create-a-shortcode-for-local-videos/ */
 
 .primary-color                      {color: var(--primary-color)}

--- a/docs/configure/agent.md
+++ b/docs/configure/agent.md
@@ -33,7 +33,7 @@ To provision machines using `viam-agent`, see
 
 ## Installation
 
-You can install `viam-agent` using either an existing machine's part ID and API key, or using an existing <file>/etc/viam.json</file> configuration file.
+You can install `viam-agent` using either an existing machine's part ID and API key, or using an existing machine credentials configuration file at <file>/etc/viam.json</file>.
 
 {{< alert title="Important" color="note" >}}
 Your machine must have `curl` available in order to install `viam-agent`.

--- a/docs/fleet/provision.md
+++ b/docs/fleet/provision.md
@@ -38,6 +38,12 @@ For Bullseye, the installation of `viam-agent` changes the network configuration
 
 {{< /alert >}}
 
+For a guide on how to configure provisioning for your machine, see:
+
+{{< cards >}}
+{{% card link="/how-tos/provision/" %}}
+{{< /cards >}}
+
 ## End user experience
 
 End users receive a machine, and use either a captive web portal or mobile app to complete the machine setup.
@@ -49,6 +55,12 @@ To add your branding, you can build your own mobile app and use the [Flutter SDK
 
 If you are not using Flutter or TypeScript and would like to use provisioning, please [contact us](mailto:support@viam.com).
 
+For an end-user guide to setting up their machine, see:
+
+{{< cards >}}
+{{% card link="/how-tos/provision-setup/" %}}
+{{< /cards >}}
+
 This is the general process for provisioning depending on whether you are using a captive web portal or a mobile app:
 
 {{< tabs >}}
@@ -58,7 +70,7 @@ This is the general process for provisioning depending on whether you are using 
 
 1. If the provisioning happens with a mobile app, open the app and follow any instructions there until the app directs you to turn on the machine.
 
-   - If you are using the Viam mobile app, create a new machine and then follow the instructions.
+   - If you are using the Viam mobile app, create a new machine or click on an existing machine that has not yet been set up and follow the instructions.
 
 1. When you power on the machine that has `viam-agent` installed and `agent-provisioning` configured, `agent-provisioning` creates a WiFi hotspot.
 

--- a/docs/fleet/provision.md
+++ b/docs/fleet/provision.md
@@ -41,7 +41,7 @@ For Bullseye, the installation of `viam-agent` changes the network configuration
 For a guide on how to configure provisioning for your machine, see:
 
 {{< cards >}}
-{{% card link="/how-tos/provision/" %}}
+{{% card link="/how-tos/provision-setup/" %}}
 {{< /cards >}}
 
 ## End user experience
@@ -58,7 +58,7 @@ If you are not using Flutter or TypeScript and would like to use provisioning, p
 For an end-user guide to setting up their machine, see:
 
 {{< cards >}}
-{{% card link="/how-tos/provision-setup/" %}}
+{{% card link="/how-tos/provision/" %}}
 {{< /cards >}}
 
 This is the general process for provisioning depending on whether you are using a captive web portal or a mobile app:

--- a/docs/how-tos/_index.md
+++ b/docs/how-tos/_index.md
@@ -25,6 +25,8 @@ Click on one of the following guides that provide solutions for common tasks and
 {{% card link="/how-tos/manage-modules/" class="fit-contain" %}}
 {{% card link="/how-tos/navigate/" %}}
 {{% card link="/how-tos/one-to-many/" class="fit-contain" %}}
+{{% card link="/how-tos/provision/" class="fit-contain" %}}
+{{% card link="/how-tos/provision-setup/" %}}
 {{% card link="/how-tos/manage-fleet/" class="fit-contain" %}}
 {{< /cards >}}
 

--- a/docs/how-tos/_index.md
+++ b/docs/how-tos/_index.md
@@ -25,8 +25,8 @@ Click on one of the following guides that provide solutions for common tasks and
 {{% card link="/how-tos/manage-modules/" class="fit-contain" %}}
 {{% card link="/how-tos/navigate/" %}}
 {{% card link="/how-tos/one-to-many/" class="fit-contain" %}}
-{{% card link="/how-tos/provision/" class="fit-contain" %}}
 {{% card link="/how-tos/provision-setup/" %}}
+{{% card link="/how-tos/provision/" class="fit-contain" %}}
 {{% card link="/how-tos/manage-fleet/" class="fit-contain" %}}
 {{< /cards >}}
 

--- a/docs/how-tos/provision-setup.md
+++ b/docs/how-tos/provision-setup.md
@@ -115,6 +115,14 @@ sudo ./preinstall.sh
 Follow the instructions.
 If you created a <FILE>viam-provisioning.json</FILE>, specify its location when prompted.
 
+{{% expand "Using a Raspberry Pi?" %}}
+
+For Raspberry Pis, the script will automatically perform the required next steps, it will:
+
+- create a tarball
+- update `firstrun.sh`.
+- extract the tarball to the mounted root filesystem
+
 ```sh {class="command-line" data-prompt="$" data-output="2-40"}
 sudo ./preinstall.sh
 
@@ -149,7 +157,12 @@ a usr/local/lib/systemd/system/multi-user.target.wants/viam-agent.service
 Install complete! You can eject/unmount and boot the image now.
 ```
 
-If you get an error, run the script for the target system's architecture:
+{{% /expand%}}
+
+{{% expand "Error: no valid image found at mountpoints (or manually provided path)" %}}
+
+If you get this error, you can run the script for the target system's architecture.
+It will create a tarball for the system's architecture which you will then need to manually extract.
 
 {{< tabs >}}
 {{% tab name="arm64" %}}
@@ -168,11 +181,23 @@ sudo ./preinstall.sh --x86_64
 {{% /tab %}}
 {{< /tabs >}}
 
-If this command fails because the script cannot detect your mountpoint, you can specify it directly:
+To extract the tarball, run:
+
+```sh {class="command-line" data-prompt="$"}
+sudo tar -xJvpf $TARBALL -C <PATH_TO_ROOT_FS>
+```
+
+{{% /expand%}}
+
+{{% expand "Refusing to install to unknown/unset ROOTFS" %}}
+
+If your root file system cannot be detected, you can specify it directly:
 
 ```sh {class="command-line" data-prompt="$"}
 sudo ./preinstall.sh /path/to/rootfs
 ```
+
+{{% /expand%}}
 
 {{< /tablestep >}}
 {{< /table >}}

--- a/docs/how-tos/provision-setup.md
+++ b/docs/how-tos/provision-setup.md
@@ -43,7 +43,7 @@ If you choose to have a mobile app experience, you can use the [Viam mobile app]
 If you choose to use the Viam mobile app, you must provide a {{< glossary_tooltip term_id="fragment" text="fragment" >}} for provisioning.
 If you do not yet have a fragment, follow the steps to [Create a configuration fragment](/how-tos/one-to-many/) and make a note of the fragment ID.
 
-If you choose to use the captive web portal, you can optionally create a machine already and provide its credentials configuration file at <FILE>/etc/viam.json</FILE>.
+If you choose to use the captive web portal, you can optionally create a machine in advance and provide its credentials configuration file at <FILE>/etc/viam.json</FILE>.
 
 You can get the `viam-server` machine credentials by clicking the copy icon next to **Viam server config** in the part status dropdown to the right of your machine's name on the top of the page.
 

--- a/docs/how-tos/provision-setup.md
+++ b/docs/how-tos/provision-setup.md
@@ -1,0 +1,205 @@
+---
+title: "Complete setup for a machine"
+linkTitle: "Set a machine up"
+weight: 69
+type: "docs"
+description: "If you have received a machine that uses Viam and have been pointed to this guide, this guide will show you how to set it up."
+images: ["/platform/provisioning-demo.gif"]
+videos: ["/platform/provisioning-demo.webm", "/platform/provisioning-demo.mp4"]
+---
+
+If you have received a machine with Viam pre-installed on it, this guide will show you how to complete your device setup.
+
+{{< alert title="In this page" color="tip" >}}
+
+1. [Set up your machine using the Viam mobile app](#set-up-your-machine-using-the-viam-mobile-app).
+1. [Set up your machine using the captive portal](#set-up-your-machine-using-the-captive-portal).
+1. [Update machine configuration](#update-machine-configuration) to update hotspot details or add additional networks.
+   {{< /alert >}}
+
+## Prerequisites
+
+- Physical hardware constituting a machine
+- A laptop or mobile device if using the Viam mobile app
+
+## Set up your machine using the Viam mobile app
+
+{{<video webm_src="/platform/provisioning-demo.webm" mp4_src="/platform/provisioning-demo.mp4" alt="Using the Viam mobile app to provision a new machine with viam-agent." poster="/platform/provisioning-demo.jpg" max-width="400px" class="aligncenter imgzoom">}}
+
+{{< table >}}
+{{% tablestep %}}
+**1. Install the Viam mobile app**
+
+You can find the mobile app on the [App Store](https://apps.apple.com/vn/app/viam-robotics/id6451424162) and on [Google Play](https://play.google.com/store/apps/details?id=com.viam.viammobile&hl=en&gl=US).
+
+<a href="https://apps.apple.com/vn/app/viam-robotics/id6451424162" target="_blank">
+  <img src="https://github.com/viamrobotics/docs/assets/90707162/a470b65d-1b97-412f-9f97-daf902f2f053" width="200px" alt="apple store icon" class="center-if-small" >
+</a>
+
+<a href="https://play.google.com/store/apps/details?id=com.viam.viammobile&hl=en&gl=US" target="_blank">
+  <img src="https://github.com/viamrobotics/docs/assets/90707162/6ebd6960-08c5-41d4-81f9-42293fbfdfd4" width="200px" alt="google play store icon" class="center-if-small" >
+</a>
+
+{{% /tablestep %}}
+{{% tablestep %}}
+**2. Create a machine**
+
+Open the Viam mobile app and sign in.
+Then, select an organization and location for your machine.
+If you have already created a machine, select it.
+If you have not yet created a machine, click on **Add new smart machine** and give your machine a name.
+{{% /tablestep %}}
+{{% tablestep %}}
+**3. Connect to your machine's WiFi hotspot**
+
+Turn on the smart machine you are attempting to connect to.
+Then leave the app and navigate to your mobile device's WiFi settings and connect to the WiFi hotspot your machine has created.
+You may need to wait a short time for your machine to boot and create its WiFi hotspot.
+Your machine's WiFi hotspot name will begin with `viam-setup-`.
+Unless you have been given other instructions, the WiFi password for this hotspot network is `viamsetup`.
+
+Once you are connected to your machine's WiFi hotspot return to the Viam mobile app.
+{{% /tablestep %}}
+{{% tablestep %}}
+**4. Provide the network information for the machine**
+
+In the mobile app, you will be prompted to provide the network information for the machine.
+
+The machine will now disable the hotspot network and attempt to connect using the provided network information.
+If the machine cannot establish a connection using the provided network information, the machine will create the hotspot again and prompt you to re-enter the network information until a connection is successfully established.
+{{% /tablestep %}}
+{{% tablestep %}}
+**5. Wait for machine to complete setup**
+
+If the machine can successfully connect to the network it will now complete its setup and become **live**.
+
+Note that any features that require internet access will not function if the connected WiFi network is not connected to the internet.
+{{% /tablestep %}}
+{{< /table >}}
+
+## Set up your machine using the captive portal
+
+{{< table >}}
+{{% tablestep %}}
+**1. Turn on the smart machine**
+
+Turn on the smart machine you are attempting to set up.
+{{% /tablestep %}}
+{{% tablestep %}}
+**2. Connect to your machine's WiFi hotspot**
+
+On a laptop or mobile device, navigate to your WiFi settings and connect to the WiFi hotspot your machine has created.
+You may need to wait a short time for your machine to boot and create its WiFi hotspot.
+Your machine's WiFi hotspot name will begin with `viam-setup-`.
+Unless you have been given other instructions, the WiFi password for this hotspot network is `viamsetup`.
+
+Once you are connected to your machine's WiFi hotspot you will be redirected to a sign-in page.
+If you are using a laptop or are not redirected, try opening [http://viam.setup/](http://viam.setup/) in a browser.
+{{% /tablestep %}}
+{{% tablestep %}}
+**3. Follow the captive portal's instructions to provide network information**
+
+In the captive web portal, you will then be prompted to provide the network information for the machine.
+{{% /tablestep %}}
+{{% tablestep %}}
+**4. If prompted, provide a machine credentials configuration**
+
+Depending on how the machine was set up so far, the captive portal may also require you to paste a machine credentials configuration file.
+This is the JSON object which contains your machine part secret key and cloud app address, which your machine's `viam-server` instance needs to connect to the Viam app.
+
+Navigate to [the Viam app](https://app.viam.com) and create a new machine.
+
+To copy a machine credentials configuration file:
+
+- Navigate to your machine's page on [the Viam app](https://app.viam.com).
+- Select the part status dropdown to the right of your machine's name on the top of the page.
+  {{<imgproc src="configure/machine-part-info.png" resize="500x" declaredimensions=true alt="Restart button on the machine part info dropdown">}}
+- Click the copy icon next to **Viam server config** to copy the machine credentials configuration file.
+- Paste the `viam-server` app config when prompted.
+
+{{% /tablestep %}}
+{{% tablestep %}}
+**5. Wait for machine to complete setup**
+
+The machine will now disable the hotspot network and attempt to connect using the provided network information.
+If the machine cannot establish a connection using the provided network information, the machine will create the hotspot again and prompt you to re-enter the network information until a connection is successfully established.
+
+If the machine can successfully connect to the network it will now complete its setup and become **live**.
+
+Note that any features that require internet access will not function if the connected WiFi network is not connected to the internet.
+{{% /tablestep %}}
+{{< /table >}}
+
+## Update machine configuration
+
+{{< table >}}
+{{% tablestep link="/configure/agent/#agent-provisioning"%}}
+**1. Update the `agent-provisioning` configuration**
+
+For security purposes, you should change the `hotspot_password` attribute.
+
+Go to your machine's page in [the Viam app](https://app.viam.com) and use the JSON editor.
+
+Look for the `agent` configuration and add line 7 with a suitable password:
+
+```json {class="line-numbers linkable-line-numbers" data-line="7"}
+...
+"agent": {
+  "agent-provisioning": {
+    ...
+    "attributes": {
+      ...
+      "hotspot_password": "NewAndSafePassword",
+    }
+  }
+}
+```
+
+{{% /tablestep %}}
+{{% tablestep link="/configure/agent/#networks"%}}
+**2. Add WiFi networks**
+
+If your machine might move between different WiFi networks, you can enable `roaming_mode` and add additional networks to the [`viam-agent` configuration](/configure/agent/#configuration).
+
+To add additional networks, go to your machine's page in [the Viam app](https://app.viam.com) and use the JSON editor.
+
+Look for the `agent` configuration and add lines 7-19 to your configuration, changing the credentials as to the ones for your networks:
+
+```json {class="line-numbers linkable-line-numbers" data-line="7-20"}
+...
+"agent": {
+  "agent-provisioning": {
+    ...
+    "attributes": {
+      ...
+      "roaming_mode": true,
+      "networks": [
+        {
+          "type": "wifi",
+          "ssid": "fallbackNetOne",
+          "psk": "myFirstPassword",
+          "priority": 30
+        },
+        {
+          "type": "wifi",
+          "ssid": "fallbackNetTwo",
+          "psk": "mySecondPassword",
+          "priority": 10
+        }
+      ]
+    }
+  }
+}
+```
+
+{{% /tablestep %}}
+{{< /table >}}
+
+## Next Steps
+
+You can now use your machine.
+For information on how to use your machine's controls, see:
+
+{{< cards >}}
+{{% card link="/fleet/control/" %}}
+{{< /cards >}}

--- a/docs/how-tos/provision-setup.md
+++ b/docs/how-tos/provision-setup.md
@@ -1,205 +1,287 @@
 ---
-title: "Complete setup for a machine"
-linkTitle: "Set a machine up"
-weight: 69
+title: "Configure provisioning with viam-agent"
+linkTitle: "Setup for provisioning"
+weight: 68
 type: "docs"
-description: "If you have received a machine that uses Viam and have been pointed to this guide, this guide will show you how to set it up."
-images: ["/platform/provisioning-demo.gif"]
-videos: ["/platform/provisioning-demo.webm", "/platform/provisioning-demo.mp4"]
+description: "Install and configure viam-agent for provisioning one or many machines."
+images: ["/installation/thumbnails/install.png"]
+imageAlt: "Install Viam"
 ---
 
-If you have received a machine with Viam pre-installed on it, this guide will show you how to complete your device setup.
+The provisioning subsystem is a feature of `viam-agent`, which you can install as part of your manufacturing process. `agent-provisioning` will then perform the rest of the first-time setup for your machine once an end user sets up the machine.
+
+This is useful when deploying a fleet of machines directly from the factory to a customer, or when bundling proprietary software on your Viam machine.
+
+This guide will show you how to install and configure `viam-agent`.
 
 {{< alert title="In this page" color="tip" >}}
 
-1. [Set up your machine using the Viam mobile app](#set-up-your-machine-using-the-viam-mobile-app).
-1. [Set up your machine using the captive portal](#set-up-your-machine-using-the-captive-portal).
-1. [Update machine configuration](#update-machine-configuration) to update hotspot details or add additional networks.
-   {{< /alert >}}
+1. [Decide on the provisioning method](#decide-on-the-provisioning-method)
+1. [Configure `agent-provisioning`](#configure-agent-provisioning)
+1. [Install `viam-agent`](#install-viam-agent)
+
+{{< /alert >}}
 
 ## Prerequisites
 
-- Physical hardware constituting a machine
-- A laptop or mobile device if using the Viam mobile app
+{{% expand "One or more physical devices with supported operating system" %}}
 
-## Set up your machine using the Viam mobile app
+To find out more about supported systems, see [Compatibility](/installation/#compatibility).
 
-{{<video webm_src="/platform/provisioning-demo.webm" mp4_src="/platform/provisioning-demo.mp4" alt="Using the Viam mobile app to provision a new machine with viam-agent." poster="/platform/provisioning-demo.jpg" max-width="400px" class="aligncenter imgzoom">}}
+If you are flashing a Raspberry Pi using the Raspberry Pi Imager, flash a 64-bit image to your SD card and customize at least the hostname when prompted.
 
-{{< table >}}
-{{% tablestep %}}
-**1. Install the Viam mobile app**
+Eject and reinsert the card to make sure it's mounted with the newly written contents.
 
-You can find the mobile app on the [App Store](https://apps.apple.com/vn/app/viam-robotics/id6451424162) and on [Google Play](https://play.google.com/store/apps/details?id=com.viam.viammobile&hl=en&gl=US).
+{{% /expand%}}
 
-<a href="https://apps.apple.com/vn/app/viam-robotics/id6451424162" target="_blank">
-  <img src="https://github.com/viamrobotics/docs/assets/90707162/a470b65d-1b97-412f-9f97-daf902f2f053" width="200px" alt="apple store icon" class="center-if-small" >
-</a>
+## Decide on the provisioning method
 
-<a href="https://play.google.com/store/apps/details?id=com.viam.viammobile&hl=en&gl=US" target="_blank">
-  <img src="https://github.com/viamrobotics/docs/assets/90707162/6ebd6960-08c5-41d4-81f9-42293fbfdfd4" width="200px" alt="google play store icon" class="center-if-small" >
-</a>
+You can choose to let your end users complete machine setup by using a captive web portal or a mobile app.
 
-{{% /tablestep %}}
-{{% tablestep %}}
-**2. Create a machine**
+If you choose to have a mobile app experience, you can use the [Viam mobile app](/fleet/control/#control-interface-in-the-viam-mobile-app) or create your own custom mobile app using the [Flutter SDK](https://flutter.viam.dev/viam_protos.provisioning.provisioning/ProvisioningServiceClient-class.html) or the [TypeScript SDK](https://github.com/viamrobotics/viam-typescript-sdk/blob/main/src/app/provisioning-client.ts) to connect to `viam-agent` and provision your machines.
 
-Open the Viam mobile app and sign in.
-Then, select an organization and location for your machine.
-If you have already created a machine, select it.
-If you have not yet created a machine, click on **Add new smart machine** and give your machine a name.
-{{% /tablestep %}}
-{{% tablestep %}}
-**3. Connect to your machine's WiFi hotspot**
+If you choose to use the Viam mobile app, you must provide a {{< glossary_tooltip term_id="fragment" text="fragment" >}} for provisioning.
+If you do not yet have a fragment, follow the steps to [Create a configuration fragment](/how-tos/one-to-many/) and make a note of the fragment ID.
 
-Turn on the smart machine you are attempting to connect to.
-Then leave the app and navigate to your mobile device's WiFi settings and connect to the WiFi hotspot your machine has created.
-You may need to wait a short time for your machine to boot and create its WiFi hotspot.
-Your machine's WiFi hotspot name will begin with `viam-setup-`.
-Unless you have been given other instructions, the WiFi password for this hotspot network is `viamsetup`.
+If you choose to use the captive web portal, you can optionally create a machine already and provide its credentials configuration file at <FILE>/etc/viam.json</FILE>.
 
-Once you are connected to your machine's WiFi hotspot return to the Viam mobile app.
-{{% /tablestep %}}
-{{% tablestep %}}
-**4. Provide the network information for the machine**
+You can get the `viam-server` machine credentials by clicking the copy icon next to **Viam server config** in the part status dropdown to the right of your machine's name on the top of the page.
 
-In the mobile app, you will be prompted to provide the network information for the machine.
+{{<imgproc src="configure/machine-part-info.png" resize="500x" declaredimensions=true alt="Restart button on the machine part info dropdown">}}
 
-The machine will now disable the hotspot network and attempt to connect using the provided network information.
-If the machine cannot establish a connection using the provided network information, the machine will create the hotspot again and prompt you to re-enter the network information until a connection is successfully established.
-{{% /tablestep %}}
-{{% tablestep %}}
-**5. Wait for machine to complete setup**
-
-If the machine can successfully connect to the network it will now complete its setup and become **live**.
-
-Note that any features that require internet access will not function if the connected WiFi network is not connected to the internet.
-{{% /tablestep %}}
-{{< /table >}}
-
-## Set up your machine using the captive portal
+## Configure `agent-provisioning`
 
 {{< table >}}
-{{% tablestep %}}
-**1. Turn on the smart machine**
 
-Turn on the smart machine you are attempting to set up.
-{{% /tablestep %}}
-{{% tablestep %}}
-**2. Connect to your machine's WiFi hotspot**
+{{% tablestep link="/fleet/provision/#configuration" %}}
+**Configure provisioning**
 
-On a laptop or mobile device, navigate to your WiFi settings and connect to the WiFi hotspot your machine has created.
-You may need to wait a short time for your machine to boot and create its WiFi hotspot.
-Your machine's WiFi hotspot name will begin with `viam-setup-`.
-Unless you have been given other instructions, the WiFi password for this hotspot network is `viamsetup`.
+If you are using the captive portal, this step is optional.
+If you are using a mobile app, you must create a provisioning configuration file, specifying at least a `fragment_id`.
 
-Once you are connected to your machine's WiFi hotspot you will be redirected to a sign-in page.
-If you are using a laptop or are not redirected, try opening [http://viam.setup/](http://viam.setup/) in a browser.
-{{% /tablestep %}}
-{{% tablestep %}}
-**3. Follow the captive portal's instructions to provide network information**
+Create a file called <FILE>viam-provisioning.json</FILE> with the following format and customize the [attributes](/fleet/provision/#configuration):
 
-In the captive web portal, you will then be prompted to provide the network information for the machine.
-{{% /tablestep %}}
-{{% tablestep %}}
-**4. If prompted, provide a machine credentials configuration**
-
-Depending on how the machine was set up so far, the captive portal may also require you to paste a machine credentials configuration file.
-This is the JSON object which contains your machine part secret key and cloud app address, which your machine's `viam-server` instance needs to connect to the Viam app.
-
-Navigate to [the Viam app](https://app.viam.com) and create a new machine.
-
-To copy a machine credentials configuration file:
-
-- Navigate to your machine's page on [the Viam app](https://app.viam.com).
-- Select the part status dropdown to the right of your machine's name on the top of the page.
-  {{<imgproc src="configure/machine-part-info.png" resize="500x" declaredimensions=true alt="Restart button on the machine part info dropdown">}}
-- Click the copy icon next to **Viam server config** to copy the machine credentials configuration file.
-- Paste the `viam-server` app config when prompted.
-
-{{% /tablestep %}}
-{{% tablestep %}}
-**5. Wait for machine to complete setup**
-
-The machine will now disable the hotspot network and attempt to connect using the provided network information.
-If the machine cannot establish a connection using the provided network information, the machine will create the hotspot again and prompt you to re-enter the network information until a connection is successfully established.
-
-If the machine can successfully connect to the network it will now complete its setup and become **live**.
-
-Note that any features that require internet access will not function if the connected WiFi network is not connected to the internet.
-{{% /tablestep %}}
-{{< /table >}}
-
-## Update machine configuration
-
-{{< table >}}
-{{% tablestep link="/configure/agent/#agent-provisioning"%}}
-**1. Update the `agent-provisioning` configuration**
-
-For security purposes, you should change the `hotspot_password` attribute.
-
-Go to your machine's page in [the Viam app](https://app.viam.com) and use the JSON editor.
-
-Look for the `agent` configuration and add line 7 with a suitable password:
-
-```json {class="line-numbers linkable-line-numbers" data-line="7"}
-...
-"agent": {
-  "agent-provisioning": {
-    ...
-    "attributes": {
-      ...
-      "hotspot_password": "NewAndSafePassword",
-    }
-  }
-}
-```
-
-{{% /tablestep %}}
-{{% tablestep link="/configure/agent/#networks"%}}
-**2. Add WiFi networks**
-
-If your machine might move between different WiFi networks, you can enable `roaming_mode` and add additional networks to the [`viam-agent` configuration](/configure/agent/#configuration).
-
-To add additional networks, go to your machine's page in [the Viam app](https://app.viam.com) and use the JSON editor.
-
-Look for the `agent` configuration and add lines 7-19 to your configuration, changing the credentials as to the ones for your networks:
-
-```json {class="line-numbers linkable-line-numbers" data-line="7-20"}
-...
-"agent": {
-  "agent-provisioning": {
-    ...
-    "attributes": {
-      ...
-      "roaming_mode": true,
-      "networks": [
-        {
-          "type": "wifi",
-          "ssid": "fallbackNetOne",
-          "psk": "myFirstPassword",
-          "priority": 30
-        },
-        {
-          "type": "wifi",
-          "ssid": "fallbackNetTwo",
-          "psk": "mySecondPassword",
-          "priority": 10
-        }
-      ]
-    }
-  }
+```json {class="line-numbers linkable-line-numbers"}
+{
+  "manufacturer": "<NAME>", # your company name
+  "model": "<NAME>", # the machine's model
+  "fragment_id": "<ID>", # the fragment id, required for mobile app
+  "hotspot_prefix": "<PREFIX>", # machine creates a hotspot during setup
+  "disable_dns_redirect": true, # disable if using a mobile app
+  "hotspot_password": "<PASSWORD>", # password for the hotspot
 }
 ```
 
 {{% /tablestep %}}
 {{< /table >}}
+
+## Install `viam-agent`
+
+`viam-agent` is a self-updating service manager that maintains the lifecycle for several Viam services and keeps them updated.
+If you intend to use `viam-agent` to keep your device's Viam software up-to-date or to use its provisioning plugin to let end users set up their own machines, you need to use `viam-agent` and install it on the machine before sending it to the user.
+
+You can [install `viam-agent` on live systems](/installation/) or preinstall it:
+
+{{< tabs >}}
+{{% tab name="Preinstall on an SD card (or other image)" %}}
+
+Viam provides a preinstall script that works with images to add `viam-agent`.
+
+{{< alert title="Support notice" color="note" >}}
+Please note this script works only under POSIX (MacOS and Linux) at the moment.
+{{< /alert >}}
+
+{{< table >}}
+{{< tablestep >}}
+**1. Download the preinstall script**
+
+Run the following commands to download the preinstall script and make the script executable:
+
+```sh {class="command-line" data-prompt="$"}
+wget https://storage.googleapis.com/packages.viam.com/apps/viam-agent/preinstall.sh
+chmod 755 preinstall.sh
+```
+
+{{< /tablestep >}}
+{{< tablestep >}}
+**2. Run the preinstall script**
+
+Run the preinstall script without options and it will attempt to auto-detect a mounted root filesystem (or for Raspberry Pi, bootfs) and also automatically determine the architecture.
+
+```sh {class="command-line" data-prompt="$"}
+sudo ./preinstall.sh
+```
+
+Follow the instructions.
+If you created a <FILE>viam-provisioning.json</FILE>, specify its location when prompted.
+
+```sh {class="command-line" data-prompt="$" data-output="2-40"}
+sudo ./preinstall.sh
+
+
+Found Raspberry Pi bootfs mounted at /Volumes/bootfs
+
+
+A Raspberry Pi boot partition has been found mounted at /Volumes/bootfs
+This script will modify firstrun.sh on that partition to install Viam agent.
+Continue pre-install? (y/n): y
+Path to custom viam-provisioning.json (leave empty to skip):
+Creating tarball for install.
+a opt
+a opt/viam
+a opt/viam/cache
+a opt/viam/bin
+a opt/viam/bin/viam-agent
+a opt/viam/bin/agent-provisioning
+a opt/viam/cache/viam-agent-provisioning-factory-aarch64
+a opt/viam/cache/viam-agent-factory-aarch64
+a etc
+a usr
+a usr/local
+a usr/local/lib
+a usr/local/lib/systemd
+a usr/local/lib/systemd/system
+a usr/local/lib/systemd/system/viam-agent.service
+a usr/local/lib/systemd/system/multi-user.target.wants
+a usr/local/lib/systemd/system/multi-user.target.wants/viam-agent.service
+
+
+Install complete! You can eject/unmount and boot the image now.
+```
+
+If you get an error, run the script for the target system's architecture:
+
+{{< tabs >}}
+{{% tab name="arm64" %}}
+
+```sh {class="command-line" data-prompt="$"}
+sudo ./preinstall.sh --aarch64
+```
+
+{{% /tab %}}
+{{% tab name="x86_64" %}}
+
+```sh {class="command-line" data-prompt="$"}
+sudo ./preinstall.sh --x86_64
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+If this command fails because the script cannot detect your mountpoint, you can specify it directly:
+
+```sh {class="command-line" data-prompt="$"}
+sudo ./preinstall.sh /path/to/rootfs
+```
+
+{{< /tablestep >}}
+{{< /table >}}
+
+{{% /tab %}}
+{{% tab name="Manual install" %}}
+
+{{< table >}}
+{{< tablestep >}}
+**1. Create and download files**
+
+Run the following commands to create directories for the provisioning binaries, then download the binaries and make them executable:
+
+{{< tabs >}}
+{{% tab name="x86_64" %}}
+
+```sh {class="command-line" data-prompt="$"}
+mkdir -p /opt/viam/bin/ /opt/viam/tmp/
+curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent/viam-agent-stable-x86_64 -o /opt/viam/bin/viam-agent-stable-x86_64
+curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent-provisioning/viam-agent-provisioning-stable-x86_64 -o /opt/viam/bin/viam-agent-provisioning-stable-x86_64
+chmod 755 /opt/viam/tmp/viam-agent*
+```
+
+{{% /tab %}}
+{{% tab name="aarch64" %}}
+
+```sh {class="command-line" data-prompt="$"}
+mkdir -p /opt/viam/bin/ /opt/viam/tmp/
+curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent/viam-agent-stable-aarch64 -o /opt/viam/bin/viam-agent-stable-aarch64
+curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent-provisioning/viam-agent-provisioning-stable-aarch64 -o /opt/viam/bin/viam-agent-provisioning-stable-aarch64
+chmod 755 /opt/viam/tmp/viam-agent*
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+{{< /tablestep >}}
+{{< tablestep >}}
+**2. Symlink the binaries**
+
+Symlink the agent binary to `bin/viam-agent` and the provisioning binary to `bin/agent-provisioning`:
+
+{{< tabs >}}
+{{% tab name="x86_64" %}}
+
+```sh {class="command-line" data-prompt="$"}
+ln -s /opt/viam/bin/viam-agent-stable-x86_64 bin/viam-agent
+ln -s /opt/viam/bin/viam-agent-provisioning-stable-x86_64 bin/agent-provisioning
+```
+
+{{% /tab %}}
+{{% tab name="aarch64" %}}
+
+```sh {class="command-line" data-prompt="$"}
+ln -s /opt/viam/bin/viam-agent-stable-aarch64 bin/viam-agent
+ln -s /opt/viam/bin/viam-agent-provisioning-stable-aarch64 bin/agent-provisioning
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+{{< alert title="Note" color="note" >}}
+Use relative symlinks, especially if working on a mounted image (that is not a booted system).
+{{< /alert >}}
+
+{{< /tablestep >}}
+{{< tablestep >}}
+**3. Create the systemd service file**
+
+Copy the systemd [service file](https://github.com/viamrobotics/agent/blob/main/subsystems/viamagent/viam-agent.service) from the agent repo to `/etc/systemd/system/viam-agent.service`.
+
+Then, symlink the service file to <FILE>/etc/systemd/system/multi-user.target.wants/viam-agent.service</FILE>
+
+```sh {class="command-line" data-prompt="$"}
+curl -fsSL https://github.com/viamrobotics/agent/raw/main/subsystems/viamagent/viam-agent.service -o /etc/systemd/system/viam-agent.service
+ln -s /etc/systemd/system/viam-agent.service /etc/systemd/system/multi-user.target.wants/viam-agent.service
+```
+
+{{< alert title="Note" color="note" >}}
+Use relative symlinks, especially if working on a mounted image (that is not a booted system).
+{{< /alert >}}
+
+{{< /tablestep >}}
+{{< tablestep >}}
+**4. Ensure NetworkManager is installed**
+
+Make sure NetworkManager version 1.42 or newer is installed and enabled in `systemd`.
+
+{{< /tablestep >}}
+{{< tablestep >}}
+
+If you create a provisioning file, the file must be at <file>/etc/viam-provisioning.json</file> on the machine that will be provisioned.
+If you follow the installation instructions in the next section
+
+{{< /tablestep >}}
+{{< /table >}}
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Troubleshooting
+
+If you need to test the GRPC components of the provisioning service, there is a CLI client available.
+Get the code from the [`agent-provisioning` repo](https://github.com/viamrobotics/agent-provisioning) and run `go run ./cmd/client/` for info.
 
 ## Next Steps
 
-You can now use your machine.
-For information on how to use your machine's controls, see:
+With provisioning configured, you can now direct the end user to follow the setup steps:
 
 {{< cards >}}
-{{% card link="/fleet/control/" %}}
+{{% card link="/how-tos/provision/" %}}
 {{< /cards >}}

--- a/docs/how-tos/provision.md
+++ b/docs/how-tos/provision.md
@@ -1,310 +1,146 @@
 ---
-title: "Configure provisioning with viam-agent"
-linkTitle: "Prepare provisioning"
-weight: 68
+title: "Complete setup for a machine"
+linkTitle: "Set a machine up"
+weight: 69
 type: "docs"
-description: "Install and configure viam-agent for provisioning one or many machines."
-images: ["/installation/thumbnails/install.png"]
-imageAlt: "Install Viam"
+description: "If you have received a machine that uses Viam and have been pointed to this guide, this guide will show you how to set it up."
+images: ["/platform/provisioning-demo.gif"]
+videos: ["/platform/provisioning-demo.webm", "/platform/provisioning-demo.mp4"]
 ---
 
-The provisioning subsystem is a feature of `viam-agent`, which you can install as part of your manufacturing process. `agent-provisioning` will then perform the rest of the first-time setup for your machine once an end user sets up the machine.
+If you have received a machine with Viam pre-installed on it, this guide will show you how to complete your device setup using either the [Viam mobile app](#set-up-your-machine-using-the-viam-mobile-app) or the [captive portal](#set-up-your-machine-using-the-captive-portal).
 
-This is useful when deploying a fleet of machines directly from the factory to a customer, or when bundling proprietary software on your Viam machine.
-
-This guide will show you how to install and configure `viam-agent`.
+Unless you have been told to use the captive portal, we recommend you use the Viam mobile app.
 
 {{< alert title="In this page" color="tip" >}}
 
-1. [Configure `agent-provisioning`](#configure-agent-provisioning)
-1. [Decide on the provisioning method](#decide-on-the-provisioning-method)
-1. [Install `viam-agent`](#install-viam-agent)
+1. [Set up your machine using the Viam mobile app](#set-up-your-machine-using-the-viam-mobile-app).
+1. [Set up your machine using the captive portal](#set-up-your-machine-using-the-captive-portal).
 
 {{< /alert >}}
 
 ## Prerequisites
 
-{{% expand "One or more physical devices with supported operating system" %}}
+- Physical hardware constituting a machine
+- A WiFi-enabled laptop or mobile device if using the Viam mobile app
 
-To find out more about supported systems, see [Compatibility](/installation/#compatibility).
+## Set up your machine using the Viam mobile app
 
-{{% /expand%}}
-
-{{% expand "A machine fragment" %}}
-
-Viam has a built-in tool called _{{< glossary_tooltip term_id="fragment" text="fragments" >}}_ for copying parts of a configuration file to multiple machines.
-
-Follow the steps to [Create a configuration fragment](/how-tos/one-to-many/) and make a note of the fragment ID.
-
-{{% /expand%}}
-
-## Decide on the provisioning method
-
-You can choose to let your end users complete machine setup by using a captive web portal or a mobile app.
-
-If you choose to have a mobile app experience, you can use the [Viam mobile app](/fleet/control/#control-interface-in-the-viam-mobile-app) or create your own custom mobile app using the [Flutter SDK](https://flutter.viam.dev/viam_protos.provisioning.provisioning/ProvisioningServiceClient-class.html) or the [TypeScript SDK](https://github.com/viamrobotics/viam-typescript-sdk/blob/main/src/app/provisioning-client.ts) to connect to `viam-agent` and provision your machines.
-
-If you choose to use the Viam mobile app, you must provide a fragment for provisioning.
-
-If you choose to use the captive web portal, you can optionally create a machine already and provide its credentials configuration file at <FILE>/etc/viam.json</FILE>.
-
-You can get the `viam-server` app JSON configuration by clicking the copy icon next to **Viam server config** in the part status dropdown to the right of your machine's name on the top of the page.
-
-{{<imgproc src="configure/machine-part-info.png" resize="500x" declaredimensions=true alt="Restart button on the machine part info dropdown">}}
-
-## Configure `agent-provisioning`
+{{<video webm_src="/platform/provisioning-demo.webm" mp4_src="/platform/provisioning-demo.mp4" alt="Using the Viam mobile app to provision a new machine with viam-agent." poster="/platform/provisioning-demo.jpg" max-width="400px" class="aligncenter imgzoom">}}
 
 {{< table >}}
+{{% tablestep %}}
+**1. Install the Viam mobile app**
 
-{{% tablestep link="/fleet/provision/#configuration" %}}
-**Configure provisioning**
+You can find the mobile app on the [App Store](https://apps.apple.com/vn/app/viam-robotics/id6451424162) and on [Google Play](https://play.google.com/store/apps/details?id=com.viam.viammobile&hl=en&gl=US).
 
-You may optionally provide a provisioning configuration file to customize the experience.
-Place the file at <file>/etc/viam-provisioning.json</file> with the following format:
+<a href="https://apps.apple.com/vn/app/viam-robotics/id6451424162" target="_blank">
+  <img src="https://github.com/viamrobotics/docs/assets/90707162/a470b65d-1b97-412f-9f97-daf902f2f053" width="200px" alt="apple store icon" class="center-if-small" >
+</a>
 
-```json {class="line-numbers linkable-line-numbers"}
-{
-  "manufacturer": "<NAME>", # your company name
-  "model": "<NAME>", # the machine's model
-  "fragment_id": "<ID>", # the fragment id, required for mobile app
-  "hotspot_prefix": "<PREFIX>", # machine creates a hotspot during setup
-  "disable_dns_redirect": true, # disable if using a mobile app
-  "hotspot_password": "<PASSWORD>", # password for the hotspot
-}
-```
+<a href="https://play.google.com/store/apps/details?id=com.viam.viammobile&hl=en&gl=US" target="_blank">
+  <img src="https://github.com/viamrobotics/docs/assets/90707162/6ebd6960-08c5-41d4-81f9-42293fbfdfd4" width="200px" alt="google play store icon" class="center-if-small" >
+</a>
 
+{{% /tablestep %}}
+{{% tablestep %}}
+**2. Create a machine**
+
+Open the Viam mobile app and sign in.
+Then, select an organization and location for your machine.
+If you have already created a machine, select it.
+If you have not yet created a machine, click on **Add new smart machine** and give your machine a name.
+{{% /tablestep %}}
+{{% tablestep %}}
+**3. Follow the instructions in the app**
+
+Turn on the smart machine you are attempting to connect to.
+Then leave the app and navigate to your mobile device's WiFi settings and connect to the WiFi hotspot your machine has created.
+You may need to wait a short time for your machine to boot and create its WiFi hotspot.
+Your machine's WiFi hotspot name will begin with `viam-setup-`.
+Unless you have been given other instructions, the WiFi password for this hotspot network is `viamsetup`.
+
+Once you are connected to your machine's WiFi hotspot return to the Viam mobile app.
+{{% /tablestep %}}
+{{% tablestep %}}
+**4. Provide the network information for the machine**
+
+In the mobile app, you will be prompted to provide the network information for the machine.
+
+The machine will now disable the hotspot network and attempt to connect using the provided network information.
+If the machine cannot establish a connection using the provided network information, the machine will create the hotspot again and prompt you to re-enter the network information until a connection is successfully established.
+{{% /tablestep %}}
+{{% tablestep %}}
+**5. Wait for machine to complete setup**
+
+If the machine can successfully connect to the network it will now complete its setup and become **live**.
+
+Note that any features that require internet access will not function if the connected WiFi network is not connected to the internet.
 {{% /tablestep %}}
 {{< /table >}}
 
-## Install `viam-agent`
-
-`viam-agent` is a self-updating service manager that maintains the lifecycle for several Viam services and keeps them updated.
-If you intend to use `viam-agent` to keep your device's Viam software up-to-date or to use its provisioning plugin to let end users set up their own machines, you need to use `viam-agent` and install it on the machine before sending it to the user.
-
-You can [install `viam-agent` on live systems](/installation/) or preinstall it:
-
-{{< tabs >}}
-{{% tab name="Preinstall on an image" %}}
-
-Viam provides a preinstall script that works with images to add `viam-agent`.
-
-{{< alert title="Support notice" color="note" >}}
-Please note this script works only under POSIX (MacOS and Linux) at the moment.
-{{< /alert >}}
+## Set up your machine using the captive portal
 
 {{< table >}}
-{{< tablestep >}}
-**1. Download the preinstall script**
+{{% tablestep %}}
+**1. Turn on the smart machine**
 
-Run the following commands to download the preinstall script and make the script executable:
+Turn on the smart machine you are attempting to set up.
+{{% /tablestep %}}
+{{% tablestep %}}
+**2. Connect to your machine's WiFi hotspot**
 
-```sh {class="command-line" data-prompt="$"}
-wget https://storage.googleapis.com/packages.viam.com/apps/viam-agent/preinstall.sh
-chmod 755 preinstall.sh
-```
+On a laptop or mobile device, navigate to your WiFi settings and connect to the WiFi hotspot your machine has created.
+You may need to wait a short time for your machine to boot and create its WiFi hotspot.
+Your machine's WiFi hotspot name will begin with `viam-setup-`.
+Unless you have been given other instructions, the WiFi password for this hotspot network is `viamsetup`.
 
-{{< /tablestep >}}
-{{< tablestep >}}
-**2. Run the script**
+Once you are connected to your machine's WiFi hotspot you will be redirected to a sign-in page.
+If you are using a laptop or are not redirected, try opening [http://viam.setup/](http://viam.setup/) in a browser.
+{{% /tablestep %}}
+{{% tablestep %}}
+**3. Follow the captive portal's instructions to provide network information**
 
-Run the preinstall script without options and it will attempt to auto-detect a mounted root filesystem (or for Raspberry Pi, bootfs) and also automatically determine the architecture.
+In the captive web portal, you will then be prompted to provide the network information for the machine.
+{{% /tablestep %}}
+{{% tablestep %}}
+**4. If prompted, provide a machine credentials configuration**
 
-```sh {class="command-line" data-prompt="$"}
-sudo ./preinstall.sh
-```
+Depending on how the machine was set up so far, the captive portal may also require you to paste a machine credentials configuration file.
+This is the JSON object which contains your machine part secret key and cloud app address, which your machine's `viam-server` instance needs to connect to the Viam app.
 
-If this succeeds, continue to step 5.
-Alternatively, go to step 3.
+Navigate to [the Viam app](https://app.viam.com) and create a new machine.
 
-{{< /tablestep >}}
-{{< tablestep >}}
-**3. Run the script for the target system's architecture**
+To copy a machine credentials configuration file:
 
-The following command creates a tarball you can extract on your own:
+- Navigate to your machine's page on [the Viam app](https://app.viam.com).
+- Select the part status dropdown to the right of your machine's name on the top of the page.
+  {{<imgproc src="configure/machine-part-info.png" resize="500x" declaredimensions=true alt="Restart button on the machine part info dropdown">}}
+- Click the copy icon next to **Viam server config** to copy the machine credentials configuration file.
+- Paste the `viam-server` app config when prompted.
 
-{{< tabs >}}
-{{% tab name="arm64" %}}
+{{% /tablestep %}}
+{{% tablestep %}}
+**5. Wait for machine to complete setup**
 
-```sh {class="command-line" data-prompt="$"}
-sudo ./preinstall.sh --aarch64
-```
+The machine will now disable the hotspot network and attempt to connect using the provided network information.
+If the machine cannot establish a connection using the provided network information, the machine will create the hotspot again and prompt you to re-enter the network information until a connection is successfully established.
 
-{{% /tab %}}
-{{% tab name="x86_64" %}}
+If the machine can successfully connect to the network it will now complete its setup and become **live**.
 
-```sh {class="command-line" data-prompt="$"}
-sudo ./preinstall.sh --x86_64
-```
-
-{{% /tab %}}
-{{< /tabs >}}
-
-If this command fails because the script cannot detect your mountpoint, you can specify it directly:
-
-```sh {class="command-line" data-prompt="$"}
-sudo ./preinstall.sh /path/to/rootfs
-```
-
-{{< /tablestep >}}
+Note that any features that require internet access will not function if the connected WiFi network is not connected to the internet.
+{{% /tablestep %}}
 {{< /table >}}
-
-{{% /tab %}}
-{{% tab name="Preinstall on an SD card" %}}
-
-{{< table >}}
-{{< tablestep >}}
-**1. Flash a 64-bit image to your SD card**
-
-Flash a 64-bit image to your SD card using the Raspberry Pi Imager, and customize at least the hostname when prompted.
-
-{{< /tablestep >}}
-{{< tablestep >}}
-**2. Run the preinstall script**
-
-Eject and reinsert the card to make sure it's mounted with the newly written contents. Then run the following script:
-
-```sh {class="command-line" data-prompt="$"}
-sudo /bin/sh -c "$(curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent/preinstall.sh)"
-```
-
-Follow the instructions:
-
-```sh {class="command-line" data-prompt="$" data-output="2-40"}
-coding sudo /bin/sh -c "$(curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent/preinstall.sh)"
-
-
-Found Raspberry Pi bootfs mounted at /Volumes/bootfs
-
-
-A Raspberry Pi boot partition has been found mounted at /Volumes/bootfs
-This script will modify firstrun.sh on that partition to install Viam agent.
-Continue pre-install? (y/n): y
-Path to custom viam-provisioning.json (leave empty to skip):
-Creating tarball for install.
-a opt
-a opt/viam
-a opt/viam/cache
-a opt/viam/bin
-a opt/viam/bin/viam-agent
-a opt/viam/bin/agent-provisioning
-a opt/viam/cache/viam-agent-provisioning-factory-aarch64
-a opt/viam/cache/viam-agent-factory-aarch64
-a etc
-a usr
-a usr/local
-a usr/local/lib
-a usr/local/lib/systemd
-a usr/local/lib/systemd/system
-a usr/local/lib/systemd/system/viam-agent.service
-a usr/local/lib/systemd/system/multi-user.target.wants
-a usr/local/lib/systemd/system/multi-user.target.wants/viam-agent.service
-
-
-Install complete! You can eject/unmount and boot the image now.
-```
-
-{{< /tablestep >}}
-{{< /table >}}
-
-{{% /tab %}}
-{{% tab name="Manual install" %}}
-
-{{< table >}}
-{{< tablestep >}}
-**1. Create and download files**
-
-Run the following commands to create directories for the provisioning binaries, then download the binaries and make them executable:
-
-{{< tabs >}}
-{{% tab name="x86_64" %}}
-
-```sh {class="command-line" data-prompt="$"}
-mkdir -p /opt/viam/bin/ /opt/viam/tmp/
-curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent/viam-agent-stable-x86_64 -o /opt/viam/bin/viam-agent-stable-x86_64
-curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent-provisioning/viam-agent-provisioning-stable-x86_64 -o /opt/viam/bin/viam-agent-provisioning-stable-x86_64
-chmod 755 /opt/viam/tmp/viam-agent*
-```
-
-{{% /tab %}}
-{{% tab name="aarch64" %}}
-
-```sh {class="command-line" data-prompt="$"}
-mkdir -p /opt/viam/bin/ /opt/viam/tmp/
-curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent/viam-agent-stable-aarch64 -o /opt/viam/bin/viam-agent-stable-aarch64
-curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent-provisioning/viam-agent-provisioning-stable-aarch64 -o /opt/viam/bin/viam-agent-provisioning-stable-aarch64
-chmod 755 /opt/viam/tmp/viam-agent*
-```
-
-{{% /tab %}}
-{{< /tabs >}}
-
-{{< /tablestep >}}
-{{< tablestep >}}
-**2. Symlink the binaries**
-
-Symlink the agent binary to `bin/viam-agent` and the provisioning binary to `bin/agent-provisioning`:
-
-{{< tabs >}}
-{{% tab name="x86_64" %}}
-
-```sh {class="command-line" data-prompt="$"}
-ln -s /opt/viam/bin/viam-agent-stable-x86_64 bin/viam-agent
-ln -s /opt/viam/bin/viam-agent-provisioning-stable-x86_64 bin/agent-provisioning
-```
-
-{{% /tab %}}
-{{% tab name="aarch64" %}}
-
-```sh {class="command-line" data-prompt="$"}
-ln -s /opt/viam/bin/viam-agent-stable-aarch64 bin/viam-agent
-ln -s /opt/viam/bin/viam-agent-provisioning-stable-aarch64 bin/agent-provisioning
-```
-
-{{% /tab %}}
-{{< /tabs >}}
-
-{{< alert title="Note" color="note" >}}
-Use relative symlinks, especially if working on a mounted image (that is not a booted system).
-{{< /alert >}}
-
-{{< /tablestep >}}
-{{< tablestep >}}
-**3. Create the systemd service file**
-
-Copy the systemd [service file](https://github.com/viamrobotics/agent/blob/main/subsystems/viamagent/viam-agent.service) from the agent repo to `/etc/systemd/system/viam-agent.service`.
-
-Then, symlink the service file to <FILE>/etc/systemd/system/multi-user.target.wants/viam-agent.service</FILE>
-
-```sh {class="command-line" data-prompt="$"}
-curl -fsSL https://github.com/viamrobotics/agent/raw/main/subsystems/viamagent/viam-agent.service -o /etc/systemd/system/viam-agent.service
-ln -s /etc/systemd/system/viam-agent.service /etc/systemd/system/multi-user.target.wants/viam-agent.service
-```
-
-{{< alert title="Note" color="note" >}}
-Use relative symlinks, especially if working on a mounted image (that is not a booted system).
-{{< /alert >}}
-
-{{< /tablestep >}}
-{{< tablestep >}}
-**4. Ensure NetworkManager is installed**
-
-Make sure NetworkManager is installed and enabled in `systemd`.
-
-{{< /tablestep >}}
-{{< /table >}}
-
-{{% /tab %}}
-{{< /tabs >}}
-
-## Troubleshooting
-
-If you need to test the GRPC components of the provisioning service, there is a CLI client available.
-Get the code from the [`agent-provisioning` repo](https://github.com/viamrobotics/agent-provisioning) and run `go run ./cmd/client/` for info.
 
 ## Next Steps
 
-With provisioning configured, you can now direct the end user to follow the setup steps:
+You can now use your machine.
+
+If your machine needs to be able to connect to more than one WiFi network, you can add additional networks in the [`viam-agent` network configuration](/configure/agent/#networks).
+You can also override other configuration details in the [`viam-agent` configuration](/configure/agent/#configuration).
+
+For information on how to use your machine's controls, see:
 
 {{< cards >}}
-{{% card link="/how-tos/provision-setup/" %}}
+{{% card link="/fleet/control/" %}}
 {{< /cards >}}

--- a/docs/how-tos/provision.md
+++ b/docs/how-tos/provision.md
@@ -1,0 +1,310 @@
+---
+title: "Configure provisioning with viam-agent"
+linkTitle: "Prepare provisioning"
+weight: 68
+type: "docs"
+description: "Install and configure viam-agent for provisioning one or many machines."
+images: ["/installation/thumbnails/install.png"]
+imageAlt: "Install Viam"
+---
+
+The provisioning subsystem is a feature of `viam-agent`, which you can install as part of your manufacturing process. `agent-provisioning` will then perform the rest of the first-time setup for your machine once an end user sets up the machine.
+
+This is useful when deploying a fleet of machines directly from the factory to a customer, or when bundling proprietary software on your Viam machine.
+
+This guide will show you how to install and configure `viam-agent`.
+
+{{< alert title="In this page" color="tip" >}}
+
+1. [Configure `agent-provisioning`](#configure-agent-provisioning)
+1. [Decide on the provisioning method](#decide-on-the-provisioning-method)
+1. [Install `viam-agent`](#install-viam-agent)
+
+{{< /alert >}}
+
+## Prerequisites
+
+{{% expand "One or more physical devices with supported operating system" %}}
+
+To find out more about supported systems, see [Compatibility](/installation/#compatibility).
+
+{{% /expand%}}
+
+{{% expand "A machine fragment" %}}
+
+Viam has a built-in tool called _{{< glossary_tooltip term_id="fragment" text="fragments" >}}_ for copying parts of a configuration file to multiple machines.
+
+Follow the steps to [Create a configuration fragment](/how-tos/one-to-many/) and make a note of the fragment ID.
+
+{{% /expand%}}
+
+## Decide on the provisioning method
+
+You can choose to let your end users complete machine setup by using a captive web portal or a mobile app.
+
+If you choose to have a mobile app experience, you can use the [Viam mobile app](/fleet/control/#control-interface-in-the-viam-mobile-app) or create your own custom mobile app using the [Flutter SDK](https://flutter.viam.dev/viam_protos.provisioning.provisioning/ProvisioningServiceClient-class.html) or the [TypeScript SDK](https://github.com/viamrobotics/viam-typescript-sdk/blob/main/src/app/provisioning-client.ts) to connect to `viam-agent` and provision your machines.
+
+If you choose to use the Viam mobile app, you must provide a fragment for provisioning.
+
+If you choose to use the captive web portal, you can optionally create a machine already and provide its credentials configuration file at <FILE>/etc/viam.json</FILE>.
+
+You can get the `viam-server` app JSON configuration by clicking the copy icon next to **Viam server config** in the part status dropdown to the right of your machine's name on the top of the page.
+
+{{<imgproc src="configure/machine-part-info.png" resize="500x" declaredimensions=true alt="Restart button on the machine part info dropdown">}}
+
+## Configure `agent-provisioning`
+
+{{< table >}}
+
+{{% tablestep link="/fleet/provision/#configuration" %}}
+**Configure provisioning**
+
+You may optionally provide a provisioning configuration file to customize the experience.
+Place the file at <file>/etc/viam-provisioning.json</file> with the following format:
+
+```json {class="line-numbers linkable-line-numbers"}
+{
+  "manufacturer": "<NAME>", # your company name
+  "model": "<NAME>", # the machine's model
+  "fragment_id": "<ID>", # the fragment id, required for mobile app
+  "hotspot_prefix": "<PREFIX>", # machine creates a hotspot during setup
+  "disable_dns_redirect": true, # disable if using a mobile app
+  "hotspot_password": "<PASSWORD>", # password for the hotspot
+}
+```
+
+{{% /tablestep %}}
+{{< /table >}}
+
+## Install `viam-agent`
+
+`viam-agent` is a self-updating service manager that maintains the lifecycle for several Viam services and keeps them updated.
+If you intend to use `viam-agent` to keep your device's Viam software up-to-date or to use its provisioning plugin to let end users set up their own machines, you need to use `viam-agent` and install it on the machine before sending it to the user.
+
+You can [install `viam-agent` on live systems](/installation/) or preinstall it:
+
+{{< tabs >}}
+{{% tab name="Preinstall on an image" %}}
+
+Viam provides a preinstall script that works with images to add `viam-agent`.
+
+{{< alert title="Support notice" color="note" >}}
+Please note this script works only under POSIX (MacOS and Linux) at the moment.
+{{< /alert >}}
+
+{{< table >}}
+{{< tablestep >}}
+**1. Download the preinstall script**
+
+Run the following commands to download the preinstall script and make the script executable:
+
+```sh {class="command-line" data-prompt="$"}
+wget https://storage.googleapis.com/packages.viam.com/apps/viam-agent/preinstall.sh
+chmod 755 preinstall.sh
+```
+
+{{< /tablestep >}}
+{{< tablestep >}}
+**2. Run the script**
+
+Run the preinstall script without options and it will attempt to auto-detect a mounted root filesystem (or for Raspberry Pi, bootfs) and also automatically determine the architecture.
+
+```sh {class="command-line" data-prompt="$"}
+sudo ./preinstall.sh
+```
+
+If this succeeds, continue to step 5.
+Alternatively, go to step 3.
+
+{{< /tablestep >}}
+{{< tablestep >}}
+**3. Run the script for the target system's architecture**
+
+The following command creates a tarball you can extract on your own:
+
+{{< tabs >}}
+{{% tab name="arm64" %}}
+
+```sh {class="command-line" data-prompt="$"}
+sudo ./preinstall.sh --aarch64
+```
+
+{{% /tab %}}
+{{% tab name="x86_64" %}}
+
+```sh {class="command-line" data-prompt="$"}
+sudo ./preinstall.sh --x86_64
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+If this command fails because the script cannot detect your mountpoint, you can specify it directly:
+
+```sh {class="command-line" data-prompt="$"}
+sudo ./preinstall.sh /path/to/rootfs
+```
+
+{{< /tablestep >}}
+{{< /table >}}
+
+{{% /tab %}}
+{{% tab name="Preinstall on an SD card" %}}
+
+{{< table >}}
+{{< tablestep >}}
+**1. Flash a 64-bit image to your SD card**
+
+Flash a 64-bit image to your SD card using the Raspberry Pi Imager, and customize at least the hostname when prompted.
+
+{{< /tablestep >}}
+{{< tablestep >}}
+**2. Run the preinstall script**
+
+Eject and reinsert the card to make sure it's mounted with the newly written contents. Then run the following script:
+
+```sh {class="command-line" data-prompt="$"}
+sudo /bin/sh -c "$(curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent/preinstall.sh)"
+```
+
+Follow the instructions:
+
+```sh {class="command-line" data-prompt="$" data-output="2-40"}
+coding sudo /bin/sh -c "$(curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent/preinstall.sh)"
+
+
+Found Raspberry Pi bootfs mounted at /Volumes/bootfs
+
+
+A Raspberry Pi boot partition has been found mounted at /Volumes/bootfs
+This script will modify firstrun.sh on that partition to install Viam agent.
+Continue pre-install? (y/n): y
+Path to custom viam-provisioning.json (leave empty to skip):
+Creating tarball for install.
+a opt
+a opt/viam
+a opt/viam/cache
+a opt/viam/bin
+a opt/viam/bin/viam-agent
+a opt/viam/bin/agent-provisioning
+a opt/viam/cache/viam-agent-provisioning-factory-aarch64
+a opt/viam/cache/viam-agent-factory-aarch64
+a etc
+a usr
+a usr/local
+a usr/local/lib
+a usr/local/lib/systemd
+a usr/local/lib/systemd/system
+a usr/local/lib/systemd/system/viam-agent.service
+a usr/local/lib/systemd/system/multi-user.target.wants
+a usr/local/lib/systemd/system/multi-user.target.wants/viam-agent.service
+
+
+Install complete! You can eject/unmount and boot the image now.
+```
+
+{{< /tablestep >}}
+{{< /table >}}
+
+{{% /tab %}}
+{{% tab name="Manual install" %}}
+
+{{< table >}}
+{{< tablestep >}}
+**1. Create and download files**
+
+Run the following commands to create directories for the provisioning binaries, then download the binaries and make them executable:
+
+{{< tabs >}}
+{{% tab name="x86_64" %}}
+
+```sh {class="command-line" data-prompt="$"}
+mkdir -p /opt/viam/bin/ /opt/viam/tmp/
+curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent/viam-agent-stable-x86_64 -o /opt/viam/bin/viam-agent-stable-x86_64
+curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent-provisioning/viam-agent-provisioning-stable-x86_64 -o /opt/viam/bin/viam-agent-provisioning-stable-x86_64
+chmod 755 /opt/viam/tmp/viam-agent*
+```
+
+{{% /tab %}}
+{{% tab name="aarch64" %}}
+
+```sh {class="command-line" data-prompt="$"}
+mkdir -p /opt/viam/bin/ /opt/viam/tmp/
+curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent/viam-agent-stable-aarch64 -o /opt/viam/bin/viam-agent-stable-aarch64
+curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent-provisioning/viam-agent-provisioning-stable-aarch64 -o /opt/viam/bin/viam-agent-provisioning-stable-aarch64
+chmod 755 /opt/viam/tmp/viam-agent*
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+{{< /tablestep >}}
+{{< tablestep >}}
+**2. Symlink the binaries**
+
+Symlink the agent binary to `bin/viam-agent` and the provisioning binary to `bin/agent-provisioning`:
+
+{{< tabs >}}
+{{% tab name="x86_64" %}}
+
+```sh {class="command-line" data-prompt="$"}
+ln -s /opt/viam/bin/viam-agent-stable-x86_64 bin/viam-agent
+ln -s /opt/viam/bin/viam-agent-provisioning-stable-x86_64 bin/agent-provisioning
+```
+
+{{% /tab %}}
+{{% tab name="aarch64" %}}
+
+```sh {class="command-line" data-prompt="$"}
+ln -s /opt/viam/bin/viam-agent-stable-aarch64 bin/viam-agent
+ln -s /opt/viam/bin/viam-agent-provisioning-stable-aarch64 bin/agent-provisioning
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+{{< alert title="Note" color="note" >}}
+Use relative symlinks, especially if working on a mounted image (that is not a booted system).
+{{< /alert >}}
+
+{{< /tablestep >}}
+{{< tablestep >}}
+**3. Create the systemd service file**
+
+Copy the systemd [service file](https://github.com/viamrobotics/agent/blob/main/subsystems/viamagent/viam-agent.service) from the agent repo to `/etc/systemd/system/viam-agent.service`.
+
+Then, symlink the service file to <FILE>/etc/systemd/system/multi-user.target.wants/viam-agent.service</FILE>
+
+```sh {class="command-line" data-prompt="$"}
+curl -fsSL https://github.com/viamrobotics/agent/raw/main/subsystems/viamagent/viam-agent.service -o /etc/systemd/system/viam-agent.service
+ln -s /etc/systemd/system/viam-agent.service /etc/systemd/system/multi-user.target.wants/viam-agent.service
+```
+
+{{< alert title="Note" color="note" >}}
+Use relative symlinks, especially if working on a mounted image (that is not a booted system).
+{{< /alert >}}
+
+{{< /tablestep >}}
+{{< tablestep >}}
+**4. Ensure NetworkManager is installed**
+
+Make sure NetworkManager is installed and enabled in `systemd`.
+
+{{< /tablestep >}}
+{{< /table >}}
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Troubleshooting
+
+If you need to test the GRPC components of the provisioning service, there is a CLI client available.
+Get the code from the [`agent-provisioning` repo](https://github.com/viamrobotics/agent-provisioning) and run `go run ./cmd/client/` for info.
+
+## Next Steps
+
+With provisioning configured, you can now direct the end user to follow the setup steps:
+
+{{< cards >}}
+{{% card link="/how-tos/provision-setup/" %}}
+{{< /cards >}}

--- a/docs/how-tos/provision.md
+++ b/docs/how-tos/provision.md
@@ -22,7 +22,7 @@ Unless you have been told to use the captive portal, we recommend you use the Vi
 ## Prerequisites
 
 - Physical hardware constituting a machine
-- A WiFi-enabled laptop or mobile device if using the Viam mobile app
+- A WiFi-enabled computer, or mobile device (if using the Viam mobile app)
 
 ## Set up your machine using the Viam mobile app
 

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -23,10 +23,11 @@ A {{< glossary_tooltip term_id="machine" text="machine" >}} is any computer (SBC
 
 Learn more about the structure and configuration of machines:
 
-|                        | Structure...                            | Configuration...                     |
-| ---------------------- | --------------------------------------- | ------------------------------------ |
-| ...of one machine ->   | [Architecture](/architecture/)          | [Machine Configuration](/configure/) |
-| ...of many machines -> | [Cloud Organization Hierarchy](/cloud/) | [Deploy a Large Fleet](/fleet/)      |
+<!-- prettier-ignore -->
+|   | Structure... | Configuration... | Installation... |
+| - | ------------ | ---------------- | --------------- |
+| ...of one machine -> | [Architecture](/architecture/) | [Machine Configuration](/configure/) | [Installation](/installation/) |
+| ...of many machines -> | [Cloud Organization Hierarchy](/cloud/) | [Deploy a Large Fleet](/fleet/) | [Provisioning](/fleet/provision/) |
 
 ## The things that make up a machine
 


### PR DESCRIPTION
I've added two guides:

- [Prepare provisioning](https://docs-test.viam.dev/3269/how-tos/provision/)
- [Set a machine up](https://docs-test.viam.dev/3269/how-tos/provision-setup/)