### PR TITLE
Update data-client.md remove support notice

### DIFF
--- a/docs/dev/reference/apis/data-client.md
+++ b/docs/dev/reference/apis/data-client.md
@@ -27,12 +27,6 @@ date: "2024-09-19"
 
 The data client API allows you to upload and retrieve data to and from the Viam Cloud.
 
-{{% alert title="Support Notice" color="note" %}}
-
-Data client API methods are only available in the Python SDK.
-
-{{% /alert %}}
-
 The data client API supports the following methods:
 
 Methods to upload data like images or sensor readings directly to the [Viam app](https://app.viam.com):


### PR DESCRIPTION
Vignesh pointed out that this is outdated as the data client API is now Golang, Python, Typescript, and Flutter SDKs. We have yet to add automation for any of those other ones but for now I thought removing the notice is a start to make it more accurate. 