### PR TITLE
Update air-quality-fleet to use new preferred pm_2_5 key

### DIFF
--- a/docs/tutorials/control/air-quality-fleet.md
+++ b/docs/tutorials/control/air-quality-fleet.md
@@ -545,7 +545,7 @@ The following instructions describe how to set up an API key for one location.
      for (const entry of alltheData) {
        if (entry.robot_id == machineID) {
          thedata.push({
-           PM25: entry.data.readings["pm_2.5"],
+           PM25: entry.data.readings["pm_2_5"],
            time: entry.time_received,
          });
        }


### PR DESCRIPTION
I changed the `pm_2.5` key to `pm_2_5` for my module.

`pm_2.5` still works (it is not backwards-breaking), but `pm_2_5` is the preferred new way to access this key.

(periods in the keys are painful)