### PR TITLE
update hardware requirements for micro-server

### DIFF
--- a/docs/operate/get-started/setup.md
+++ b/docs/operate/get-started/setup.md
@@ -48,7 +48,7 @@ Viam also offers a lightweight binary to support the following 32-bit microcontr
 
 - [ESP32-WROVER Series](https://www.espressif.com/en/products/modules/esp32)
 
-ESP32 microcontrollers must have at least 2 cores, 384kB SRAM, 2MB PSRAM and 4MB flash to work with Viam.
+ESP32 microcontrollers must have at least 2 cores, 384kB SRAM, 2MB PSRAM and 8MB flash to work with Viam.
 
 Viam can run on Windows Subsystem for Linux (WSL), but WSL itself does not currently support exposing many types of Windows hardware to the embedded Linux kernel.
 This means that some hardware, such as a connected webcam, may not be available to `viam-server` with WSL, even though it is fully supported for native Linux systems.

--- a/docs/operate/reference/components/board/esp32.md
+++ b/docs/operate/reference/components/board/esp32.md
@@ -26,7 +26,7 @@ The following ESP32 microcontrollers are supported:
 
 Your microcontroller should have at least the following resources available to work with `viam-micro-server`:
 
-- 2 Cores + 384kB SRAM + 2MB PSRAM + 4MB Flash
+- 2 Cores + 384kB SRAM + 2MB PSRAM + 8MB Flash
 
 {{% /alert %}}
 

--- a/static/include/micro-rdk-hardware.md
+++ b/static/include/micro-rdk-hardware.md
@@ -8,9 +8,9 @@ You will also need a data cable to connect the microcontroller to your developme
 
 Your microcontroller should have at least the following resources available to work with `viam-micro-server`:
 
-- 2 Cores + 384kB SRAM + 2MB PSRAM + 4MB Flash
+- 2 Cores + 384kB SRAM + 2MB PSRAM + 8MB Flash
 
 {{< alert title="Tip" color="tip" >}}
-The WROVER allows a max of 3 incoming gRPC connections (whether over HTTP2 or WebRTC).
-You can change this max by [building your own version of `viam-micro-server`](/operate/get-started/other-hardware/micro-module/).
+The WROVER allows only a small number of incoming gRPC connections (1-5, depending on resources), whether over HTTP2 or WebRTC.
+You can change this max by [building your own firmware](/operate/get-started/other-hardware/micro-module/).
 {{< /alert >}}


### PR DESCRIPTION
The changes set the minimum Flash requirements for the micro-server to 8MB. 

While it's technically possible for a user to build their project with a custom partition table to utilize a 4MB device, they would not be able to utilize certain key features (ex. OTA). 

Also updated some adjacent wording.
