### PR TITLE
Improve trigger sync guide

### DIFF
--- a/docs/how-tos/performance-metrics.md
+++ b/docs/how-tos/performance-metrics.md
@@ -42,10 +42,16 @@ You can use the [`viam-telegraf-sensor`](https://app.viam.com/module/viam/viam-t
 
 {{% /expand%}}
 
-{{< alert title="Note" color="note" >}}
-You must run `viam-server` with `sudo` to monitor machine performance metrics.
+{{% expand "Install telegraf. Click to see instructions." %}}
 
 On macOS, you must also install telegraf by running `brew install telegraf` in your terminal before using this module.
+
+If you are on another operating system, telegraf will be installed automatically for you.
+
+{{% /expand%}}
+
+{{< alert title="Note" color="note" >}}
+You must run `viam-server` with `sudo` to monitor machine performance metrics.
 {{< /alert >}}
 
 ## Add the telegraf-sensor


### PR DESCRIPTION
Minor update to the performance data guide.
Structural change to the trigger sync guide. The guide is supposed to teach people how to add their own logic, I think it does a better job at that now.