### PR TITLE
DOCS-3412: Show left nav for tutorials and hidden pages

### DIFF
--- a/assets/js/toc.js
+++ b/assets/js/toc.js
@@ -58,7 +58,6 @@ if (toc) {
         let atLeastOne = false;
         let lastElem;
 
-        console.log(tocItems)
         for (var i = 0; i < tocItems.length; i++) {
             let item = tocItems[i];
             if (item && item.target) {

--- a/assets/js/toc.js
+++ b/assets/js/toc.js
@@ -58,6 +58,7 @@ if (toc) {
         let atLeastOne = false;
         let lastElem;
 
+        console.log(tocItems)
         for (var i = 0; i < tocItems.length; i++) {
             let item = tocItems[i];
             if (item && item.target) {

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -2856,6 +2856,15 @@ a.tree-root {
 
 // Top level nav END
 
+// For tutorials, make side nav heading smaller
+
+li.active-path.tutorial-heading > a {
+  color: #0000EA;
+  margin-top: 1rem;
+  font-size: 0.833rem;
+  font-weight: 600;
+}
+
 // Next page START
 
 #next-page {

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -232,11 +232,11 @@ a > code {
   color: #333333 !important;
 }
 
-.nav-fold * #TableOfContents ul li ul {
+#TableOfContents ul li ul {
   padding: 0;
 }
 
-.nav-fold * #TableOfContents ul li ul.is-collapsed {
+#TableOfContents ul li ul.is-collapsed {
   display: none;
 }
 

--- a/docs/dev/reference/contributing.md
+++ b/docs/dev/reference/contributing.md
@@ -5,6 +5,8 @@ weight: 99
 type: "docs"
 description: "Learn about our style guide and how to work with hugo to contribute to these docs."
 toc_hide: true
+aliases:
+  - /dev/contributing/
 ---
 
 Thank you for wanting to help us make the docs better.

--- a/docs/dev/tools/tutorials.md
+++ b/docs/dev/tools/tutorials.md
@@ -16,7 +16,7 @@ images:
     "/tutorials/try-viam-sdk/image1.gif",
   ]
 description: "Build a machine yourself by following along with a tutorial."
-no_list: true
+# no_list: true
 hide_children: true
 sitemap:
   priority: 1.0

--- a/docs/dev/tools/tutorials.md
+++ b/docs/dev/tools/tutorials.md
@@ -16,7 +16,7 @@ images:
     "/tutorials/try-viam-sdk/image1.gif",
   ]
 description: "Build a machine yourself by following along with a tutorial."
-# no_list: true
+no_list: true
 hide_children: true
 sitemap:
   priority: 1.0

--- a/docs/dev/tools/tutorials.md
+++ b/docs/dev/tools/tutorials.md
@@ -22,6 +22,7 @@ sitemap:
   priority: 1.0
 aliases:
   - /build/
+  - /tutorials/
 outputs:
   - rss
   - html

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -4,11 +4,10 @@ linkTitle: "Tutorials"
 weight: 300
 type: docs
 layout: "empty"
-hide_children: true
+# hide_children: true
 sitemap:
   priority: 1.0
-toc_hide: true
-canonical: "/dev/tools/tutorials/"
+toc_hide: false
 outputs:
   - rss
   - html

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -4,7 +4,6 @@ linkTitle: "Tutorials"
 weight: 300
 type: docs
 layout: "empty"
-# hide_children: true
 sitemap:
   priority: 1.0
 toc_hide: false

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -7,8 +7,8 @@ layout: "empty"
 hide_children: true
 sitemap:
   priority: 1.0
-hidden: true
-# canonical: "/dev/tools/tutorials/"
+toc_hide: true
+canonical: "/dev/tools/tutorials/"
 outputs:
   - rss
   - html

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -3,12 +3,12 @@ title: "Tutorials"
 linkTitle: "Tutorials"
 weight: 300
 type: docs
-hide_children: true
 layout: "empty"
-canonical: "/dev/tools/tutorials/"
+hide_children: true
 sitemap:
   priority: 1.0
 hidden: true
+# canonical: "/dev/tools/tutorials/"
 outputs:
   - rss
   - html

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -3,8 +3,9 @@ title: "Tutorials"
 linkTitle: "Tutorials"
 weight: 300
 type: docs
-layout: "tutorials"
 hide_children: true
+layout: "empty"
+canonical: "/dev/tools/tutorials/"
 sitemap:
   priority: 1.0
 hidden: true

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -73,6 +73,10 @@
           {{ end }}
           {{ if $s.Params.canonical }}<i class="fas fa-external-link-alt fa-sm"></i>{{ end }}
         </a>
+        {{ else }}
+          <a href="/dev/tools/tutorials/" target="{{ . }}" rel="noopener" class="">
+          <span> Tutorials </span>
+          </a>
         {{ end }}
       {{- end }}
       {{- if (or (and $withChild (not $treeRoot) ) (not $hideChildren) ) }}
@@ -105,6 +109,13 @@
   {{- end }}
   {{- if $withChild }}
     {{- if $hideChildren -}}
+      {{ if eq $p.Section "tutorials" }}
+      <li class="active-path tutorial-heading">
+        <a href="" title="{{ $p.Title }}" class="active">{{ $p.LinkTitle }}
+        </a>
+        <div class="td-toc" id="TableOfContents"></div>
+      </li>
+      {{ end }}
     {{- else -}}
       {{- $ulNr := add $ulNr 1 }}
       <ul class="ul-{{ $ulNr }}">

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -77,9 +77,9 @@
             {{ if $s.Params.canonical }}<i class="fas fa-external-link-alt fa-sm"></i>{{ end }}
           </a>
           {{ else }}
-            <a href="/dev/tools/tutorials/" target="{{ . }}" rel="noopener" class="">
+            <!-- <a href="/dev/tools/tutorials/" target="{{ . }}" rel="noopener" class="">
             <span> Tutorials </span>
-            </a>
+            </a> -->
           {{ end }}
         {{- end }}
       {{- end }}
@@ -114,11 +114,11 @@
   {{- if $withChild }}
     {{- if $hideChildren -}}
       {{ if eq $p.Section "tutorials" }}
-      <li class="active-path tutorial-heading">
+      <!-- <li class="active-path tutorial-heading">
         <a href="" title="{{ $p.Title }}" class="active">{{ $p.LinkTitle }}
         </a>
         <div class="td-toc" id="TableOfContents"></div>
-      </li>
+      </li> -->
       {{ end }}
     {{- else -}}
       {{- $ulNr := add $ulNr 1 }}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -53,6 +53,24 @@
 {{ $toc_hide := $s.Params.toc_hide -}}
 {{ $openOnDesk := $s.Params.open_on_desktop }}
 {{ $headerOnly := $s.Params.header_only }}
+
+{{ warnf "1!%s %s %s" $p $p.Section}}
+
+{{ if eq $p.Section "tutorials"}}
+<!-- If this is a tutorial -->
+<a href="/dev/tools/tutorials/" target="{{ . }}" rel="noopener" class="">
+<span> Tutorials </span>
+</a>
+<li class="active-path tutorial-heading">
+  <a href="" title="{{ $p.Title }}" class="active">{{ $p.LinkTitle }}
+  </a>
+  <div class="td-toc" id="TableOfContents"></div>
+</li>
+
+{{ warnf "2!%s" $p }}
+
+{{ else }}
+
 {{ if or (not $toc_hide) ($activePath)}}
 <li class="{{ if $withChild }}nav-fold{{ end }}{{ if $activePath }} active-path{{ else }}{{ if $p.Parent }} hide-if-desktop{{ end }}{{ end }}{{ if (not (or $show $p.Site.Params.ui.sidebar_menu_foldable )) }} {{ if not $activePath }}collapse{{ end }}{{ end }}{{ if $empty_node }} empty-node-submenu{{ end }}{{if $s.Params.menuindent }} indent{{ end }}{{ if $openOnDesk }} open-on-desktop{{ end }}{{ if $headerOnly }} header-only{{ end }}" >
   {{ if (and $p.Site.Params.ui.sidebar_menu_foldable (ge $ulNr 1)) -}}
@@ -77,9 +95,6 @@
             {{ if $s.Params.canonical }}<i class="fas fa-external-link-alt fa-sm"></i>{{ end }}
           </a>
           {{ else }}
-            <a href="/dev/tools/tutorials/" target="{{ . }}" rel="noopener" class="">
-            <span> Tutorials </span>
-            </a>
           {{ end }}
         {{- end }}
       {{- end }}
@@ -113,13 +128,6 @@
   {{- end }}
   {{- if $withChild }}
     {{- if $hideChildren -}}
-      {{ if eq $p.Section "tutorials" }}
-      <li class="active-path tutorial-heading">
-        <a href="" title="{{ $p.Title }}" class="active">{{ $p.LinkTitle }}
-        </a>
-        <div class="td-toc" id="TableOfContents"></div>
-      </li>
-      {{ end }}
     {{- else -}}
       {{- $ulNr := add $ulNr 1 }}
       <ul class="ul-{{ $ulNr }}">
@@ -132,3 +140,4 @@
 </li>
 {{- end }}
 {{- end }}
+{{- end}}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -77,9 +77,9 @@
             {{ if $s.Params.canonical }}<i class="fas fa-external-link-alt fa-sm"></i>{{ end }}
           </a>
           {{ else }}
-            <!-- <a href="/dev/tools/tutorials/" target="{{ . }}" rel="noopener" class="">
+            <a href="/dev/tools/tutorials/" target="{{ . }}" rel="noopener" class="">
             <span> Tutorials </span>
-            </a> -->
+            </a>
           {{ end }}
         {{- end }}
       {{- end }}
@@ -114,11 +114,11 @@
   {{- if $withChild }}
     {{- if $hideChildren -}}
       {{ if eq $p.Section "tutorials" }}
-      <!-- <li class="active-path tutorial-heading">
+      <li class="active-path tutorial-heading">
         <a href="" title="{{ $p.Title }}" class="active">{{ $p.LinkTitle }}
         </a>
         <div class="td-toc" id="TableOfContents"></div>
-      </li> -->
+      </li>
       {{ end }}
     {{- else -}}
       {{- $ulNr := add $ulNr 1 }}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -43,15 +43,17 @@
 {{ $activePath := and (not $shouldDelayActive) (or ($p.IsDescendant $s) (eq $p $s)) -}}
 {{ $show := cond (or (lt $ulNr $ulShow) $activePath (and (not $shouldDelayActive) (eq $s.Parent $p.Parent)) (and (not $shouldDelayActive) (eq $s.Parent $p)) (not $p.Site.Params.ui.sidebar_menu_compact) (and (not $shouldDelayActive) ($p.IsDescendant $s.Parent))) true false -}}
 {{ $mid := printf "m-%s" ($s.RelPermalink | anchorize) -}}
-{{ $pages_tmp := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true -}}
+{{ $pages_tmp := (union $s.Pages $s.Sections).ByWeight -}}
 {{ $pages := $pages_tmp | first $sidebarMenuTruncate -}}
 {{ $withChild := gt (len $pages) 0 -}}
 {{ $hideChildren := cond (isset $s.Params "hide_children") true false -}}
 {{ $manualLink := cond (isset $s.Params "manuallink") $s.Params.manualLink ( cond (isset $s.Params "manuallinkrelref") (relref $s $s.Params.manualLinkRelref) $s.RelPermalink) -}}
 {{ $manualLinkTitle := cond (isset $s.Params "manuallinktitle") $s.Params.manualLinkTitle $s.Title -}}
 {{ $empty_node := $s.Params.empty_node -}}
+{{ $toc_hide := $s.Params.toc_hide -}}
 {{ $openOnDesk := $s.Params.open_on_desktop }}
 {{ $headerOnly := $s.Params.header_only }}
+{{ if or (not $toc_hide) ($activePath)}}
 <li class="{{ if $withChild }}nav-fold{{ end }}{{ if $activePath }} active-path{{ else }}{{ if $p.Parent }} hide-if-desktop{{ end }}{{ end }}{{ if (not (or $show $p.Site.Params.ui.sidebar_menu_foldable )) }} {{ if not $activePath }}collapse{{ end }}{{ end }}{{ if $empty_node }} empty-node-submenu{{ end }}{{if $s.Params.menuindent }} indent{{ end }}{{ if $openOnDesk }} open-on-desktop{{ end }}{{ if $headerOnly }} header-only{{ end }}" >
   {{ if (and $p.Site.Params.ui.sidebar_menu_foldable (ge $ulNr 1)) -}}
   <input type="checkbox" id="{{ $mid }}-check"{{ if $activePath}} checked{{ end }}/>
@@ -60,24 +62,26 @@
   {{ else -}}
   {{- if $withChild }}
     <span>
-      {{ if $empty_node }}
-      <!-- IF EMPTY NODE WITH CHILDREN -->
-        <span class="emptynode {{ if $active}}active{{ end }} {{ if $treeRoot }} tree-root{{ end }}">{{ $s.LinkTitle }}</span>
-      {{ else }}
-        {{ if not (eq $s.LinkTitle "Tutorials") }}
-        <a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="{{ if $active}} active{{ end }}{{ if $treeRoot }} tree-root{{ end }}">
-          {{ if $s.Params.overview }}
-          <span class="section-overview"> Overview </span><span class="section-overview-title"> {{ $s.LinkTitle }} </span>
-          {{ else }}
-          <span> {{ $s.LinkTitle }} </span>
-          {{ end }}
-          {{ if $s.Params.canonical }}<i class="fas fa-external-link-alt fa-sm"></i>{{ end }}
-        </a>
+      {{ if or (not $toc_hide) ($activePath)}}
+        {{ if $empty_node }}
+        <!-- IF EMPTY NODE WITH CHILDREN -->
+          <span class="emptynode {{ if $active}}active{{ end }} {{ if $treeRoot }} tree-root{{ end }}">{{ $s.LinkTitle }}</span>
         {{ else }}
-          <a href="/dev/tools/tutorials/" target="{{ . }}" rel="noopener" class="">
-          <span> Tutorials </span>
+          {{ if not (eq $s.LinkTitle "Tutorials") }}
+          <a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="{{ if $active}} active{{ end }}{{ if $treeRoot }} tree-root{{ end }}">
+            {{ if $s.Params.overview }}
+            <span class="section-overview"> Overview </span><span class="section-overview-title"> {{ $s.LinkTitle }} </span>
+            {{ else }}
+            <span> {{ $s.LinkTitle }} </span>
+            {{ end }}
+            {{ if $s.Params.canonical }}<i class="fas fa-external-link-alt fa-sm"></i>{{ end }}
           </a>
-        {{ end }}
+          {{ else }}
+            <a href="/dev/tools/tutorials/" target="{{ . }}" rel="noopener" class="">
+            <span> Tutorials </span>
+            </a>
+          {{ end }}
+        {{- end }}
       {{- end }}
       {{- if (or (and $withChild (not $treeRoot) ) (not $hideChildren) ) }}
       {{- if (or $hideChildren $treeRoot) -}}
@@ -126,4 +130,5 @@
     {{- end }}
   {{- end }}
 </li>
+{{- end }}
 {{- end }}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -66,7 +66,7 @@
 </li>
 {{ else }}
 
-{{ if or (not $toc_hide) ($activePath)}}
+{{ if or ( or (not $toc_hide) ($activePath) ) $active }}
 <li class="{{ if $withChild }}nav-fold{{ end }}{{ if $activePath }} active-path{{ else }}{{ if $p.Parent }} hide-if-desktop{{ end }}{{ end }}{{ if (not (or $show $p.Site.Params.ui.sidebar_menu_foldable )) }} {{ if not $activePath }}collapse{{ end }}{{ end }}{{ if $empty_node }} empty-node-submenu{{ end }}{{if $s.Params.menuindent }} indent{{ end }}{{ if $openOnDesk }} open-on-desktop{{ end }}{{ if $headerOnly }} header-only{{ end }}" >
   {{ if (and $p.Site.Params.ui.sidebar_menu_foldable (ge $ulNr 1)) -}}
   <input type="checkbox" id="{{ $mid }}-check"{{ if $activePath}} checked{{ end }}/>
@@ -122,7 +122,7 @@
   {{ end }}
   {{- end }}
   {{- if $withChild }}
-    {{- if $hideChildren -}}
+    {{- if and ($hideChildren) (not $activePath) -}}
     {{- else -}}
       {{- $ulNr := add $ulNr 1 }}
       <ul class="ul-{{ $ulNr }}">

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -54,8 +54,6 @@
 {{ $openOnDesk := $s.Params.open_on_desktop }}
 {{ $headerOnly := $s.Params.header_only }}
 
-{{ warnf "1!%s %s %s" $p $p.Section}}
-
 {{ if eq $p.Section "tutorials"}}
 <!-- If this is a tutorial -->
 <a href="/dev/tools/tutorials/" target="{{ . }}" rel="noopener" class="">
@@ -66,9 +64,6 @@
   </a>
   <div class="td-toc" id="TableOfContents"></div>
 </li>
-
-{{ warnf "2!%s" $p }}
-
 {{ else }}
 
 {{ if or (not $toc_hide) ($activePath)}}


### PR DESCRIPTION
This cleans up the sidenav for hidden pages and tutorials. Previously this would be either empty or not show the active path. Now it will show something sensible:

- For tutorials it will show a link to the tutorials page and the table of contents.
- For hidden pages, it will show the path to the page if we're on the page and hide it otherwise.