### PR TITLE
Fix Markdown typo in CLI docs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -121,7 +121,7 @@ You can authenticate your CLI session using either a personal access token, or a
   ```
 
   {{< alert title="Note" color="note" >}}
-  To use an organization, location, or machine part API key to authenticate, you can create one from the organization's settings page in the [Viam app](https://app.viam.com) or authenticate with a personal access token and then [create an organization API key](#create-an-organization-api-key, a [location](#create-a-location-api-key), or a [machine part API key](#create-a-machine-part-api-key).
+  To use an organization, location, or machine part API key to authenticate, you can create one from the organization's settings page in the [Viam app](https://app.viam.com) or authenticate with a personal access token and then [create an organization API key](#create-an-organization-api-key), a [location](#create-a-location-api-key), or a [machine part API key](#create-a-machine-part-api-key).
   {{< /alert >}}
 
 An authenticated session is valid for 24 hours, unless you explicitly [log out](#logout).


### PR DESCRIPTION
Missing closing bracket for Markdown link: https://docs.viam.com/cli/
![image](https://github.com/user-attachments/assets/3847691e-0559-428c-b280-ab6b9de4f2a2)