### PR TITLE
Fix bug that added the expand icon for tutorials

### DIFF
--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -7,6 +7,8 @@ layout: "empty"
 sitemap:
   priority: 1.0
 toc_hide: false
+# do not remove hide children - it causes a layout issue
+hide_children: true
 outputs:
   - rss
   - html


### PR DESCRIPTION
We need to hide children to ensure the tutorials aren't put into the side nav