### PR TITLE
DOCS-3481: Add billing fragment

### DIFF
--- a/docs/manage/fleet/reuse-configuration.md
+++ b/docs/manage/fleet/reuse-configuration.md
@@ -53,7 +53,7 @@ In your machine's **CONFIGURE** tab, switch to **JSON** and copy the raw JSON.
 {{<imgproc src="/how-tos/one-to-many/raw-json.png" resize="700x" class="fill aligncenter" style="width: 400px" declaredimensions=true alt="JSON subtab of the CONFIGURE tab">}}
 
 {{% /tablestep %}}
-{{% tablestep link="/manage/fleet/reuse-configuration/" %}}
+{{% tablestep %}}
 **3. Create a fragment**
 
 On the **FLEET** page, go to the [**FRAGMENTS** tab](https://app.viam.com/fragments).

--- a/docs/manage/manage/white-labelled-billing.md
+++ b/docs/manage/manage/white-labelled-billing.md
@@ -15,6 +15,7 @@ Once set up:
 
 - You will have a branded billing dashboard for each org
 - Invoices will be sent from your provided support email address and will contain your provided logo
+- You can set custom pricing
 
 {{<imgproc src="/operate/wlbilling.png" resize="1000x" declaredimensions=true alt="Example billing dashboard" style="width:600px" class="imgzoom">}}
 
@@ -104,6 +105,35 @@ https://app.viam.com/billing/<public-namespace>?id=<org-id>
 ```
 
 {{<imgproc src="/operate/wlbilling.png" resize="1000x" declaredimensions=true alt="Example billing dashboard" style="width:600px" class="imgzoom">}}
+
+{{% /tablestep %}}
+{{< /table >}}
+
+## Set custom pricing
+
+You can set custom pricing for machines within your organization:
+
+{{< table >}}
+{{% tablestep link="" %}}
+**1. Create a fragment with billing information**
+
+For example:
+
+```json {class="line-numbers linkable-line-numbers" data-line="5"}
+{
+  "billing": {
+    "cost_per_month": {
+      "per_machine": 10
+    },
+    "tier_name": "not-free"
+  }
+}
+```
+
+{{% /tablestep %}}
+{{% tablestep link="/manage/fleet/reuse-configuration/" %}}
+**2. Add the fragment to each machine**
+
 
 {{% /tablestep %}}
 {{< /table >}}

--- a/docs/manage/manage/white-labelled-billing.md
+++ b/docs/manage/manage/white-labelled-billing.md
@@ -120,7 +120,7 @@ You can set custom pricing for machines within your organization.
 On the **FLEET** page, go to the [**FRAGMENTS** tab](https://app.viam.com/fragments) and select the fragment you use for your machines.
 If you are not using a fragment, you can instead add the billing configuration to individual machine configurations.
 
-In the JSON configuration, add the `billing`  object, adjust attributes as needed and save.
+In the JSON configuration, add the `billing` object, adjust attributes as needed and save.
 
 {{< tabs >}}
 {{% tab name="Example" %}}

--- a/docs/manage/manage/white-labelled-billing.md
+++ b/docs/manage/manage/white-labelled-billing.md
@@ -117,9 +117,15 @@ You can set custom pricing for machines within your organization:
 {{% tablestep link="" %}}
 **1. Create a fragment with billing information**
 
-For example:
+On the **FLEET** page, go to the [**FRAGMENTS** tab](https://app.viam.com/fragments).
 
-```json {class="line-numbers linkable-line-numbers" data-line="5"}
+Click **Create fragment**, and paste the following JSON configuration into it.
+Adjust attributes as needed and save.
+
+{{< tabs >}}
+{{% tab name="Example" %}}
+
+```json { class="line-numbers linkable-line-numbers" }
 {
   "billing": {
     "cost_per_month": {
@@ -130,9 +136,74 @@ For example:
 }
 ```
 
+{{% /tab %}}
+{{% tab name="Full Template" %}}
+
+```json
+{
+  "billing": {
+    "cost_per_month": {
+      "per_machine": 0,
+      "binary_data_upload_bytes": 0.0,
+      "binary_data_egress_bytes": 0.0,
+      "binary_data_cloud_storage_bytes": 0.0,
+      "tabular_data_upload_bytes": 0.0,
+      "tabular_data_egress_bytes": 0.0,
+      "tabular_data_cloud_storage_bytes": 0.0,
+      "history_cloud_storage_bytes": 0.0,
+      "logs_cloud_storage_bytes": 0.0,
+      "logs_data_upload_bytes": 0.0,
+      "logs_data_egress_bytes": 0.0
+    },
+    "tier_name": "example-tier",
+    "description": "",
+    "tier_credit": 0.0
+  }
+}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+{{% expand "Click to view billing attributes" %}}
+
+<!-- prettier-ignore -->
+| Name | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `cost_per_month` | object | Optional | See [cost per month attributes](/manage/manage/white-labelled-billing/#click-to-view-cost-per-month-attributes). Default: `{}` (all machines cost `0`). |
+| `tier_name` | string | **Required** | The name of the billing tier. |
+| `description` |  | Optional | Description for the billing tier. Default: `""`. |
+| `tier_credit` | number | Optional | Credit that should be applied to final total for the org. Default: `0`. |
+
+{{% /expand%}}
+
+
+{{% expand "Click to view cost per month attributes" %}}
+
+<!-- prettier-ignore -->
+| Name | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `per_machine` | number | Optional | Charge a flat fee per machine. Default: `0`. |
+| `binary_data_upload_bytes` | float | Optional | Cost per byte for binary data upload. Default: `0`. |
+| `binary_data_egress_bytes` | float | Optional | Cost per byte for binary data download. Default: `0`. |
+| `binary_data_cloud_storage_bytes` | float | Optional | Cost per byte per month for binary data stored. Default: `0`. |
+| `tabular_data_upload_bytes` |  | Optional | Cost per byte per month for tabular data upload. Default: `0`. |
+| `tabular_data_egress_bytes` |  | Optional | Cost per byte per month for tabular data egress. Default: `0`. |
+| `tabular_data_cloud_storage_bytes` |  | Optional | Cost per byte per month for tabular data cloud storage. Default: `0`. |
+| `history_cloud_storage_bytes` |  | Optional | Cost per byte per month for config history stored. Default: `0`. |
+| `logs_cloud_storage_bytes` |  | Optional | Cost per byte per month for logs cloud storage. Default: `0`. |
+| `logs_data_upload_bytes` |  | Optional | Cost per byte per month for logs data upload. Default: `0`. |
+| `logs_data_egress_bytes` |  | Optional | Cost per byte per month for logs data egress. Default: `0`. |
+
+{{% /expand%}}
 {{% /tablestep %}}
 {{% tablestep link="/manage/fleet/reuse-configuration/" %}}
+{{<imgproc src="appendix/try-viam/rover-resources/fragments/fragments_list.png" resize="800x" class="fill alignleft imgzoom" style="width: 250px" declaredimensions=true alt="Add fragment">}}
 **2. Add the fragment to each machine**
+
+Inside the fragment you use to provision your machines, add the billing fragment.
+
+Click **Save** in the upper right corner of the screen.
 
 
 {{% /tablestep %}}

--- a/docs/manage/manage/white-labelled-billing.md
+++ b/docs/manage/manage/white-labelled-billing.md
@@ -111,22 +111,24 @@ https://app.viam.com/billing/<public-namespace>?id=<org-id>
 
 ## Set custom pricing
 
-You can set custom pricing for machines within your organization:
+You can set custom pricing for machines within your organization.
 
 {{< table >}}
 {{% tablestep link="" %}}
-**1. Create a fragment with billing information**
+**1. Add billing configuration to the fragment for your machines**
 
-On the **FLEET** page, go to the [**FRAGMENTS** tab](https://app.viam.com/fragments).
+On the **FLEET** page, go to the [**FRAGMENTS** tab](https://app.viam.com/fragments) and select the fragment you use for your machines.
+If you are not using a fragment, you can instead add the billing configuration to individual machine configurations.
 
-Click **Create fragment**, and paste the following JSON configuration into it.
-Adjust attributes as needed and save.
+In the JSON configuration, add the `billing`  object, adjust attributes as needed and save.
 
 {{< tabs >}}
 {{% tab name="Example" %}}
 
 ```json { class="line-numbers linkable-line-numbers" }
 {
+  "components": { ... },
+  "services" : { ... },
   "billing": {
     "cost_per_month": {
       "per_machine": 10
@@ -195,14 +197,6 @@ Adjust attributes as needed and save.
 | `logs_data_egress_bytes` |  | Optional | Cost per byte per month for logs data egress. Default: `0`. |
 
 {{% /expand%}}
-{{% /tablestep %}}
-{{% tablestep link="/manage/fleet/reuse-configuration/" %}}
-{{<imgproc src="appendix/try-viam/rover-resources/fragments/fragments_list.png" resize="800x" class="fill alignleft imgzoom" style="width: 250px" declaredimensions=true alt="Add fragment">}}
-**2. Add the fragment to each machine**
-
-Inside the fragment you use to provision your machines, add the billing fragment.
-
-Click **Save** in the upper right corner of the screen.
 
 {{% /tablestep %}}
 {{< /table >}}

--- a/docs/manage/manage/white-labelled-billing.md
+++ b/docs/manage/manage/white-labelled-billing.md
@@ -177,7 +177,6 @@ Adjust attributes as needed and save.
 
 {{% /expand%}}
 
-
 {{% expand "Click to view cost per month attributes" %}}
 
 <!-- prettier-ignore -->
@@ -204,7 +203,6 @@ Adjust attributes as needed and save.
 Inside the fragment you use to provision your machines, add the billing fragment.
 
 Click **Save** in the upper right corner of the screen.
-
 
 {{% /tablestep %}}
 {{< /table >}}


### PR DESCRIPTION
@RoxyFarhad and @adithyagurunathan is this how you think this should work? https://deploy-preview-3957--viam-docs.netlify.app/manage/manage/white-labelled-billing/#set-custom-pricing You add a billing fragment and then add the fragment to another fragment that is used for provisioning?