### PR TITLE
DOCS-3456: Raspberry pi ai camera IMX500 not officially supported

### DIFF
--- a/docs/operate/reference/components/camera/webcam.md
+++ b/docs/operate/reference/components/camera/webcam.md
@@ -239,6 +239,7 @@ If you are capturing camera data, it can happen that the camera captures and syn
 {{% expand "CSI Camera not working on a Raspberry Pi" %}}
 If you are using a CSI camera v1.3 or v2.0 on a Raspberry Pi, you need to [enable legacy mode](/operate/reference/prepare/rpi-setup/#enable-communication-protocols).
 If you are using a CSI camera v3.0, you need to use the [`viam:camera:csi` module](https://github.com/viamrobotics/csi-camera/) instead.
+IMX500 AI cameras are not offically supported.
 {{% /expand%}}
 
 {{% expand "High CPU usage" %}}


### PR DESCRIPTION
* got a question or two about it and sean said it should be the ai camera module but that he hasn't tested with this and it doesn't look like it will work bc requires additional firmware installs