### PR TITLE
DOCS-3009: Add token field to build-action for private build support

### DIFF
--- a/docs/how-tos/manage-modules.md
+++ b/docs/how-tos/manage-modules.md
@@ -137,6 +137,7 @@ jobs:
           ref: ${{ github.sha }}
           key-id: ${{ secrets.viam_key_id }}
           key-value: ${{ secrets.viam_key_value }}
+          token: ${{ github.token }} # only required for private git repos
 ```
 
 The `build-action` GitHub action relies on a build command that you need to specify in the <file>meta.json</file> file that you created for your module when you first [uploaded it](/how-tos/create-module/#upload-your-module-to-the-modular-resource-registry).


### PR DESCRIPTION
* adds line for token and description that this is only for private git repos
