### PR TITLE
docs(service/base-rc): fix control_mode instructions

### DIFF
--- a/docs/services/base-rc/_index.md
+++ b/docs/services/base-rc/_index.md
@@ -19,12 +19,12 @@ This uses the [`input` API](/components/input-controller/#api) to make it easy t
 
 Add the base remote control service after configuring your machine with a base and input controller to control the linear and angular velocity of the base with the controller's button or joystick controls.
 
-Control mode is determined by the configuration attribute `"mode"`, for which there are five options:
+Control mode is determined by the configuration attribute `"control_mode"`, for which there are five options:
 
 1. `"arrowControl"`: Arrow buttons control speed and angle
 2. `"triggerSpeedControl"`: Trigger button controls speed and joystick controls angle
 3. `"buttonControl"`: Four buttons (usually X, Y, A, B) control speed and angle
-4. `"joyStickControl"`: One joystick controls speed and angle
+4. `"joystickControl"`: One joystick controls speed and angle
 5. `"droneControl"`: Two joysticks control speed and angle
 
 You can monitor the input from these controls in the **CONTROL** tab of the [Viam app](https://app.viam.com).
@@ -106,7 +106,7 @@ The following attributes are available for base remote control services:
 | ---- | ---- | --------- | ----------- |
 | `base` | string | **Required** | The `name` of the [base](/components/base/) you have configured for the base you are operating with this service. |
 | `input_controller` | string | **Required** | The `name` of the [input controller](/components/input-controller/) you have configured for the base you are operating with this service. |
-| `control_mode` | string | Optional | The mode of remote control you want to use. <br> Options: <ul><li>`"arrowControl"`</li><li>`"triggerSpeedControl"`</li><li>`"buttonControl"`</li><li>`"joyStickControl"`</li> <li>`"droneControl"`</li></ul> <br> Default: `"arrowControl"` |
+| `control_mode` | string | Optional | The mode of remote control you want to use. <br> Options: <ul><li>`"arrowControl"`</li><li>`"triggerSpeedControl"`</li><li>`"buttonControl"`</li><li>`"joystickControl"`</li> <li>`"droneControl"`</li></ul> <br> Default: `"arrowControl"` |
 | `max_angular_degs_per_sec` | float | Optional | The max angular velocity for the [base](/components/base/) in degrees per second. |
 | `max_linear_mm_per_sec` | float | Optional | The max linear velocity for the [base](/components/base/) in meters per second. |
 


### PR DESCRIPTION
While helping a Discord community member configure a base remote control service to use the input controller's joysticks to control their base, following the current documentation around the `control_mode` attribute for the service did not work. After digging into [the code](https://github.com/viamrobotics/rdk/blob/main/services/baseremotecontrol/builtin/builtin.go#L130-L142) for the service, it appears to be a spelling discrepancy between the RDK and the docs. The docs specify "joyStickControl" as the expected mode name, while the RDK is looking for "joystickControl". 

I'm choosing to fix this in the docs as the quicker solution, however this could be seen as a bug in the RDK instead. If the latter is the better long term solution, please let me know and I will open the corresponding PR in that repo. In any case, I will probably still propose some validation logic to be added to the base-rc service to help catch these types of mistakes in the future. 
