### PR TITLE
DOCS-3377: Add link to architecture from each reference section

### DIFF
--- a/docs/data-ai/reference/architecture.md
+++ b/docs/data-ai/reference/architecture.md
@@ -1,0 +1,9 @@
+---
+linkTitle: "Machine-cloud architecture"
+title: "Viam Architecture"
+weight: 1000
+layout: "docs"
+type: "docs"
+layout: "empty"
+canonical: "/operate/reference/architecture/"
+---

--- a/docs/dev/reference/architecture.md
+++ b/docs/dev/reference/architecture.md
@@ -1,0 +1,9 @@
+---
+linkTitle: "Architecture"
+title: "Viam Architecture"
+weight: 1000
+layout: "docs"
+type: "docs"
+layout: "empty"
+canonical: "/operate/reference/architecture/"
+---

--- a/docs/manage/reference/architecture.md
+++ b/docs/manage/reference/architecture.md
@@ -1,0 +1,9 @@
+---
+linkTitle: "Architecture of a machine"
+title: "Viam Architecture"
+weight: 65
+layout: "docs"
+type: "docs"
+layout: "empty"
+canonical: "/operate/reference/architecture/"
+---


### PR DESCRIPTION
Made link titles that are hopefully helpful in each separate context. For example, in Manage, didn't want people confused between this and Organize machines.
