### PR TITLE
Add missing `viam module create` step in hello world module docs

### DIFF
--- a/docs/how-tos/hello-world-module.md
+++ b/docs/how-tos/hello-world-module.md
@@ -766,11 +766,11 @@ To create the module in the registry, package your code (for Python), and upload
 
 1. Create the module in the registry, from within your <file>hello-world</file> directory, run the `viam module create` CLI command:
 
-    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-    viam module create --name <your-module-name> --org-id <your-org-id>
-    ```
+   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+   viam module create --name <your-module-name> --org-id <your-org-id>
+   ```
 
-    Get the `org-id` for your {{< glossary_tooltip term_id="organization" text="organization" >}} from your organization's **Settings** page in the [Viam app](https://app.viam.com/).
+   Get the `org-id` for your {{< glossary_tooltip term_id="organization" text="organization" >}} from your organization's **Settings** page in the [Viam app](https://app.viam.com/).
 
 2. Package the module as an archive, run the following command:
 
@@ -791,17 +791,17 @@ To create the module in the registry, package your code (for Python), and upload
 
 1. Create the module in the registry, from within your <file>hello-world</file> directory, run the `viam module create` CLI command:
 
-    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-    viam module create --name <your-module-name> --org-id <your-org-id>
-    ```
+   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+   viam module create --name <your-module-name> --org-id <your-org-id>
+   ```
 
-    Get the `org-id` for your {{< glossary_tooltip term_id="organization" text="organization" >}} from your organization's **Settings** page in the [Viam app](https://app.viam.com/).
+   Get the `org-id` for your {{< glossary_tooltip term_id="organization" text="organization" >}} from your organization's **Settings** page in the [Viam app](https://app.viam.com/).
 
 2. Run the `viam module upload` CLI command to upload the module to the registry:
 
-    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-    viam module upload --version 1.0.0 --platform any .
-    ```
+   ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+   viam module upload --version 1.0.0 --platform any .
+   ```
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/docs/how-tos/hello-world-module.md
+++ b/docs/how-tos/hello-world-module.md
@@ -764,7 +764,7 @@ To create the module in the registry, package your code (for Python), and upload
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-1. Create the module in the registry, from within your <file>hello-world</file> directory, run the `viam module upload` CLI command:
+1. Create the module in the registry, from within your <file>hello-world</file> directory, run the `viam module create` CLI command:
 
     ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
     viam module create --name <your-module-name> --org-id <your-org-id>
@@ -789,7 +789,7 @@ To create the module in the registry, package your code (for Python), and upload
 {{% /tab %}}
 {{% tab name="Go" %}}
 
-1. Create the module in the registry, from within your <file>hello-world</file> directory, run the `viam module upload` CLI command:
+1. Create the module in the registry, from within your <file>hello-world</file> directory, run the `viam module create` CLI command:
 
     ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
     viam module create --name <your-module-name> --org-id <your-org-id>

--- a/docs/how-tos/hello-world-module.md
+++ b/docs/how-tos/hello-world-module.md
@@ -759,12 +759,20 @@ The hello world module you created is for learning purposes, not to provide any 
 
 {{< /expand >}}
 
-To package (for Python) and upload your module and make it available to configure on machines in your organization:
+To create the module in the registry, package your code (for Python), and upload your module to make it available for use on machines in your organization:
 
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-1. Package the module as an archive, run the following command from inside the <file>hello-world</file> directory:
+1. Create the module in the registry, from within your <file>hello-world</file> directory, run the `viam module upload` CLI command:
+
+    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+    viam module create --name <your-module-name> --org-id <your-org-id>
+    ```
+
+    Get the `org-id` for your {{< glossary_tooltip term_id="organization" text="organization" >}} from your organization's **Settings** page in the [Viam app](https://app.viam.com/).
+
+2. Package the module as an archive, run the following command:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    tar -czf module.tar.gz run.sh setup.sh requirements.txt src
@@ -772,7 +780,7 @@ To package (for Python) and upload your module and make it available to configur
 
    This creates a tarball called <file>module.tar.gz</file>.
 
-1. Run the `viam module upload` CLI command to upload the module to the registry:
+3. Run the `viam module upload` CLI command to upload the module to the registry:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
    viam module upload --version 1.0.0 --platform any module.tar.gz
@@ -781,11 +789,19 @@ To package (for Python) and upload your module and make it available to configur
 {{% /tab %}}
 {{% tab name="Go" %}}
 
-From within your <file>hello-world</file> directory, run the `viam module upload` CLI command to upload the module to the registry:
+1. Create the module in the registry, from within your <file>hello-world</file> directory, run the `viam module upload` CLI command:
 
-```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-viam module upload --version 1.0.0 --platform any .
-```
+    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+    viam module create --name <your-module-name> --org-id <your-org-id>
+    ```
+
+    Get the `org-id` for your {{< glossary_tooltip term_id="organization" text="organization" >}} from your organization's **Settings** page in the [Viam app](https://app.viam.com/).
+
+2. Run the `viam module upload` CLI command to upload the module to the registry:
+
+    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+    viam module upload --version 1.0.0 --platform any .
+    ```
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
Was going through the [Create a Hello World module](https://docs.viam.com/how-tos/hello-world-module/#package-and-upload-the-module) doc and discovered that the `viam module create` step was missing, but that it was present in the dedicated [Upload a module to the Viam Registry](https://docs.viam.com/how-tos/upload-module/#upload-a-module) doc. Added in that information, for both Python and Go, and updated the language in the existing steps to be consistent with the change.

**Screenshots:**
![Screenshot 2024-12-09 at 5 25 31 PM](https://github.com/user-attachments/assets/a7fb2e48-9522-4cfc-a8e2-33f2f9d8ee45)
_Python_

![Screenshot 2024-12-09 at 5 25 37 PM](https://github.com/user-attachments/assets/1b085ca5-cbcf-4ebc-b56f-8dc1101a8f6b)
_Go_