### PR TITLE
DOCS-3423: Update training script to parse labels based on feedback from etai/tahiya

### DIFF
--- a/docs/data-ai/ai/train.md
+++ b/docs/data-ai/ai/train.md
@@ -115,6 +115,8 @@ DEFAULT_EPOCHS = 200
 # the ML model that this script creates should be stored.
 # The data_json variable will contain the metadata for the dataset
 # that you should use to train the model.
+
+
 def parse_args():
     """Returns dataset file, model output directory, and num_epochs
     if present. These must be parsed as command line arguments and then used

--- a/docs/data-ai/ai/train.md
+++ b/docs/data-ai/ai/train.md
@@ -303,7 +303,7 @@ if __name__ == "__main__":
 
 {{% /expand %}}
 
-{{% expand "Click to see the template with labels parsed" %}}
+{{% expand "Click to see the template with parsed labels" %}}
 
 ```python {class="line-numbers linkable-line-numbers" data-line="148" }
 import argparse

--- a/docs/data-ai/ai/train.md
+++ b/docs/data-ai/ai/train.md
@@ -92,13 +92,13 @@ If you haven't already, create a folder called <file>model</file> and create an 
 
 {{% expand "Click to see the template" %}}
 
-```python {class="line-numbers linkable-line-numbers" data-line="140" }
+```python {class="line-numbers linkable-line-numbers" data-line="148" }
 import argparse
 import json
 import os
 import typing as ty
 from tensorflow.keras import Model  # Add proper import
-import tensorflow as tf # Add proper import
+import tensorflow as tf  # Add proper import
 
 single_label = "MODEL_TYPE_SINGLE_LABEL_CLASSIFICATION"
 multi_label = "MODEL_TYPE_MULTI_LABEL_CLASSIFICATION"
@@ -115,34 +115,42 @@ DEFAULT_EPOCHS = 200
 # the ML model that this script creates should be stored.
 # The data_json variable will contain the metadata for the dataset
 # that you should use to train the model.
+
+
 def parse_args():
-    """Returns dataset file, model output directory, labels, and num_epochs if present.
-    These must be parsed as command line arguments and then used as the model
-    input and output, respectively. The number of epochs can be used to
-    optionally override the default.
+    """Returns dataset file, model output directory, labels, and num_epochs
+    if present. These must be parsed as command line arguments and then used
+    as the model input and output, respectively. The number of epochs can be
+    used to optionally override the default.
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument("--dataset_file", dest="data_json", type=str, required=True)
-    parser.add_argument("--model_output_directory", dest="model_dir", type=str, required=True)
+    parser.add_argument("--dataset_file", dest="data_json",
+                        type=str, required=True)
+    parser.add_argument("--model_output_directory", dest="model_dir",
+                        type=str, required=True)
     parser.add_argument("--num_epochs", dest="num_epochs", type=int)
     parser.add_argument(
         "--labels",
         dest="labels",
         type=str,
         required=True,
-        help="Space-separated list of labels, enclosed in single quotes (e.g., 'label1 label2').",
+        help="Space-separated list of labels, \
+            enclosed in single quotes (e.g., 'label1 label2').",
     )
     args = parser.parse_args()
-    
+
     if not args.labels:
         raise ValueError("Labels must be provided")
-        
+
     labels = [label.strip() for label in args.labels.strip("'").split()]
     return args.data_json, args.model_dir, args.num_epochs, labels
+
 
 # This is used for parsing the dataset file (produced and stored in Viam),
 # parse it to get the label annotations
 # Used for training classifiction models
+
+
 def parse_filenames_and_labels_from_json(
     filename: str, all_labels: ty.List[str], model_type: str
 ) -> ty.Tuple[ty.List[str], ty.List[str]]:
@@ -265,11 +273,11 @@ def save_model(
     # Save the model to the output directory
     file_type = "tflite"  # Add proper file type
     filename = os.path.join(model_dir, f"{model_name}.{file_type}")
-    
+
     # Example: Convert to TFLite
     converter = tf.lite.TFLiteConverter.from_keras_model(model)
     tflite_model = converter.convert()
-    
+
     # Save the model
     with open(filename, "wb") as f:
         f.write(tflite_model)
@@ -289,7 +297,8 @@ if __name__ == "__main__":
 
     # Validate epochs
     epochs = (
-        DEFAULT_EPOCHS if NUM_EPOCHS is None or NUM_EPOCHS <= 0 else int(NUM_EPOCHS)
+        DEFAULT_EPOCHS if NUM_EPOCHS is None
+        or NUM_EPOCHS <= 0 else int(NUM_EPOCHS)
     )
 
     # Build and compile model on data

--- a/docs/data-ai/ai/train.md
+++ b/docs/data-ai/ai/train.md
@@ -261,6 +261,7 @@ def save_model(
         model_dir: output directory for model artifacts
         model_name: name of saved model
     """
+    # Save the model to the output directory
     file_type = "tflite"  # Add proper file type
     filename = os.path.join(model_dir, f"{model_name}.{file_type}")
     

--- a/docs/data-ai/ai/train.md
+++ b/docs/data-ai/ai/train.md
@@ -88,7 +88,7 @@ If you haven't already, create a folder called <file>model</file> and create an 
 
 <p><strong>4. Add <code>training.py</code> code</strong></p>
 
-<p>Copy one of the following templates into <file>training.py</file>, depending on whether or not you wish to parse labels instead of having to hard code the labels in the training script and re-upload for each set of labels, allowing you to more easily reuse training scripts:</p>
+<p>Copy one of the following templates into <file>training.py</file>, depending on whether or not you wish to parse labels instead of having to hard code the labels in the training script and re-upload for each set of labels, which allows you to more easily reuse training scripts:</p>
 
 {{% expand "Click to see the template without parsing labels (recommended for use with UI)" %}}
 

--- a/docs/data-ai/ai/train.md
+++ b/docs/data-ai/ai/train.md
@@ -88,7 +88,8 @@ If you haven't already, create a folder called <file>model</file> and create an 
 
 <p><strong>4. Add <code>training.py</code> code</strong></p>
 
-<p>Copy one of the following templates into <file>training.py</file>, depending on whether or not you wish to parse labels instead of having to hard code the labels in the training script and re-upload for each set of labels, which allows you to more easily reuse training scripts:</p>
+<p>You can set up your training script to use a hard coded set of labels or allow users to pass in a set of labels when using the training script. Allowing users to pass in labels when using training scripts makes your training script more flexible for reuse.</p>
+<p>Copy one of the following templates into <file>training.py</file>, depending on how you want to handle labels:</p>
 
 {{% expand "Click to see the template without parsing labels (recommended for use with UI)" %}}
 
@@ -541,7 +542,7 @@ The script you are creating must take the following command line inputs:
 - `dataset_file`: a file containing the data and metadata for the training job
 - `model_output_directory`: the location where the produced model artifacts are saved to
 
-If you used the version with parsed labels, it will also take the following command line inputs:
+If you used the training script template that allows users to pass in labels, it will also take the following command line inputs:
 
 - `labels`: space separated list of labels, enclosed in single quotes
 
@@ -793,7 +794,7 @@ In the Viam app, navigate to your list of [**DATASETS**](https://app.viam.com/da
 Click **Train model** and select **Train on a custom training script**, then follow the prompts.
 
 {{% alert title="Tip" color="tip" %}}
-If you used the version of <file>training.py</file> with parsed labels, your training job will fail with the error `ERROR training.py: error: the following arguments are required: --labels`.
+If you used the version of <file>training.py</file> that allows users to pass in labels, your training job will fail with the error `ERROR training.py: error: the following arguments are required: --labels`.
 To use labels, you must use the CLI.
 {{% /alert %}}
 

--- a/docs/data-ai/ai/train.md
+++ b/docs/data-ai/ai/train.md
@@ -72,8 +72,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        "google-cloud-aiplatform",
-        "google-cloud-storage",
         # TODO: Add additional required packages
     ],
 )
@@ -124,6 +122,13 @@ def parse_args():
     parser.add_argument("--dataset_file", dest="data_json", type=str)
     parser.add_argument("--model_output_directory", dest="model_dir", type=str)
     parser.add_argument("--num_epochs", dest="num_epochs", type=int)
+    parser.add_argument(
+        "--labels",
+        dest="labels",
+        type=str,
+        required=False,
+        help="Space-separated list of labels, enclosed in single quotes (e.g., 'label1 label2').",
+    )
     args = parser.parse_args()
     return args.data_json, args.model_dir, args.num_epochs
 

--- a/docs/data-ai/ai/train.md
+++ b/docs/data-ai/ai/train.md
@@ -92,7 +92,7 @@ If you haven't already, create a folder called <file>model</file> and create an 
 
 {{% expand "Click to see the template" %}}
 
-```python {class="line-numbers linkable-line-numbers" data-line="139" }
+```python {class="line-numbers linkable-line-numbers" data-line="140" }
 import argparse
 import json
 import os

--- a/docs/data-ai/ai/train.md
+++ b/docs/data-ai/ai/train.md
@@ -88,7 +88,7 @@ If you haven't already, create a folder called <file>model</file> and create an 
 
 <p><strong>4. Add <code>training.py</code> code</strong></p>
 
-<p>Copy one of the following templates into <file>training.py</file>, depending on whether or not you wish to parse labels:</p>
+<p>Copy one of the following templates into <file>training.py</file>, depending on whether or not you wish to parse labels instead of having to hard code the labels in the training script and re-upload for each set of labels, allowing you to more easily reuse training scripts:</p>
 
 {{% expand "Click to see the template without parsing labels (recommended for use with UI)" %}}
 
@@ -541,7 +541,7 @@ The script you are creating must take the following command line inputs:
 - `dataset_file`: a file containing the data and metadata for the training job
 - `model_output_directory`: the location where the produced model artifacts are saved to
 
-If you used the version with labels parsed, it will also take the following command line inputs:
+If you used the version with parsed labels, it will also take the following command line inputs:
 
 - `labels`: space separated list of labels, enclosed in single quotes
 
@@ -793,8 +793,8 @@ In the Viam app, navigate to your list of [**DATASETS**](https://app.viam.com/da
 Click **Train model** and select **Train on a custom training script**, then follow the prompts.
 
 {{% alert title="Tip" color="tip" %}}
-If you used the version of <file>training.py</file> with labels parsed, your training job will fail with the error `ERROR training.py: error: the following arguments are required: --labels`.
-Use the CLI and enter labels.
+If you used the version of <file>training.py</file> with parsed labels, your training job will fail with the error `ERROR training.py: error: the following arguments are required: --labels`.
+To use labels, you must use the CLI.
 {{% /alert %}}
 
 {{% /tab %}}

--- a/docs/data-ai/ai/train.md
+++ b/docs/data-ai/ai/train.md
@@ -130,7 +130,7 @@ def parse_args():
         help="Space-separated list of labels, enclosed in single quotes (e.g., 'label1 label2').",
     )
     args = parser.parse_args()
-    return args.data_json, args.model_dir, args.num_epochs
+    return args.data_json, args.model_dir, args.num_epochs, args.labels
 
 
 # This is used for parsing the dataset file (produced and stored in Viam),
@@ -264,14 +264,11 @@ def save_model(
 
 
 if __name__ == "__main__":
-    DATA_JSON, MODEL_DIR = parse_args()
+    DATA_JSON, MODEL_DIR, NUM_EPOCHS, LABELS = parse_args()
 
     IMG_SIZE = (256, 256)
 
     # Read dataset file.
-    # TODO: change labels to the desired model output.
-    LABELS = ["orange_triangle", "blue_star"]
-
     # The model type can be changed based on whether you want the model to
     # output one label per image or multiple labels per image
     model_type = multi_label

--- a/docs/data-ai/ai/train.md
+++ b/docs/data-ai/ai/train.md
@@ -327,6 +327,7 @@ The script you are creating must take the following command line inputs:
 
 - `dataset_file`: a file containing the data and metadata for the training job
 - `model_output_directory`: the location where the produced model artifacts are saved to
+- `labels`: space separated list of labels, enclosed in single quotes
 
 The `parse_args()` function in the template parses your arguments.
 

--- a/docs/data-ai/ai/train.md
+++ b/docs/data-ai/ai/train.md
@@ -222,7 +222,8 @@ def parse_filenames_and_bboxes_from_json(
 
 # Build the model
 def build_and_compile_model(
-    labels: ty.List[str], model_type: str, input_shape: ty.Tuple[int, int, int]) -> Model:
+    labels: ty.List[str], model_type: str, input_shape: ty.Tuple[int, int, int]
+) -> Model:
     """Builds and compiles a model
     Args:
         labels: list of string lists, where each string list contains up to

--- a/docs/data-ai/ai/train.md
+++ b/docs/data-ai/ai/train.md
@@ -92,7 +92,7 @@ If you haven't already, create a folder called <file>model</file> and create an 
 
 {{% expand "Click to see the template without parsing labels (recommended for use with UI)" %}}
 
-```python {class="line-numbers linkable-line-numbers" data-line="132" }
+```python {class="line-numbers linkable-line-numbers" data-line="134" }
 import argparse
 import json
 import os


### PR DESCRIPTION
* parsing labels and adding validation for num_epochs (used later if they decide to implement a fit function)
* removing google cloud imports bc already gets imported 
Manual testing notes:
* did test and successfully submitted training job with the labels which succeeded with cli (not with UI bc you have to put labels in the arg, put notes for that on docs and made alternate template with the corrections I found but without parsing labels)