### PR TITLE
DOCS-3623: Review subtype vs API distinction

### DIFF
--- a/docs/dev/reference/glossary/api-namespace-triplet.md
+++ b/docs/dev/reference/glossary/api-namespace-triplet.md
@@ -2,15 +2,15 @@
 title: API Namespace Triplet
 id: api-namespace-triplet
 full_link:
-short_description: namespace:type:api, for example `rdk:component:sensor`
+short_description: namespace:type:subtype, for example `rdk:component:sensor`
 ---
 
 Every Viam {{< glossary_tooltip term_id="resource" text="resource" >}} implements an [application programming interface (API)](https://en.wikipedia.org/wiki/API) that describes how you can interact with that resource.
 
-These APIs are organized by colon-delimited-triplet identifiers, in the form of `namespace:type:api`.
+These APIs are organized by colon-delimited-triplet identifiers, in the form of `namespace:type:subtype`.
 
 The `namespace` for built-in Viam resources is `rdk`, while the `type` is `component` or `service`.
-`api` refers to a specific component or service, like a `camera` or `vision`.
+`subtype` refers to a specific component or service, like a `camera` or `vision`.
 
 One API can have various {{< glossary_tooltip term_id="model" text="models" >}}, custom or built-in, but they all must conform to the same API definition.
 This requirement ensures that when a resource of that model is deployed, you can [interface with it](/dev/reference/sdks/) using the same [client API methods](/dev/reference/apis/) you would when programming resources of the same API with a different model.

--- a/docs/dev/reference/glossary/subtype.md
+++ b/docs/dev/reference/glossary/subtype.md
@@ -1,0 +1,16 @@
+---
+title: Subtype
+id: subtype
+full_link:
+short_description: A group of component or service models that share the same API. For example, arm is a subtype of component.
+---
+
+A category within a {{< glossary_tooltip term_id="type" text="type" >}} of {{< glossary_tooltip term_id="resource" text="resource" >}}.
+Resource models belonging to a subtype share the same API.
+{{< glossary_tooltip term_id="model" text="Models" >}} implement that subtype's API protocol with different drivers.
+
+For example, an arm is a subtype of the {{< glossary_tooltip term_id="component" text="component" >}} resource type, while the `ur5e` is a {{< glossary_tooltip term_id="model" text="model" >}} of the arm subtype's API.
+
+The [Vision Service](/operate/reference/services/vision/) is a subtype of the {{< glossary_tooltip term_id="service" text="service" >}} resource type.
+
+The `subtype` string is the third part of the {{< glossary_tooltip term_id="api-namespace-triplet" text="API namespace triplet" >}}.

--- a/docs/operate/get-started/other-hardware/cpp-module.md
+++ b/docs/operate/get-started/other-hardware/cpp-module.md
@@ -90,14 +90,14 @@ The three pieces of the API namespace triplet are as follows:
 
 - `namespace`: `rdk`
 - `type`: `component`
-- `api`: any one of [these component proto files](https://github.com/viamrobotics/api/tree/main/proto/viam/component), for example `motor` if you are creating a new model of motor
+- `subtype`: any one of [these component proto files](https://github.com/viamrobotics/api/tree/main/proto/viam/component), for example `motor` if you are creating a new model of motor
 
 {{% /tab %}}
 {{% tab name="Service" %}}
 
 - `namespace`: `rdk`
 - `type`: `service`
-- `api`: any one of [these service proto files](https://github.com/viamrobotics/api/tree/main/proto/viam/service), for example `vision` if you are creating a new model of vision service
+- `subtype`: any one of [these service proto files](https://github.com/viamrobotics/api/tree/main/proto/viam/service), for example `vision` if you are creating a new model of vision service
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/docs/operate/reference/advanced-modules/create-subtype.md
+++ b/docs/operate/reference/advanced-modules/create-subtype.md
@@ -39,6 +39,7 @@ The following steps guide you through this process in more detail:
    If it provides an interface to control hardware, it is a component.
    If it provides higher-level functionality, it is a service.
 1. Choose a name for your API.
+   This is called the `{{< glossary_tooltip term_id="subtype" text="subtype" >}}` of your API.
    For example, `gizmo`.
 
    Determine a valid {{< glossary_tooltip term_id="api-namespace-triplet" text="API namespace triplet" >}} based on your API name.
@@ -46,7 +47,7 @@ The following steps guide you through this process in more detail:
 
    {{< expand "API namespace triplet and model namespace triplet example" >}}
 
-   The `viam-labs:audioout:pygame` model uses the repository name [audioout](https://github.com/viam-labs/audioout).
+   The `viam-labs:audioout:pygame` model uses the module name [audioout](https://github.com/viam-labs/audioout).
    It implements the custom API `viam-labs:service:audioout`:
 
    ```json


### PR DESCRIPTION
I don't think anything else from https://github.com/viamrobotics/docs/pull/3994 needs reverting because the rest is conceptually true either way