### PR TITLE
DOCS-3233: Fix tabular data upload to include tip to include key readings for sensors 

### DIFF
--- a/static/include/app/apis/generated/data_sync.md
+++ b/static/include/app/apis/generated/data_sync.md
@@ -61,6 +61,7 @@ Uploaded tabular data can be found under the **Sensors** subtab of the app's [**
 **Parameters:**
 
 - `tabular_data` (List[Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]]) (required): List of the data to be uploaded, represented tabularly as a collection of dictionaries.
+  Must include the key `"readings"` for sensors.
 - `part_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): Part ID of the component used to capture the data.
 - `component_type` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): Type of the component used to capture the data (for example, “rdk:component:movement_sensor”).
 - `component_name` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): Name of the component used to capture the data.


### PR DESCRIPTION
* example is still correct, with a motor 
* tip from matt vella 