### PR TITLE
update windows CLI instructions

### DIFF
--- a/docs/dev/tools/cli.md
+++ b/docs/dev/tools/cli.md
@@ -77,7 +77,7 @@ brew install viam
 {{% /tab %}}
 {{% tab name="Windows" %}}
 
-[Download the installer](https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-windows-amd64.exe) to use the Viam CLI on a Windows computer.
+[Download the binary](https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-windows-amd64.exe) and run it directly to use the Viam CLI on a Windows computer.
 
 {{% /tab %}}
 {{% tab name="Source" %}}

--- a/static/include/how-to/install-cli.md
+++ b/static/include/how-to/install-cli.md
@@ -38,7 +38,7 @@ brew install viam
 {{% /tab %}}
 {{% tab name="Windows" %}}
 
-[Download the installer](https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-windows-amd64.exe) to use the Viam CLI on a Windows computer.
+[Download the binary](https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-windows-amd64.exe) and run it directly to use the Viam CLI on a Windows computer.
 
 {{% /tab %}}
 {{% tab name="Source" %}}


### PR DESCRIPTION
## What changed
- change windows CLI instructions to make it clear this a binary you run directly
## Why
This is not an installer yet. (It's annoying to keep track of the loose binary so it's a good idea to make it an installer though).