### PR TITLE
[RSDK-9015][RSDK-9023][RSDK-9015] Remove Vectornav, renogy and dmc4000 from docs

### DIFF
--- a/docs/components/motor/28byj48.md
+++ b/docs/components/motor/28byj48.md
@@ -17,7 +17,7 @@ The `28byj48` model of the motor component supports small unipolar [stepper moto
 Viam also supports:
 
 - stepper motors with higher step resolution with the [`gpiostepper`](../gpiostepper/) model
-- advanced stepper driver chips like [TMC5072](../tmc5072/) or [DMC4000](../dmc4000/) that have their own microcontrollers that handle things like speed and acceleration control
+- advanced stepper driver chips like [TMC5072](../tmc5072/) that have their own microcontrollers that handle things like speed and acceleration control
 
 {{< /alert >}}
 

--- a/docs/components/motor/gpiostepper.md
+++ b/docs/components/motor/gpiostepper.md
@@ -15,7 +15,7 @@ usage: 900000
 The `gpiostepper` model of the motor component supports bipolar [stepper motors](https://en.wikipedia.org/wiki/Stepper_motor) controlled by basic stepper driver chips (such as [DRV8825](https://www.ti.com/product/DRV8825), [A4988](https://www.pololu.com/product/1182), or [TMC2209](https://www.trinamic.com/support/eval-kits/details/tmc2209-bob/)) that take step and direction input through GPIO and move the motor one step per pulse.
 
 {{< alert title="Tip" color="tip" >}}
-Viam also supports some more advanced stepper driver chips ([TMC5072](../tmc5072/), [DMC4000](../dmc4000/)) that have their own microcontrollers that handle things like speed and acceleration control.
+Viam also supports some more advanced stepper driver chips like the [TMC5072](../tmc5072/) that have their own microcontrollers that handle things like speed and acceleration control.
 {{< /alert >}}
 
 To use a `gpiostepper` motor as a component of your machine, first wire your motor to a suitable stepper motor driver, which is in turn wired to a board.


### PR DESCRIPTION
This pr removes the docs for the builtin imu-vectornav movement_sensor, dmc4000 motor, and renogy power_sensor.