### PR TITLE
DOCS-2853: Add label_path attribute to mlmodel vision service

### DIFF
--- a/docs/services/vision/mlmodel.md
+++ b/docs/services/vision/mlmodel.md
@@ -131,6 +131,7 @@ The following attributes are available for an `mlmodel` detector or classifier:
 | `input_image_std_dev` | array | Optional | The standard deviation of the RGB (or BGR) values. Only required if the ML model service expects the input image to be normalized. <br> Default: `[0.5, 0.5, 0.5]` |
 | `default_minimum_confidence` | number | Optional | Set this to apply a minimum confidence score filter on all outputs. If left blank, no confidence filter is applied. <br> Example: `0.81` |
 | `label_confidences` | object | Optional | A map that filters on label names, applying a specified minimum confidence to a specific label. `label_confidences` overwrites `default_minimum_confidence`. If you set `label_confidences`, then `default_minimum_confidence` does not apply (the service will only use `label_confidences`). If you leave this attribute blank, no filtering on labels is applied. <br> Example: `{"DOG": 0.8, "CARROT": 0.3}` |
+| `label_path` | string | Optional | The path to a file containing labels for the ML model. Set this to overwrite the default label path for this model. |
 
 ### Tensor names
 

--- a/docs/services/vision/mlmodel.md
+++ b/docs/services/vision/mlmodel.md
@@ -131,7 +131,7 @@ The following attributes are available for an `mlmodel` detector or classifier:
 | `input_image_std_dev` | array | Optional | The standard deviation of the RGB (or BGR) values. Only required if the ML model service expects the input image to be normalized. <br> Default: `[0.5, 0.5, 0.5]` |
 | `default_minimum_confidence` | number | Optional | Set this to apply a minimum confidence score filter on all outputs. If left blank, no confidence filter is applied. <br> Example: `0.81` |
 | `label_confidences` | object | Optional | A map that filters on label names, applying a specified minimum confidence to a specific label. `label_confidences` overwrites `default_minimum_confidence`. If you set `label_confidences`, then `default_minimum_confidence` does not apply (the service will only use `label_confidences`). If you leave this attribute blank, no filtering on labels is applied. <br> Example: `{"DOG": 0.8, "CARROT": 0.3}` |
-| `label_path` | string | Optional | The path to a file containing labels for the ML model. Set this to overwrite the default label path for this model. |
+| `label_path` | string | Optional | The path to a file containing labels for the configured ML model. Set this to overwrite the default label path for this model. |
 
 ### Tensor names
 


### PR DESCRIPTION
* overwrites default label path
