### PR TITLE
DATA-2672: Update data manager config default docs

### DIFF
--- a/docs/services/data/capture-sync.md
+++ b/docs/services/data/capture-sync.md
@@ -238,10 +238,9 @@ The following attributes are available for the data management service:
 | `tags` | array of strings | Optional | Tags to apply to all images captured by this machine part. May include alphanumeric characters, underscores, and dashes. |
 | `sync_disabled` | bool | Optional | Toggle cloud sync on or off for the entire machine {{< glossary_tooltip term_id="part" text="part" >}}. <br> Default: `false` |
 | `additional_sync_paths` | string array | Optional | Paths to any other directories on your machine from which you want to sync data to the cloud. Once data is synced from a directory, it is automatically deleted from your machine. |
-| `sync_interval_minutes` | float | Optional | Time interval in minutes between syncing to the cloud. Viam does not impose a minimum or maximum on the frequency of data syncing. However, in practice, your hardware or network speed may impose limits on the frequency of data syncing. <br> Default: `0.1`, meaning once every 6 seconds. |
+| `sync_interval_mins` | float | Optional | Time interval in minutes between syncing to the cloud. Viam does not impose a minimum or maximum on the frequency of data syncing. However, in practice, your hardware or network speed may impose limits on the frequency of data syncing. <br> Default: `0.1`, meaning once every 6 seconds. |
 | `delete_every_nth_when_disk_full` | int | Optional | How many files to delete when local storage meets the [fullness criteria](/services/data/capture-sync/#storage). The data management service will delete every Nth file that has been captured upon reaching this threshold. Use JSON mode to configure this attribute. <br> Default: `5`, meaning that every fifth captured file will be deleted. |
 | `maximum_num_sync_threads` | int | Optional | Max number of CPU threads to use for syncing data to the Viam cloud. <br> Default: [runtime.NumCPU](https://pkg.go.dev/runtime#NumCPU)/2 so half the number of logical CPUs available to viam-server |
-| `sync_interval_mins` | float | Optional | Frequency (in minutes) that data sync will walk the capture directory and additional sync paths and attempt to sync the files of all their subdirectories to the cloud. <br> Default: `0.1`, meaning once every 6 seconds. |
 
 {{% /tab %}}
 {{% tab name="viam-micro-server" %}}

--- a/docs/services/data/capture-sync.md
+++ b/docs/services/data/capture-sync.md
@@ -240,7 +240,8 @@ The following attributes are available for the data management service:
 | `additional_sync_paths` | string array | Optional | Paths to any other directories on your machine from which you want to sync data to the cloud. Once data is synced from a directory, it is automatically deleted from your machine. |
 | `sync_interval_minutes` | float | Optional | Time interval in minutes between syncing to the cloud. Viam does not impose a minimum or maximum on the frequency of data syncing. However, in practice, your hardware or network speed may impose limits on the frequency of data syncing. <br> Default: `0.1`, meaning once every 6 seconds. |
 | `delete_every_nth_when_disk_full` | int | Optional | How many files to delete when local storage meets the [fullness criteria](/services/data/capture-sync/#storage). The data management service will delete every Nth file that has been captured upon reaching this threshold. Use JSON mode to configure this attribute. <br> Default: `5`, meaning that every fifth captured file will be deleted. |
-| `maximum_num_sync_threads` | int | Optional | Max number of CPU threads to use for syncing data to the Viam cloud. <br> Default: `1000` |
+| `maximum_num_sync_threads` | int | Optional | Max number of CPU threads to use for syncing data to the Viam cloud. <br> Default: [runtime.NumCPU](https://pkg.go.dev/runtime#NumCPU)/2 so half the number of logical CPUs available to viam-server |
+| `sync_interval_mins` | float | Optional | Frequency (in minutes) that data sync will walk the capture directory and additional sync paths and attempt to sync the files of all their subdirectories to the cloud. <br> Default: `0.1`, meaning once every 6 seconds. |
 
 {{% /tab %}}
 {{% tab name="viam-micro-server" %}}


### PR DESCRIPTION
Updates docs to reflect new data manager config defaults going in to next RDK release:
PR that introduced the changes:
https://github.com/viamrobotics/rdk/pull/4161

1. `sync_interval_mins` is and has always been the config key, this PR updates docs to match the viam-server implementation
2. `maximum_num_sync_threads` now has a new default. 