### PR TITLE
DOCS-3554: Add TypeScript

### DIFF
--- a/.github/workflows/parse_flutter.py
+++ b/.github/workflows/parse_flutter.py
@@ -185,7 +185,7 @@ class FlutterParser:
 
                                 ## Markdownify return usage and replace relative links with absolute:
                                 formatted_return_usage = md(return_usage, strip=['wbr']).replace("../../", "https://flutter.viam.dev/")
-                                this_method_return_dict["return_usage"] = formatted_return_usage.replace('>>', '>\\>').replace("dart-core/Future-class.html", "dart-async/Future-class.html")
+                                this_method_return_dict["return_usage"] = formatted_return_usage.replace('>>', '>\\>').replace("dart-core/Future-class.html", "dart-async/Future-class.html").replace("dart-core/Stream-class.html","dart-async/Stream-class.html")
 
                                 # Parse return type:
                                 if return_tag.find('span', class_ = 'type-parameter'):

--- a/.github/workflows/parse_typescript.py
+++ b/.github/workflows/parse_typescript.py
@@ -1,0 +1,140 @@
+import pprint
+
+from parser_utils import make_soup
+from markdownify import markdownify as md
+
+## Language-specific resource name overrides:
+typescript_resource_overrides = {
+    "generic_component": "GenericComponent",
+    "generic_service": "GenericService",
+    "movement_sensor": "MovementSensor",
+    "power_sensor": "PowerSensor",
+    "vision": "Vision",
+    "robot": "Robot",
+    "data": "Data",
+    "dataset": "Data",
+    "data_sync": "Data",
+    "data_manager": "DataManager",
+    "mltraining": "MlTraining"
+}
+
+## Ignore these specific APIs if they error, are deprecated, etc:
+typescript_ignore_apis = [
+    'getRoverRentalRobots' # internal use
+]
+
+## Use these URLs for data types that are built-in to the language:
+typescript_datatype_links = {}
+
+class TypeScriptParser:
+    def __init__(self, proto_map_file, typescript_staging_url = None):
+        self.proto_map_file = proto_map_file
+        self.sdk_url = "https://ts.viam.dev"
+
+        if typescript_staging_url:
+            self.scrape_url = typescript_staging_url
+            self.staging = True
+        else:
+            self.scrape_url = "https://ts.viam.dev"
+            self.staging = False
+        self.typescript_methods = {}
+
+
+    def parse(self, type, viam_resources, args):
+        self.typescript_methods[type] = {}
+
+        # Skip resources not supported in TypeScript
+        unsupported_resources = [
+            "base_remote_control", "input_controller", "pose_tracker",
+            "mlmodel"
+        ]
+
+        for resource in viam_resources:
+
+            ## Determine URL form for TypeScript depending on type (like 'component').
+            ## TEMP: Manually exclude Base Remote Control Service (Go only):
+            ## TODO: Handle resources with 0 implemented methods for this SDK better.
+
+            # Initialize TypeScript methods dictionary if it doesn't exist
+            self.typescript_methods[type][resource] = {}
+
+            print("!!!", resource)
+            if resource in unsupported_resources:
+                if args.verbose:
+                    print(f'DEBUG: Skipping unsupported TypeScript resource: {resource}')
+                continue
+
+            url = f"{self.scrape_url}/classes/{resource.capitalize()}Client.html"
+            if resource in typescript_resource_overrides:
+                url = f"{self.scrape_url}/classes/{typescript_resource_overrides[resource]}Client.html"
+
+            if args.verbose:
+                print(f'DEBUG: Parsing TypeScript URL: {url}')
+
+            ## Scrape each parent method tag and all contained child tags for TypeScript by resource.
+            ## TEMP: Manually exclude Base Remote Control Service (Go only).
+            ## TODO: Handle resources with 0 implemented methods for this SDK better.
+            soup = make_soup(url)
+            top_level_sections = soup.find_all('section', class_='tsd-panel-group tsd-member-group')
+            methods = []
+
+            for section in top_level_sections:
+                if section.find('h2').text == 'Methods':
+                    methods = section.find_all('section', class_='tsd-panel tsd-member')
+                if resource == 'robot':
+                    if section.find('h2').text in ['App/Cloud', 'ComponentConfig', 'Discovery', "Frame System", "Operations", "Resources", "Sessions"]:
+                        methods.extend(section.find_all('section', class_='tsd-panel tsd-member'))
+
+
+            for method in methods:
+                # print(method)
+                method_name = method.find('h3').text
+
+                param_object = {}
+                if method.find('div', class_="tsd-parameters"):
+                    parameters = method.find('div', class_="tsd-parameters").find_all('li')
+                    for param in parameters:
+                        param_name = param.find('span', class_="tsd-kind-parameter").text
+                        param_description = ''
+                        if param.find('div', class_="tsd-comment"):
+                            param_description = param.find('div', class_="tsd-comment").text
+                        signature = method.find(class_='tsd-signature').text
+                        param_type = md(str(param.find(class_="tsd-signature-type"))).strip()
+
+                        if param_description:
+                            param_usage = "%s (%s) - %s" % (param_name, param_type, param_description)
+                        else:
+                            param_usage = "%s (%s)" % (param_name, param_type)
+
+                        param_object[param_name] = {
+                            'optional': param_name + '?' in signature, # todo
+                            'param_description': param_description,
+                            'param_type':param_type,
+                            'param_usage': param_usage
+                        }
+
+                returns = md(str(method.find('h4', class_="tsd-returns-title"))).replace("#### Returns ", "").strip().replace('\\', '')
+
+                return_object = {
+                    'return_description': '',
+                    'return_type': returns,
+                    'return_usage': returns
+                }
+
+                method_description = ""
+                if method.find('li', class_="tsd-description").find('div', class_="tsd-comment"):
+                    method_description = method.find('li', class_="tsd-description").find('div', class_="tsd-comment").text.strip()
+
+                self.typescript_methods[type][resource][method_name] = {
+                    'method_description': method_description,
+                    'method_link': url + method.find('a', class_='tsd-anchor-icon')["href"],
+                    'parameters': param_object,
+                    'proto': '', # method_name ?
+                    'return': return_object
+                }
+                    # 'code_sample': "", # No code samples yet method.find('pre').text
+                # print(self.typescript_methods[type][resource][method_name])
+                # print()
+
+
+        return self.typescript_methods

--- a/.github/workflows/parse_typescript.py
+++ b/.github/workflows/parse_typescript.py
@@ -1,7 +1,6 @@
-import pprint
-
 from parser_utils import make_soup
 from markdownify import markdownify as md
+from urllib.parse import urljoin
 
 ## Language-specific resource name overrides:
 typescript_resource_overrides = {
@@ -58,7 +57,6 @@ class TypeScriptParser:
             # Initialize TypeScript methods dictionary if it doesn't exist
             self.typescript_methods[type][resource] = {}
 
-            print("!!!", resource)
             if resource in unsupported_resources:
                 if args.verbose:
                     print(f'DEBUG: Skipping unsupported TypeScript resource: {resource}')
@@ -75,6 +73,10 @@ class TypeScriptParser:
             ## TEMP: Manually exclude Base Remote Control Service (Go only).
             ## TODO: Handle resources with 0 implemented methods for this SDK better.
             soup = make_soup(url)
+            for a in soup.find_all('a'):
+                if a.get('href') and not a.get('href').startswith('http'):
+                    a['href'] = urljoin(url, a.get('href'))
+
             top_level_sections = soup.find_all('section', class_='tsd-panel-group tsd-member-group')
             methods = []
 
@@ -127,7 +129,7 @@ class TypeScriptParser:
 
                 self.typescript_methods[type][resource][method_name] = {
                     'method_description': method_description,
-                    'method_link': url + method.find('a', class_='tsd-anchor-icon')["href"],
+                    'method_link': method.find('a', class_='tsd-anchor-icon')["href"],
                     'parameters': param_object,
                     'proto': '', # method_name ?
                     'return': return_object

--- a/.github/workflows/sdk_protos_map.csv
+++ b/.github/workflows/sdk_protos_map.csv
@@ -1,480 +1,478 @@
-## RESOURCE, PROTO, MICRO RDK, PYTHON METHOD, GO METHOD, FLUTTER METHOD
+## RESOURCE, PROTO, MICRO RDK, PYTHON METHOD, GO METHOD, FLUTTER METHOD, TYPESCRIPT METHOD
 
 ## Arm
-arm,GetEndPosition,,get_end_position,EndPosition,endPosition
-arm,MoveToPosition,,move_to_position,MoveToPosition,moveToPosition
-arm,MoveToJointPositions,,move_to_joint_positions,MoveToJointPositions,moveToJointPositions
-arm,MoveThroughJointPositions,,,MoveThroughJointPositions,
-arm,GetJointPositions,,get_joint_positions,JointPositions,jointPositions
-arm,GetKinematics,,get_kinematics,,
+arm,GetEndPosition,,get_end_position,EndPosition,endPosition,getEndPosition
+arm,MoveToPosition,,move_to_position,MoveToPosition,moveToPosition,moveToPosition
+arm,MoveToJointPositions,,move_to_joint_positions,MoveToJointPositions,moveToJointPositions,moveToJointPositions
+arm,MoveThroughJointPositions,,,MoveThroughJointPositions,,
+arm,GetJointPositions,,get_joint_positions,JointPositions,jointPositions,getJointPositions
+arm,GetKinematics,,get_kinematics,,,
 ## HACK:  proto for these (and/or inherited in Go SDK), manually mapping:
-arm,IsMoving,,is_moving,IsMoving,isMoving
-arm,Stop,,stop,Stop,stop
-arm,GetGeometries,,get_geometries,Geometries,
-arm,Reconfigure,,,Reconfigure,
-arm,DoCommand,,do_command,DoCommand,doCommand
-arm,GetResourceName,,get_resource_name,,getResourceName
-arm,Close,,close,Close,
+arm,IsMoving,,is_moving,IsMoving,isMoving,isMoving
+arm,Stop,,stop,Stop,stop,stop
+arm,GetGeometries,,get_geometries,Geometries,,getGeometries
+arm,Reconfigure,,,Reconfigure,,
+arm,DoCommand,,do_command,DoCommand,doCommand,doCommand
+arm,GetResourceName,,get_resource_name,,getResourceName,
+arm,Close,,close,Close,,
 
 ## Base
-base,MoveStraight,No,move_straight,MoveStraight,moveStraight
-base,Spin,No,spin,Spin,spin
-base,SetPower,Yes,set_power,SetPower,setPower
-base,SetVelocity,No,set_velocity,SetVelocity,setVelocity
-base,GetProperties,No,get_properties,Properties,
+base,MoveStraight,No,move_straight,MoveStraight,moveStraight,moveStraight
+base,Spin,No,spin,Spin,spin,spin
+base,SetPower,Yes,set_power,SetPower,setPower,setPower
+base,SetVelocity,No,set_velocity,SetVelocity,setVelocity,setVelocity
+base,GetProperties,No,get_properties,Properties,,getProperties
 ## HACK: No proto for these (and/or inherited in Go SDK), manually mapping:
-base,IsMoving,No,is_moving,IsMoving,isMoving
-base,Stop,Yes,stop,Stop,stop
-base,GetGeometries,No,get_geometries,Geometries,
-base,Reconfigure,No,,Reconfigure,
-base,DoCommand,Yes,do_command,DoCommand,doCommand
-base,GetResourceName,No,get_resource_name,,getResourceName
-base,Close,No,close,Close,
+base,IsMoving,No,is_moving,IsMoving,isMoving,isMoving
+base,Stop,Yes,stop,Stop,stop,stop
+base,GetGeometries,No,get_geometries,Geometries,,getGeometries
+base,Reconfigure,No,,Reconfigure,,
+base,DoCommand,Yes,do_command,DoCommand,doCommand,doCommand
+base,GetResourceName,No,get_resource_name,,getResourceName,
+base,Close,No,close,Close,,
 
 ## Board
-board,SetGPIO,Yes,set,Set,setGpioState
-board,GetGPIO,Yes,get,Get,gpio
+board,SetGPIO,Yes,set,Set,setGpioState,setGPIO
+board,GetGPIO,Yes,get,Get,gpio,getGPIO
 ## HACK: Proto is PWM but we call it GetPWM in docs. Upstream likely to change to match soonish:
-board,GetPWM,Yes,get_pwm,PWM,pwm
-board,SetPWM,Yes,set_pwm,SetPWM,setPwm
-board,PWMFrequency,Yes,get_pwm_frequency,PWMFreq,pwmFrequency
-board,SetPWMFrequency,Yes,set_pwm_frequency,SetPWMFreq,setPwmFrequency
-board,GetDigitalInterruptValue,No,value,Value,digitalInterruptValue
-board,ReadAnalogReader,Yes,read,Read,analogReaderValue
+board,GetPWM,Yes,get_pwm,PWM,pwm,getPWM
+board,SetPWM,Yes,set_pwm,SetPWM,setPwm,setPWM
+board,PWMFrequency,Yes,get_pwm_frequency,PWMFreq,pwmFrequency,getPWMFrequency
+board,SetPWMFrequency,Yes,set_pwm_frequency,SetPWMFreq,setPwmFrequency,setPWMFrequency
+board,GetDigitalInterruptValue,No,value,Value,digitalInterruptValue,getDigitalInterruptValue
+board,ReadAnalogReader,Yes,read,Read,analogReaderValue,readAnalogReader
 ## HACK: PySDK: write_analog currently borked; deprecated in favor of write: https://python.viam.dev/autoapi/viam/components/board/client/index.html#viam.components.board.client.BoardClient.write_analog
-board,WriteAnalog,Yes,write,Write,writeAnalog
-board,StreamTicks,No,stream_ticks,StreamTicks,streamTicks
-board,SetPowerMode,No,set_power_mode,SetPowerMode,setPowerMode
+board,WriteAnalog,Yes,write,Write,writeAnalog,writeAnalog
+board,StreamTicks,No,stream_ticks,StreamTicks,streamTicks,streamTicks
+board,SetPowerMode,No,set_power_mode,SetPowerMode,setPowerMode,setPowerMode
 ## HACK: Board (python, go) provides additional helper functions, adding 5 pseudo-entries:
-board,AnalogByName,No,analog_by_name,AnalogByName,
+board,AnalogByName,No,analog_by_name,AnalogByName,,
 board,DigitalInterruptByName,No,digital_interrupt_by_name,DigitalInterruptByName,,
-board,GPIOPinByName,No,gpio_pin_by_name,GPIOPinByName,
+board,GPIOPinByName,No,gpio_pin_by_name,GPIOPinByName,,
 ## HACK: No proto for these (and/or inherited in Go SDK), manually mapping:
-board,GetGeometries,No,get_geometries,,
-board,Reconfigure,No,,Reconfigure,
-board,DoCommand,Yes,do_command,DoCommand,doCommand
-board,Name,No,,Name,
-board,GetResourceName,No,get_resource_name,,getResourceName
-board,Close,No,close,Close,
+board,GetGeometries,No,get_geometries,,,
+board,Reconfigure,No,,Reconfigure,,
+board,DoCommand,Yes,do_command,DoCommand,doCommand,doCommand
+board,Name,No,,Name,,
+board,GetResourceName,No,get_resource_name,,getResourceName,
+board,Close,No,close,Close,,
 
 ## Button
-button,Push,No,,Push,
-button,DoCommand,No,,DoCommand,
-button,Close,No,,Close,
+button,Push,No,,Push,,push
+button,DoCommand,No,,DoCommand,,doCommand
+button,Close,No,,Close,,
 
 ## Camera
-camera,GetImage,,get_image,Image,image
-camera,GetImages,,get_images,Images,
-camera,RenderFrame,,,,
-camera,GetPointCloud,,get_point_cloud,NextPointCloud,pointCloud
-camera,GetProperties,,get_properties,Properties,properties
+camera,GetImage,,get_image,Image,image,getImage
+camera,GetImages,,get_images,Images,,
+camera,RenderFrame,,,,,renderFrame
+camera,GetPointCloud,,get_point_cloud,NextPointCloud,pointCloud,getPointCloud
+camera,GetProperties,,get_properties,Properties,properties,getProperties
 ## TED: Camera in Go SDK doesn't appear to implement (inherit) these:
-camera,DoCommand,,do_command,,doCommand
-camera,GetGeometries,,get_geometries,,
+camera,DoCommand,,do_command,,doCommand,doCommand
+camera,GetGeometries,,get_geometries,,,getGeometries
 ## HACK:  proto for close, manually mapping:
-camera,GetResourceName,,get_resource_name,,getResourceName
-camera,Close,,close,Close,
+camera,GetResourceName,,get_resource_name,,getResourceName,
+camera,Close,,close,Close,,
 
 ## Encoder
-encoder,GetPosition,Yes,get_position,Position,
-encoder,ResetPosition,Yes,reset_position,ResetPosition,
-encoder,GetProperties,Yes,get_properties,Properties,
-encoder,GetGeometries,No,get_geometries,,
+encoder,GetPosition,Yes,get_position,Position,,getPosition
+encoder,ResetPosition,Yes,reset_position,ResetPosition,,resetPosition
+encoder,GetProperties,Yes,get_properties,Properties,,getProperties
+encoder,GetGeometries,No,get_geometries,,,
 ## HACK: No proto for these (and/or inherited in Go SDK), manually mapping:
-encoder,Reconfigure,No,,Reconfigure,
-encoder,DoCommand,Yes,do_command,DoCommand,
-encoder,GetResourceName,No,get_resource_name,,
-encoder,Close,No,close,Close,
+encoder,Reconfigure,No,,Reconfigure,,
+encoder,DoCommand,Yes,do_command,DoCommand,,doCommand
+encoder,GetResourceName,No,get_resource_name,,,
+encoder,Close,No,close,Close,,
 
 ## Gantry
-gantry,GetPosition,,get_position,Position,position
-gantry,MoveToPosition,,move_to_position,MoveToPosition,moveToPosition
-gantry,GetLengths,,get_lengths,Lengths,lengths
-gantry,Home,,home,Home,home
+gantry,GetPosition,,get_position,Position,position,getPosition
+gantry,MoveToPosition,,move_to_position,MoveToPosition,moveToPosition,moveToPosition
+gantry,GetLengths,,get_lengths,Lengths,lengths,getLengths
+gantry,Home,,home,Home,home,home
 ## TED: Gantry in Go SDK doesn't appear to implement (inherit) this:
-gantry,GetGeometries,,,,
+gantry,GetGeometries,,,,,getGeometries
 ## HACK:  proto for these (and/or inherited in Go SDK), manually mapping:
-gantry,IsMoving,,is_moving,IsMoving,isMoving
-gantry,Stop,,stop,Stop,stop
-gantry,GetGeometries,,get_geometries,,
-gantry,Reconfigure,,,Reconfigure,
-gantry,DoCommand,,do_command,,doCommand
-gantry,GetResourceName,,get_resource_name,,getResourceName
-gantry,Close,,close,Close,
+gantry,IsMoving,,is_moving,IsMoving,isMoving,isMoving
+gantry,Stop,,stop,Stop,stop,stop
+gantry,Reconfigure,,,Reconfigure,,
+gantry,DoCommand,,do_command,,doCommand,doCommand
+gantry,GetResourceName,,get_resource_name,,getResourceName,
+gantry,Close,,close,Close,,
 
 ## Generic Component
 ## NOTED:Generic Component in Go SDK doesn't appear to implement (inherit) these:
-generic_component,DoCommand,Yes,do_command,DoCommand,doCommand
-generic_component,GetGeometries,No,get_geometries,,
-generic_component,DoCommand,,do_command,,doCommand
+generic_component,DoCommand,Yes,do_command,DoCommand,doCommand,doCommand
+generic_component,GetGeometries,No,get_geometries,,,
 ## HACK: No proto for close, manually mapping:
 ## NOTED: Go SDK also missing Close, but we have it in our docs?:
-generic_component,GetResourceName,No,get_resource_name,,getResourceName
-generic_component,Close,No,close,,
+generic_component,GetResourceName,No,get_resource_name,,getResourceName,
+generic_component,Close,No,close,,,
 
 ## Gripper
-gripper,Open,,open,Open,open
-gripper,Grab,,grab,Grab,grab
+gripper,Open,,open,Open,open,open
+gripper,Grab,,grab,Grab,grab,grab
 ## HACK:  proto for these (and/or inherited in Go SDK), manually mapping:
-gripper,IsMoving,,is_moving,IsMoving,isMoving
-gripper,Stop,,stop,Stop,stop
-gripper,GetGeometries,,get_geometries,Geometries,
-gripper,Reconfigure,,,Reconfigure,
-gripper,DoCommand,,,,doCommand
-gripper,GetResourceName,,get_resource_name,,getResourceName
-gripper,Close,,close,Close,
+gripper,IsMoving,,is_moving,IsMoving,isMoving,isMoving
+gripper,Stop,,stop,Stop,stop,stop
+gripper,GetGeometries,,get_geometries,Geometries,,getGeometries
+gripper,Reconfigure,,,Reconfigure,,
+gripper,DoCommand,,,,doCommand,doCommand
+gripper,GetResourceName,,get_resource_name,,getResourceName,
+gripper,Close,,close,Close,,
 
 ## Input Controller
-input_controller,GetControls,,get_controls,Controls,
-input_controller,GetEvents,,get_events,Events,
-input_controller,StreamEvents,,,,
-input_controller,TriggerEvent,,trigger_event,TriggerEvent,
+input_controller,GetControls,,get_controls,Controls,,
+input_controller,GetEvents,,get_events,Events,,
+input_controller,StreamEvents,,,,,
+input_controller,TriggerEvent,,trigger_event,TriggerEvent,,
 ## TED: Go SDK doesn't appear to implement this:
-input_controller,GetGeometries,,get_geometries,,
+input_controller,GetGeometries,,get_geometries,,,
 ## HACK: Input (python, go) provides additional helper function, adding 1 pseudo-entries:
-input_controller,RegisterControlCallback,,register_control_callback,RegisterControlCallback,
+input_controller,RegisterControlCallback,,register_control_callback,RegisterControlCallback,,
 ## HACK:  proto for these (and/or inherited in Go SDK), manually mapping:
-input_controller,Reconfigure,,,Reconfigure,
-input_controller,DoCommand,,do_command,,
-input_controller,GetResourceName,,get_resource_name,,
-input_controller,Close,,close,Close,
+input_controller,Reconfigure,,,Reconfigure,,
+input_controller,DoCommand,,do_command,,,
+input_controller,GetResourceName,,get_resource_name,,,
+input_controller,Close,,close,Close,,
 
 ## Motor
-motor,SetPower,Yes,set_power,SetPower,setPower
-motor,SetRPM,No,set_rpm,SetRPM,setRPM
-motor,GoFor,No,go_for,GoFor,goFor
-motor,GoTo,No,go_to,GoTo,goTo
-motor,ResetZeroPosition,No,reset_zero_position,ResetZeroPosition,resetZeroPosition
-motor,GetPosition,Yes,get_position,Position,position
-motor,GetProperties,Yes,get_properties,Properties,properties
-motor,IsPowered,No,is_powered,IsPowered,powerState
-# NOT implemented motor,GetGeometries,No,get_geometries,,
+motor,SetPower,Yes,set_power,SetPower,setPower,setPower
+motor,SetRPM,No,set_rpm,SetRPM,setRPM,setRPM
+motor,GoFor,No,go_for,GoFor,goFor,goFor
+motor,GoTo,No,go_to,GoTo,goTo,goTo
+motor,ResetZeroPosition,No,reset_zero_position,ResetZeroPosition,resetZeroPosition,resetZeroPosition
+motor,GetPosition,Yes,get_position,Position,position,getPosition
+motor,GetProperties,Yes,get_properties,Properties,properties,getProperties
+motor,IsPowered,No,is_powered,IsPowered,powerState,isPowered
+# NOT implemented motor,GetGeometries,No,get_geometries,,,
 ## HACK: No proto for these (and/or inherited in Go SDK), manually mapping:
-motor,IsMoving,Yes,is_moving,IsMoving,isMoving
-motor,Stop,Yes,stop,Stop,stop
-motor,Reconfigure,No,,Reconfigure,
+motor,IsMoving,Yes,is_moving,IsMoving,isMoving,isMoving
+motor,Stop,Yes,stop,Stop,stop,stop
+motor,Reconfigure,No,,Reconfigure,,
 # NOT implemented in other languages
-motor,DoCommand,,,,doCommand
-motor,GetResourceName,No,get_resource_name,,getResourceName
-motor,Close,No,close,Close,
+motor,DoCommand,,,,doCommand,doCommand
+motor,GetResourceName,No,get_resource_name,,getResourceName,
+motor,Close,No,close,Close,,
 
 ## Movement Sensor
-movement_sensor,GetLinearVelocity,Yes,get_linear_velocity,LinearVelocity,linearVelocity
-movement_sensor,GetAngularVelocity,Yes,get_angular_velocity,AngularVelocity,angularVelocity
-movement_sensor,GetCompassHeading,Yes,get_compass_heading,CompassHeading,compassHeading
-movement_sensor,GetOrientation,No,get_orientation,Orientation,orientation
-movement_sensor,GetPosition,Yes,get_position,Position,position
-movement_sensor,GetProperties,Yes,get_properties,Properties,properties
-movement_sensor,GetAccuracy,No,get_accuracy,Accuracy,accuracy
-movement_sensor,GetLinearAcceleration,Yes,get_linear_acceleration,LinearAcceleration,linearAcceleration
+movement_sensor,GetLinearVelocity,Yes,get_linear_velocity,LinearVelocity,linearVelocity,getLinearVelocity
+movement_sensor,GetAngularVelocity,Yes,get_angular_velocity,AngularVelocity,angularVelocity,getAngularVelocity
+movement_sensor,GetCompassHeading,Yes,get_compass_heading,CompassHeading,compassHeading,getCompassHeading
+movement_sensor,GetOrientation,No,get_orientation,Orientation,orientation,getOrientation
+movement_sensor,GetPosition,Yes,get_position,Position,position,getPosition
+movement_sensor,GetProperties,Yes,get_properties,Properties,properties,getProperties
+movement_sensor,GetAccuracy,No,get_accuracy,Accuracy,accuracy,getAccuracy
+movement_sensor,GetLinearAcceleration,Yes,get_linear_acceleration,LinearAcceleration,linearAcceleration,getLinearAcceleration
 ## NOTED: Go SDK doesn't appear to implement this:
-movement_sensor,GetGeometries,No,get_geometries,,
+movement_sensor,GetGeometries,No,get_geometries,,,
 ## HACK: No proto for these (and/or inherited in Go SDK), manually mapping:
-movement_sensor,GetReadings,Yes,get_readings,Readings,readings
-movement_sensor,Reconfigure,No,,Reconfigure,
-movement_sensor,DoCommand,Yes,do_command,DoCommand,doCommand
-movement_sensor,GetResourceName,No,get_resource_name,,getResourceName
-movement_sensor,Close,No,close,Close,
+movement_sensor,GetReadings,Yes,get_readings,Readings,readings,getReadings
+movement_sensor,Reconfigure,No,,Reconfigure,,
+movement_sensor,DoCommand,Yes,do_command,DoCommand,doCommand,doCommand
+movement_sensor,GetResourceName,No,get_resource_name,,getResourceName,
+movement_sensor,Close,No,close,Close,,
 
 ## Power Sensor
-power_sensor,GetVoltage,,get_voltage,Voltage,voltage
-power_sensor,GetCurrent,,get_current,Current,current
-power_sensor,GetPower,,get_power,Power,power
-power_sensor,GetReadings,,get_readings,Readings,readings
+power_sensor,GetVoltage,,get_voltage,Voltage,voltage,getVoltage
+power_sensor,GetCurrent,,get_current,Current,current,getCurrent
+power_sensor,GetPower,,get_power,Power,power,getPower
+power_sensor,GetReadings,,get_readings,Readings,readings,getReadings
 ## HACK:  GetGeometries proto for power sensor component, adding 1 pseudo-entry:
 ## TED: But t for Go SDK:
-# NOT implemented power_sensor,GetGeometries,,get_geometries,,
+# NOT implemented power_sensor,GetGeometries,,get_geometries,,,
 ## HACK:  proto for these (and/or inherited in Go SDK), manually mapping:
-power_sensor,Reconfigure,,,Reconfigure,
-power_sensor,DoCommand,,do_command,DoCommand,doCommand
-power_sensor,GetResourceName,,get_resource_name,,getResourceName
-power_sensor,Close,,close,Close,
+power_sensor,Reconfigure,,,Reconfigure,,
+power_sensor,DoCommand,,do_command,DoCommand,doCommand,doCommand
+power_sensor,GetResourceName,,get_resource_name,,getResourceName,
+power_sensor,Close,,close,Close,,
 
 ## Sensor
-sensor,GetReadings,Yes,get_readings,Readings,readings
-# NOT implemented sensor,GetGeometries,No,get_geometries,,
+sensor,GetReadings,Yes,get_readings,Readings,readings,getReadings
+# NOT implemented sensor,GetGeometries,No,get_geometries,,,
 ## HACK: No proto for close (and/or inherited in Go SDK), manually mapping:
-sensor,GetGeometries,,get_geometries,,
-sensor,Reconfigure,No,,Reconfigure,
+sensor,GetGeometries,,get_geometries,,,
+sensor,Reconfigure,No,,Reconfigure,,
 # NOT implemented in other languages
-sensor,DoCommand,,,,doCommand
-sensor,GetResourceName,No,get_resource_name,,getResourceName
-sensor,Close,No,close,Close,
+sensor,DoCommand,,,,doCommand,doCommand
+sensor,GetResourceName,No,get_resource_name,,getResourceName,
+sensor,Close,No,close,Close,,
 
 ## Servo
-servo,Move,Yes,move,Move,move
-servo,GetPosition,Yes,get_position,Position,position
-# NOT implemented servo,GetGeometries,No,get_geometries,,
+servo,Move,Yes,move,Move,move,move
+servo,GetPosition,Yes,get_position,Position,position,getPosition
+# NOT implemented servo,GetGeometries,No,get_geometries,,,
 ## HACK: No proto for these (and/or inherited in Go SDK), manually mapping:
-servo,IsMoving,No,is_moving,IsMoving,isMoving
-servo,Stop,Yes,stop,Stop,stop
-servo,Reconfigure,No,,Reconfigure,
+servo,IsMoving,No,is_moving,IsMoving,isMoving,isMoving
+servo,Stop,Yes,stop,Stop,stop,stop
+servo,Reconfigure,No,,Reconfigure,,
 # NOT implemented in other languages
-servo,DoCommand,,,,doCommand
-servo,GetResourceName,No,get_resource_name,,getResourceName
-servo,Close,No,close,Close,
+servo,DoCommand,,,,doCommand,doCommand
+servo,GetResourceName,No,get_resource_name,,getResourceName,
+servo,Close,No,close,Close,,
 
 ## Switch
-switch,SetPosition,No,,SetPosition,
-switch,GetPosition,No,,GetPosition,
-switch,GetNumberOfPositions,No,,GetNumberOfPositions,
-switch,DoCommand,No,,DoCommand,
-switch,Close,No,,Close,
+switch,SetPosition,No,,SetPosition,,setPosition
+switch,GetPosition,No,,GetPosition,,getPosition
+switch,GetNumberOfPositions,No,,GetNumberOfPositions,,getNumberOfPositions
+switch,DoCommand,No,,DoCommand,,doCommand
+switch,Close,No,,Close,,
 
 ## Base Remote Control
 ## HACK: No proto for Base Remote Control, manually adding:
-base_remote_control,ControllerInputs,,,ControllerInputs,
+base_remote_control,ControllerInputs,,,ControllerInputs,,
 ## HACK: No proto for these (and/or inherited in Go SDK), manually mapping:
-base_remote_control,Reconfigure,,,Reconfigure,
-base_remote_control,DoCommand,,,DoCommand,
-base_remote_control,Close,,,Close,
+base_remote_control,Reconfigure,,,Reconfigure,,
+base_remote_control,DoCommand,,,DoCommand,,
+base_remote_control,Close,,,Close,,
 
 ## Data Manager
-data_manager,Sync,No,,Sync,
+data_manager,Sync,No,,Sync,,sync
 ## HACK: No proto for these (and/or inherited in Go SDK), manually mapping:
-data_manager,Reconfigure,No,,Reconfigure,
-data_manager,DoCommand,No,,DoCommand,
-data_manager,Close,No,,Close,
+data_manager,Reconfigure,No,,Reconfigure,,
+data_manager,DoCommand,No,,DoCommand,,doCommand
+data_manager,Close,No,,Close,,
 
 ## Generic Service
 ## TED:Generic Component in Go SDK doesn't appear to implement (inherit) these:
-generic_service,DoCommand,,do_command,DoCommand,
-generic_service,GetResourceName,,get_resource_name,,
+generic_service,DoCommand,,do_command,DoCommand,,doCommand
+generic_service,GetResourceName,,get_resource_name,,,
 ## HACK:  proto for close, manually mapping:
 ## TED: Go SDK also missing Close, but we have it in our docs?:
-generic_service,Close,,close,,
+generic_service,Close,,close,,,
 
 ## MLModel
-mlmodel,Infer,,infer,Infer,
-mlmodel,Metadata,,metadata,Metadata,
+mlmodel,Infer,,infer,Infer,,
+mlmodel,Metadata,,metadata,Metadata,,
 ## HACK:  proto for DoCommand or Close (and/or inherited in Go SDK), manually mapping:
-mlmodel,Reconfigure,,,Reconfigure,
-mlmodel,DoCommand,,,DoCommand,
-mlmodel,GetResourceName,,get_resource_name,,
-mlmodel,Close,,close,Close,
+mlmodel,Reconfigure,,,Reconfigure,,
+mlmodel,DoCommand,,,DoCommand,,
+mlmodel,GetResourceName,,get_resource_name,,,
+mlmodel,Close,,close,Close,,
 
 ## Motion
-motion,Move,,move,Move,
-motion,MoveOnMap,,move_on_map,MoveOnMap,
-motion,MoveOnGlobe,,move_on_globe,MoveOnGlobe,
-motion,GetPose,,get_pose,GetPose,
-motion,StopPlan,,stop_plan,StopPlan,
-motion,ListPlanStatuses,,list_plan_statuses,ListPlanStatuses,
-motion,GetPlan,,get_plan,PlanHistory,
+motion,Move,,move,Move,,move
+motion,MoveOnMap,,move_on_map,MoveOnMap,,moveOnMap
+motion,MoveOnGlobe,,move_on_globe,MoveOnGlobe,,moveOnGlobe
+motion,GetPose,,get_pose,GetPose,,getPose
+motion,StopPlan,,stop_plan,StopPlan,,stopPlan
+motion,ListPlanStatuses,,list_plan_statuses,ListPlanStatuses,,listPlanStatuses
+motion,GetPlan,,get_plan,PlanHistory,,getPlan
 ## HACK:  proto for these (and/or inherited in Go SDK), manually mapping:
-motion,Reconfigure,,,Reconfigure,
-motion,FromRobot,,from_robot,,
-motion,DoCommand,,do_command,DoCommand,
-motion,GetResourceName,,get_resource_name,,
-motion,Close,,close,Close,
+motion,Reconfigure,,,Reconfigure,,
+motion,FromRobot,,from_robot,,,
+motion,DoCommand,,do_command,DoCommand,,doCommand
+motion,GetResourceName,,get_resource_name,,,
+motion,Close,,close,Close,,
 
 ## Navigation
-navigation,GetMode,,get_mode,Mode,
-navigation,SetMode,,set_mode,SetMode,
-navigation,GetLocation,,get_location,Location,
-navigation,GetWaypoints,,get_waypoints,Waypoints,
-navigation,AddWaypoint,,add_waypoint,AddWaypoint,
-navigation,RemoveWaypoint,,remove_waypoint,RemoveWaypoint,
-navigation,GetObstacles,,get_obstacles,Obstacles,
-navigation,GetPaths,,get_paths,Paths,
-navigation,GetProperties,,get_properties,Properties,
+navigation,GetMode,,get_mode,Mode,,getMode
+navigation,SetMode,,set_mode,SetMode,,setMode
+navigation,GetLocation,,get_location,Location,,getLocation
+navigation,GetWaypoints,,get_waypoints,Waypoints,,getWayPoints
+navigation,AddWaypoint,,add_waypoint,AddWaypoint,,addWayPoint
+navigation,RemoveWaypoint,,remove_waypoint,RemoveWaypoint,,removeWayPoint
+navigation,GetObstacles,,get_obstacles,Obstacles,,getObstacles
+navigation,GetPaths,,get_paths,Paths,,getPaths
+navigation,GetProperties,,get_properties,Properties,,getProperties
 ## HACK:  proto for these (and/or inherited in Go SDK), manually mapping:
-navigation,Reconfigure,,,Reconfigure,
-navigation,DoCommand,,do_command,DoCommand,
-navigation,GetResourceName,,get_resource_name,,
-navigation,Close,,close,Close,
+navigation,Reconfigure,,,Reconfigure,,
+navigation,DoCommand,,do_command,DoCommand,,doCommand
+navigation,GetResourceName,,get_resource_name,,,
+navigation,Close,,close,Close,,
 
 ## SLAM
-slam,GetPosition,,get_position,Position,
+slam,GetPosition,,get_position,Position,,getPosition
 ## HACK: SLAM (Go) implements proto GetPointCloudMap in user-facing helper PointCloudMapFull instead:
-slam,GetPointCloudMap,,get_point_cloud_map,,
+slam,GetPointCloudMap,,get_point_cloud_map,,,getPointCloudMap
 ## HACK: SLAM (Go) implements proto GetInternalState in user-facing helper InternalStateFull instead:
-slam,GetInternalState,,get_internal_state,,
-slam,GetProperties,,get_properties,Properties,
+slam,GetInternalState,,get_internal_state,,,getInternalState
+slam,GetProperties,,get_properties,Properties,,getProperties
 ## HACK: SLAM (Go) provides 2 additional helper functions, adding 2 pseudo-entries:
-slam,InternalStateFull,,,InternalStateFull,
-slam,PointCloudMapFull,,,PointCloudMapFull,
+slam,InternalStateFull,,,InternalStateFull,,
+slam,PointCloudMapFull,,,PointCloudMapFull,,
 ## HACK:  proto for these (and/or inherited in Go SDK), manually mapping:
-slam,Reconfigure,,,Reconfigure,
-slam,DoCommand,,do_command,DoCommand,
-slam,GetResourceName,,get_resource_name,,
-slam,Close,,close,Close,
+slam,Reconfigure,,,Reconfigure,,
+slam,DoCommand,,do_command,DoCommand,,doCommand
+slam,GetResourceName,,get_resource_name,,,
+slam,Close,,close,Close,,
 
 ## Vision
-vision,GetDetectionsFromCamera,,get_detections_from_camera,DetectionsFromCamera,detectionsFromCamera
-vision,GetDetections,,get_detections,Detections,detections
-vision,GetClassificationsFromCamera,,get_classifications_from_camera,ClassificationsFromCamera,classificationsFromCamera
-vision,GetClassifications,,get_classifications,Classifications,classifications
-vision,GetObjectPointClouds,,get_object_point_clouds,GetObjectPointClouds,objectPointClouds
-vision,CaptureAllFromCamera,,capture_all_from_camera,CaptureAllFromCamera,
+vision,GetDetectionsFromCamera,,get_detections_from_camera,DetectionsFromCamera,detectionsFromCamera,getDetectionsFromCamera
+vision,GetDetections,,get_detections,Detections,detections,getDetections
+vision,GetClassificationsFromCamera,,get_classifications_from_camera,ClassificationsFromCamera,classificationsFromCamera,getClassificationsFromCamera
+vision,GetClassifications,,get_classifications,Classifications,classifications,getClassifications
+vision,GetObjectPointClouds,,get_object_point_clouds,GetObjectPointClouds,objectPointClouds,getObjectPointClouds
+vision,CaptureAllFromCamera,,capture_all_from_camera,CaptureAllFromCamera,,captureAllFromCamera
 ## HACK:  proto for these (and/or inherited in Go SDK), manually mapping:
-vision,Reconfigure,,,Reconfigure,
-vision,DoCommand,,do_command,DoCommand,doCommand
-vision,GetResourceName,,get_resource_name,,getResourceName
-vision,GetProperties,,get_properties,GetProperties,properties
-vision,Close,,close,Close,
+vision,Reconfigure,,,Reconfigure,,
+vision,DoCommand,,do_command,DoCommand,doCommand,doCommand
+vision,GetResourceName,,get_resource_name,,getResourceName,
+vision,GetProperties,,get_properties,GetProperties,properties,getProperties
+vision,Close,,close,Close,,
 
 ## App
-app,GetUserIDByEmail,,get_user_id_by_email,,
-app,CreateOrganization,,create_organization,,
-app,ListOrganizations,,list_organizations,,
-app,GetOrganizationsWithAccessToLocation,,get_organizations_with_access_to_location,,
-app,ListOrganizationsByUser,,list_organizations_by_user,,
-app,GetOrganization,,get_organization,,
-app,GetOrganizationNamespaceAvailability,,get_organization_namespace_availability,,
-app,UpdateOrganization,,update_organization,,
-app,DeleteOrganization,,delete_organization,,
-app,ListOrganizationMembers,,list_organization_members,,
-app,CreateOrganizationInvite,,create_organization_invite,,
-app,UpdateOrganizationInviteAuthorizations,,update_organization_invite_authorizations,,
-app,DeleteOrganizationMember,,delete_organization_member,,
-app,DeleteOrganizationInvite,,delete_organization_invite,,
-app,ResendOrganizationInvite,,resend_organization_invite,,
-app,CreateLocation,,create_location,,
-app,GetLocation,,get_location,,
-app,UpdateLocation,,update_location,,
-app,DeleteLocation,,delete_location,,
-app,ListLocations,,list_locations,,
-app,ShareLocation,,share_location,,
-app,UnshareLocation,,unshare_location,,
-app,LocationAuth,,location_auth,,
-app,CreateLocationSecret,,create_location_secret,,
-app,DeleteLocationSecret,,delete_location_secret,,
-app,GetRobot,,get_robot,,
-app,GetRobotAPIKeys,,get_robot_api_keys,,
+app,GetUserIDByEmail,,get_user_id_by_email,,,getUserIDByEmail
+app,CreateOrganization,,create_organization,,,createOrganization
+app,ListOrganizations,,list_organizations,,,listOrganizations
+app,GetOrganizationsWithAccessToLocation,,get_organizations_with_access_to_location,,,getOrganizationsWithAccessToLocation
+app,ListOrganizationsByUser,,list_organizations_by_user,,,listOrganizationsByUser
+app,GetOrganization,,get_organization,,,getOrganization
+app,GetOrganizationNamespaceAvailability,,get_organization_namespace_availability,,,getOrganizationNamespaceAvailability
+app,UpdateOrganization,,update_organization,,,updateOrganization
+app,DeleteOrganization,,delete_organization,,,deleteOrganization
+app,ListOrganizationMembers,,list_organization_members,,,listOrganizationMembers
+app,CreateOrganizationInvite,,create_organization_invite,,,createOrganizationInvite
+app,UpdateOrganizationInviteAuthorizations,,update_organization_invite_authorizations,,,updateOrganizationInviteAuthorizations
+app,DeleteOrganizationMember,,delete_organization_member,,,deleteOrganizationMember
+app,DeleteOrganizationInvite,,delete_organization_invite,,,deleteOrganizationInvite
+app,ResendOrganizationInvite,,resend_organization_invite,,,resendOrganizationInvite
+app,CreateLocation,,create_location,,,createLocation
+app,GetLocation,,get_location,,,getLocation
+app,UpdateLocation,,update_location,,,updateLocation
+app,DeleteLocation,,delete_location,,,deleteLocation
+app,ListLocations,,list_locations,,,listLocations
+app,ShareLocation,,share_location,,,shareLocation
+app,UnshareLocation,,unshare_location,,,unshareLocation
+app,LocationAuth,,location_auth,,,locationAuth
+app,CreateLocationSecret,,create_location_secret,,,createLocationSecret
+app,DeleteLocationSecret,,delete_location_secret,,,deleteLocationSecret
+app,GetRobot,,get_robot,,,getRobot
+app,GetRobotAPIKeys,,get_robot_api_keys,,,getRobotAPIKeys
 ## TODO: Rover stuff is implemented in py,flutter, but internal in design. Omit at proto-level, t lang-level:
-app,GetRoverRentalRobots,,,,
-app,GetRobotParts,,get_robot_parts,,
-app,GetRobotPart,,get_robot_part,,
-app,GetRobotPartLogs,,get_robot_part_logs,,
-app,TailRobotPartLogs,,tail_robot_part_logs,,
-app,GetRobotPartHistory,,get_robot_part_history,,
-app,UpdateRobotPart,,update_robot_part,,
-app,NewRobotPart,,new_robot_part,,
-app,DeleteRobotPart,,delete_robot_part,,
-app,MarkPartAsMain,,mark_part_as_main,,
-app,MarkPartForRestart,,mark_part_for_restart,,
-app,CreateRobotPartSecret,,create_robot_part_secret,,
-app,DeleteRobotPartSecret,,delete_robot_part_secret,,
-app,ListRobots,,list_robots,,
-app,NewRobot,,new_robot,,
-app,UpdateRobot,,update_robot,,
-app,DeleteRobot,,delete_robot,,
-app,ListFragments,,list_fragments,,
-app,GetFragment,,get_fragment,,
-app,CreateFragment,,create_fragment,,
-app,UpdateFragment,,update_fragment,,
-app,DeleteFragment,,delete_fragment,,
-app,GetFragmentHistory,,get_fragment_history,,
-app,AddRole,,add_role,,
-app,RemoveRole,,remove_role,,
-app,ChangeRole,,change_role,,
-app,ListAuthorizations,,list_authorizations,,
-app,CheckPermissions,,check_permissions,,
-app,GetRegistryItem,,get_registry_item,,
-app,CreateRegistryItem,,create_registry_item,,
-app,UpdateRegistryItem,,update_registry_item,,
-app,ListRegistryItems,,list_registry_items,,
-app,DeleteRegistryItem,,delete_registry_item,,
-app,CreateModule,,create_module,,
-app,UpdateModule,,update_module,,
-app,UploadModuleFile,,upload_module_file,,
-app,GetModule,,get_module,,
-app,ListModules,,list_modules,,
-app,CreateKey,,create_key,,
-app,DeleteKey,,delete_key,,
-app,RotateKey,,rotate_key,,
-app,ListKeys,,list_keys,,
-app,CreateKeyFromExistingKeyAuthorizations,,create_key_from_existing_key_authorizations,,
+app,GetRoverRentalRobots,,,,,
+app,GetRobotParts,,get_robot_parts,,,getRobotParts
+app,GetRobotPart,,get_robot_part,,,getRobotPart
+app,GetRobotPartLogs,,get_robot_part_logs,,,getRobotPartLogs
+app,TailRobotPartLogs,,tail_robot_part_logs,,,tailRobotPartLogs
+app,GetRobotPartHistory,,get_robot_part_history,,,getRobotPartHistory
+app,UpdateRobotPart,,update_robot_part,,,updateRobotPart
+app,NewRobotPart,,new_robot_part,,,newRobotPart
+app,DeleteRobotPart,,delete_robot_part,,,deleteRobotPart
+app,MarkPartAsMain,,mark_part_as_main,,,markPartAsMain
+app,MarkPartForRestart,,mark_part_for_restart,,,markPartForRestart
+app,CreateRobotPartSecret,,create_robot_part_secret,,,createRobotPartSecret
+app,DeleteRobotPartSecret,,delete_robot_part_secret,,,deleteRobotPartSecret
+app,ListRobots,,list_robots,,,listRobots
+app,NewRobot,,new_robot,,,newRobot
+app,UpdateRobot,,update_robot,,,updateRobot
+app,DeleteRobot,,delete_robot,,,deleteRobot
+app,ListFragments,,list_fragments,,,listFragments
+app,GetFragment,,get_fragment,,,getFragment
+app,CreateFragment,,create_fragment,,,createFragment
+app,UpdateFragment,,update_fragment,,,updateFragment
+app,DeleteFragment,,delete_fragment,,,deleteFragment
+app,GetFragmentHistory,,get_fragment_history,,,
+app,AddRole,,add_role,,,addRole
+app,RemoveRole,,remove_role,,,removeRole
+app,ChangeRole,,change_role,,,changeRole
+app,ListAuthorizations,,list_authorizations,,,listAuthorizations
+app,CheckPermissions,,check_permissions,,,checkPermissions
+app,GetRegistryItem,,get_registry_item,,,getRegistryItem
+app,CreateRegistryItem,,create_registry_item,,,createRegistryItem
+app,UpdateRegistryItem,,update_registry_item,,,updateRegistryItem
+app,ListRegistryItems,,list_registry_items,,,listRegistryItems
+app,DeleteRegistryItem,,delete_registry_item,,,deleteRegistryItem
+app,CreateModule,,create_module,,,createModule
+app,UpdateModule,,update_module,,,updateModule
+app,UploadModuleFile,,upload_module_file,,,
+app,GetModule,,get_module,,,getModule
+app,ListModules,,list_modules,,,listModules
+app,CreateKey,,create_key,,,createKey
+app,DeleteKey,,delete_key,,,deleteKey
+app,RotateKey,,rotate_key,,,rotateKey
+app,ListKeys,,list_keys,,,listKeys
+app,CreateKeyFromExistingKeyAuthorizations,,create_key_from_existing_key_authorizations,,,createKeyFromExistingKeyAuthorizations
 
 ## Billing
-billing,GetCurrentMonthUsage,,get_current_month_usage,,
-billing,GetOrgBillingInformation,,get_org_billing_information,,
-billing,GetInvoicesSummary,,get_invoices_summary,,
-billing,GetInvoicePdf,,get_invoice_pdf,,
+billing,GetCurrentMonthUsage,,get_current_month_usage,,,getCurrentMonthUsage
+billing,GetOrgBillingInformation,,get_org_billing_information,,,getOrgBillingInformation
+billing,GetInvoicesSummary,,get_invoices_summary,,,getInvoicesSummary
+billing,GetInvoicePdf,,get_invoice_pdf,,,getInvoicePdf
 
 ## Data
-data,GetLatestTabularData,,get_latest_tabular_data,,getLatestTabularData
-data,ExportTabularData,,export_tabular_data,,exportTabularData
-data,TabularDataByFilter,,tabular_data_by_filter,,tabularDataByFilter
-data,TabularDataBySQL,,tabular_data_by_sql,,tabularDataBySql
-data,TabularDataByMQL,,tabular_data_by_mql,,tabularDataByMql
-data,BinaryDataByFilter,,binary_data_by_filter,,binaryDataByFilter
-data,BinaryDataByIDs,,binary_data_by_ids,,binaryDataByIds
-data,DeleteTabularData,,delete_tabular_data,,deleteTabularData
-data,DeleteBinaryDataByFilter,,delete_binary_data_by_filter,,deleteBinaryDataByFilter
-data,DeleteBinaryDataByIDs,,delete_binary_data_by_ids,,deleteBinaryDataByIds
-data,AddTagsToBinaryDataByIDs,,add_tags_to_binary_data_by_ids,,addTagsToBinaryDataByIds
-data,AddTagsToBinaryDataByFilter,,add_tags_to_binary_data_by_filter,,addTagsToBinaryDataByFilter
-data,RemoveTagsFromBinaryDataByIDs,,remove_tags_from_binary_data_by_ids,,removeTagsFromBinaryDataByIds
-data,RemoveTagsFromBinaryDataByFilter,,remove_tags_from_binary_data_by_filter,,removeTagsFromBinaryDataByFilter
-data,TagsByFilter,,tags_by_filter,,tagsByFilter
-data,AddBoundingBoxToImageByID,,add_bounding_box_to_image_by_id,,addBoundingBoxToImageById
-data,RemoveBoundingBoxFromImageByID,,remove_bounding_box_from_image_by_id,,removeBoundingBoxFromImageById
-data,BoundingBoxLabelsByFilter,,bounding_box_labels_by_filter,,boundingBoxLabelsByFilter
-data,GetDatabaseConnection,,get_database_connection,,getDatabaseConnection
-data,ConfigureDatabaseUser,,configure_database_user,,configureDatabaseUser
-data,AddBinaryDataToDatasetByIDs,,add_binary_data_to_dataset_by_ids,,addBinaryDataToDatasetByIds
-data,RemoveBinaryDataFromDatasetByIDs,,remove_binary_data_from_dataset_by_ids,,removeBinaryDataFromDatasetByIds
+data,GetLatestTabularData,,get_latest_tabular_data,,getLatestTabularData,getLatestTabularData
+data,ExportTabularData,,export_tabular_data,,exportTabularData,exportTabularData
+data,TabularDataByFilter,,tabular_data_by_filter,,tabularDataByFilter,tabularDataByFilter
+data,TabularDataBySQL,,tabular_data_by_sql,,tabularDataBySql,tabularDataBySQL
+data,TabularDataByMQL,,tabular_data_by_mql,,tabularDataByMql,tabularDataByMQL
+data,BinaryDataByFilter,,binary_data_by_filter,,binaryDataByFilter,binaryDataByFilter
+data,BinaryDataByIDs,,binary_data_by_ids,,binaryDataByIds,binaryDataByIds
+data,DeleteTabularData,,delete_tabular_data,,deleteTabularData,deleteTabularData
+data,DeleteBinaryDataByFilter,,delete_binary_data_by_filter,,deleteBinaryDataByFilter,deleteBinaryDataByFilter
+data,DeleteBinaryDataByIDs,,delete_binary_data_by_ids,,deleteBinaryDataByIds,deleteBinaryDataByIds
+data,AddTagsToBinaryDataByIDs,,add_tags_to_binary_data_by_ids,,addTagsToBinaryDataByIds,addTagsToBinaryDataByIds
+data,AddTagsToBinaryDataByFilter,,add_tags_to_binary_data_by_filter,,addTagsToBinaryDataByFilter,addTagsToBinaryDataByFilter
+data,RemoveTagsFromBinaryDataByIDs,,remove_tags_from_binary_data_by_ids,,removeTagsFromBinaryDataByIds,removeTagsFromBinaryDataByIds
+data,RemoveTagsFromBinaryDataByFilter,,remove_tags_from_binary_data_by_filter,,removeTagsFromBinaryDataByFilter,removeTagsFromBinaryDataByFilter
+data,TagsByFilter,,tags_by_filter,,tagsByFilter,tagsByFilter
+data,AddBoundingBoxToImageByID,,add_bounding_box_to_image_by_id,,addBoundingBoxToImageById,addBoundingBoxToImageById
+data,RemoveBoundingBoxFromImageByID,,remove_bounding_box_from_image_by_id,,removeBoundingBoxFromImageById,removeBoundingBoxFromImageById
+data,BoundingBoxLabelsByFilter,,bounding_box_labels_by_filter,,boundingBoxLabelsByFilter,boundingBoxLabelsByFilter
+data,GetDatabaseConnection,,get_database_connection,,getDatabaseConnection,getDatabaseConnection
+data,ConfigureDatabaseUser,,configure_database_user,,configureDatabaseUser,configureDatabaseUser
+data,AddBinaryDataToDatasetByIDs,,add_binary_data_to_dataset_by_ids,,addBinaryDataToDatasetByIds,addBinaryDataToDatasetByIds
+data,RemoveBinaryDataFromDatasetByIDs,,remove_binary_data_from_dataset_by_ids,,removeBinaryDataFromDatasetByIds,removeBinaryDataFromDatasetByIds
 
 ## Dataset
-dataset,CreateDataset,,create_dataset,,createDataset
-dataset,DeleteDataset,,delete_dataset,,deleteDataset
-dataset,RenameDataset,,rename_dataset,,renameDataset
-dataset,ListDatasetsByOrganizationID,,list_datasets_by_organization_id,,listDatasetsByOrganizationID
+dataset,CreateDataset,,create_dataset,,createDataset,
+dataset,DeleteDataset,,delete_dataset,,deleteDataset,
+dataset,RenameDataset,,rename_dataset,,renameDataset,
+dataset,ListDatasetsByOrganizationID,,list_datasets_by_organization_id,,listDatasetsByOrganizationID,
 ## TE: yes PySDK is singular:
-dataset,ListDatasetsByIDs,,list_dataset_by_ids,,listDatasetsByIDs
+dataset,ListDatasetsByIDs,,list_dataset_by_ids,,listDatasetsByIDs,
 
 ## Datasync
-data_sync,DataCaptureUpload,,,,
+data_sync,DataCaptureUpload,,,,,
 ## HACK: DataCaptureUpload instead implemented in binary_data_capture_upload (python), adding pseudo-entry:
-data_sync,BinaryDataCaptureUpload,,binary_data_capture_upload,,binaryDataCaptureUpload
+data_sync,BinaryDataCaptureUpload,,binary_data_capture_upload,,binaryDataCaptureUpload,
 ## HACK: DataCaptureUpload instead implemented in tabular_data_capture_upload (python), adding pseudo-entry:
-data_sync,TabularDataCaptureUpload,,tabular_data_capture_upload,,tabularDataCaptureUpload
-data_sync,FileUpload,,file_upload,,uploadFile
+data_sync,TabularDataCaptureUpload,,tabular_data_capture_upload,,tabularDataCaptureUpload,
+data_sync,FileUpload,,file_upload,,uploadFile,
 ## HACK: FileUpload also implemented in file_upload_from_path (python), adding pseudo-entry:
-data_sync,FileUploadFromPath,,file_upload_from_path,,
-data_sync,StreamingDataCaptureUpload,,streaming_data_capture_upload,,streamingDataCaptureUpload
+data_sync,FileUploadFromPath,,file_upload_from_path,,,
+data_sync,StreamingDataCaptureUpload,,streaming_data_capture_upload,,streamingDataCaptureUpload,
 
 ## Discovery
-discovery,DiscoverResources,,discover_resources,DiscoverResources,
+discovery,DiscoverResources,,discover_resources,DiscoverResources,,discoverResources
 
 ## MLTraining
-mltraining,SubmitTrainingJob,,submit_training_job,,
-mltraining,SubmitCustomTrainingJob,,submit_custom_training_job,,
-mltraining,GetTrainingJob,,get_training_job,,
-mltraining,ListTrainingJobs,,list_training_jobs,,
-mltraining,CancelTrainingJob,,cancel_training_job,,
-mltraining,DeleteCompletedTrainingJob,,delete_completed_training_job,,
+mltraining,SubmitTrainingJob,,submit_training_job,,,submitTrainingJob
+mltraining,SubmitCustomTrainingJob,,submit_custom_training_job,,,submitCustomTrainingJob
+mltraining,GetTrainingJob,,get_training_job,,,getTrainingJob
+mltraining,ListTrainingJobs,,list_training_jobs,,,listTrainingJobs
+mltraining,CancelTrainingJob,,cancel_training_job,,,cancelTrainingJob
+mltraining,DeleteCompletedTrainingJob,,delete_completed_training_job,,,deleteCompletedTrainingJob
 
 ## Robot
 ## Omitting some Flutter methods from w until we can determine what they do
 ## ( counterpart description text in other SDKs, as other SDKs implement these)
-robot,GetOperations,,get_operations,,
-robot,GetMachineStatus,,get_machine_status,,
-robot,GetSessions,,,,
-robot,ResourceNames,,,ResourceNames,
-robot,ResourceRPCSubtypes,,,,
-robot,CancelOperation,,cancel_operation,,
-robot,BlockForOperation,,block_for_operation,,
-robot,FrameSystemConfig,,get_frame_system_config,FrameSystemConfig,
-robot,TransformPose,,transform_pose,TransformPose,
-robot,TransformPCD,,,TransformPointCloud,
-robot,StreamStatus,,,,
-# DEPRECATED robot,DiscoverComponents,,discover_components,DiscoverComponents,
-robot,GetModelsFromModules,,get_models_from_modules,,
-robot,StopAll,,stop_all,StopAll,
-robot,RestartModule,,,RestartModule,
-robot,StartSession,,,,
-robot,SendSessionHeartbeat,,,,
-robot,Log,,log,,
-robot,GetCloudMetadata,,get_cloud_metadata,CloudMetadata,getCloudMetadata
-robot,GetVersion,,get_version,Version,
+robot,GetOperations,,get_operations,,,getOperations
+robot,GetMachineStatus,,get_machine_status,,,getMachineStatus
+robot,GetSessions,,,,,
+robot,ResourceNames,,,ResourceNames,,resourceNames
+robot,ResourceRPCSubtypes,,,,,
+robot,CancelOperation,,cancel_operation,,,cancelOperation
+robot,BlockForOperation,,block_for_operation,,,blockForOperation
+robot,FrameSystemConfig,,get_frame_system_config,FrameSystemConfig,,frameSystemConfig
+robot,TransformPose,,transform_pose,TransformPose,,transformPose
+robot,TransformPCD,,,TransformPointCloud,,transformPCD
+robot,StreamStatus,,,,,
+# DEPRECATED robot,DiscoverComponents,,discover_components,DiscoverComponents,,discoverComponents
+robot,GetModelsFromModules,,get_models_from_modules,,,getModelsFromModules
+robot,StopAll,,stop_all,StopAll,,stopAll
+robot,RestartModule,,,RestartModule,,
+robot,StartSession,,,,,
+robot,SendSessionHeartbeat,,,,,
+robot,Log,,log,,,
+robot,GetCloudMetadata,,get_cloud_metadata,CloudMetadata,getCloudMetadata,getCloudMetadata
+robot,GetVersion,,get_version,Version,,
 ## HACK: Robot (python) provides additional helper function, adding 4 pseudo-entries:
-robot,Options.with_api_key,,with_api_key,,
-robot,AtAddress,,at_address,,atAddress
-robot,WithChannel,,with_channel,,
-robot,Refresh,,refresh,,refresh
-robot,Shutdown,Yes,shutdown,Shutdown,
+robot,Options.with_api_key,,with_api_key,,,
+robot,AtAddress,,at_address,,atAddress,
+robot,WithChannel,,with_channel,,,
+robot,Refresh,,refresh,,refresh,
+robot,Shutdown,Yes,shutdown,Shutdown,,
 ## HACK:  proto for close, manually mapping:
-robot,Close,,close,Close,close
+robot,Close,,close,Close,close,

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -13,8 +13,6 @@ from parse_flutter import FlutterParser
 from parse_typescript import TypeScriptParser
 from parser_utils import make_soup
 
-import pprint
-
 ## The full list of SDK languages we scrape. You can use the sdk_languages
 ## positional parameter to refine this at runtime if desired:
 sdks_supported = ["go", "python", "flutter", "typescript"]
@@ -1015,7 +1013,7 @@ def write_markdown(type, names, methods):
 
                             # Close tabs
                             output_file.write("{{% /tab %}}\n")
-                            if not (go_method_name and "go" in sdks) and not (flutter_method_name and "flutter" in sdks):
+                            if not (go_method_name and "go" in sdks) and not (flutter_method_name and "flutter" in sdks) and not (typescript_method_name and "typescript" in sdks):
                                 output_file.write("{{< /tabs >}}\n")
 
                         if go_method_name and "go" in sdks:
@@ -1129,12 +1127,10 @@ def write_markdown(type, names, methods):
                             output_file.write('**Parameters:**\n\n')
 
                             if typescript_method_name not in methods['typescript'][type][resource]:
-                                print("ERROR: Method not found in typescript SDK: ", typescript_method_name)
-                                print(type, resource)
-                                print(methods['typescript'][type])
+                                print("ERROR: Method not found in typescript SDK: ", typescript_method_name, type, resource)
                                 continue
 
-                            if 'parameters' in methods['typescript'][type][resource][typescript_method_name]:
+                            if 'parameters' in methods['typescript'][type][resource][typescript_method_name] and methods['typescript'][type][resource][typescript_method_name]['parameters']:
 
                                 for parameter in methods['typescript'][type][resource][typescript_method_name]['parameters'].keys():
 

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -10,11 +10,14 @@ import argparse
 from parse_python import PythonParser
 from parse_go import GoParser
 from parse_flutter import FlutterParser
+from parse_typescript import TypeScriptParser
 from parser_utils import make_soup
+
+import pprint
 
 ## The full list of SDK languages we scrape. You can use the sdk_languages
 ## positional parameter to refine this at runtime if desired:
-sdks_supported = ["go", "python", "flutter"]
+sdks_supported = ["go", "python", "flutter", "typescript"]
 
 ## Arrays of resources to scrape, by type:
 ##   type = ["array", "of", "resources"]
@@ -52,14 +55,14 @@ parser.add_argument('-v', '--verbose', action='store_true', help="Run in verbose
 
 ## Parse provided parameters and arguments, if any:
 args = parser.parse_args()
+sdk_list = ''
+resource_list = ''
+only_run_against = ''
+
 if args.map:
     ## We check for args.map again in both proto_map() and run().
     sdks = sdks_supported
 else:
-    sdk_list = ''
-    resource_list = ''
-    only_run_against = ''
-
     ## Using specific argument names to allow help text to be specific, but checking both
     ## for sdk or resource values, to allow providing either in any position on the CLI.
     if args.sdk_languages is not None:
@@ -126,17 +129,17 @@ if args.verbose:
     print('              Try, in a separate terminal window:\n')
     print('              DURING RUN: tail -f /tmp/update_sdk_methods_debug.txt')
     print('              AFTER RUN: less /tmp/update_sdk_methods_debug.txt\n')
-if sdk_list and args.verbose:
-    print('SDKS OVERRIDE: Only running against ' + str(sdks) + '\n')
-if resource_list and args.verbose:
-    print('RESOURCE OVERRIDE: Only running against ' + str(resource_list) + '\n')
-if args.overrides and args.verbose:
-    print("ERROR: You cannot use verbose mode with print overrides mode.")
-    print("       If you want this script to print the overrides filepaths it needs")
-    print("       for param | return description overrides, rerun this script with")
-    print("       the -o flag but WITHOUT the -v flag.")
-    print("Exiting ...")
-    exit(1)
+    if sdk_list:
+        print('SDKS OVERRIDE: Only running against ' + str(sdks) + '\n')
+    if resource_list:
+        print('RESOURCE OVERRIDE: Only running against ' + str(resource_list) + '\n')
+    if args.overrides:
+        print("ERROR: You cannot use verbose mode with print overrides mode.")
+        print("       If you want this script to print the overrides filepaths it needs")
+        print("       for param | return description overrides, rerun this script with")
+        print("       the -o flag but WITHOUT the -v flag.")
+        print("Exiting ...")
+        exit(1)
 
 ## This script must be run within the 'docs' git repo. Here we check
 ## to make sure this is the case, and get the root of our git-managed
@@ -349,7 +352,8 @@ override_description_links = {
 code_fence_fmt = {
     'python': 'python',
     'go': 'go',
-    'flutter': 'dart'
+    'flutter': 'dart',
+    'typescript': 'ts'
 }
 
 ## Check to see if we have a locally-staged version of any of the supported SDK docs sites.
@@ -359,6 +363,8 @@ code_fence_fmt = {
 python_staging_url = ''
 go_staging_url = ''
 flutter_staging_url = ''
+# TODO: NOT implemented yet
+typescript_staging_url = ''
 
 ## Check for GO SDK docs staging on local workstation:
 go_process_pid = subprocess.run(["ps -ef | grep pkgsite | grep -v grep | awk {'print $2'}"], shell=True, text=True, capture_output=True).stdout.rstrip()
@@ -473,13 +479,6 @@ def parse(type, names):
 
     ## Iterate through each sdk (like 'python') in sdks array:
     for sdk in sdks:
-
-        ## Determine SDK URL based on resource type:
-        sdk_url = sdk_url_mapping[sdk]
-        scrape_url = sdk_url
-
-        ## Build empty dict to house methods, and update scrape_url
-        ## with staging link if we detected one earlier:
         if sdk == "go":
             go_parser = GoParser(proto_map_file, go_staging_url)
             all_methods["go"] = go_parser.parse(type, names)
@@ -489,6 +488,9 @@ def parse(type, names):
         elif sdk == "flutter":
             flutter_parser = FlutterParser(proto_map_file, flutter_staging_url)
             all_methods["flutter"] = flutter_parser.parse(type, names, args)
+        elif sdk == "typescript":
+            typescript_parser = TypeScriptParser(proto_map_file, typescript_staging_url)
+            all_methods["typescript"] = typescript_parser.parse(type, names, args)
         else:
             print("unsupported language!")
 
@@ -753,10 +755,11 @@ def write_markdown(type, names, methods):
                     py_method_name = row.split(',')[3]
                     go_method_name = row.split(',')[4]
                     flutter_method_name = row.split(',')[5].rstrip()
+                    typescript_method_name = row.split(',')[6].rstrip()
 
                     ## Allow setting protos with 0 sdk method maps, to allow us to disable writing MD
                     ## for specific protos as needed, if needed:
-                    if (py_method_name and "python" in sdks) or (go_method_name and "go" in sdks) or (flutter_method_name and "flutter" in sdks):
+                    if (py_method_name and "python" in sdks) or (go_method_name and "go" in sdks) or (typescript_method_name and "typescript" in sdks) or (flutter_method_name and "flutter" in sdks):
 
                         ## We have at least one implemented method for this proto, so begin writing output markdown for this resource.
                         ## Write proto as H3, with leading newlines if appending to ongoing {resource}.md file:
@@ -1104,8 +1107,172 @@ def write_markdown(type, names, methods):
                             output_file.write(f'\nFor more information, see the [Go SDK Docs]({methods["go"][type][resource][go_method_name]["method_link"]}).\n\n')
 
                             output_file.write("{{% /tab %}}\n")
+                            if not (typescript_method_name and "typescript" in sdks) and not(flutter_method_name and "flutter" in sdks):
+                                output_file.write("{{< /tabs >}}\n")
+
+                        if typescript_method_name and "typescript" in sdks:
+                            output_file.write('{{% tab name="TypeScript" %}}\n\n')
+
+                            ## Assemble possible method override filepaths. Provide a file at one or both of these locations to
+                            ## inject additional MD content either before or after the auto-generated method content:
+                            ## 'before': injects immediately after the opening SDK tab and before the first parameter is listed.
+                            ## 'after': injects immediately after the code sample (or last return if none), and before the closing SDK tab.
+                            ## .../overrides/methods/{sdk}.{resource}.{method_name}.before|after.md
+                            before_method_override_filepath = path_to_methods_override + '/typescript.' + resource + '.' + typescript_method_name + '.before.md'
+                            after_method_override_filepath = path_to_methods_override + '/typescript.' + resource + '.' + typescript_method_name + '.after.md'
+
+                            ## If we detected a 'before' method override file, write it out here:
+                            if os.path.exists(before_method_override_filepath):
+                                for line in open(before_method_override_filepath, 'r', encoding='utf-8'):
+                                    output_file.write(line)
+
+                            output_file.write('**Parameters:**\n\n')
+
+                            if typescript_method_name not in methods['typescript'][type][resource]:
+                                print("ERROR: Method not found in typescript SDK: ", typescript_method_name)
+                                print(type, resource)
+                                print(methods['typescript'][type])
+                                continue
+
+                            if 'parameters' in methods['typescript'][type][resource][typescript_method_name]:
+
+                                for parameter in methods['typescript'][type][resource][typescript_method_name]['parameters'].keys():
+
+                                    param_data = methods['typescript'][type][resource][typescript_method_name]['parameters'][parameter]
+
+                                    param_type = param_data.get("param_type")
+
+                                    param_description = ''
+                                    ## .../overrides/methods/{sdk}.{resource}.{typescript_method_name}.{param_name}.md
+                                    param_desc_override_file = path_to_methods_override + '/typescript.' + resource + '.' + typescript_method_name + '.' + parameter + '.md'
+
+                                    if args.overrides:
+                                        print(param_desc_override_file)
+
+                                    if os.path.exists(param_desc_override_file):
+                                        preserve_formatting = False
+                                        for line in open(param_desc_override_file, 'r', encoding='utf-8'):
+                                            if '<!-- preserve-formatting -->' in line:
+                                                preserve_formatting = True
+                                            if preserve_formatting and '<!-- preserve-formatting -->' not in line:
+                                                param_description = param_description + line
+                                            elif '<!-- preserve-formatting -->' not in line:
+                                                param_description = param_description + line.replace('\n', ' ')
+                                        param_description = param_description.rstrip()
+                                    else:
+                                        param_description = param_data.get("param_description").strip()
+
+                                    optional = param_data.get("optional")
+
+                                    output_file.write(f'- `{parameter}` ({param_type})')
+
+                                    if optional:
+                                        output_file.write(' (optional)')
+                                    else:
+                                        output_file.write(' (required)')
+
+                                    if param_description:
+
+                                        ## Add a trailing period if it is missing, either from upstream or from override file,
+                                        ## but skip doing so if the copy instead ends with an HTML tag (like a closing '</ul>' tag):
+                                        if not param_description.endswith('.') and not param_description.endswith('>'):
+                                            param_description = param_description + '.'
+
+                                        output_file.write(f": {param_description}")
+
+                                    # line break for parameters list
+                                    output_file.write('\n')
+
+                            # Handle case where no parameters are found
+                            else:
+                                output_file.write("- None.\n")
+
+                            output_file.write('\n**Returns:**\n\n')
+
+                            if 'return' in methods['typescript'][type][resource][typescript_method_name]:
+
+                                return_data = methods['typescript'][type][resource][typescript_method_name]["return"]
+                                return_type = return_data.get("return_type")
+
+                                return_description = ''
+                                ## .../overrides/methods/{sdk}.{resource}.{typescript_method_name}.return.md
+                                return_desc_override_file = path_to_methods_override + '/python.' + resource + '.' + typescript_method_name + '.return.md'
+
+                                if args.overrides:
+                                    print(return_desc_override_file)
+
+                                if os.path.exists(return_desc_override_file):
+                                    preserve_formatting = False
+                                    for line in open(return_desc_override_file, 'r', encoding='utf-8'):
+                                        if '<!-- preserve-formatting -->' in line:
+                                            preserve_formatting = True
+                                        if preserve_formatting and '<!-- preserve-formatting -->' not in line:
+                                            return_description = return_description + line
+                                        elif '<!-- preserve-formatting -->' not in line:
+                                            return_description = return_description + line.replace('\n', ' ')
+                                    return_description = return_description.rstrip()
+                                else:
+                                    return_description = return_data.get("return_description")
+
+                                if return_type:
+                                    output_file.write(f"- ({return_type})")
+
+                                    if return_description:
+
+                                        ## Add a trailing period if it is missing, either from upstream or from override file,
+                                        ## but skip doing so if the copy instead ends with an HTML tag (like a closing '</ul>' tag):
+                                        if not return_description.endswith('.') and not return_description.endswith('>'):
+                                            return_description = return_description + '.'
+
+                                        output_file.write(f": {return_description}\n")
+                                    else:
+                                        output_file.write("\n")
+                            # Handle case where no returns are found
+                            else:
+                                output_file.write("- None.\n")
+
+                            if 'raises' in methods['typescript'][type][resource][typescript_method_name]:
+                                output_file.write('\n**Raises:**\n\n')
+
+                                raises_object = methods['typescript'][type][resource][typescript_method_name]["raises"]
+                                raises_types = methods['typescript'][type][resource][typescript_method_name]["raises"].keys()
+                                for raises_type in raises_types:
+                                    output_file.write(f"- ({raises_type})")
+                                    if "raises_description" in raises_object[raises_type]:
+                                        raises_description= raises_object[raises_type]["raises_description"]
+                                        ## Add a trailing period if it is missing, either from upstream or from override file,
+                                        ## but skip doing so if the copy instead ends with an HTML tag (like a closing '</ul>' tag):
+                                        if not raises_description.endswith('.') and not raises_description.endswith('>'):
+                                            raises_description = raises_description + '.'
+
+                                        output_file.write(f": {raises_description}\n")
+                                    else:
+                                        output_file.write("\n")
+
+                            ## If the method has a code sample, print it here:
+                            if 'code_sample' in methods['typescript'][type][resource][typescript_method_name]:
+
+                                output_file.write('\n**Example:**\n')
+                                output_file.write('\n```' + code_fence_fmt['typescript'] + ' {class="line-numbers linkable-line-numbers"}\n')
+                                output_file.write(methods['typescript'][type][resource][typescript_method_name]['code_sample'])
+                                output_file.write('```\n')
+
+                            ## If we detected an 'after' method override file earlier, write it out here:
+                            if os.path.exists(after_method_override_filepath):
+
+                                output_file.write('\n')
+                                for line in open(after_method_override_filepath, 'r', encoding='utf-8'):
+                                    output_file.write(line)
+
+                            # Output the method link
+                            output_file.write(f'\nFor more information, see the [TypeScript SDK Docs]({methods["typescript"][type][resource][typescript_method_name]["method_link"]}).\n\n')
+
+                            # Close tabs
+                            output_file.write("{{% /tab %}}\n")
                             if not (flutter_method_name and "flutter" in sdks):
                                 output_file.write("{{< /tabs >}}\n")
+
+
 
                         if flutter_method_name and "flutter" in sdks:
                             output_file.write('{{% tab name="Flutter" %}}\n\n')
@@ -1256,6 +1423,7 @@ def write_markdown(type, names, methods):
                         ## This switch tells us at the start of the loop for this same resource that we should double-newline the next
                         ## proto encountered:
                         is_first_method_in_this_resource = False
+
 
         ## Close file handles:
         output_file.close()

--- a/static/include/app/apis/generated/app.md
+++ b/static/include/app/apis/generated/app.md
@@ -23,6 +23,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `email` (string) (required): The email address of the user.
+
+**Returns:**
+
+- (Promise<string>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getUserIDByEmail).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### CreateOrganization
 
@@ -46,6 +60,20 @@ organization = await cloud.create_organization("name")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_organization).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `name` (string) (required): The name of the new organization.
+
+**Returns:**
+
+- (Promise<undefined | [Organization](appApi.Organization.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createOrganization).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -75,6 +103,19 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+
+**Returns:**
+
+- (Promise<[Organization](appApi.Organization.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listOrganizations).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### GetOrganizationsWithAccessToLocation
 
@@ -101,6 +142,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `locationId` (string) (required): The ID of the location to query.
+
+**Returns:**
+
+- (Promise<[OrganizationIdentity](appApi.OrganizationIdentity.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getOrganizationsWithAccessToLocation).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### ListOrganizationsByUser
 
@@ -124,6 +179,20 @@ org_list = await cloud.list_organizations_by_user("<YOUR-USER-ID>")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.list_organizations_by_user).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `userId` (string) (required): The ID of the user to query.
+
+**Returns:**
+
+- (Promise<[OrgDetails](appApi.OrgDetails.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listOrganizationsByUser).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -157,6 +226,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization.
+
+**Returns:**
+
+- (Promise<undefined | [Organization](appApi.Organization.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getOrganization).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### GetOrganizationNamespaceAvailability
 
@@ -185,6 +268,20 @@ available = await cloud.get_organization_namespace_availability(
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_organization_namespace_availability).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `namespace` (string) (required): The namespace to query for availability.
+
+**Returns:**
+
+- (Promise<boolean>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getOrganizationNamespaceAvailability).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -226,6 +323,24 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The id of the organization to update.
+- `name` (string) (optional): Optional name to update the organization with.
+- `publicNamespace` (string) (optional): Optional namespace to update the organization with.
+- `region` (string) (optional): Optional region to update the organization with.
+- `cid` (string) (optional): Optional CRM ID to update the organization with.
+
+**Returns:**
+
+- (Promise<undefined | [Organization](appApi.Organization.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#updateOrganization).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### DeleteOrganization
 
@@ -248,6 +363,20 @@ await cloud.delete_organization("<YOUR-ORG-ID>")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.delete_organization).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The id of the organization to delete.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deleteOrganization).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -274,6 +403,20 @@ member_list, invite_list = await cloud.list_organization_members("<YOUR-ORG-ID>"
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.list_organization_members).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The id of the organization to query.
+
+**Returns:**
+
+- (Promise<[ListOrganizationMembersResponse](appApi.ListOrganizationMembersResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listOrganizationMembers).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -307,6 +450,24 @@ await cloud.create_organization_invite("<YOUR-ORG-ID>", "youremail@email.com")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_organization_invite).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The id of the organization to create the invite for.
+- `email` (string) (required): The email address of the user to generate an invite for.
+- `authorizations` ([Authorization](appApi.Authorization.html)) (required): The authorizations to associate with the new invite.
+- `sendEmailInvite` (boolean) (optional): Bool of whether to send an email invite (true) or
+  automatically add a user. Defaults to true.
+
+**Returns:**
+
+- (Promise<undefined | [OrganizationInvite](appApi.OrganizationInvite.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createOrganizationInvite).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -360,6 +521,23 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The id of the organization.
+- `email` (string) (required): The email address associated with the invite.
+- `addAuthsList` ([Authorization](appApi.Authorization.html)) (required): List of authorizations to add to the invite.
+- `removeAuthsList` ([Authorization](appApi.Authorization.html)) (required): List of authorizations to remove from the invite.
+
+**Returns:**
+
+- (Promise<undefined | [OrganizationInvite](appApi.OrganizationInvite.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#updateOrganizationInviteAuthorizations).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### DeleteOrganizationMember
 
@@ -387,6 +565,21 @@ await cloud.delete_organization_member(org_id="org_id", user_id=first_user_id)
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.delete_organization_member).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization.
+- `userId` (string) (required): The ID of the user.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deleteOrganizationMember).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -421,6 +614,21 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization.
+- `email` (string) (required): The email associated with the invite to delete.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deleteOrganizationInvite).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### ResendOrganizationInvite
 
@@ -449,6 +657,21 @@ org_invite = await cloud.resend_organization_invite("<YOUR-ORG-ID>", "youremail@
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.resend_organization_invite).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization.
+- `email` (string) (required): The email associated with the invite to resend.
+
+**Returns:**
+
+- (Promise<undefined | [OrganizationInvite](appApi.OrganizationInvite.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#resendOrganizationInvite).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -485,6 +708,24 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization to create the location
+  under.
+- `name` (string) (required): The name of the location to create.
+- `parentLocationId` (string) (optional): Optional name of a parent location to create the
+  new location under.
+
+**Returns:**
+
+- (Promise<undefined | [Location](appApi.Location.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createLocation).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### GetLocation
 
@@ -512,6 +753,20 @@ location = await cloud.get_location(location_id="123ab12345")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_location).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `locId` (string) (required): The ID of the location to query.
+
+**Returns:**
+
+- (Promise<undefined | [Location](appApi.Location.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getLocation).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -566,6 +821,24 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `locId` (string) (required): The ID of the location to update.
+- `name` (string) (optional): Optional string to update the location's name to.
+- `parentLocId` (string) (optional): Optional string to update the location's parent location
+  to.
+- `region` (string) (optional): Optional string to update the location's region to.
+
+**Returns:**
+
+- (Promise<undefined | [Location](appApi.Location.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#updateLocation).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### DeleteLocation
 
@@ -596,6 +869,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `locId` (string) (required): The ID of the location to delete.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deleteLocation).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### ListLocations
 
@@ -619,6 +906,20 @@ locations = await cloud.list_locations("<YOUR-ORG-ID>")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.list_locations).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization to query.
+
+**Returns:**
+
+- (Promise<[Location](appApi.Location.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listLocations).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -649,6 +950,21 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization to share with.
+- `locId` (string) (required): The ID of the location to share.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#shareLocation).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### UnshareLocation
 
@@ -673,6 +989,21 @@ await cloud.unshare_location("<YOUR-ORG-ID>", "<YOUR-LOCATION-ID>")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.unshare_location).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization to unshare with.
+- `locId` (string) (required): The ID of the location to unshare.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#unshareLocation).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -706,6 +1037,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `locId` (string) (required): The ID of the location to retrieve LocationAuth from.
+
+**Returns:**
+
+- (Promise<undefined | [LocationAuth](appApi.LocationAuth.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#locationAuth).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### CreateLocationSecret
 
@@ -733,6 +1078,20 @@ new_loc_auth = await cloud.create_location_secret(location_id="123xy12345")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_location_secret).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `locId` (string) (required): The ID of the location to create a LocationAuth for.
+
+**Returns:**
+
+- (Promise<undefined | [LocationAuth](appApi.LocationAuth.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createLocationSecret).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -770,6 +1129,21 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `locId` (string) (required): The ID of the location to delete the LocationAuth from.
+- `secretId` (string) (required): The ID of the location secret to delete.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deleteLocationSecret).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### GetRobot
 
@@ -800,6 +1174,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required): The ID of the robot.
+
+**Returns:**
+
+- (Promise<undefined | [appApi](../modules/appApi.html).[Robot](appApi.Robot.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getRobot).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### GetRobotAPIKeys
 
@@ -823,6 +1211,20 @@ api_keys = await cloud.get_robot_api_keys(robot_id="robot-id")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_robot_api_keys).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `robotId` (string) (required): The ID of the robot to get API keys for.
+
+**Returns:**
+
+- (Promise<[APIKeyWithAuthorizations](appApi.APIKeyWithAuthorizations.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getRobotAPIKeys).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -858,6 +1260,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `robotId` (string) (required): The ID of the robot to query.
+
+**Returns:**
+
+- (Promise<[RobotPart](appApi.RobotPart.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getRobotParts).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### GetRobotPart
 
@@ -889,6 +1305,20 @@ my_robot_part = await cloud.get_robot_part(
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_robot_part).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required): The ID of the requested robot part.
+
+**Returns:**
+
+- (Promise<[GetRobotPartResponse](appApi.GetRobotPartResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getRobotPart).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -929,6 +1359,25 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required): The ID of the requested robot part.
+- `filter` (string) (optional): Optional string to filter logs on.
+- `levels` (string) (optional): Optional array of log levels to return. Defaults to returning
+  all log levels.
+- `pageToken` (string) (optional): Optional string indicating which page of logs to query.
+  Defaults to the most recent.
+
+**Returns:**
+
+- (Promise<[GetRobotPartLogsResponse](appApi.GetRobotPartLogsResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getRobotPartLogs).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### TailRobotPartLogs
 
@@ -956,6 +1405,24 @@ logs_stream = await cloud.tail_robot_part_logs(
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.tail_robot_part_logs).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required): The ID of the requested robot part.
+- `queue` ([LogEntry](commonApi.LogEntry.html)) (required): A queue to put the log entries into.
+- `filter` (string) (optional): Optional string to filter logs on.
+- `errorsOnly` (boolean) (optional): Optional bool to indicate whether or not only error-level
+  logs should be returned. Defaults to true.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#tailRobotPartLogs).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -988,6 +1455,20 @@ part_history = await cloud.get_robot_part_history(
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_robot_part_history).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required): The ID of the requested robot part.
+
+**Returns:**
+
+- (Promise<[RobotPartHistoryEntry](appApi.RobotPartHistoryEntry.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getRobotPartHistory).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -1025,6 +1506,22 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required): The ID of the requested robot part.
+- `name` (string) (required): The new name of the robot part.
+- `robotConfig` ([Struct](Struct.html)) (required): The new config for the robot part.
+
+**Returns:**
+
+- (Promise<undefined | [RobotPart](appApi.RobotPart.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#updateRobotPart).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### NewRobotPart
 
@@ -1055,6 +1552,21 @@ new_part_id = await cloud.new_robot_part(
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.new_robot_part).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `robotId` (string) (required): The ID of the robot to create a part for.
+- `partName` (string) (required): The name for the new robot part.
+
+**Returns:**
+
+- (Promise<string>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#newRobotPart).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -1090,6 +1602,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `partId` (string) (required): The ID of the part to delete.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deleteRobotPart).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### MarkPartAsMain
 
@@ -1118,6 +1644,20 @@ await cloud.mark_part_as_main(
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.mark_part_as_main).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `partId` (string) (required): The ID of the part to mark as main.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#markPartAsMain).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -1152,6 +1692,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `partId` (string) (required): The ID of the part to mark for restart.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#markPartForRestart).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### CreateRobotPartSecret
 
@@ -1180,6 +1734,20 @@ part_with_new_secret = await cloud.create_robot_part_secret(
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_robot_part_secret).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `partId` (string) (required): The ID of the part to create a secret for.
+
+**Returns:**
+
+- (Promise<undefined | [RobotPart](appApi.RobotPart.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createRobotPartSecret).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -1216,6 +1784,21 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `partId` (string) (required): The ID of the part to delete a secret from.
+- `secretId` (string) (required): The ID of the secret to delete.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deleteRobotPartSecret).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### ListRobots
 
@@ -1243,6 +1826,20 @@ list_of_machines = await cloud.list_robots(location_id="123ab12345")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.list_robots).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `locId` (string) (required): The ID of the location to list robots for.
+
+**Returns:**
+
+- (Promise<[appApi](../modules/appApi.html).[Robot](appApi.Robot.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listRobots).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -1274,6 +1871,21 @@ new_machine_id = await cloud.new_robot(name="beepboop", location_id="my-location
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.new_robot).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `locId` (string) (required): The ID of the location to create the robot in.
+- `name` (string) (required): The name of the new robot.
+
+**Returns:**
+
+- (Promise<string>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#newRobot).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -1313,6 +1925,22 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `robotId` (string) (required): The ID of the robot to update.
+- `locId` (string) (required): The ID of the location to move the robot to.
+- `name` (string) (required): The name to update the robot to.
+
+**Returns:**
+
+- (Promise<undefined | [appApi](../modules/appApi.html).[Robot](appApi.Robot.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#updateRobot).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### DeleteRobot
 
@@ -1343,6 +1971,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required): The ID of the robot to delete.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deleteRobot).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### ListFragments
 
@@ -1368,6 +2010,24 @@ fragments_list = await cloud.list_fragments(org_id="org-id", visibilities=[])
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.list_fragments).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization to list fragments for.
+- `publicOnly` (boolean) (optional): Optional, deprecated boolean. Use fragmentVisibilities
+  instead. If true then only public fragments will be listed. Defaults to
+  true.
+- `fragmentVisibility` ([FragmentVisibility](../enums/appApi.FragmentVisibility.html)) (optional)
+
+**Returns:**
+
+- (Promise<[Fragment](appApi.Fragment.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listFragments).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -1404,6 +2064,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required): The ID of the fragment to look up.
+
+**Returns:**
+
+- (Promise<undefined | [Fragment](appApi.Fragment.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getFragment).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### CreateFragment
 
@@ -1433,6 +2107,23 @@ new_fragment = await cloud.create_fragment(org_id="org-id", name="cool_smart_mac
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_fragment).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization to create the fragment
+  under.
+- `name` (string) (required): The name of the new fragment.
+- `config` ([Struct](Struct.html)) (required): The new fragment's config.
+
+**Returns:**
+
+- (Promise<undefined | [Fragment](appApi.Fragment.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createFragment).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -1472,6 +2163,30 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required): The ID of the fragment to update.
+- `name` (string) (required): The name to update the fragment to.
+- `config` ([Struct](Struct.html)) (required): The config to update the fragment to.
+- `makePublic` (boolean) (optional): Optional, deprecated boolean specifying whether the
+  fragment should be public or not. If not passed, the visibility will be
+  unchanged. Fragments are private by default when created.
+- `visibility` ([FragmentVisibility](../enums/appApi.FragmentVisibility.html)) (optional): Optional FragmentVisibility specifying the updated
+  fragment visibility. If not passed, the visibility will be unchanged. If
+  visibility is not set and makePublic is set, makePublic takes effect. If
+  makePublic and visibility are set, they must not be conflicting. If
+  neither is set, the fragment visibility will remain unchanged.
+
+**Returns:**
+
+- (Promise<undefined | [Fragment](appApi.Fragment.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#updateFragment).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### DeleteFragment
 
@@ -1500,6 +2215,20 @@ await cloud.delete_fragment(
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.delete_fragment).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required): The ID of the fragment to delete.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deleteFragment).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -1578,6 +2307,25 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization to create the role under.
+- `entityId` (string) (required): The ID of the entity the role belongs to (e.g., a user ID).
+- `role` (string) (required): The role to add ("owner" or "operator").
+- `resourceType` (string) (required): The type of resource to create the role for ("robot",
+  "location", or "organization").
+- `resourceId` (string) (required): The ID of the resource the role is being created for.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#addRole).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### RemoveRole
 
@@ -1615,6 +2363,25 @@ await cloud.remove_role(
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.remove_role).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization to remove the role from.
+- `entityId` (string) (required): The ID of the entity the role belongs to (e.g., a user ID).
+- `role` (string) (required): The role to remove ("owner" or "operator").
+- `resourceType` (string) (required): The type of resource to remove the role from ("robot",
+  "location", or "organization").
+- `resourceId` (string) (required): The ID of the resource the role is being removes from.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#removeRole).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -1662,6 +2429,21 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `oldAuthorization` ([Authorization](appApi.Authorization.html)) (required)
+- `newAuthorization` ([Authorization](appApi.Authorization.html)) (required)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#changeRole).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### ListAuthorizations
 
@@ -1693,6 +2475,22 @@ list_of_auths = await cloud.list_authorizations(
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.list_authorizations).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization to list authorizations for.
+- `resourceIds` (string) (optional): Optional list of IDs of resources to list authorizations
+  for. If not provided, all resources will be included.
+
+**Returns:**
+
+- (Promise<[Authorization](appApi.Authorization.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listAuthorizations).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -1793,6 +2591,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `permissions` ([AuthorizedPermissions](appApi.AuthorizedPermissions.html)) (required): A list of permissions to check.
+
+**Returns:**
+
+- (Promise<[AuthorizedPermissions](appApi.AuthorizedPermissions.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#checkPermissions).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### GetRegistryItem
 
@@ -1816,6 +2628,20 @@ item = await cloud.get_registry_item("item-id")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_registry_item).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `itemId` (string) (required): The ID of the item to get.
+
+**Returns:**
+
+- (Promise<undefined | [RegistryItem](appApi.RegistryItem.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getRegistryItem).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -1846,6 +2672,23 @@ await cloud.create_registry_item("<YOUR-ORG-ID>", "name", PackageType.PACKAGE_TY
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_registry_item).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization to create the registry
+  item under.
+- `name` (string) (required): The name of the registry item.
+- `type` (PackageType) (required): The type of the item in the registry.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createRegistryItem).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -1883,6 +2726,23 @@ await cloud.update_registry_item(
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.update_registry_item).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `itemId` (string) (required): The ID of the registry item to update.
+- `type` (PackageType) (required): The PackageType to update the item to.
+- `description` (string) (required): A description of the item.
+- `visibility` ([Visibility](../enums/appApi.Visibility.html)) (required): A visibility value to update to.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#updateRegistryItem).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -1937,6 +2797,31 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization to query registry items
+  for.
+- `types` (PackageType) (required): A list of types to query. If empty, will not filter on type.
+- `visibilities` ([Visibility](../enums/appApi.Visibility.html)) (required): A list of visibilities to query for. If empty, will not
+  filter on visibility.
+- `platforms` (string) (required): A list of platforms to query for. If empty, will not
+  filter on platform.
+- `statuses` ([RegistryItemStatus](../enums/appApi.RegistryItemStatus.html)) (required): A list of statuses to query for. If empty, will not filter
+  on status.
+- `searchTerm` (string) (optional): Optional search term to filter on.
+- `pageToken` (string) (optional): Optional page token for results. If not provided, will
+  return all results.
+
+**Returns:**
+
+- (Promise<[RegistryItem](appApi.RegistryItem.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listRegistryItems).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### DeleteRegistryItem
 
@@ -1960,6 +2845,20 @@ await cloud.delete_registry_item("your-namespace:your-name")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.delete_registry_item).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `itemId` (string) (required): The ID of the item to delete.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deleteRegistryItem).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -1992,6 +2891,21 @@ print("Module ID:", new_module[0])
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_module).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization to create the module under.
+- `name` (string) (required): The name of the module.
+
+**Returns:**
+
+- (Promise<[CreateModuleResponse](appApi.CreateModuleResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createModule).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -2040,6 +2954,25 @@ url_of_my_module = await cloud.update_module(
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.update_module).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `moduleId` (string) (required): The ID of the module to update.
+- `visibility` ([Visibility](../enums/appApi.Visibility.html)) (required): The visibility to set for the module.
+- `url` (string) (required): The url to reference for documentation, code, etc.
+- `description` (string) (required): A short description of the module.
+- `models` ([Model](appApi.Model.html)) (required): A list of models available in the module.
+- `entrypoint` (string) (required): The executable to run to start the module program.
+
+**Returns:**
+
+- (Promise<string>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#updateModule).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -2111,6 +3044,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `moduleId` (string) (required): The ID of the module.
+
+**Returns:**
+
+- (Promise<undefined | [Module](appApi.Module.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getModule).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### ListModules
 
@@ -2134,6 +3081,20 @@ modules_list = await cloud.list_modules("<YOUR-ORG-ID>")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.list_modules).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization to query.
+
+**Returns:**
+
+- (Promise<[Module](appApi.Module.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listModules).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -2181,6 +3142,22 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `authorizations` ([Authorization](appApi.Authorization.html)) (required): The list of authorizations to provide for the API key.
+- `name` (string) (optional): An optional name for the key. If none is passed, defaults to
+  present timestamp.
+
+**Returns:**
+
+- (Promise<[CreateKeyResponse](appApi.CreateKeyResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createKey).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### DeleteKey
 
@@ -2204,6 +3181,20 @@ await cloud.delete_key("key-id")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.delete_key).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required): The ID of the key to delete.
+
+**Returns:**
+
+- (Promise<[DeleteKeyResponse](appApi.DeleteKeyResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deleteKey).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -2233,6 +3224,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required): The ID of the key to rotate.
+
+**Returns:**
+
+- (Promise<[RotateKeyResponse](appApi.RotateKeyResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#rotateKey).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### ListKeys
 
@@ -2256,6 +3261,20 @@ keys = await cloud.list_keys(org_id="<YOUR-ORG-ID>")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.list_keys).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `orgId` (string) (required): The ID of the organization to query.
+
+**Returns:**
+
+- (Promise<[APIKeyWithAuthorizations](appApi.APIKeyWithAuthorizations.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listKeys).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -2283,6 +3302,20 @@ api_key, api_key_id = await cloud.create_key_from_existing_key_authorizations(
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_key_from_existing_key_authorizations).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required): The ID of the key to duplicate.
+
+**Returns:**
+
+- (Promise<[CreateKeyFromExistingKeyAuthorizationsResponse](appApi.CreateKeyFromExistingKeyAuthorizationsResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createKeyFromExistingKeyAuthorizations).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/static/include/app/apis/generated/app.md
+++ b/static/include/app/apis/generated/app.md
@@ -22,7 +22,6 @@ id = await cloud.get_user_id_by_email("youremail@email.com")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_user_id_by_email).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -62,7 +61,6 @@ organization = await cloud.create_organization("name")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_organization).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -71,7 +69,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<undefined | [Organization](appApi.Organization.html)>)
+- (Promise<undefined | [Organization](https://ts.viam.dev/classes/appApi.Organization.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createOrganization).
 
@@ -102,15 +100,15 @@ org_list = await cloud.list_organizations()
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.list_organizations).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
 
+- None.
 
 **Returns:**
 
-- (Promise<[Organization](appApi.Organization.html)[]>)
+- (Promise<[Organization](https://ts.viam.dev/classes/appApi.Organization.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listOrganizations).
 
@@ -141,7 +139,6 @@ org_list = await cloud.get_organizations_with_access_to_location("location-id")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_organizations_with_access_to_location).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -150,7 +147,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[OrganizationIdentity](appApi.OrganizationIdentity.html)[]>)
+- (Promise<[OrganizationIdentity](https://ts.viam.dev/classes/appApi.OrganizationIdentity.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getOrganizationsWithAccessToLocation).
 
@@ -181,7 +178,6 @@ org_list = await cloud.list_organizations_by_user("<YOUR-USER-ID>")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.list_organizations_by_user).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -190,7 +186,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[OrgDetails](appApi.OrgDetails.html)[]>)
+- (Promise<[OrgDetails](https://ts.viam.dev/classes/appApi.OrgDetails.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listOrganizationsByUser).
 
@@ -225,7 +221,6 @@ org = await cloud.get_organization("<YOUR-ORG-ID>")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_organization).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -234,7 +229,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<undefined | [Organization](appApi.Organization.html)>)
+- (Promise<undefined | [Organization](https://ts.viam.dev/classes/appApi.Organization.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getOrganization).
 
@@ -270,7 +265,6 @@ available = await cloud.get_organization_namespace_availability(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_organization_namespace_availability).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -322,7 +316,6 @@ organization = await cloud.update_organization(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.update_organization).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -335,7 +328,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<undefined | [Organization](appApi.Organization.html)>)
+- (Promise<undefined | [Organization](https://ts.viam.dev/classes/appApi.Organization.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#updateOrganization).
 
@@ -365,7 +358,6 @@ await cloud.delete_organization("<YOUR-ORG-ID>")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.delete_organization).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -405,7 +397,6 @@ member_list, invite_list = await cloud.list_organization_members("<YOUR-ORG-ID>"
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.list_organization_members).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -414,7 +405,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[ListOrganizationMembersResponse](appApi.ListOrganizationMembersResponse.html)>)
+- (Promise<[ListOrganizationMembersResponse](https://ts.viam.dev/classes/appApi.ListOrganizationMembersResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listOrganizationMembers).
 
@@ -452,20 +443,19 @@ await cloud.create_organization_invite("<YOUR-ORG-ID>", "youremail@email.com")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_organization_invite).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
 
 - `organizationId` (string) (required): The id of the organization to create the invite for.
 - `email` (string) (required): The email address of the user to generate an invite for.
-- `authorizations` ([Authorization](appApi.Authorization.html)) (required): The authorizations to associate with the new invite.
+- `authorizations` ([Authorization](https://ts.viam.dev/classes/appApi.Authorization.html)) (required): The authorizations to associate with the new invite.
 - `sendEmailInvite` (boolean) (optional): Bool of whether to send an email invite (true) or
   automatically add a user. Defaults to true.
 
 **Returns:**
 
-- (Promise<undefined | [OrganizationInvite](appApi.OrganizationInvite.html)>)
+- (Promise<undefined | [OrganizationInvite](https://ts.viam.dev/classes/appApi.OrganizationInvite.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createOrganizationInvite).
 
@@ -520,19 +510,18 @@ update_invite = await cloud.update_organization_invite_authorizations(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.update_organization_invite_authorizations).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
 
 - `organizationId` (string) (required): The id of the organization.
 - `email` (string) (required): The email address associated with the invite.
-- `addAuthsList` ([Authorization](appApi.Authorization.html)) (required): List of authorizations to add to the invite.
-- `removeAuthsList` ([Authorization](appApi.Authorization.html)) (required): List of authorizations to remove from the invite.
+- `addAuthsList` ([Authorization](https://ts.viam.dev/classes/appApi.Authorization.html)) (required): List of authorizations to add to the invite.
+- `removeAuthsList` ([Authorization](https://ts.viam.dev/classes/appApi.Authorization.html)) (required): List of authorizations to remove from the invite.
 
 **Returns:**
 
-- (Promise<undefined | [OrganizationInvite](appApi.OrganizationInvite.html)>)
+- (Promise<undefined | [OrganizationInvite](https://ts.viam.dev/classes/appApi.OrganizationInvite.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#updateOrganizationInviteAuthorizations).
 
@@ -567,7 +556,6 @@ await cloud.delete_organization_member(org_id="org_id", user_id=first_user_id)
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.delete_organization_member).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -613,7 +601,6 @@ await cloud.delete_organization_invite("<YOUR-ORG-ID>", "youremail@email.com")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.delete_organization_invite).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -659,7 +646,6 @@ org_invite = await cloud.resend_organization_invite("<YOUR-ORG-ID>", "youremail@
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.resend_organization_invite).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -669,7 +655,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<undefined | [OrganizationInvite](appApi.OrganizationInvite.html)>)
+- (Promise<undefined | [OrganizationInvite](https://ts.viam.dev/classes/appApi.OrganizationInvite.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#resendOrganizationInvite).
 
@@ -707,7 +693,6 @@ my_new_location = await cloud.create_location(org_id="<YOUR-ORG-ID>", name="Robo
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_location).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -720,7 +705,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<undefined | [Location](appApi.Location.html)>)
+- (Promise<undefined | [Location](https://ts.viam.dev/classes/appApi.Location.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createLocation).
 
@@ -755,7 +740,6 @@ location = await cloud.get_location(location_id="123ab12345")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_location).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -764,7 +748,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<undefined | [Location](appApi.Location.html)>)
+- (Promise<undefined | [Location](https://ts.viam.dev/classes/appApi.Location.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getLocation).
 
@@ -820,7 +804,6 @@ my_updated_location = await cloud.update_location(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.update_location).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -833,7 +816,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<undefined | [Location](appApi.Location.html)>)
+- (Promise<undefined | [Location](https://ts.viam.dev/classes/appApi.Location.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#updateLocation).
 
@@ -868,7 +851,6 @@ await cloud.delete_location(location_id="abc12abcde")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.delete_location).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -908,7 +890,6 @@ locations = await cloud.list_locations("<YOUR-ORG-ID>")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.list_locations).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -917,7 +898,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[Location](appApi.Location.html)[]>)
+- (Promise<[Location](https://ts.viam.dev/classes/appApi.Location.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listLocations).
 
@@ -949,7 +930,6 @@ await cloud.share_location("<YOUR-ORG-ID>", "<YOUR-LOCATION-ID>")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.share_location).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -991,7 +971,6 @@ await cloud.unshare_location("<YOUR-ORG-ID>", "<YOUR-LOCATION-ID>")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.unshare_location).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1036,7 +1015,6 @@ loc_auth = await cloud.location_auth(location_id="123xy12345")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.location_auth).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1045,7 +1023,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<undefined | [LocationAuth](appApi.LocationAuth.html)>)
+- (Promise<undefined | [LocationAuth](https://ts.viam.dev/classes/appApi.LocationAuth.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#locationAuth).
 
@@ -1080,7 +1058,6 @@ new_loc_auth = await cloud.create_location_secret(location_id="123xy12345")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_location_secret).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1089,7 +1066,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<undefined | [LocationAuth](appApi.LocationAuth.html)>)
+- (Promise<undefined | [LocationAuth](https://ts.viam.dev/classes/appApi.LocationAuth.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createLocationSecret).
 
@@ -1128,7 +1105,6 @@ await cloud.delete_location_secret(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.delete_location_secret).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1173,7 +1149,6 @@ machine = await cloud.get_robot(robot_id="1a123456-x1yz-0ab0-a12xyzabc")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_robot).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1182,7 +1157,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<undefined | [appApi](../modules/appApi.html).[Robot](appApi.Robot.html)>)
+- (Promise<undefined | [appApi](https://ts.viam.dev/modules/appApi.html).[Robot](https://ts.viam.dev/classes/appApi.Robot.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getRobot).
 
@@ -1213,7 +1188,6 @@ api_keys = await cloud.get_robot_api_keys(robot_id="robot-id")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_robot_api_keys).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1222,7 +1196,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[APIKeyWithAuthorizations](appApi.APIKeyWithAuthorizations.html)[]>)
+- (Promise<[APIKeyWithAuthorizations](https://ts.viam.dev/classes/appApi.APIKeyWithAuthorizations.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getRobotAPIKeys).
 
@@ -1259,7 +1233,6 @@ list_of_parts = await cloud.get_robot_parts(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_robot_parts).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1268,7 +1241,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[RobotPart](appApi.RobotPart.html)[]>)
+- (Promise<[RobotPart](https://ts.viam.dev/classes/appApi.RobotPart.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getRobotParts).
 
@@ -1307,7 +1280,6 @@ my_robot_part = await cloud.get_robot_part(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_robot_part).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1316,7 +1288,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[GetRobotPartResponse](appApi.GetRobotPartResponse.html)>)
+- (Promise<[GetRobotPartResponse](https://ts.viam.dev/classes/appApi.GetRobotPartResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getRobotPart).
 
@@ -1358,7 +1330,6 @@ part_logs = await cloud.get_robot_part_logs(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_robot_part_logs).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1372,7 +1343,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[GetRobotPartLogsResponse](appApi.GetRobotPartLogsResponse.html)>)
+- (Promise<[GetRobotPartLogsResponse](https://ts.viam.dev/classes/appApi.GetRobotPartLogsResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getRobotPartLogs).
 
@@ -1394,7 +1365,7 @@ Get an asynchronous iterator that receives live machine part logs.
 
 **Returns:**
 
-- ([viam.app._logs._LogsStream[List[LogEntry]]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.LogEntry)): The asynchronous iterator receiving live machine part logs.
+- ([viam.app.\_logs.\_LogsStream[List[LogEntry]]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.LogEntry)): The asynchronous iterator receiving live machine part logs.
 
 **Example:**
 
@@ -1407,13 +1378,12 @@ logs_stream = await cloud.tail_robot_part_logs(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.tail_robot_part_logs).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
 
 - `id` (string) (required): The ID of the requested robot part.
-- `queue` ([LogEntry](commonApi.LogEntry.html)) (required): A queue to put the log entries into.
+- `queue` ([LogEntry](https://ts.viam.dev/classes/commonApi.LogEntry.html)) (required): A queue to put the log entries into.
 - `filter` (string) (optional): Optional string to filter logs on.
 - `errorsOnly` (boolean) (optional): Optional bool to indicate whether or not only error-level
   logs should be returned. Defaults to true.
@@ -1457,7 +1427,6 @@ part_history = await cloud.get_robot_part_history(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_robot_part_history).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1466,7 +1435,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[RobotPartHistoryEntry](appApi.RobotPartHistoryEntry.html)[]>)
+- (Promise<[RobotPartHistoryEntry](https://ts.viam.dev/classes/appApi.RobotPartHistoryEntry.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getRobotPartHistory).
 
@@ -1505,18 +1474,17 @@ my_machine_part = await cloud.update_robot_part(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.update_robot_part).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
 
 - `id` (string) (required): The ID of the requested robot part.
 - `name` (string) (required): The new name of the robot part.
-- `robotConfig` ([Struct](Struct.html)) (required): The new config for the robot part.
+- `robotConfig` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The new config for the robot part.
 
 **Returns:**
 
-- (Promise<undefined | [RobotPart](appApi.RobotPart.html)>)
+- (Promise<undefined | [RobotPart](https://ts.viam.dev/classes/appApi.RobotPart.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#updateRobotPart).
 
@@ -1554,7 +1522,6 @@ new_part_id = await cloud.new_robot_part(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.new_robot_part).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1601,7 +1568,6 @@ await cloud.delete_robot_part(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.delete_robot_part).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1646,7 +1612,6 @@ await cloud.mark_part_as_main(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.mark_part_as_main).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1691,7 +1656,6 @@ await cloud.mark_part_for_restart(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.mark_part_for_restart).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1736,7 +1700,6 @@ part_with_new_secret = await cloud.create_robot_part_secret(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_robot_part_secret).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1745,7 +1708,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<undefined | [RobotPart](appApi.RobotPart.html)>)
+- (Promise<undefined | [RobotPart](https://ts.viam.dev/classes/appApi.RobotPart.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createRobotPartSecret).
 
@@ -1783,7 +1746,6 @@ await cloud.delete_robot_part_secret(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.delete_robot_part_secret).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1828,7 +1790,6 @@ list_of_machines = await cloud.list_robots(location_id="123ab12345")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.list_robots).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1837,7 +1798,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[appApi](../modules/appApi.html).[Robot](appApi.Robot.html)[]>)
+- (Promise<[appApi](https://ts.viam.dev/modules/appApi.html).[Robot](https://ts.viam.dev/classes/appApi.Robot.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listRobots).
 
@@ -1873,7 +1834,6 @@ new_machine_id = await cloud.new_robot(name="beepboop", location_id="my-location
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.new_robot).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1924,7 +1884,6 @@ updated_robot = await cloud.update_robot(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.update_robot).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1935,7 +1894,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<undefined | [appApi](../modules/appApi.html).[Robot](appApi.Robot.html)>)
+- (Promise<undefined | [appApi](https://ts.viam.dev/modules/appApi.html).[Robot](https://ts.viam.dev/classes/appApi.Robot.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#updateRobot).
 
@@ -1970,7 +1929,6 @@ await cloud.delete_robot(robot_id="1a123456-x1yz-0ab0-a12xyzabc")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.delete_robot).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -1996,7 +1954,7 @@ Get a list of {{< glossary_tooltip term_id="fragment" text="fragments" >}} in th
 **Parameters:**
 
 - `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to list fragments for. You can obtain your organization ID from the Viam app’s organization settings page.
-- `show_public` ([bool](https://docs.python.org/3/library/stdtypes.html#boolean-type-bool)) (required): Optional boolean specifying whether or not to only show public fragments. If True, only public fragments will return. If False, only private fragments will return. Defaults to True.  Deprecated since version 0.25.0: Use visibilities instead.
+- `show_public` ([bool](https://docs.python.org/3/library/stdtypes.html#boolean-type-bool)) (required): Optional boolean specifying whether or not to only show public fragments. If True, only public fragments will return. If False, only private fragments will return. Defaults to True. Deprecated since version 0.25.0: Use visibilities instead.
 - `visibilities` ([List[Fragment]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.Fragment.Visibility)) (optional): List of FragmentVisibilities specifying which types of fragments to include in the results. If empty, by default only public fragments will be returned.
 
 **Returns:**
@@ -2012,7 +1970,6 @@ fragments_list = await cloud.list_fragments(org_id="org-id", visibilities=[])
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.list_fragments).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -2021,11 +1978,11 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - `publicOnly` (boolean) (optional): Optional, deprecated boolean. Use fragmentVisibilities
   instead. If true then only public fragments will be listed. Defaults to
   true.
-- `fragmentVisibility` ([FragmentVisibility](../enums/appApi.FragmentVisibility.html)) (optional)
+- `fragmentVisibility` ([FragmentVisibility](https://ts.viam.dev/enums/appApi.FragmentVisibility.html)) (optional)
 
 **Returns:**
 
-- (Promise<[Fragment](appApi.Fragment.html)[]>)
+- (Promise<[Fragment](https://ts.viam.dev/classes/appApi.Fragment.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listFragments).
 
@@ -2063,7 +2020,6 @@ print("Name: ", the_fragment.name, "\nCreated on: ", the_fragment.created_on)
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_fragment).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -2072,7 +2028,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<undefined | [Fragment](appApi.Fragment.html)>)
+- (Promise<undefined | [Fragment](https://ts.viam.dev/classes/appApi.Fragment.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getFragment).
 
@@ -2109,7 +2065,6 @@ new_fragment = await cloud.create_fragment(org_id="org-id", name="cool_smart_mac
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_fragment).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -2117,11 +2072,11 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - `organizationId` (string) (required): The ID of the organization to create the fragment
   under.
 - `name` (string) (required): The name of the new fragment.
-- `config` ([Struct](Struct.html)) (required): The new fragment's config.
+- `config` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The new fragment's config.
 
 **Returns:**
 
-- (Promise<undefined | [Fragment](appApi.Fragment.html)>)
+- (Promise<undefined | [Fragment](https://ts.viam.dev/classes/appApi.Fragment.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createFragment).
 
@@ -2140,7 +2095,7 @@ Update a {{< glossary_tooltip term_id="fragment" text="fragment" >}} name and it
 - `fragment_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): ID of the fragment to update.
 - `name` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): New name to associate with the fragment.
 - `config` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (optional): Optional Dictionary representation of new config to assign to specified fragment. Not passing this parameter will leave the fragment’s config unchanged.
-- `public` ([bool](https://docs.python.org/3/library/stdtypes.html#boolean-type-bool)) (optional): Boolean specifying whether the fragment is public. Not passing this parameter will leave the fragment’s visibility unchanged. A fragment is private by default when created.  Deprecated since version 0.25.0: Use visibility instead.
+- `public` ([bool](https://docs.python.org/3/library/stdtypes.html#boolean-type-bool)) (optional): Boolean specifying whether the fragment is public. Not passing this parameter will leave the fragment’s visibility unchanged. A fragment is private by default when created. Deprecated since version 0.25.0: Use visibility instead.
 - `visibility` ([Fragment](https://python.viam.dev/autoapi/viam/gen/app/v1/app_pb2/index.html#viam.gen.app.v1.app_pb2.FragmentVisibility)) (optional): Optional FragmentVisibility list specifying who should be allowed to view the fragment. Not passing this parameter will leave the fragment’s visibility unchanged. A fragment is private by default when created.
 
 **Returns:**
@@ -2162,18 +2117,17 @@ updated_fragment = await cloud.update_fragment(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.update_fragment).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
 
 - `id` (string) (required): The ID of the fragment to update.
 - `name` (string) (required): The name to update the fragment to.
-- `config` ([Struct](Struct.html)) (required): The config to update the fragment to.
+- `config` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The config to update the fragment to.
 - `makePublic` (boolean) (optional): Optional, deprecated boolean specifying whether the
   fragment should be public or not. If not passed, the visibility will be
   unchanged. Fragments are private by default when created.
-- `visibility` ([FragmentVisibility](../enums/appApi.FragmentVisibility.html)) (optional): Optional FragmentVisibility specifying the updated
+- `visibility` ([FragmentVisibility](https://ts.viam.dev/enums/appApi.FragmentVisibility.html)) (optional): Optional FragmentVisibility specifying the updated
   fragment visibility. If not passed, the visibility will be unchanged. If
   visibility is not set and makePublic is set, makePublic takes effect. If
   makePublic and visibility are set, they must not be conflicting. If
@@ -2181,7 +2135,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<undefined | [Fragment](appApi.Fragment.html)>)
+- (Promise<undefined | [Fragment](https://ts.viam.dev/classes/appApi.Fragment.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#updateFragment).
 
@@ -2217,7 +2171,6 @@ await cloud.delete_fragment(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.delete_fragment).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -2306,13 +2259,12 @@ await cloud.add_role(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.add_role).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
 
 - `organizationId` (string) (required): The ID of the organization to create the role under.
-- `entityId` (string) (required): The ID of the entity the role belongs to (e.g., a user ID).
+- `entityId` (string) (required): The ID of the entity the role belongs to (for example, a user ID).
 - `role` (string) (required): The role to add ("owner" or "operator").
 - `resourceType` (string) (required): The type of resource to create the role for ("robot",
   "location", or "organization").
@@ -2365,13 +2317,12 @@ await cloud.remove_role(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.remove_role).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
 
 - `organizationId` (string) (required): The ID of the organization to remove the role from.
-- `entityId` (string) (required): The ID of the entity the role belongs to (e.g., a user ID).
+- `entityId` (string) (required): The ID of the entity the role belongs to (for example, a user ID).
 - `role` (string) (required): The role to remove ("owner" or "operator").
 - `resourceType` (string) (required): The type of resource to remove the role from ("robot",
   "location", or "organization").
@@ -2428,13 +2379,12 @@ await cloud.change_role(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.change_role).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
 
-- `oldAuthorization` ([Authorization](appApi.Authorization.html)) (required)
-- `newAuthorization` ([Authorization](appApi.Authorization.html)) (required)
+- `oldAuthorization` ([Authorization](https://ts.viam.dev/classes/appApi.Authorization.html)) (required)
+- `newAuthorization` ([Authorization](https://ts.viam.dev/classes/appApi.Authorization.html)) (required)
 
 **Returns:**
 
@@ -2477,7 +2427,6 @@ list_of_auths = await cloud.list_authorizations(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.list_authorizations).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -2488,7 +2437,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[Authorization](appApi.Authorization.html)[]>)
+- (Promise<[Authorization](https://ts.viam.dev/classes/appApi.Authorization.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listAuthorizations).
 
@@ -2590,16 +2539,15 @@ For more information about managing permissions, see [Role-Based Access Control]
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.check_permissions).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
 
-- `permissions` ([AuthorizedPermissions](appApi.AuthorizedPermissions.html)) (required): A list of permissions to check.
+- `permissions` ([AuthorizedPermissions](https://ts.viam.dev/classes/appApi.AuthorizedPermissions.html)) (required): A list of permissions to check.
 
 **Returns:**
 
-- (Promise<[AuthorizedPermissions](appApi.AuthorizedPermissions.html)[]>)
+- (Promise<[AuthorizedPermissions](https://ts.viam.dev/classes/appApi.AuthorizedPermissions.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#checkPermissions).
 
@@ -2630,7 +2578,6 @@ item = await cloud.get_registry_item("item-id")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_registry_item).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -2639,7 +2586,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<undefined | [RegistryItem](appApi.RegistryItem.html)>)
+- (Promise<undefined | [RegistryItem](https://ts.viam.dev/classes/appApi.RegistryItem.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getRegistryItem).
 
@@ -2674,7 +2621,6 @@ await cloud.create_registry_item("<YOUR-ORG-ID>", "name", PackageType.PACKAGE_TY
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_registry_item).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -2728,7 +2674,6 @@ await cloud.update_registry_item(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.update_registry_item).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -2736,7 +2681,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - `itemId` (string) (required): The ID of the registry item to update.
 - `type` (PackageType) (required): The PackageType to update the item to.
 - `description` (string) (required): A description of the item.
-- `visibility` ([Visibility](../enums/appApi.Visibility.html)) (required): A visibility value to update to.
+- `visibility` ([Visibility](https://ts.viam.dev/enums/appApi.Visibility.html)) (required): A visibility value to update to.
 
 **Returns:**
 
@@ -2796,7 +2741,6 @@ registry_items = await cloud.list_registry_items(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.list_registry_items).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -2804,11 +2748,11 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - `organizationId` (string) (required): The ID of the organization to query registry items
   for.
 - `types` (PackageType) (required): A list of types to query. If empty, will not filter on type.
-- `visibilities` ([Visibility](../enums/appApi.Visibility.html)) (required): A list of visibilities to query for. If empty, will not
+- `visibilities` ([Visibility](https://ts.viam.dev/enums/appApi.Visibility.html)) (required): A list of visibilities to query for. If empty, will not
   filter on visibility.
 - `platforms` (string) (required): A list of platforms to query for. If empty, will not
   filter on platform.
-- `statuses` ([RegistryItemStatus](../enums/appApi.RegistryItemStatus.html)) (required): A list of statuses to query for. If empty, will not filter
+- `statuses` ([RegistryItemStatus](https://ts.viam.dev/enums/appApi.RegistryItemStatus.html)) (required): A list of statuses to query for. If empty, will not filter
   on status.
 - `searchTerm` (string) (optional): Optional search term to filter on.
 - `pageToken` (string) (optional): Optional page token for results. If not provided, will
@@ -2816,7 +2760,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[RegistryItem](appApi.RegistryItem.html)[]>)
+- (Promise<[RegistryItem](https://ts.viam.dev/classes/appApi.RegistryItem.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listRegistryItems).
 
@@ -2847,7 +2791,6 @@ await cloud.delete_registry_item("your-namespace:your-name")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.delete_registry_item).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -2893,7 +2836,6 @@ print("Module ID:", new_module[0])
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_module).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -2903,7 +2845,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[CreateModuleResponse](appApi.CreateModuleResponse.html)>)
+- (Promise<[CreateModuleResponse](https://ts.viam.dev/classes/appApi.CreateModuleResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createModule).
 
@@ -2956,16 +2898,15 @@ url_of_my_module = await cloud.update_module(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.update_module).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
 
 - `moduleId` (string) (required): The ID of the module to update.
-- `visibility` ([Visibility](../enums/appApi.Visibility.html)) (required): The visibility to set for the module.
+- `visibility` ([Visibility](https://ts.viam.dev/enums/appApi.Visibility.html)) (required): The visibility to set for the module.
 - `url` (string) (required): The url to reference for documentation, code, etc.
 - `description` (string) (required): A short description of the module.
-- `models` ([Model](appApi.Model.html)) (required): A list of models available in the module.
+- `models` ([Model](https://ts.viam.dev/classes/appApi.Model.html)) (required): A list of models available in the module.
 - `entrypoint` (string) (required): The executable to run to start the module program.
 
 **Returns:**
@@ -3043,7 +2984,6 @@ the_module = await cloud.get_module(module_id="my-group:my-cool-modular-base")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.get_module).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -3052,7 +2992,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<undefined | [Module](appApi.Module.html)>)
+- (Promise<undefined | [Module](https://ts.viam.dev/classes/appApi.Module.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getModule).
 
@@ -3083,7 +3023,6 @@ modules_list = await cloud.list_modules("<YOUR-ORG-ID>")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.list_modules).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -3092,7 +3031,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[Module](appApi.Module.html)[]>)
+- (Promise<[Module](https://ts.viam.dev/classes/appApi.Module.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listModules).
 
@@ -3141,18 +3080,17 @@ api_key, api_key_id = cloud.create_key(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_key).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
 
-- `authorizations` ([Authorization](appApi.Authorization.html)) (required): The list of authorizations to provide for the API key.
+- `authorizations` ([Authorization](https://ts.viam.dev/classes/appApi.Authorization.html)) (required): The list of authorizations to provide for the API key.
 - `name` (string) (optional): An optional name for the key. If none is passed, defaults to
   present timestamp.
 
 **Returns:**
 
-- (Promise<[CreateKeyResponse](appApi.CreateKeyResponse.html)>)
+- (Promise<[CreateKeyResponse](https://ts.viam.dev/classes/appApi.CreateKeyResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createKey).
 
@@ -3183,7 +3121,6 @@ await cloud.delete_key("key-id")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.delete_key).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -3192,7 +3129,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[DeleteKeyResponse](appApi.DeleteKeyResponse.html)>)
+- (Promise<[DeleteKeyResponse](https://ts.viam.dev/classes/appApi.DeleteKeyResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deleteKey).
 
@@ -3223,7 +3160,6 @@ id, key = await cloud.rotate_key("key-id")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.rotate_key).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -3232,7 +3168,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[RotateKeyResponse](appApi.RotateKeyResponse.html)>)
+- (Promise<[RotateKeyResponse](https://ts.viam.dev/classes/appApi.RotateKeyResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#rotateKey).
 
@@ -3263,7 +3199,6 @@ keys = await cloud.list_keys(org_id="<YOUR-ORG-ID>")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.list_keys).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -3272,7 +3207,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[APIKeyWithAuthorizations](appApi.APIKeyWithAuthorizations.html)[]>)
+- (Promise<[APIKeyWithAuthorizations](https://ts.viam.dev/classes/appApi.APIKeyWithAuthorizations.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listKeys).
 
@@ -3304,7 +3239,6 @@ api_key, api_key_id = await cloud.create_key_from_existing_key_authorizations(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.AppClient.create_key_from_existing_key_authorizations).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -3313,7 +3247,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[CreateKeyFromExistingKeyAuthorizationsResponse](appApi.CreateKeyFromExistingKeyAuthorizationsResponse.html)>)
+- (Promise<[CreateKeyFromExistingKeyAuthorizationsResponse](https://ts.viam.dev/classes/appApi.CreateKeyFromExistingKeyAuthorizationsResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createKeyFromExistingKeyAuthorizations).
 

--- a/static/include/app/apis/generated/billing.md
+++ b/static/include/app/apis/generated/billing.md
@@ -24,7 +24,6 @@ usage = await billing_client.get_current_month_usage("<ORG-ID>")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/billing_client/index.html#viam.app.billing_client.BillingClient.get_current_month_usage).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -66,7 +65,6 @@ information = await billing_client.get_org_billing_information("<ORG-ID>")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/billing_client/index.html#viam.app.billing_client.BillingClient.get_org_billing_information).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -75,7 +73,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[GetOrgBillingInformationResponse](billingApi.GetOrgBillingInformationResponse.html)>)
+- (Promise<[GetOrgBillingInformationResponse](https://ts.viam.dev/classes/billingApi.GetOrgBillingInformationResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BillingClient.html#getOrgBillingInformation).
 
@@ -107,7 +105,6 @@ summary = await billing_client.get_invoices_summary("<ORG-ID>")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/billing_client/index.html#viam.app.billing_client.BillingClient.get_invoices_summary).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -116,7 +113,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[GetInvoicesSummaryResponse](billingApi.GetInvoicesSummaryResponse.html)>)
+- (Promise<[GetInvoicesSummaryResponse](https://ts.viam.dev/classes/billingApi.GetInvoicesSummaryResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BillingClient.html#getInvoicesSummary).
 
@@ -151,7 +148,6 @@ await billing_client.get_invoice_pdf("<INVOICE-ID>", "<ORG-ID>", "invoice.pdf")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/billing_client/index.html#viam.app.billing_client.BillingClient.get_invoice_pdf).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**

--- a/static/include/app/apis/generated/billing.md
+++ b/static/include/app/apis/generated/billing.md
@@ -25,6 +25,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `orgId` (string) (required)
+
+**Returns:**
+
+- (Promise<GetCurrentMonthUsageResponse>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BillingClient.html#getCurrentMonthUsage).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### GetOrgBillingInformation
 
@@ -50,6 +64,20 @@ information = await billing_client.get_org_billing_information("<ORG-ID>")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/billing_client/index.html#viam.app.billing_client.BillingClient.get_org_billing_information).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `orgId` (string) (required)
+
+**Returns:**
+
+- (Promise<[GetOrgBillingInformationResponse](billingApi.GetOrgBillingInformationResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BillingClient.html#getOrgBillingInformation).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -80,6 +108,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `orgId` (string) (required)
+
+**Returns:**
+
+- (Promise<[GetInvoicesSummaryResponse](billingApi.GetInvoicesSummaryResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BillingClient.html#getInvoicesSummary).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### GetInvoicePdf
 
@@ -107,6 +149,21 @@ await billing_client.get_invoice_pdf("<INVOICE-ID>", "<ORG-ID>", "invoice.pdf")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/billing_client/index.html#viam.app.billing_client.BillingClient.get_invoice_pdf).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required)
+- `orgId` (string) (required)
+
+**Returns:**
+
+- (Promise<Uint8Array>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BillingClient.html#getInvoicePdf).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/static/include/app/apis/generated/data.md
+++ b/static/include/app/apis/generated/data.md
@@ -38,6 +38,24 @@ else:
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.get_latest_tabular_data).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `partId` (string) (required): The ID of the part that owns the data.
+- `resourceName` (string) (required): The name of the requested resource that captured the
+  data. Ex: "my-sensor".
+- `resourceSubtype` (string) (required): The subtype of the requested resource that captured
+  the data. Ex: "rdk:component:sensor".
+- `methodName` (string) (required): The data capture method name. Ex: "Readings".
+
+**Returns:**
+
+- (Promise<null | [Date, Date, Record<string, [JsonValue](../types/JsonValue.html)>]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#getLatestTabularData).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -115,6 +133,28 @@ print(f"My data: {tabular_data}")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.export_tabular_data).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `partId` (string) (required): The ID of the part that owns the data.
+- `resourceName` (string) (required): The name of the requested resource that captured the
+  data.
+- `resourceSubtype` (string) (required): The subtype of the requested resource that captured
+  the data.
+- `methodName` (string) (required): The data capture method name.
+- `startTime` (Date) (optional): Optional start time (Date object) for requesting a
+  specific range of data.
+- `endTime` (Date) (optional): Optional end time (Date object) for requesting a specific
+  range of data.
+
+**Returns:**
+
+- (Promise<TabularDataPoint[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#exportTabularData).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -215,6 +255,30 @@ print(f"My data: {my_data}")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.tabular_data_by_filter).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `filter` ([Filter](dataApi.Filter.html)) (optional): Optional pb.Filter specifying tabular data to retrieve. No
+  filter implies all tabular data.
+- `limit` (number) (optional): The maximum number of entries to include in a page. Defaults
+  to 50 if unspecfied.
+- `sortOrder` ([Order](../enums/dataApi.Order.html)) (optional): The desired sort order of the data.
+- `last` (string) (optional): Optional string indicating the ID of the last-returned data. If
+  provided, the server will return the next data entries after the last
+  ID.
+- `countOnly` (boolean) (optional): Whether to return only the total count of entries.
+- `includeInternalData` (boolean) (optional): Whether to retun internal data. Internal data is
+  used for Viam-specific data ingestion, like cloud SLAM. Defaults to
+  false.
+
+**Returns:**
+
+- (Promise<{     count: bigint;     data: TabularData[];     last: string; }>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#tabularDataByFilter).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -296,6 +360,20 @@ data = await data_client.tabular_data_by_sql(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.tabular_data_by_sql).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization that owns the data.
+- `query` (string) (required): The SQL query to run.
+
+**Returns:**
+
+- (Promise<(Object | any[])[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#tabularDataBySQL).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -363,6 +441,22 @@ print(f"Tabular Data: {tabular_data}")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.tabular_data_by_mql).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization that owns the data.
+- `query` (Uint8Array) (required): The MQL query to run as a list of BSON documents.
+- `useRecentData` (boolean) (optional): Whether to query blob storage or your recent data
+  store. Defaults to false.
+
+**Returns:**
+
+- (Promise<(Object | any[])[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#tabularDataByMQL).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -479,6 +573,32 @@ while True:
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.binary_data_by_filter).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `filter` ([Filter](dataApi.Filter.html)) (optional): Optional pb.Filter specifying binary data to retrieve. No
+  filter implies all binary data.
+- `limit` (number) (optional): The maximum number of entries to include in a page. Defaults
+  to 50 if unspecfied.
+- `sortOrder` ([Order](../enums/dataApi.Order.html)) (optional): The desired sort order of the data.
+- `last` (string) (optional): Optional string indicating the ID of the last-returned data. If
+  provided, the server will return the next data entries after the last
+  ID.
+- `includeBinary` (boolean) (optional): Whether to include binary file data with each
+  retrieved file.
+- `countOnly` (boolean) (optional): Whether to return only the total count of entries.
+- `includeInternalData` (boolean) (optional): Whether to retun internal data. Internal data is
+  used for Viam-specific data ingestion, like cloud SLAM. Defaults to
+  false.
+
+**Returns:**
+
+- (Promise<{     count: bigint;     data: [BinaryData](dataApi.BinaryData.html)[];     last: string; }>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#binaryDataByFilter).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -576,6 +696,19 @@ binary_data = await data_client.binary_data_by_ids(my_ids)
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.binary_data_by_ids).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `ids` ([BinaryID](BinaryID.html)) (required): The IDs of the requested binary data.
+
+**Returns:**
+
+- (Promise<[BinaryData](dataApi.BinaryData.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#binaryDataByIds).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -651,6 +784,23 @@ tabular_data = await data_client.delete_tabular_data(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.delete_tabular_data).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of organization to delete data from.
+- `deleteOlderThanDays` (number) (required): Delete data that was captured more than this
+  many days ago. For example if deleteOlderThanDays is 10, this deletes
+  any data that was captured more than 10 days ago. If it is 0, all
+  existing data is deleted.
+
+**Returns:**
+
+- (Promise<bigint>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#deleteTabularData).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -711,6 +861,22 @@ res = await data_client.delete_binary_data_by_filter(my_filter)
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.delete_binary_data_by_filter).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `filter` ([Filter](dataApi.Filter.html)) (optional): Optional pb.Filter specifying binary data to delete. No
+  filter implies all binary data.
+- `includeInternalData` (boolean) (optional): Whether or not to delete internal data. Default
+  is true.
+
+**Returns:**
+
+- (Promise<bigint>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#deleteBinaryDataByFilter).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -800,6 +966,19 @@ binary_data = await data_client.delete_binary_data_by_ids(my_ids)
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.delete_binary_data_by_ids).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `ids` ([BinaryID](BinaryID.html)) (required): The IDs of the data to be deleted. Must be non-empty.
+
+**Returns:**
+
+- (Promise<bigint>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#deleteBinaryDataByIds).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -893,6 +1072,21 @@ binary_data = await data_client.add_tags_to_binary_data_by_ids(tags, my_ids)
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.add_tags_to_binary_data_by_ids).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `tags` (string) (required): The list of tags to add to specified binary data. Must be
+  non-empty.
+- `ids` ([BinaryID](BinaryID.html)) (required): The IDs of the data to be tagged. Must be non-empty.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#addTagsToBinaryDataByIds).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -967,6 +1161,21 @@ await data_client.add_tags_to_binary_data_by_filter(tags, my_filter)
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.add_tags_to_binary_data_by_filter).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `tags` (string) (required): The tags to add to the data.
+- `filter` ([Filter](dataApi.Filter.html)) (optional): Optional pb.Filter specifying binary data to add tags to.
+  No filter implies all binary data.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#addTagsToBinaryDataByFilter).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -1065,6 +1274,21 @@ binary_data = await data_client.remove_tags_from_binary_data_by_ids(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.remove_tags_from_binary_data_by_ids).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `tags` (string) (required): List of tags to remove from specified binary data. Must be
+  non-empty.
+- `ids` ([BinaryID](BinaryID.html)) (required): The IDs of the data to be edited. Must be non-empty.
+
+**Returns:**
+
+- (Promise<bigint>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#removeTagsFromBinaryDataByIds).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -1141,6 +1365,22 @@ res = await data_client.remove_tags_from_binary_data_by_filter(tags, my_filter)
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.remove_tags_from_binary_data_by_filter).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `tags` (string) (required): List of tags to remove from specified binary data. Must be
+  non-empty.
+- `filter` ([Filter](dataApi.Filter.html)) (optional): Optional pb.Filter specifying binary data to add tags to.
+  No filter implies all binary data.
+
+**Returns:**
+
+- (Promise<bigint>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#removeTagsFromBinaryDataByFilter).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -1208,6 +1448,20 @@ tags = await data_client.tags_by_filter(my_filter)
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.tags_by_filter).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `filter` ([Filter](dataApi.Filter.html)) (optional): Optional pb.Filter specifying what data to get tags from.
+  No filter implies all data.
+
+**Returns:**
+
+- (Promise<string[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#tagsByFilter).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -1299,6 +1553,28 @@ print(bbox_id)
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.add_bounding_box_to_image_by_id).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` ([BinaryID](BinaryID.html)) (required)
+- `label` (string) (required): A label for the bounding box.
+- `xMinNormalized` (number) (required): The min X value of the bounding box normalized from 0
+  to 1.
+- `yMinNormalized` (number) (required): The min Y value of the bounding box normalized from 0
+  to 1.
+- `xMaxNormalized` (number) (required): The max X value of the bounding box normalized from 0
+  to 1.
+- `yMaxNormalized` (number) (required): The max Y value of the bounding box normalized from 0
+  to 1.
+
+**Returns:**
+
+- (Promise<string>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#addBoundingBoxToImageById).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -1382,6 +1658,20 @@ bbox_id="your-bounding-box-id-to-delete"
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.remove_bounding_box_from_image_by_id).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `binId` ([BinaryID](BinaryID.html)) (required): The ID of the image to remove the bounding box from.
+- `bboxId` (string) (required): The ID of the bounding box to remove.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#removeBoundingBoxFromImageById).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -1454,6 +1744,20 @@ print(bounding_box_labels)
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.bounding_box_labels_by_filter).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `filter` ([Filter](dataApi.Filter.html)) (optional): Optional pb.Filter specifying what data to get tags from.
+  No filter implies all labels.
+
+**Returns:**
+
+- (Promise<string[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#boundingBoxLabelsByFilter).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -1515,6 +1819,19 @@ hostname = await data_client.get_database_connection(organization_id="<YOUR-ORG-
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.get_database_connection).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): Organization to retrieve connection for.
+
+**Returns:**
+
+- (Promise<string>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#getDatabaseConnection).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -1582,6 +1899,20 @@ await data_client.configure_database_user(
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.configure_database_user).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization.
+- `password` (string) (required): The password of the user.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#configureDatabaseUser).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -1665,6 +1996,20 @@ await data_client.add_binary_data_to_dataset_by_ids(
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.add_binary_data_to_dataset_by_ids).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `ids` ([BinaryID](BinaryID.html)) (required): The IDs of binary data to add to dataset.
+- `datasetId` (string) (required): The ID of the dataset to be added to.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#addBinaryDataToDatasetByIds).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -1757,6 +2102,20 @@ await data_client.remove_binary_data_from_dataset_by_ids(
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.remove_binary_data_from_dataset_by_ids).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `ids` ([BinaryID](BinaryID.html)) (required): The IDs of the binary data to remove from dataset.
+- `datasetId` (string) (required): The ID of the dataset to be removed from.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#removeBinaryDataFromDatasetByIds).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}

--- a/static/include/app/apis/generated/data.md
+++ b/static/include/app/apis/generated/data.md
@@ -51,7 +51,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<null | [Date, Date, Record<string, [JsonValue](../types/JsonValue.html)>]>)
+- (Promise<null | [Date, Date, Record<string, [JsonValue](https://ts.viam.dev/types/JsonValue.html)>]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#getLatestTabularData).
 
@@ -259,11 +259,11 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Parameters:**
 
-- `filter` ([Filter](dataApi.Filter.html)) (optional): Optional pb.Filter specifying tabular data to retrieve. No
+- `filter` ([Filter](https://ts.viam.dev/classes/dataApi.Filter.html)) (optional): Optional pb.Filter specifying tabular data to retrieve. No
   filter implies all tabular data.
 - `limit` (number) (optional): The maximum number of entries to include in a page. Defaults
   to 50 if unspecfied.
-- `sortOrder` ([Order](../enums/dataApi.Order.html)) (optional): The desired sort order of the data.
+- `sortOrder` ([Order](https://ts.viam.dev/enums/dataApi.Order.html)) (optional): The desired sort order of the data.
 - `last` (string) (optional): Optional string indicating the ID of the last-returned data. If
   provided, the server will return the next data entries after the last
   ID.
@@ -577,11 +577,11 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Parameters:**
 
-- `filter` ([Filter](dataApi.Filter.html)) (optional): Optional pb.Filter specifying binary data to retrieve. No
+- `filter` ([Filter](https://ts.viam.dev/classes/dataApi.Filter.html)) (optional): Optional pb.Filter specifying binary data to retrieve. No
   filter implies all binary data.
 - `limit` (number) (optional): The maximum number of entries to include in a page. Defaults
   to 50 if unspecfied.
-- `sortOrder` ([Order](../enums/dataApi.Order.html)) (optional): The desired sort order of the data.
+- `sortOrder` ([Order](https://ts.viam.dev/enums/dataApi.Order.html)) (optional): The desired sort order of the data.
 - `last` (string) (optional): Optional string indicating the ID of the last-returned data. If
   provided, the server will return the next data entries after the last
   ID.
@@ -594,7 +594,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<{     count: bigint;     data: [BinaryData](dataApi.BinaryData.html)[];     last: string; }>)
+- (Promise<{     count: bigint;     data: [BinaryData](https://ts.viam.dev/classes/dataApi.BinaryData.html)[];     last: string; }>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#binaryDataByFilter).
 
@@ -700,11 +700,11 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Parameters:**
 
-- `ids` ([BinaryID](BinaryID.html)) (required): The IDs of the requested binary data.
+- `ids` ([BinaryID](https://ts.viam.dev/classes/BinaryID.html)) (required): The IDs of the requested binary data.
 
 **Returns:**
 
-- (Promise<[BinaryData](dataApi.BinaryData.html)[]>)
+- (Promise<[BinaryData](https://ts.viam.dev/classes/dataApi.BinaryData.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#binaryDataByIds).
 
@@ -867,7 +867,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Parameters:**
 
-- `filter` ([Filter](dataApi.Filter.html)) (optional): Optional pb.Filter specifying binary data to delete. No
+- `filter` ([Filter](https://ts.viam.dev/classes/dataApi.Filter.html)) (optional): Optional pb.Filter specifying binary data to delete. No
   filter implies all binary data.
 - `includeInternalData` (boolean) (optional): Whether or not to delete internal data. Default
   is true.
@@ -972,7 +972,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Parameters:**
 
-- `ids` ([BinaryID](BinaryID.html)) (required): The IDs of the data to be deleted. Must be non-empty.
+- `ids` ([BinaryID](https://ts.viam.dev/classes/BinaryID.html)) (required): The IDs of the data to be deleted. Must be non-empty.
 
 **Returns:**
 
@@ -1078,7 +1078,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 - `tags` (string) (required): The list of tags to add to specified binary data. Must be
   non-empty.
-- `ids` ([BinaryID](BinaryID.html)) (required): The IDs of the data to be tagged. Must be non-empty.
+- `ids` ([BinaryID](https://ts.viam.dev/classes/BinaryID.html)) (required): The IDs of the data to be tagged. Must be non-empty.
 
 **Returns:**
 
@@ -1168,7 +1168,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Parameters:**
 
 - `tags` (string) (required): The tags to add to the data.
-- `filter` ([Filter](dataApi.Filter.html)) (optional): Optional pb.Filter specifying binary data to add tags to.
+- `filter` ([Filter](https://ts.viam.dev/classes/dataApi.Filter.html)) (optional): Optional pb.Filter specifying binary data to add tags to.
   No filter implies all binary data.
 
 **Returns:**
@@ -1280,7 +1280,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 - `tags` (string) (required): List of tags to remove from specified binary data. Must be
   non-empty.
-- `ids` ([BinaryID](BinaryID.html)) (required): The IDs of the data to be edited. Must be non-empty.
+- `ids` ([BinaryID](https://ts.viam.dev/classes/BinaryID.html)) (required): The IDs of the data to be edited. Must be non-empty.
 
 **Returns:**
 
@@ -1371,7 +1371,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 - `tags` (string) (required): List of tags to remove from specified binary data. Must be
   non-empty.
-- `filter` ([Filter](dataApi.Filter.html)) (optional): Optional pb.Filter specifying binary data to add tags to.
+- `filter` ([Filter](https://ts.viam.dev/classes/dataApi.Filter.html)) (optional): Optional pb.Filter specifying binary data to add tags to.
   No filter implies all binary data.
 
 **Returns:**
@@ -1454,7 +1454,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Parameters:**
 
-- `filter` ([Filter](dataApi.Filter.html)) (optional): Optional pb.Filter specifying what data to get tags from.
+- `filter` ([Filter](https://ts.viam.dev/classes/dataApi.Filter.html)) (optional): Optional pb.Filter specifying what data to get tags from.
   No filter implies all data.
 
 **Returns:**
@@ -1557,7 +1557,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Parameters:**
 
-- `id` ([BinaryID](BinaryID.html)) (required)
+- `id` ([BinaryID](https://ts.viam.dev/classes/BinaryID.html)) (required)
 - `label` (string) (required): A label for the bounding box.
 - `xMinNormalized` (number) (required): The min X value of the bounding box normalized from 0
   to 1.
@@ -1662,7 +1662,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Parameters:**
 
-- `binId` ([BinaryID](BinaryID.html)) (required): The ID of the image to remove the bounding box from.
+- `binId` ([BinaryID](https://ts.viam.dev/classes/BinaryID.html)) (required): The ID of the image to remove the bounding box from.
 - `bboxId` (string) (required): The ID of the bounding box to remove.
 
 **Returns:**
@@ -1748,7 +1748,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Parameters:**
 
-- `filter` ([Filter](dataApi.Filter.html)) (optional): Optional pb.Filter specifying what data to get tags from.
+- `filter` ([Filter](https://ts.viam.dev/classes/dataApi.Filter.html)) (optional): Optional pb.Filter specifying what data to get tags from.
   No filter implies all labels.
 
 **Returns:**
@@ -2002,7 +2002,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Parameters:**
 
-- `ids` ([BinaryID](BinaryID.html)) (required): The IDs of binary data to add to dataset.
+- `ids` ([BinaryID](https://ts.viam.dev/classes/BinaryID.html)) (required): The IDs of binary data to add to dataset.
 - `datasetId` (string) (required): The ID of the dataset to be added to.
 
 **Returns:**
@@ -2108,7 +2108,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Parameters:**
 
-- `ids` ([BinaryID](BinaryID.html)) (required): The IDs of the binary data to remove from dataset.
+- `ids` ([BinaryID](https://ts.viam.dev/classes/BinaryID.html)) (required): The IDs of the binary data to remove from dataset.
 - `datasetId` (string) (required): The ID of the dataset to be removed from.
 
 **Returns:**

--- a/static/include/app/apis/generated/mltraining.md
+++ b/static/include/app/apis/generated/mltraining.md
@@ -36,7 +36,6 @@ job_id = await ml_training_client.submit_training_job(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/ml_training_client/index.html#viam.app.ml_training_client.MLTrainingClient.submit_training_job).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -45,7 +44,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - `datasetId` (string) (required)
 - `modelName` (string) (required)
 - `modelVersion` (string) (required)
-- `modelType` ([ModelType](../enums/ModelType.html)) (required)
+- `modelType` ([ModelType](https://ts.viam.dev/enums/ModelType.html)) (required)
 - `tags` (string) (required)
 
 **Returns:**
@@ -94,7 +93,6 @@ job_id = await ml_training_client.submit_custom_training_job(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/ml_training_client/index.html#viam.app.ml_training_client.MLTrainingClient.submit_custom_training_job).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -140,7 +138,6 @@ job_metadata = await ml_training_client.get_training_job(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/ml_training_client/index.html#viam.app.ml_training_client.MLTrainingClient.get_training_job).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -149,7 +146,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<undefined | [TrainingJobMetadata](mlTrainingApi.TrainingJobMetadata.html)>)
+- (Promise<undefined | [TrainingJobMetadata](https://ts.viam.dev/classes/mlTrainingApi.TrainingJobMetadata.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MlTrainingClient.html#getTrainingJob).
 
@@ -184,17 +181,16 @@ first_job_id = jobs_metadata[1].id
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/ml_training_client/index.html#viam.app.ml_training_client.MLTrainingClient.list_training_jobs).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
 
 - `organizationId` (string) (required)
-- `status` ([TrainingStatus](../enums/TrainingStatus.html)) (required)
+- `status` ([TrainingStatus](https://ts.viam.dev/enums/TrainingStatus.html)) (required)
 
 **Returns:**
 
-- (Promise<[TrainingJobMetadata](mlTrainingApi.TrainingJobMetadata.html)[]>)
+- (Promise<[TrainingJobMetadata](https://ts.viam.dev/classes/mlTrainingApi.TrainingJobMetadata.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MlTrainingClient.html#listTrainingJobs).
 
@@ -230,7 +226,6 @@ await ml_training_client.cancel_training_job(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/ml_training_client/index.html#viam.app.ml_training_client.MLTrainingClient.cancel_training_job).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -271,7 +266,6 @@ await ml_training_client.delete_completed_training_job(
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/ml_training_client/index.html#viam.app.ml_training_client.MLTrainingClient.delete_completed_training_job).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**

--- a/static/include/app/apis/generated/mltraining.md
+++ b/static/include/app/apis/generated/mltraining.md
@@ -37,6 +37,25 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required)
+- `datasetId` (string) (required)
+- `modelName` (string) (required)
+- `modelVersion` (string) (required)
+- `modelType` ([ModelType](../enums/ModelType.html)) (required)
+- `tags` (string) (required)
+
+**Returns:**
+
+- (Promise<string>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MlTrainingClient.html#submitTrainingJob).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### SubmitCustomTrainingJob
 
@@ -76,6 +95,25 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required)
+- `datasetId` (string) (required)
+- `registryItemId` (string) (required)
+- `registryItemVersion` (string) (required)
+- `modelName` (string) (required)
+- `modelVersion` (string) (required)
+
+**Returns:**
+
+- (Promise<string>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MlTrainingClient.html#submitCustomTrainingJob).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### GetTrainingJob
 
@@ -100,6 +138,20 @@ job_metadata = await ml_training_client.get_training_job(
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/ml_training_client/index.html#viam.app.ml_training_client.MLTrainingClient.get_training_job).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required)
+
+**Returns:**
+
+- (Promise<undefined | [TrainingJobMetadata](mlTrainingApi.TrainingJobMetadata.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MlTrainingClient.html#getTrainingJob).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -130,6 +182,21 @@ first_job_id = jobs_metadata[1].id
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/ml_training_client/index.html#viam.app.ml_training_client.MLTrainingClient.list_training_jobs).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required)
+- `status` ([TrainingStatus](../enums/TrainingStatus.html)) (required)
+
+**Returns:**
+
+- (Promise<[TrainingJobMetadata](mlTrainingApi.TrainingJobMetadata.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MlTrainingClient.html#listTrainingJobs).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -164,6 +231,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required)
+
+**Returns:**
+
+- (Promise<null>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MlTrainingClient.html#cancelTrainingJob).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### DeleteCompletedTrainingJob
 
@@ -188,6 +269,20 @@ await ml_training_client.delete_completed_training_job(
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/ml_training_client/index.html#viam.app.ml_training_client.MLTrainingClient.delete_completed_training_job).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required)
+
+**Returns:**
+
+- (Promise<null>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MlTrainingClient.html#deleteCompletedTrainingJob).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/static/include/components/apis/generated/arm.md
+++ b/static/include/components/apis/generated/arm.md
@@ -49,6 +49,20 @@ pos, err := myArm.EndPosition(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/arm#Arm).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[commonApi](../modules/commonApi.html).[Pose](commonApi.Pose.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ArmClient.html#getEndPosition).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -131,6 +145,21 @@ err = myArm.MoveToPosition(context.Background(), examplePose, nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/arm#Arm).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `pose` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ArmClient.html#moveToPosition).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -226,6 +255,21 @@ err = myArm.MoveToJointPositions(context.Background(), inputs, nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/arm#Arm).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `jointPositionsList` (number) (required)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ArmClient.html#moveToJointPositions).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -343,6 +387,20 @@ pos, err := myArm.JointPositions(context.Background(), nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/arm#Arm).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JointPositions](armApi.JointPositions.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ArmClient.html#getJointPositions).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -464,6 +522,19 @@ logger.Info(is_moving)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Actuator).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<boolean>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ArmClient.html#isMoving).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -535,6 +606,20 @@ err = myArm.Stop(context.Background(), nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Actuator).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ArmClient.html#stop).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -619,6 +704,20 @@ if len(geometries) > 0 {
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Shaped).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[commonApi](../modules/commonApi.html).[Geometry](commonApi.Geometry.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ArmClient.html#getGeometries).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### Reconfigure
@@ -699,6 +798,20 @@ result, err := myArm.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ArmClient.html#doCommand).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}

--- a/static/include/components/apis/generated/arm.md
+++ b/static/include/components/apis/generated/arm.md
@@ -58,7 +58,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Returns:**
 
-- (Promise<[commonApi](../modules/commonApi.html).[Pose](commonApi.Pose.html)>)
+- (Promise<[commonApi](https://ts.viam.dev/modules/commonApi.html).[Pose](https://ts.viam.dev/classes/commonApi.Pose.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ArmClient.html#getEndPosition).
 
@@ -151,7 +151,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Parameters:**
 
-- `pose` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `pose` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required)
 - `extra` (None) (optional)
 - `callOptions` (CallOptions) (optional)
 
@@ -398,7 +398,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Returns:**
 
-- (Promise<[JointPositions](armApi.JointPositions.html)>)
+- (Promise<[JointPositions](https://ts.viam.dev/classes/armApi.JointPositions.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ArmClient.html#getJointPositions).
 
@@ -713,7 +713,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Returns:**
 
-- (Promise<[commonApi](../modules/commonApi.html).[Geometry](commonApi.Geometry.html)[]>)
+- (Promise<[commonApi](https://ts.viam.dev/modules/commonApi.html).[Geometry](https://ts.viam.dev/classes/commonApi.Geometry.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ArmClient.html#getGeometries).
 
@@ -804,12 +804,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The command to execute.
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ArmClient.html#doCommand).
 

--- a/static/include/components/apis/generated/base.md
+++ b/static/include/components/apis/generated/base.md
@@ -58,6 +58,22 @@ myBase.MoveStraight(context.Background(), 40, -90, nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/base#Base).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `distanceMm` (number) (required): Distance to move, in millimeters.
+- `mmPerSec` (number) (required): Movement speed, in millimeters per second.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BaseClient.html#moveStraight).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -135,6 +151,22 @@ myBase.Spin(context.Background(), 10, 15, nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/base#Base).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `angleDeg` (number) (required): Degrees to spin.
+- `degsPerSec` (number) (required): Angular speed, in degrees per second.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BaseClient.html#spin).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -251,6 +283,22 @@ err = myBase.SetPower(context.Background(), r3.Vector{}, r3.Vector{Z: -.75}, nil
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/base#Base).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `linear` ([PlainMessage](../types/PlainMessage.html)) (required): Desired linear power percentage from -1 to 1.
+- `angular` ([PlainMessage](../types/PlainMessage.html)) (required): Desired angular power percentage from -1 to 1.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BaseClient.html#setPower).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -339,6 +387,22 @@ myBase.SetVelocity(context.Background(), r3.Vector{Y: 50}, r3.Vector{Z: 15}, nil
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/base#Base).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `linear` ([PlainMessage](../types/PlainMessage.html)) (required): Desired linear velocity in millimeters per second.
+- `angular` ([PlainMessage](../types/PlainMessage.html)) (required): Desired angular velocity in degrees per second.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BaseClient.html#setVelocity).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -437,6 +501,20 @@ myBaseWheelCircumference := properties.WheelCircumferenceMeters
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/base#Base).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[baseApi](../modules/baseApi.html).[GetPropertiesResponse](baseApi.GetPropertiesResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BaseClient.html#getProperties).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### IsMoving
@@ -493,6 +571,19 @@ logger.Info(is_moving)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Actuator).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<boolean>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BaseClient.html#isMoving).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -570,6 +661,20 @@ err = myArm.Stop(context.Background(), nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Actuator).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BaseClient.html#stop).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -654,6 +759,20 @@ if len(geometries) > 0 {
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Shaped).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[commonApi](../modules/commonApi.html).[Geometry](commonApi.Geometry.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BaseClient.html#getGeometries).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### Reconfigure
@@ -735,6 +854,20 @@ result, err := myBase.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BaseClient.html#doCommand).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}

--- a/static/include/components/apis/generated/base.md
+++ b/static/include/components/apis/generated/base.md
@@ -287,8 +287,8 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Parameters:**
 
-- `linear` ([PlainMessage](../types/PlainMessage.html)) (required): Desired linear power percentage from -1 to 1.
-- `angular` ([PlainMessage](../types/PlainMessage.html)) (required): Desired angular power percentage from -1 to 1.
+- `linear` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required): Desired linear power percentage from -1 to 1.
+- `angular` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required): Desired angular power percentage from -1 to 1.
 - `extra` (None) (optional)
 - `callOptions` (CallOptions) (optional)
 
@@ -393,8 +393,8 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Parameters:**
 
-- `linear` ([PlainMessage](../types/PlainMessage.html)) (required): Desired linear velocity in millimeters per second.
-- `angular` ([PlainMessage](../types/PlainMessage.html)) (required): Desired angular velocity in degrees per second.
+- `linear` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required): Desired linear velocity in millimeters per second.
+- `angular` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required): Desired angular velocity in degrees per second.
 - `extra` (None) (optional)
 - `callOptions` (CallOptions) (optional)
 
@@ -510,7 +510,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Returns:**
 
-- (Promise<[baseApi](../modules/baseApi.html).[GetPropertiesResponse](baseApi.GetPropertiesResponse.html)>)
+- (Promise<[baseApi](https://ts.viam.dev/modules/baseApi.html).[GetPropertiesResponse](https://ts.viam.dev/classes/baseApi.GetPropertiesResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BaseClient.html#getProperties).
 
@@ -768,7 +768,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Returns:**
 
-- (Promise<[commonApi](../modules/commonApi.html).[Geometry](commonApi.Geometry.html)[]>)
+- (Promise<[commonApi](https://ts.viam.dev/modules/commonApi.html).[Geometry](https://ts.viam.dev/classes/commonApi.Geometry.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BaseClient.html#getGeometries).
 
@@ -860,12 +860,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The command to execute.
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BaseClient.html#doCommand).
 

--- a/static/include/components/apis/generated/board.md
+++ b/static/include/components/apis/generated/board.md
@@ -998,7 +998,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Stream](https://api.flutter.dev/flutter/dart-core/Stream-class.html)\<[Tick](https://flutter.viam.dev/viam_sdk/Tick.html)\>
+- [Stream](https://api.flutter.dev/flutter/dart-async/Stream-class.html)\<[Tick](https://flutter.viam.dev/viam_sdk/Tick.html)\>
 
 **Example:**
 
@@ -1057,7 +1057,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 - `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
 - `mode` [(pb.PowerMode)](https://pkg.go.dev/go.viam.com/api/component/board/v1#PowerMode): Options to specify power usage of the board: `boardpb.PowerMode_POWER_MODE_UNSPECIFIED`, `boardpb.PowerMode_POWER_MODE_NORMAL`, and `boardpb.PowerMode_POWER_MODE_OFFLINE_DEEP`.
-- `duration` [(*time.Duration)](https://pkg.go.dev/time#Duration): If provided, the board will exit the given power mode after the specified duration.
+- `duration` [(\*time.Duration)](https://pkg.go.dev/time#Duration): If provided, the board will exit the given power mode after the specified duration.
 
 **Returns:**
 

--- a/static/include/components/apis/generated/board.md
+++ b/static/include/components/apis/generated/board.md
@@ -58,6 +58,23 @@ err = pin.Set(context.Background(), true, nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/board#GPIOPin).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `pin` (string) (required): The pin.
+- `high` (boolean) (required): When true, set the given pin to high. When false, set the
+  given pin to low.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#setGPIO).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -139,6 +156,21 @@ high, err := pin.Get(context.Background(), nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/board#GPIOPin).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `pin` (string) (required)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<boolean>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#getGPIO).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -231,6 +263,21 @@ duty_cycle, err := pin.PWM(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/board#GPIOPin).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `pin` (string) (required): The pin.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<number>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#getPWM).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -315,6 +362,22 @@ err = pin.SetPWM(context.Background(), .6, nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/board#GPIOPin).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `pin` (string) (required): The pin.
+- `dutyCyle` (number) (required): A value from 0 to 1.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#setPWM).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -396,6 +459,21 @@ freqHz, err := pin.PWMFreq(context.Background(), nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/board#GPIOPin).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `pin` (string) (required): The pin.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<number>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#getPWMFrequency).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -486,6 +564,23 @@ err = pin.SetPWMFreq(context.Background(), 1600, nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/board#GPIOPin).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `pin` (string) (required): The pin.
+- `frequencyHz` (number) (required): The PWM frequency, in hertz. 0 will use the board's
+  default PWM frequency.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#setPWMFrequency).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -569,6 +664,21 @@ count, err := interrupt.Value(context.Background(), nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/board#DigitalInterrupt).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `digitalInterruptName` (string) (required): The name of the digital interrupt.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<number>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#getDigitalInterruptValue).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -657,6 +767,21 @@ stepSize := reading.StepSize
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/board#Analog).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `analogReader` (string) (required): The name of the analog reader.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[ReadAnalogReaderResponse](boardApi.ReadAnalogReaderResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#readAnalogReader).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -738,6 +863,22 @@ err = analog.Write(context.Background(), 48, nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/board#Analog).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `pin` (string) (required): The pin name.
+- `value` (number) (required): An integer value to write.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#writeAnalog).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -832,6 +973,22 @@ err = myBoard.StreamTicks(context.Background(), interrupts, ticksChan, nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/board#Board).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `interrupts` (string) (required): Names of the interrupts to stream.
+- `queue` ([Tick](../interfaces/Tick.html)) (required): Array to put the ticks in.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#streamTicks).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -916,6 +1073,22 @@ myBoard.SetPowerMode(context.Background(), boardpb.PowerMode_POWER_MODE_OFFLINE_
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/board#Board).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `powerMode` ([boardApi](../modules/boardApi.html)) (required): The requested power mode.
+- `duration` ([Duration](Duration.html)) (optional): The requested duration to stay in power mode.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#setPowerMode).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -1213,6 +1386,20 @@ result, err := myBoard.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#doCommand).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}

--- a/static/include/components/apis/generated/board.md
+++ b/static/include/components/apis/generated/board.md
@@ -777,7 +777,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Returns:**
 
-- (Promise<[ReadAnalogReaderResponse](boardApi.ReadAnalogReaderResponse.html)>)
+- (Promise<[ReadAnalogReaderResponse](https://ts.viam.dev/classes/boardApi.ReadAnalogReaderResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#readAnalogReader).
 
@@ -978,7 +978,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Parameters:**
 
 - `interrupts` (string) (required): Names of the interrupts to stream.
-- `queue` ([Tick](../interfaces/Tick.html)) (required): Array to put the ticks in.
+- `queue` ([Tick](https://ts.viam.dev/interfaces/Tick.html)) (required): Array to put the ticks in.
 - `extra` (None) (optional)
 - `callOptions` (CallOptions) (optional)
 
@@ -1079,8 +1079,8 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Parameters:**
 
-- `powerMode` ([boardApi](../modules/boardApi.html)) (required): The requested power mode.
-- `duration` ([Duration](Duration.html)) (optional): The requested duration to stay in power mode.
+- `powerMode` ([boardApi](https://ts.viam.dev/modules/boardApi.html)) (required): The requested power mode.
+- `duration` ([Duration](https://ts.viam.dev/classes/Duration.html)) (optional): The requested duration to stay in power mode.
 - `extra` (None) (optional)
 - `callOptions` (CallOptions) (optional)
 
@@ -1392,12 +1392,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The command to execute.
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#doCommand).
 

--- a/static/include/components/apis/generated/button.md
+++ b/static/include/components/apis/generated/button.md
@@ -17,6 +17,20 @@ Push the button.
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/button#Button).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ButtonClient.html#push).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### DoCommand
@@ -48,6 +62,20 @@ result, err := myButton.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ButtonClient.html#doCommand).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/static/include/components/apis/generated/button.md
+++ b/static/include/components/apis/generated/button.md
@@ -68,12 +68,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The command to execute.
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ButtonClient.html#doCommand).
 

--- a/static/include/components/apis/generated/camera-table.md
+++ b/static/include/components/apis/generated/camera-table.md
@@ -3,6 +3,7 @@
 | ----------- | ----------- |
 | [`GetImage`](/dev/reference/apis/components/camera/#getimage) | Return an image from the camera. |
 | [`GetImages`](/dev/reference/apis/components/camera/#getimages) | Get simultaneous images from different imagers, along with associated metadata. |
+| [`RenderFrame`](/dev/reference/apis/components/camera/#renderframe) | Render a frame from a camera of the underlying robot to an HTTP response. |
 | [`GetPointCloud`](/dev/reference/apis/components/camera/#getpointcloud) | Get a point cloud from the camera as bytes with a MIME type describing the structure of the data. |
 | [`GetProperties`](/dev/reference/apis/components/camera/#getproperties) | Get the camera intrinsic parameters and camera distortion, as well as whether the camera supports returning point clouds. |
 | [`DoCommand`](/dev/reference/apis/components/camera/#docommand) | Execute model-specific commands that are not otherwise defined by the component API. |

--- a/static/include/components/apis/generated/camera.md
+++ b/static/include/components/apis/generated/camera.md
@@ -109,6 +109,21 @@ To use either method, be sure to import `"go.viam.com/rdk/utils"` at the beginni
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/camera#Camera).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `mimeType` ([MimeType](../types/MimeType.html)) (optional)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<Uint8Array>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/CameraClient.html#getImage).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -193,6 +208,29 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 {{% /tab %}}
 {{< /tabs >}}
 
+### RenderFrame
+
+Render a frame from a camera of the underlying robot to an HTTP response.
+A specific MIME type can be requested but may not necessarily be the same one returned.
+
+{{< tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `mimeType` ([MimeType](../types/MimeType.html)) (optional)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<Blob>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/CameraClient.html#renderFrame).
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ### GetPointCloud
 
 Get a point cloud from the camera as bytes with a MIME type describing the structure of the data.
@@ -251,6 +289,20 @@ pointCloud, err := myCamera.NextPointCloud(context.Background())
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/camera#PointCloudSource).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<Uint8Array>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/CameraClient.html#getPointCloud).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -314,6 +366,19 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/camera#Camera).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[cameraApi](../modules/cameraApi.html).[GetPropertiesResponse](cameraApi.GetPropertiesResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/CameraClient.html#getProperties).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -368,6 +433,20 @@ result = await my_camera.do_command(command)
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/camera/client/index.html#viam.components.camera.client.CameraClient.do_command).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/CameraClient.html#doCommand).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -420,6 +499,21 @@ if geometries:
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/camera/client/index.html#viam.components.camera.client.CameraClient.get_geometries).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[commonApi](../modules/commonApi.html).[Geometry](commonApi.Geometry.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/CameraClient.html#getGeometries).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/static/include/components/apis/generated/camera.md
+++ b/static/include/components/apis/generated/camera.md
@@ -113,7 +113,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Parameters:**
 
-- `mimeType` ([MimeType](../types/MimeType.html)) (optional)
+- `mimeType` ([MimeType](https://ts.viam.dev/types/MimeType.html)) (optional)
 - `extra` (None) (optional)
 - `callOptions` (CallOptions) (optional)
 
@@ -218,7 +218,7 @@ A specific MIME type can be requested but may not necessarily be the same one re
 
 **Parameters:**
 
-- `mimeType` ([MimeType](../types/MimeType.html)) (optional)
+- `mimeType` ([MimeType](https://ts.viam.dev/types/MimeType.html)) (optional)
 - `extra` (None) (optional)
 - `callOptions` (CallOptions) (optional)
 
@@ -374,7 +374,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Returns:**
 
-- (Promise<[cameraApi](../modules/cameraApi.html).[GetPropertiesResponse](cameraApi.GetPropertiesResponse.html)>)
+- (Promise<[cameraApi](https://ts.viam.dev/modules/cameraApi.html).[GetPropertiesResponse](https://ts.viam.dev/classes/cameraApi.GetPropertiesResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/CameraClient.html#getProperties).
 
@@ -437,12 +437,12 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The command to execute.
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/CameraClient.html#doCommand).
 
@@ -501,7 +501,6 @@ if geometries:
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/camera/client/index.html#viam.components.camera.client.CameraClient.get_geometries).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -511,7 +510,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<[commonApi](../modules/commonApi.html).[Geometry](commonApi.Geometry.html)[]>)
+- (Promise<[commonApi](https://ts.viam.dev/modules/commonApi.html).[Geometry](https://ts.viam.dev/classes/commonApi.Geometry.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/CameraClient.html#getGeometries).
 

--- a/static/include/components/apis/generated/encoder.md
+++ b/static/include/components/apis/generated/encoder.md
@@ -60,6 +60,22 @@ position, posType, err := myEncoder.Position(context.Background(), encoder.Posit
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/encoder#Encoder).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `positionType` ([PositionType](../enums/encoderApi.PositionType.html)) (optional): The type of position the encoder returns (ticks or
+  degrees).
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<readonly [number, [PositionType](../enums/encoderApi.PositionType.html)]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/EncoderClient.html#getPosition).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### ResetPosition
@@ -116,6 +132,20 @@ err = myEncoder.ResetPosition(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/encoder#Encoder).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/EncoderClient.html#resetPosition).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### GetProperties
@@ -169,6 +199,20 @@ properties, err := myEncoder.Properties(context.Background(), nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/encoder#Encoder).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[encoderApi](../modules/encoderApi.html).[GetPropertiesResponse](encoderApi.GetPropertiesResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/EncoderClient.html#getProperties).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -284,6 +328,20 @@ result, err := myEncoder.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/EncoderClient.html#doCommand).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/static/include/components/apis/generated/encoder.md
+++ b/static/include/components/apis/generated/encoder.md
@@ -64,14 +64,14 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Parameters:**
 
-- `positionType` ([PositionType](../enums/encoderApi.PositionType.html)) (optional): The type of position the encoder returns (ticks or
+- `positionType` ([PositionType](https://ts.viam.dev/enums/encoderApi.PositionType.html)) (optional): The type of position the encoder returns (ticks or
   degrees).
 - `extra` (None) (optional)
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<readonly [number, [PositionType](../enums/encoderApi.PositionType.html)]>)
+- (Promise<readonly [number, [PositionType](https://ts.viam.dev/enums/encoderApi.PositionType.html)]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/EncoderClient.html#getPosition).
 
@@ -210,7 +210,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Returns:**
 
-- (Promise<[encoderApi](../modules/encoderApi.html).[GetPropertiesResponse](encoderApi.GetPropertiesResponse.html)>)
+- (Promise<[encoderApi](https://ts.viam.dev/modules/encoderApi.html).[GetPropertiesResponse](https://ts.viam.dev/classes/encoderApi.GetPropertiesResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/EncoderClient.html#getProperties).
 
@@ -334,12 +334,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The command to execute.
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/EncoderClient.html#doCommand).
 

--- a/static/include/components/apis/generated/gantry-table.md
+++ b/static/include/components/apis/generated/gantry-table.md
@@ -5,9 +5,9 @@
 | [`MoveToPosition`](/dev/reference/apis/components/gantry/#movetoposition) | Move the axes of the gantry to the desired positions (mm) at the requested speeds (mm/sec). |
 | [`GetLengths`](/dev/reference/apis/components/gantry/#getlengths) | Get the lengths of the axes of the gantry (mm). |
 | [`Home`](/dev/reference/apis/components/gantry/#home) | Run the homing sequence of the gantry to re-calibrate the axes with respect to the limit switches. |
+| [`GetGeometries`](/dev/reference/apis/components/gantry/#getgeometries) | Get all the geometries associated with the gantry in its current configuration, in the frame of the gantry. |
 | [`IsMoving`](/dev/reference/apis/components/gantry/#ismoving) | Get if the gantry is currently moving. |
 | [`Stop`](/dev/reference/apis/components/gantry/#stop) | Stop all motion of the gantry. |
-| [`GetGeometries`](/dev/reference/apis/components/gantry/#getgeometries) | Get all the geometries associated with the gantry in its current configuration, in the frame of the gantry. |
 | [`Reconfigure`](/dev/reference/apis/components/gantry/#reconfigure) | Reconfigure this resource. |
 | [`DoCommand`](/dev/reference/apis/components/gantry/#docommand) | Execute model-specific commands that are not otherwise defined by the component API. |
 | [`GetResourceName`](/dev/reference/apis/components/gantry/#getresourcename) | Get the `ResourceName` for this gantry with the given name. |

--- a/static/include/components/apis/generated/gantry.md
+++ b/static/include/components/apis/generated/gantry.md
@@ -50,6 +50,20 @@ position, err := myGantry.Position(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/gantry#Gantry).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<number[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GantryClient.html#getPosition).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -139,6 +153,22 @@ myGantry.MoveToPosition(context.Background(), examplePositions, exampleSpeeds, n
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/gantry#Gantry).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `positionsMm` (number) (required)
+- `speedsMmPerSec` (number) (required)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GantryClient.html#moveToPosition).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -214,6 +244,20 @@ lengths_mm, err := myGantry.Lengths(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/gantry#Gantry).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<number[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GantryClient.html#getLengths).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -285,6 +329,20 @@ myGantry.Home(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/gantry#Gantry).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<boolean>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GantryClient.html#home).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -302,6 +360,28 @@ var homed = await myGantry.home();
 ```
 
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/Gantry/home.html).
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### GetGeometries
+
+Get all the geometries associated with the gantry in its current configuration, in the [frame](/operate/mobility/define-geometry/) of the gantry.
+The [motion](/operate/reference/services/motion/) and [navigation](/operate/reference/services/navigation/) services use the relative position of inherent geometries to configured geometries representing obstacles for collision detection and obstacle avoidance while motion planning.
+
+{{< tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[commonApi](../modules/commonApi.html).[Geometry](commonApi.Geometry.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GantryClient.html#getGeometries).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -363,6 +443,19 @@ logger.Info(is_moving)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Actuator).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<boolean>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GantryClient.html#isMoving).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -439,6 +532,20 @@ err = myArm.Stop(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Actuator).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GantryClient.html#stop).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -456,39 +563,6 @@ await myGantry.stop();
 ```
 
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/Gantry/stop.html).
-
-{{% /tab %}}
-{{< /tabs >}}
-
-### GetGeometries
-
-Get all the geometries associated with the gantry in its current configuration, in the [frame](/operate/mobility/define-geometry/) of the gantry.
-The [motion](/operate/reference/services/motion/) and [navigation](/operate/reference/services/navigation/) services use the relative position of inherent geometries to configured geometries representing obstacles for collision detection and obstacle avoidance while motion planning.
-
-{{< tabs >}}
-{{% tab name="Python" %}}
-
-**Parameters:**
-
-- `extra` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (optional): Extra options to pass to the underlying RPC call.
-- `timeout` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
-
-**Returns:**
-
-- ([List[viam.proto.common.Geometry]](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.Geometry)): The geometries associated with the Component.
-
-**Example:**
-
-```python {class="line-numbers linkable-line-numbers"}
-my_gantry = Gantry.from_robot(robot=machine, name="my_gantry")
-geometries = await my_gantry.get_geometries()
-
-if geometries:
-    # Get the center of the first geometry
-    print(f"Pose of the first geometry's centerpoint: {geometries[0].center}")
-```
-
-For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/gantry/client/index.html#viam.components.gantry.client.GantryClient.get_geometries).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -547,6 +621,20 @@ result = await my_gantry.do_command(command)
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/gantry/client/index.html#viam.components.gantry.client.GantryClient.do_command).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GantryClient.html#doCommand).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}

--- a/static/include/components/apis/generated/gantry.md
+++ b/static/include/components/apis/generated/gantry.md
@@ -379,7 +379,7 @@ The [motion](/operate/reference/services/motion/) and [navigation](/operate/refe
 
 **Returns:**
 
-- (Promise<[commonApi](../modules/commonApi.html).[Geometry](commonApi.Geometry.html)[]>)
+- (Promise<[commonApi](https://ts.viam.dev/modules/commonApi.html).[Geometry](https://ts.viam.dev/classes/commonApi.Geometry.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GantryClient.html#getGeometries).
 
@@ -627,12 +627,12 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The command to execute.
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GantryClient.html#doCommand).
 

--- a/static/include/components/apis/generated/generic_component-table.md
+++ b/static/include/components/apis/generated/generic_component-table.md
@@ -3,6 +3,5 @@
 | ----------- | ----------- | --------------------------- |
 | [`DoCommand`](/dev/reference/apis/components/generic/#docommand) | Execute model-specific commands. | <p class="center-text"><i class="fas fa-check" title="yes"></i></p> |
 | [`GetGeometries`](/dev/reference/apis/components/generic/#getgeometries) | Get all the geometries associated with the generic component in its current configuration, in the frame of the generic component. |  |
-| [`DoCommand`](/dev/reference/apis/components/generic/#docommand) | Execute model-specific commands. |
 | [`GetResourceName`](/dev/reference/apis/components/generic/#getresourcename) | Get the `ResourceName` for this generic component with the given name. |  |
 | [`Close`](/dev/reference/apis/components/generic/#close) | Safely shut down the resource and prevent further use. |  |

--- a/static/include/components/apis/generated/generic_component.md
+++ b/static/include/components/apis/generated/generic_component.md
@@ -55,6 +55,20 @@ result, err := myGenericComponent.DoCommand(context.Background(), command)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GenericComponentClient.html#doCommand).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -107,61 +121,6 @@ if geometries:
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/generic/client/index.html#viam.components.generic.client.GenericClient.get_geometries).
-
-{{% /tab %}}
-{{< /tabs >}}
-
-### DoCommand
-
-Execute model-specific commands.
-If you are implementing your own generic component and add features that have no built-in API method, you can access them with `DoCommand`.
-
-{{< tabs >}}
-{{% tab name="Python" %}}
-
-**Parameters:**
-
-- `command` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), ValueTypes]) (required): The command to execute.
-- `timeout` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
-
-**Returns:**
-
-- (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]): Result of the executed command.
-
-**Raises:**
-
-- (NotImplementedError): Raised if the Resource does not support arbitrary commands.
-
-**Example:**
-
-```python {class="line-numbers linkable-line-numbers"}
-my_generic_component = Generic.from_robot(robot=machine, name="my_generic_component")
-command = {"cmd": "test", "data1": 500}
-result = await my_generic_component.do_command(command)
-```
-
-For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/generic/client/index.html#viam.components.generic.client.GenericClient.do_command).
-
-{{% /tab %}}
-{{% tab name="Flutter" %}}
-
-**Parameters:**
-
-- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\> (required)
-
-**Returns:**
-
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>\>
-
-**Example:**
-
-```dart {class="line-numbers linkable-line-numbers"}
-// Example using doCommand with an arm component
-const command = {'cmd': 'test', 'data1': 500};
-var result = myArm.doCommand(command);
-```
-
-For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/Resource/doCommand.html).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/static/include/components/apis/generated/generic_component.md
+++ b/static/include/components/apis/generated/generic_component.md
@@ -59,12 +59,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The command to execute.
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GenericComponentClient.html#doCommand).
 

--- a/static/include/components/apis/generated/gripper.md
+++ b/static/include/components/apis/generated/gripper.md
@@ -49,6 +49,20 @@ err := myGripper.Open(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/gripper#Gripper).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GripperClient.html#open).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -120,6 +134,20 @@ grabbed, err := myGripper.Grab(context.Background(), nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/gripper#Gripper).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GripperClient.html#grab).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -199,6 +227,19 @@ logger.Info(is_moving)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Actuator).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<boolean>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GripperClient.html#isMoving).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -271,6 +312,20 @@ err = myArm.Stop(context.Background(), nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Actuator).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GripperClient.html#stop).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -355,6 +410,20 @@ if len(geometries) > 0 {
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Shaped).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[commonApi](../modules/commonApi.html).[Geometry](commonApi.Geometry.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GripperClient.html#getGeometries).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### Reconfigure
@@ -387,6 +456,20 @@ For built-in models, model-specific commands are covered with each model's docum
 If you are implementing your own gripper and add features that have no built-in API method, you can access them with `DoCommand`.
 
 {{< tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GripperClient.html#doCommand).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**

--- a/static/include/components/apis/generated/gripper.md
+++ b/static/include/components/apis/generated/gripper.md
@@ -419,7 +419,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Returns:**
 
-- (Promise<[commonApi](../modules/commonApi.html).[Geometry](commonApi.Geometry.html)[]>)
+- (Promise<[commonApi](https://ts.viam.dev/modules/commonApi.html).[Geometry](https://ts.viam.dev/classes/commonApi.Geometry.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GripperClient.html#getGeometries).
 
@@ -460,12 +460,12 @@ If you are implementing your own gripper and add features that have no built-in 
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The command to execute.
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GripperClient.html#doCommand).
 

--- a/static/include/components/apis/generated/motor.md
+++ b/static/include/components/apis/generated/motor.md
@@ -967,12 +967,12 @@ If you are implementing your own motor and add features that have no built-in AP
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The command to execute.
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotorClient.html#doCommand).
 

--- a/static/include/components/apis/generated/motor.md
+++ b/static/include/components/apis/generated/motor.md
@@ -54,6 +54,22 @@ myMotorComponent.SetPower(context.Background(), 0.4, nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `power` (number) (required): A value between -1 and 1 where negative values indicate a
+  backwards direction and positive values a forward direction.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotorClient.html#setPower).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -126,6 +142,21 @@ myMotorComponent.SetRPM(context.Background(), 50, nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `rpm` (number) (required): Speed in revolutions per minute.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotorClient.html#setRPM).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -207,6 +238,25 @@ myMotorComponent.GoFor(context.Background(), 60, 7.2, nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `rpm` (number) (required): Speed in revolutions per minute.
+- `revolutions` (number) (required): Number of revolutions relative to the motor's starting
+  position. If this value is 0, this will run the motor at the given rpm
+  indefinitely. If this value is nonzero, this will block until the number
+  of revolutions has been completed or another operation comes in.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotorClient.html#goFor).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -286,6 +336,23 @@ myMotorComponent.GoTo(context.Background(), 75, 8.3, nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `rpm` (number) (required): Speed in revolutions per minute.
+- `positionRevolutions` (number) (required): Number of revolutions relative to the motor's
+  home position.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotorClient.html#goTo).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -359,6 +426,21 @@ myMotorComponent.ResetZeroPosition(context.Background(), 0.0, nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `offset` (number) (required): Position from which to offset the current position.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotorClient.html#resetZeroPosition).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -439,6 +521,20 @@ logger.Info(position)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<number>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotorClient.html#getPosition).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -522,6 +618,20 @@ logger.Info(properties)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<{     positionReporting: boolean; }>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotorClient.html#getProperties).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -601,6 +711,20 @@ logger.Info(pct)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/motor#Motor).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<readonly [boolean, number]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotorClient.html#isPowered).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -685,6 +809,19 @@ logger.Info(is_moving)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Actuator).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<boolean>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotorClient.html#isMoving).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -760,6 +897,20 @@ err = myArm.Stop(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Actuator).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotorClient.html#stop).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -812,6 +963,20 @@ For built-in models, model-specific commands are covered with each model's docum
 If you are implementing your own motor and add features that have no built-in API method, you can access them with `DoCommand`.
 
 {{< tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotorClient.html#doCommand).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**

--- a/static/include/components/apis/generated/movement_sensor.md
+++ b/static/include/components/apis/generated/movement_sensor.md
@@ -61,7 +61,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Returns:**
 
-- (Promise<[commonApi](../modules/commonApi.html).[Vector3](commonApi.Vector3.html)>)
+- (Promise<[commonApi](https://ts.viam.dev/modules/commonApi.html).[Vector3](https://ts.viam.dev/classes/commonApi.Vector3.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#getLinearVelocity).
 
@@ -156,7 +156,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Returns:**
 
-- (Promise<[commonApi](../modules/commonApi.html).[Vector3](commonApi.Vector3.html)>)
+- (Promise<[commonApi](https://ts.viam.dev/modules/commonApi.html).[Vector3](https://ts.viam.dev/classes/commonApi.Vector3.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#getAngularVelocity).
 
@@ -342,7 +342,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Returns:**
 
-- (Promise<[commonApi](../modules/commonApi.html).[Orientation](commonApi.Orientation.html)>)
+- (Promise<[commonApi](https://ts.viam.dev/modules/commonApi.html).[Orientation](https://ts.viam.dev/classes/commonApi.Orientation.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#getOrientation).
 
@@ -433,7 +433,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Returns:**
 
-- (Promise<[movementSensorApi](../modules/movementSensorApi.html).[GetPositionResponse](movementSensorApi.GetPositionResponse.html)>)
+- (Promise<[movementSensorApi](https://ts.viam.dev/modules/movementSensorApi.html).[GetPositionResponse](https://ts.viam.dev/classes/movementSensorApi.GetPositionResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#getPosition).
 
@@ -522,7 +522,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Returns:**
 
-- (Promise<[movementSensorApi](../modules/movementSensorApi.html).[GetPropertiesResponse](movementSensorApi.GetPropertiesResponse.html)>)
+- (Promise<[movementSensorApi](https://ts.viam.dev/modules/movementSensorApi.html).[GetPropertiesResponse](https://ts.viam.dev/classes/movementSensorApi.GetPropertiesResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#getProperties).
 
@@ -625,7 +625,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Returns:**
 
-- (Promise<[GetAccuracyResponse](movementSensorApi.GetAccuracyResponse.html)>)
+- (Promise<[GetAccuracyResponse](https://ts.viam.dev/classes/movementSensorApi.GetAccuracyResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#getAccuracy).
 
@@ -717,7 +717,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Returns:**
 
-- (Promise<[commonApi](../modules/commonApi.html).[Vector3](commonApi.Vector3.html)>)
+- (Promise<[commonApi](https://ts.viam.dev/modules/commonApi.html).[Vector3](https://ts.viam.dev/classes/commonApi.Vector3.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#getLinearAcceleration).
 
@@ -839,7 +839,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Returns:**
 
-- (Promise<Record<string, [JsonValue](../types/JsonValue.html)>>)
+- (Promise<Record<string, [JsonValue](https://ts.viam.dev/types/JsonValue.html)>>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#getReadings).
 
@@ -949,12 +949,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The command to execute.
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#doCommand).
 

--- a/static/include/components/apis/generated/movement_sensor.md
+++ b/static/include/components/apis/generated/movement_sensor.md
@@ -52,6 +52,20 @@ linVel, err := myMovementSensor.LinearVelocity(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/movementsensor#MovementSensor).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[commonApi](../modules/commonApi.html).[Vector3](commonApi.Vector3.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#getLinearVelocity).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -133,6 +147,20 @@ yAngVel := angVel.Y
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/movementsensor#MovementSensor).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[commonApi](../modules/commonApi.html).[Vector3](commonApi.Vector3.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#getAngularVelocity).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -206,6 +234,20 @@ heading, err := myMovementSensor.CompassHeading(context.Background(), nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/movementsensor#MovementSensor).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<number>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#getCompassHeading).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -291,6 +333,20 @@ logger.Info("The number of degrees that the movement sensor is rotated about the
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/movementsensor#MovementSensor).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[commonApi](../modules/commonApi.html).[Orientation](commonApi.Orientation.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#getOrientation).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -368,6 +424,20 @@ position, altitude, err := myMovementSensor.Position(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/movementsensor#MovementSensor).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[movementSensorApi](../modules/movementSensorApi.html).[GetPositionResponse](movementSensorApi.GetPositionResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#getPosition).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -441,6 +511,20 @@ properties, err := myMovementSensor.Properties(context.Background(), nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/movementsensor#MovementSensor).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[movementSensorApi](../modules/movementSensorApi.html).[GetPropertiesResponse](movementSensorApi.GetPropertiesResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#getProperties).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -532,6 +616,20 @@ accuracy, err := myMovementSensor.Accuracy(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/movementsensor#MovementSensor).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[GetAccuracyResponse](movementSensorApi.GetAccuracyResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#getAccuracy).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -608,6 +706,20 @@ linAcc, err := myMovementSensor.LinearAcceleration(context.Background(), nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/movementsensor#MovementSensor).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[commonApi](../modules/commonApi.html).[Vector3](commonApi.Vector3.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#getLinearAcceleration).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -718,6 +830,20 @@ readings, err := mySensor.Readings(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Sensor).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<Record<string, [JsonValue](../types/JsonValue.html)>>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#getReadings).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -817,6 +943,20 @@ result, err := myMovementSensor.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#doCommand).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}

--- a/static/include/components/apis/generated/power_sensor.md
+++ b/static/include/components/apis/generated/power_sensor.md
@@ -322,7 +322,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Returns:**
 
-- (Promise<Record<string, [JsonValue](../types/JsonValue.html)>>)
+- (Promise<Record<string, [JsonValue](https://ts.viam.dev/types/JsonValue.html)>>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/PowerSensorClient.html#getReadings).
 
@@ -431,12 +431,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The command to execute.
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/PowerSensorClient.html#doCommand).
 

--- a/static/include/components/apis/generated/power_sensor.md
+++ b/static/include/components/apis/generated/power_sensor.md
@@ -50,6 +50,20 @@ voltage, isAC, err := myPowerSensor.Voltage(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/powersensor#PowerSensor).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<readonly [number, boolean]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/PowerSensorClient.html#getVoltage).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -123,6 +137,20 @@ current, isAC, err := myPowerSensor.Current(context.Background(), nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/powersensor#PowerSensor).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<readonly [number, boolean]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/PowerSensorClient.html#getCurrent).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -199,6 +227,20 @@ power, err := myPowerSensor.Power(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/powersensor#PowerSensor).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<number>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/PowerSensorClient.html#getPower).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -269,6 +311,20 @@ readings, err := mySensor.Readings(context.Background(), nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Sensor).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<Record<string, [JsonValue](../types/JsonValue.html)>>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/PowerSensorClient.html#getReadings).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -369,6 +425,20 @@ result, err := myPowerSensor.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/PowerSensorClient.html#doCommand).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}

--- a/static/include/components/apis/generated/sensor.md
+++ b/static/include/components/apis/generated/sensor.md
@@ -58,9 +58,15 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Returns:**
 
-- (Promise<Record<string, [JsonValue](../types/JsonValue.html)>>)
+- (Promise<Record<string, [JsonValue](https://ts.viam.dev/types/JsonValue.html)>>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/SensorClient.html#getReadings).
+
+**Example:**
+
+```ts {class="line-numbers linkable-line-numbers"}
+const readings = await mySensor.getReadings();
+```
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -151,12 +157,12 @@ If you are implementing your own sensor and add features that have no built-in A
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The command to execute.
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/SensorClient.html#doCommand).
 

--- a/static/include/components/apis/generated/sensor.md
+++ b/static/include/components/apis/generated/sensor.md
@@ -49,6 +49,20 @@ readings, err := mySensor.Readings(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Sensor).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<Record<string, [JsonValue](../types/JsonValue.html)>>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/SensorClient.html#getReadings).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -133,6 +147,20 @@ For built-in models, model-specific commands are covered with each model's docum
 If you are implementing your own sensor and add features that have no built-in API method, you can access them with `DoCommand`.
 
 {{< tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/SensorClient.html#doCommand).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**

--- a/static/include/components/apis/generated/servo.md
+++ b/static/include/components/apis/generated/servo.md
@@ -420,12 +420,12 @@ If you are implementing your own servo and add features that have no built-in AP
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The command to execute.
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ServoClient.html#doCommand).
 

--- a/static/include/components/apis/generated/servo.md
+++ b/static/include/components/apis/generated/servo.md
@@ -66,6 +66,21 @@ myServoComponent.Move(context.Background(), 30, nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/servo#Servo).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `angleDeg` (number) (required)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ServoClient.html#move).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -157,6 +172,20 @@ logger.Info("Position 2: ", pos2)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/servo#Servo).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<number>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ServoClient.html#getPosition).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -230,6 +259,19 @@ logger.Info(is_moving)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Actuator).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<boolean>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ServoClient.html#isMoving).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -309,6 +351,20 @@ err = myArm.Stop(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Actuator).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ServoClient.html#stop).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -360,6 +416,20 @@ For built-in models, model-specific commands are covered with each model's docum
 If you are implementing your own servo and add features that have no built-in API method, you can access them with `DoCommand`.
 
 {{< tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/ServoClient.html#doCommand).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**

--- a/static/include/components/apis/generated/switch.md
+++ b/static/include/components/apis/generated/switch.md
@@ -143,12 +143,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The command to execute.
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/SwitchClient.html#doCommand).
 

--- a/static/include/components/apis/generated/switch.md
+++ b/static/include/components/apis/generated/switch.md
@@ -19,6 +19,21 @@ Position must be within the valid range for the switch type.
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/switch#Switch).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `position` (number) (required)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/SwitchClient.html#setPosition).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### GetPosition
@@ -41,6 +56,20 @@ Return the current position of the switch.
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/switch#Switch).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<number>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/SwitchClient.html#getPosition).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### GetNumberOfPositions
@@ -61,6 +90,20 @@ Return the number of valid positions for this switch.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/switch#Switch).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<number>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/SwitchClient.html#getNumberOfPositions).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -94,6 +137,20 @@ result, err := mySwitch.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/SwitchClient.html#doCommand).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/static/include/robot/apis/generated/robot.md
+++ b/static/include/robot/apis/generated/robot.md
@@ -22,15 +22,15 @@ operations = await machine.get_operations()
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient.get_operations).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
 
+- None.
 
 **Returns:**
 
-- (Promise<[Operation](robotApi.Operation.html)[]>)
+- (Promise<[Operation](https://ts.viam.dev/classes/robotApi.Operation.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#getOperations).
 
@@ -64,15 +64,15 @@ config_status = machine_status.config
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient.get_machine_status).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
 
+- None.
 
 **Returns:**
 
-- (Promise<[GetMachineStatusResponse](robotApi.GetMachineStatusResponse.html)>)
+- (Promise<[GetMachineStatusResponse](https://ts.viam.dev/classes/robotApi.GetMachineStatusResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#getMachineStatus).
 
@@ -107,10 +107,11 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
+- None.
 
 **Returns:**
 
-- (Promise<[commonApi](../modules/commonApi.html).[ResourceName](commonApi.ResourceName.html)[]>)
+- (Promise<[commonApi](https://ts.viam.dev/modules/commonApi.html).[ResourceName](https://ts.viam.dev/classes/commonApi.ResourceName.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#resourceNames).
 
@@ -141,7 +142,6 @@ await machine.cancel_operation("INSERT OPERATION ID")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient.cancel_operation).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -182,7 +182,6 @@ await machine.block_for_operation("INSERT OPERATION ID")
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient.block_for_operation).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -232,7 +231,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(*framesystem.Config)](https://pkg.go.dev/go.viam.com/rdk/robot/framesystem#Config): The configuration of the given machine’s frame system.
+- [(\*framesystem.Config)](https://pkg.go.dev/go.viam.com/rdk/robot/framesystem#Config): The configuration of the given machine’s frame system.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**
@@ -250,11 +249,11 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
-- `transforms` ([commonApi](../modules/commonApi.html)) (required)
+- `transforms` ([commonApi](https://ts.viam.dev/modules/commonApi.html)) (required)
 
 **Returns:**
 
-- (Promise<[FrameSystemConfig](robotApi.FrameSystemConfig.html)[]>)
+- (Promise<[FrameSystemConfig](https://ts.viam.dev/classes/robotApi.FrameSystemConfig.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#frameSystemConfig).
 
@@ -309,13 +308,13 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Parameters:**
 
 - `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
-- `pose` [(*referenceframe.PoseInFrame)](https://pkg.go.dev/go.viam.com/rdk/referenceframe#PoseInFrame): The pose that should be transformed.
+- `pose` [(\*referenceframe.PoseInFrame)](https://pkg.go.dev/go.viam.com/rdk/referenceframe#PoseInFrame): The pose that should be transformed.
 - `dst` [(string)](https://pkg.go.dev/builtin#string): The name of the reference pose to transform the given pose to.
-- `additionalTransforms` [([]*referenceframe.LinkInFrame)](https://pkg.go.dev/go.viam.com/rdk/referenceframe#LinkInFrame): Any additional transforms.
+- `additionalTransforms` [([]\*referenceframe.LinkInFrame)](https://pkg.go.dev/go.viam.com/rdk/referenceframe#LinkInFrame): Any additional transforms.
 
 **Returns:**
 
-- [(*referenceframe.PoseInFrame)](https://pkg.go.dev/go.viam.com/rdk/referenceframe#PoseInFrame): Transformed pose in frame.
+- [(\*referenceframe.PoseInFrame)](https://pkg.go.dev/go.viam.com/rdk/referenceframe#PoseInFrame): Transformed pose in frame.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**
@@ -337,14 +336,14 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
-- `source` ([commonApi](../modules/commonApi.html)) (required)
+- `source` ([commonApi](https://ts.viam.dev/modules/commonApi.html)) (required)
 - `destination` (string) (required): The name of the reference frame to transform the given.
-- `supplementalTransforms` ([commonApi](../modules/commonApi.html)) (required): Pose information on any additional
+- `supplementalTransforms` ([commonApi](https://ts.viam.dev/modules/commonApi.html)) (required): Pose information on any additional
   reference frames that are needed to perform the transform.
 
 **Returns:**
 
-- (Promise<[commonApi](../modules/commonApi.html).[PoseInFrame](commonApi.PoseInFrame.html)>)
+- (Promise<[commonApi](https://ts.viam.dev/modules/commonApi.html).[PoseInFrame](https://ts.viam.dev/classes/commonApi.PoseInFrame.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#transformPose).
 
@@ -379,8 +378,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Parameters:**
 
 - `pointCloudPCD` (Uint8Array) (required): The point clouds to transform. This should be in the
-  PCD format encoded into bytes:
-  https://pointclouds.org/documentation/tutorials/pcd_file_format.html.
+  [PCD format encoded into bytes](https://pointclouds.org/documentation/tutorials/pcd_file_format.html).
 - `source` (string) (required): The reference frame of the point cloud.
 - `destination` (string) (required): The reference frame into which the source data should
   be transformed, if unset this defaults to the "world" reference frame. Do
@@ -423,15 +421,15 @@ module_models = await machine.get_models_from_modules(qs)
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient.get_models_from_modules).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
 
+- None.
 
 **Returns:**
 
-- (Promise<[ModuleModel](robotApi.ModuleModel.html)[]>)
+- (Promise<[ModuleModel](https://ts.viam.dev/classes/robotApi.ModuleModel.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#getModelsFromModules).
 
@@ -488,6 +486,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
+- None.
 
 **Returns:**
 
@@ -599,10 +598,11 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
+- None.
 
 **Returns:**
 
-- (Promise<[GetCloudMetadataResponse](robotApi.GetCloudMetadataResponse.html)>)
+- (Promise<[GetCloudMetadataResponse](https://ts.viam.dev/classes/robotApi.GetCloudMetadataResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#getCloudMetadata).
 

--- a/static/include/robot/apis/generated/robot.md
+++ b/static/include/robot/apis/generated/robot.md
@@ -23,6 +23,19 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+
+**Returns:**
+
+- (Promise<[Operation](robotApi.Operation.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#getOperations).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### GetMachineStatus
 
@@ -52,6 +65,19 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+
+**Returns:**
+
+- (Promise<[GetMachineStatusResponse](robotApi.GetMachineStatusResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#getMachineStatus).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### ResourceNames
 
@@ -75,6 +101,18 @@ resource_names := machine.ResourceNames()
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/robot#Robot).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+
+**Returns:**
+
+- (Promise<[commonApi](../modules/commonApi.html).[ResourceName](commonApi.ResourceName.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#resourceNames).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -104,6 +142,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required): ID of operation to kill.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#cancelOperation).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### BlockForOperation
 
@@ -128,6 +180,20 @@ await machine.block_for_operation("INSERT OPERATION ID")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient.block_for_operation).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required): ID of operation to block on.
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#blockForOperation).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -178,6 +244,19 @@ fmt.Println(frameSystem)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/robot#Robot).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `transforms` ([commonApi](../modules/commonApi.html)) (required)
+
+**Returns:**
+
+- (Promise<[FrameSystemConfig](robotApi.FrameSystemConfig.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#frameSystemConfig).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -254,6 +333,22 @@ movementSensorToBase, err := machine.TransformPose(context.Background(), baseOri
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/robot#Robot).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `source` ([commonApi](../modules/commonApi.html)) (required)
+- `destination` (string) (required): The name of the reference frame to transform the given.
+- `supplementalTransforms` ([commonApi](../modules/commonApi.html)) (required): Pose information on any additional
+  reference frames that are needed to perform the transform.
+
+**Returns:**
+
+- (Promise<[commonApi](../modules/commonApi.html).[PoseInFrame](commonApi.PoseInFrame.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#transformPose).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### TransformPCD
@@ -277,6 +372,27 @@ Do not move the robot between the generation of the initial pointcloud and the r
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/robot#Robot).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `pointCloudPCD` (Uint8Array) (required): The point clouds to transform. This should be in the
+  PCD format encoded into bytes:
+  https://pointclouds.org/documentation/tutorials/pcd_file_format.html.
+- `source` (string) (required): The reference frame of the point cloud.
+- `destination` (string) (required): The reference frame into which the source data should
+  be transformed, if unset this defaults to the "world" reference frame. Do
+  not move the robot between the generation of the initial pointcloud and
+  the receipt of the transformed pointcloud because that will make the
+  transformations inaccurate.
+
+**Returns:**
+
+- (Promise<Uint8Array>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#transformPCD).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -305,6 +421,19 @@ module_models = await machine.get_models_from_modules(qs)
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient.get_models_from_modules).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+
+**Returns:**
+
+- (Promise<[ModuleModel](robotApi.ModuleModel.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#getModelsFromModules).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -353,6 +482,18 @@ err := machine.StopAll(context.Background(), nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/robot#Robot).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#stopAll).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -452,6 +593,18 @@ machine_part_id := metadata.MachinePartID
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/robot#Robot).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+
+**Returns:**
+
+- (Promise<[GetCloudMetadataResponse](robotApi.GetCloudMetadataResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#getCloudMetadata).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}

--- a/static/include/services/apis/generated/data_manager.md
+++ b/static/include/services/apis/generated/data_manager.md
@@ -104,12 +104,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The command to execute.
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataManagerClient.html#doCommand).
 

--- a/static/include/services/apis/generated/data_manager.md
+++ b/static/include/services/apis/generated/data_manager.md
@@ -30,6 +30,20 @@ err := data.Sync(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/datamanager#Service).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataManagerClient.html#sync).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### Reconfigure
@@ -84,6 +98,20 @@ result, err := myDataManagerSvc.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataManagerClient.html#doCommand).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/static/include/services/apis/generated/discovery.md
+++ b/static/include/services/apis/generated/discovery.md
@@ -59,4 +59,18 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/discovery#Service).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[ComponentConfig](appRobotApi.ComponentConfig.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DiscoveryClient.html#discoverResources).
+
+{{% /tab %}}
 {{< /tabs >}}

--- a/static/include/services/apis/generated/discovery.md
+++ b/static/include/services/apis/generated/discovery.md
@@ -68,7 +68,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Returns:**
 
-- (Promise<[ComponentConfig](appRobotApi.ComponentConfig.html)[]>)
+- (Promise<[ComponentConfig](https://ts.viam.dev/classes/appRobotApi.ComponentConfig.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DiscoveryClient.html#discoverResources).
 

--- a/static/include/services/apis/generated/generic_service.md
+++ b/static/include/services/apis/generated/generic_service.md
@@ -59,12 +59,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The command to execute.
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GenericServiceClient.html#doCommand).
 

--- a/static/include/services/apis/generated/generic_service.md
+++ b/static/include/services/apis/generated/generic_service.md
@@ -55,6 +55,20 @@ result, err := myGenericService.DoCommand(context.Background(), command)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GenericServiceClient.html#doCommand).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### GetResourceName

--- a/static/include/services/apis/generated/motion.md
+++ b/static/include/services/apis/generated/motion.md
@@ -107,6 +107,24 @@ moved, err := motionService.Move(context.Background(), motion.MoveReq{
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/motion#Service).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `destination` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `componentName` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `worldState` ([PlainMessage](../types/PlainMessage.html)) (optional)
+- `constraints` ([PlainMessage](../types/PlainMessage.html)) (optional)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<boolean>): Whether the move was successful (`true`) or unsuccessful (`false`).
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotionClient.html#move).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### MoveOnMap
@@ -239,6 +257,25 @@ err = motion.PollHistoryUntilSuccessOrError(
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/motion#Service).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `destination` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `componentName` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `slamServiceName` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `motionConfig` ([PlainMessage](../types/PlainMessage.html)) (optional)
+- `obstacles` ([PlainMessage](../types/PlainMessage.html)) (optional)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<string>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotionClient.html#moveOnMap).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -389,6 +426,27 @@ err = motion.PollHistoryUntilSuccessOrError(
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/motion#Service).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `destination` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `componentName` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `movementSensorName` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `heading` (number) (optional)
+- `obstaclesList` ([PlainMessage](../types/PlainMessage.html)) (optional)
+- `motionConfig` ([PlainMessage](../types/PlainMessage.html)) (optional)
+- `boundingRegionsList` ([PlainMessage](../types/PlainMessage.html)) (optional)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<string>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotionClient.html#moveOnGlobe).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### GetPose
@@ -533,6 +591,23 @@ logger.Info("Orientation of my_gripper from the motion service:", myGripperPose.
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/motion#Service).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `componentName` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `destinationFrame` (string) (required)
+- `supplementalTransforms` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[commonApi](../modules/commonApi.html).[PoseInFrame](commonApi.PoseInFrame.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotionClient.html#getPose).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### StopPlan
@@ -599,6 +674,21 @@ err := motionService.StopPlan(context.Background(), motion.StopPlanReq{
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/motion#Service).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `componentName` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<null>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotionClient.html#stopPlan).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### ListPlanStatuses
@@ -658,6 +748,21 @@ planStatuses, err := motionService.ListPlanStatuses(context.Background(), motion
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/motion#Service).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `onlyActivePlans` (boolean) (optional)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[motionApi](../modules/motionApi.html).[ListPlanStatusesResponse](motionApi.ListPlanStatusesResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotionClient.html#listPlanStatuses).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -737,6 +842,23 @@ planHistory, err := motionService.PlanHistory(context.Background(), motion.PlanH
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/motion#Service).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `componentName` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `lastPlanOnly` (boolean) (optional)
+- `executionId` (string) (optional)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[motionApi](../modules/motionApi.html).[GetPlanResponse](motionApi.GetPlanResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotionClient.html#getPlan).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -859,6 +981,20 @@ result, err := myMotionSvc.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotionClient.html#doCommand).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/static/include/services/apis/generated/motion.md
+++ b/static/include/services/apis/generated/motion.md
@@ -111,10 +111,10 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Parameters:**
 
-- `destination` ([PlainMessage](../types/PlainMessage.html)) (required)
-- `componentName` ([PlainMessage](../types/PlainMessage.html)) (required)
-- `worldState` ([PlainMessage](../types/PlainMessage.html)) (optional)
-- `constraints` ([PlainMessage](../types/PlainMessage.html)) (optional)
+- `destination` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required)
+- `componentName` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required)
+- `worldState` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (optional)
+- `constraints` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (optional)
 - `extra` (None) (optional)
 - `callOptions` (CallOptions) (optional)
 
@@ -263,11 +263,11 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Parameters:**
 
-- `destination` ([PlainMessage](../types/PlainMessage.html)) (required)
-- `componentName` ([PlainMessage](../types/PlainMessage.html)) (required)
-- `slamServiceName` ([PlainMessage](../types/PlainMessage.html)) (required)
-- `motionConfig` ([PlainMessage](../types/PlainMessage.html)) (optional)
-- `obstacles` ([PlainMessage](../types/PlainMessage.html)) (optional)
+- `destination` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required)
+- `componentName` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required)
+- `slamServiceName` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required)
+- `motionConfig` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (optional)
+- `obstacles` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (optional)
 - `extra` (None) (optional)
 - `callOptions` (CallOptions) (optional)
 
@@ -430,13 +430,13 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Parameters:**
 
-- `destination` ([PlainMessage](../types/PlainMessage.html)) (required)
-- `componentName` ([PlainMessage](../types/PlainMessage.html)) (required)
-- `movementSensorName` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `destination` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required)
+- `componentName` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required)
+- `movementSensorName` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required)
 - `heading` (number) (optional)
-- `obstaclesList` ([PlainMessage](../types/PlainMessage.html)) (optional)
-- `motionConfig` ([PlainMessage](../types/PlainMessage.html)) (optional)
-- `boundingRegionsList` ([PlainMessage](../types/PlainMessage.html)) (optional)
+- `obstaclesList` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (optional)
+- `motionConfig` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (optional)
+- `boundingRegionsList` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (optional)
 - `extra` (None) (optional)
 - `callOptions` (CallOptions) (optional)
 
@@ -595,15 +595,15 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Parameters:**
 
-- `componentName` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `componentName` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required)
 - `destinationFrame` (string) (required)
-- `supplementalTransforms` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `supplementalTransforms` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required)
 - `extra` (None) (optional)
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[commonApi](../modules/commonApi.html).[PoseInFrame](commonApi.PoseInFrame.html)>)
+- (Promise<[commonApi](https://ts.viam.dev/modules/commonApi.html).[PoseInFrame](https://ts.viam.dev/classes/commonApi.PoseInFrame.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotionClient.html#getPose).
 
@@ -678,7 +678,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Parameters:**
 
-- `componentName` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `componentName` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required)
 - `extra` (None) (optional)
 - `callOptions` (CallOptions) (optional)
 
@@ -760,7 +760,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Returns:**
 
-- (Promise<[motionApi](../modules/motionApi.html).[ListPlanStatusesResponse](motionApi.ListPlanStatusesResponse.html)>)
+- (Promise<[motionApi](https://ts.viam.dev/modules/motionApi.html).[ListPlanStatusesResponse](https://ts.viam.dev/classes/motionApi.ListPlanStatusesResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotionClient.html#listPlanStatuses).
 
@@ -848,7 +848,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Parameters:**
 
-- `componentName` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `componentName` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required)
 - `lastPlanOnly` (boolean) (optional)
 - `executionId` (string) (optional)
 - `extra` (None) (optional)
@@ -856,7 +856,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Returns:**
 
-- (Promise<[motionApi](../modules/motionApi.html).[GetPlanResponse](motionApi.GetPlanResponse.html)>)
+- (Promise<[motionApi](https://ts.viam.dev/modules/motionApi.html).[GetPlanResponse](https://ts.viam.dev/classes/motionApi.GetPlanResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotionClient.html#getPlan).
 
@@ -987,12 +987,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required): The command to execute.
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The command to execute.
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotionClient.html#doCommand).
 

--- a/static/include/services/apis/generated/navigation.md
+++ b/static/include/services/apis/generated/navigation.md
@@ -52,6 +52,20 @@ mode, err := myNav.Mode(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/navigation#Service).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[navigationApi](../modules/navigationApi.html).[Mode](../enums/navigationApi.Mode.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/NavigationClient.html#getMode).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### SetMode
@@ -109,6 +123,21 @@ err := myNav.SetMode(context.Background(), navigation.ModeWaypoint, nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/navigation#Service).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `mode` ([navigationApi](../modules/navigationApi.html)) (required)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/NavigationClient.html#setMode).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### GetLocation
@@ -160,6 +189,20 @@ location, err := myNav.Location(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/navigation#Service).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[navigationApi](../modules/navigationApi.html).[GetLocationResponse](navigationApi.GetLocationResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/NavigationClient.html#getLocation).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### GetWaypoints
@@ -209,6 +252,20 @@ waypoints, err := myNav.Waypoints(context.Background(), nil)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/navigation#Service).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[navigationApi](../modules/navigationApi.html).[Waypoint](navigationApi.Waypoint.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/NavigationClient.html#getWayPoints).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -271,6 +328,21 @@ err := myNav.AddWaypoint(context.Background(), location, nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/navigation#Service).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `location` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/NavigationClient.html#addWayPoint).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### RemoveWaypoint
@@ -330,6 +402,21 @@ err = myNav.RemoveWaypoint(context.Background(), waypoints[0].ID, nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/navigation#Service).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `id` (string) (required)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<void>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/NavigationClient.html#removeWayPoint).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### GetObstacles
@@ -384,6 +471,20 @@ obstacles, err := myNav.Obstacles(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/navigation#Service).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[commonApi](../modules/commonApi.html).[GeoGeometry](commonApi.GeoGeometry.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/NavigationClient.html#getObstacles).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### GetPaths
@@ -435,6 +536,20 @@ paths, err := myNav.Paths(context.Background(), nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/navigation#Service).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[navigationApi](../modules/navigationApi.html).[Path](navigationApi.Path.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/NavigationClient.html#getPaths).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### GetProperties
@@ -483,6 +598,19 @@ navProperties, err := myNav.Properties(context.Background())
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/navigation#Service).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[navigationApi](../modules/navigationApi.html).[GetPropertiesResponse](navigationApi.GetPropertiesResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/NavigationClient.html#getProperties).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -566,6 +694,20 @@ result, err := myNavigationSvc.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/NavigationClient.html#doCommand).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/static/include/services/apis/generated/navigation.md
+++ b/static/include/services/apis/generated/navigation.md
@@ -61,7 +61,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Returns:**
 
-- (Promise<[navigationApi](../modules/navigationApi.html).[Mode](../enums/navigationApi.Mode.html)>)
+- (Promise<[navigationApi](https://ts.viam.dev/modules/navigationApi.html).[Mode](https://ts.viam.dev/enums/navigationApi.Mode.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/NavigationClient.html#getMode).
 
@@ -127,7 +127,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Parameters:**
 
-- `mode` ([navigationApi](../modules/navigationApi.html)) (required)
+- `mode` ([navigationApi](https://ts.viam.dev/modules/navigationApi.html)) (required)
 - `extra` (None) (optional)
 - `callOptions` (CallOptions) (optional)
 
@@ -198,7 +198,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Returns:**
 
-- (Promise<[navigationApi](../modules/navigationApi.html).[GetLocationResponse](navigationApi.GetLocationResponse.html)>)
+- (Promise<[navigationApi](https://ts.viam.dev/modules/navigationApi.html).[GetLocationResponse](https://ts.viam.dev/classes/navigationApi.GetLocationResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/NavigationClient.html#getLocation).
 
@@ -263,7 +263,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Returns:**
 
-- (Promise<[navigationApi](../modules/navigationApi.html).[Waypoint](navigationApi.Waypoint.html)[]>)
+- (Promise<[navigationApi](https://ts.viam.dev/modules/navigationApi.html).[Waypoint](https://ts.viam.dev/classes/navigationApi.Waypoint.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/NavigationClient.html#getWayPoints).
 
@@ -332,7 +332,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Parameters:**
 
-- `location` ([PlainMessage](../types/PlainMessage.html)) (required)
+- `location` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required)
 - `extra` (None) (optional)
 - `callOptions` (CallOptions) (optional)
 
@@ -480,7 +480,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Returns:**
 
-- (Promise<[commonApi](../modules/commonApi.html).[GeoGeometry](commonApi.GeoGeometry.html)[]>)
+- (Promise<[commonApi](https://ts.viam.dev/modules/commonApi.html).[GeoGeometry](https://ts.viam.dev/classes/commonApi.GeoGeometry.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/NavigationClient.html#getObstacles).
 
@@ -545,7 +545,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Returns:**
 
-- (Promise<[navigationApi](../modules/navigationApi.html).[Path](navigationApi.Path.html)[]>)
+- (Promise<[navigationApi](https://ts.viam.dev/modules/navigationApi.html).[Path](https://ts.viam.dev/classes/navigationApi.Path.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/NavigationClient.html#getPaths).
 
@@ -608,7 +608,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Returns:**
 
-- (Promise<[navigationApi](../modules/navigationApi.html).[GetPropertiesResponse](navigationApi.GetPropertiesResponse.html)>)
+- (Promise<[navigationApi](https://ts.viam.dev/modules/navigationApi.html).[GetPropertiesResponse](https://ts.viam.dev/classes/navigationApi.GetPropertiesResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/NavigationClient.html#getProperties).
 
@@ -700,12 +700,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required)
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required)
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/NavigationClient.html#doCommand).
 

--- a/static/include/services/apis/generated/slam.md
+++ b/static/include/services/apis/generated/slam.md
@@ -47,6 +47,19 @@ pos, name, err := mySLAMService.Position(context.Background())
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/slam#Service).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[slamApi](../modules/slamApi.html).[GetPositionResponse](slamApi.GetPositionResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/SlamClient.html#getPosition).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### GetPointCloudMap
@@ -78,6 +91,21 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 {{% /tab %}}
 {{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `returnEditedMap` (boolean) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<Uint8Array>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/SlamClient.html#getPointCloudMap).
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### GetInternalState
 
@@ -104,6 +132,20 @@ internal_state = await slam.get_internal_state()
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/services/slam/client/index.html#viam.services.slam.client.SLAMClient.get_internal_state).
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<Uint8Array>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/SlamClient.html#getInternalState).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -161,6 +203,19 @@ properties, err := mySLAMService.Properties(context.Background())
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/slam#Service).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[slamApi](../modules/slamApi.html).[GetPropertiesResponse](slamApi.GetPropertiesResponse.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/SlamClient.html#getProperties).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -289,6 +344,20 @@ result, err := mySLAMService.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/SlamClient.html#doCommand).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/static/include/services/apis/generated/slam.md
+++ b/static/include/services/apis/generated/slam.md
@@ -55,7 +55,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Returns:**
 
-- (Promise<[slamApi](../modules/slamApi.html).[GetPositionResponse](slamApi.GetPositionResponse.html)>)
+- (Promise<[slamApi](https://ts.viam.dev/modules/slamApi.html).[GetPositionResponse](https://ts.viam.dev/classes/slamApi.GetPositionResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/SlamClient.html#getPosition).
 
@@ -90,7 +90,6 @@ pcd_map = await slam_svc.get_point_cloud_map()
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/services/slam/client/index.html#viam.services.slam.client.SLAMClient.get_point_cloud_map).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -134,7 +133,6 @@ internal_state = await slam.get_internal_state()
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/services/slam/client/index.html#viam.services.slam.client.SLAMClient.get_internal_state).
 
 {{% /tab %}}
-{{< /tabs >}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -213,7 +211,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Returns:**
 
-- (Promise<[slamApi](../modules/slamApi.html).[GetPropertiesResponse](slamApi.GetPropertiesResponse.html)>)
+- (Promise<[slamApi](https://ts.viam.dev/modules/slamApi.html).[GetPropertiesResponse](https://ts.viam.dev/classes/slamApi.GetPropertiesResponse.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/SlamClient.html#getProperties).
 
@@ -350,12 +348,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required)
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required)
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/SlamClient.html#doCommand).
 

--- a/static/include/services/apis/generated/vision.md
+++ b/static/include/services/apis/generated/vision.md
@@ -76,7 +76,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Returns:**
 
-- (Promise<[visionApi](../modules/visionApi.html).[Detection](visionApi.Detection.html)[]>)
+- (Promise<[visionApi](https://ts.viam.dev/modules/visionApi.html).[Detection](https://ts.viam.dev/classes/visionApi.Detection.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/VisionClient.html#getDetectionsFromCamera).
 
@@ -192,13 +192,13 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 - `image` (Uint8Array) (required)
 - `width` (number) (required)
 - `height` (number) (required)
-- `mimeType` ([MimeType](../types/MimeType.html)) (required)
+- `mimeType` ([MimeType](https://ts.viam.dev/types/MimeType.html)) (required)
 - `extra` (None) (optional)
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[visionApi](../modules/visionApi.html).[Detection](visionApi.Detection.html)[]>)
+- (Promise<[visionApi](https://ts.viam.dev/modules/visionApi.html).[Detection](https://ts.viam.dev/classes/visionApi.Detection.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/VisionClient.html#getDetections).
 
@@ -304,7 +304,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Returns:**
 
-- (Promise<[visionApi](../modules/visionApi.html).[Classification](visionApi.Classification.html)[]>)
+- (Promise<[visionApi](https://ts.viam.dev/modules/visionApi.html).[Classification](https://ts.viam.dev/classes/visionApi.Classification.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/VisionClient.html#getClassificationsFromCamera).
 
@@ -419,14 +419,14 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 - `image` (Uint8Array) (required)
 - `width` (number) (required)
 - `height` (number) (required)
-- `mimeType` ([MimeType](../types/MimeType.html)) (required)
+- `mimeType` ([MimeType](https://ts.viam.dev/types/MimeType.html)) (required)
 - `count` (number) (required)
 - `extra` (None) (optional)
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[visionApi](../modules/visionApi.html).[Classification](visionApi.Classification.html)[]>)
+- (Promise<[visionApi](https://ts.viam.dev/modules/visionApi.html).[Classification](https://ts.viam.dev/classes/visionApi.Classification.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/VisionClient.html#getClassifications).
 
@@ -536,7 +536,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Returns:**
 
-- (Promise<[commonApi](../modules/commonApi.html).[PointCloudObject](commonApi.PointCloudObject.html)[]>)
+- (Promise<[commonApi](https://ts.viam.dev/modules/commonApi.html).[PointCloudObject](https://ts.viam.dev/classes/commonApi.PointCloudObject.html)[]>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/VisionClient.html#getObjectPointClouds).
 
@@ -651,7 +651,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Returns:**
 
-- (Promise<{     classifications: [visionApi](../modules/visionApi.html).[Classification](visionApi.Classification.html)[];     detections: [visionApi](../modules/visionApi.html).[Detection](visionApi.Detection.html)[];     extra: undefined | [Struct](Struct.html);     image: undefined | [Image](cameraApi.Image.html);     objectPointClouds: [commonApi](../modules/commonApi.html).[PointCloudObject](commonApi.PointCloudObject.html)[]; }>)
+- (Promise<{     classifications: [visionApi](https://ts.viam.dev/modules/visionApi.html).[Classification](https://ts.viam.dev/classes/visionApi.Classification.html)[];     detections: [visionApi](https://ts.viam.dev/modules/visionApi.html).[Detection](https://ts.viam.dev/classes/visionApi.Detection.html)[];     extra: undefined | [Struct](https://ts.viam.dev/classes/Struct.html);     image: undefined | [Image](https://ts.viam.dev/classes/cameraApi.Image.html);     objectPointClouds: [commonApi](https://ts.viam.dev/modules/commonApi.html).[PointCloudObject](https://ts.viam.dev/classes/commonApi.PointCloudObject.html)[]; }>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/VisionClient.html#captureAllFromCamera).
 
@@ -743,12 +743,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
-- `command` ([Struct](Struct.html)) (required)
+- `command` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required)
 - `callOptions` (CallOptions) (optional)
 
 **Returns:**
 
-- (Promise<[JsonValue](../types/JsonValue.html)>)
+- (Promise<[JsonValue](https://ts.viam.dev/types/JsonValue.html)>)
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/VisionClient.html#doCommand).
 

--- a/static/include/services/apis/generated/vision.md
+++ b/static/include/services/apis/generated/vision.md
@@ -66,6 +66,21 @@ if len(detections) > 0 {
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/vision#Service).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `cameraName` (string) (required)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[visionApi](../modules/visionApi.html).[Detection](visionApi.Detection.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/VisionClient.html#getDetectionsFromCamera).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -170,6 +185,24 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/vision#Service).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `image` (Uint8Array) (required)
+- `width` (number) (required)
+- `height` (number) (required)
+- `mimeType` ([MimeType](../types/MimeType.html)) (required)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[visionApi](../modules/visionApi.html).[Detection](visionApi.Detection.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/VisionClient.html#getDetections).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -258,6 +291,22 @@ if len(classifications) > 0 {
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/vision#Service).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `cameraName` (string) (required)
+- `count` (number) (required)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[visionApi](../modules/visionApi.html).[Classification](visionApi.Classification.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/VisionClient.html#getClassificationsFromCamera).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -363,6 +412,25 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/vision#Service).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `image` (Uint8Array) (required)
+- `width` (number) (required)
+- `height` (number) (required)
+- `mimeType` ([MimeType](../types/MimeType.html)) (required)
+- `count` (number) (required)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[visionApi](../modules/visionApi.html).[Classification](visionApi.Classification.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/VisionClient.html#getClassifications).
+
+{{% /tab %}}
 {{% tab name="Flutter" %}}
 
 **Parameters:**
@@ -456,6 +524,21 @@ if len(objects) > 0 {
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/vision#Service).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `cameraName` (string) (required)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[commonApi](../modules/commonApi.html).[PointCloudObject](commonApi.PointCloudObject.html)[]>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/VisionClient.html#getObjectPointClouds).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -557,6 +640,22 @@ objects := capture.Objects
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/vision#Service).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `cameraName` (string) (required)
+- `__namedParameters` (CaptureAllOptions) (required)
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<{     classifications: [visionApi](../modules/visionApi.html).[Classification](visionApi.Classification.html)[];     detections: [visionApi](../modules/visionApi.html).[Detection](visionApi.Detection.html)[];     extra: undefined | [Struct](Struct.html);     image: undefined | [Image](cameraApi.Image.html);     objectPointClouds: [commonApi](../modules/commonApi.html).[PointCloudObject](commonApi.PointCloudObject.html)[]; }>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/VisionClient.html#captureAllFromCamera).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### Reconfigure
@@ -638,6 +737,20 @@ result, err := myVisionSvc.DoCommand(context.Background(), command)
 ```
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/resource#Resource).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `command` ([Struct](Struct.html)) (required)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<[JsonValue](../types/JsonValue.html)>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/VisionClient.html#doCommand).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}
@@ -749,6 +862,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/services/vision#Service).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise<{     classificationsSupported: boolean;     detectionsSupported: boolean;     objectPointCloudsSupported: boolean; }>)
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/VisionClient.html#getProperties).
 
 {{% /tab %}}
 {{% tab name="Flutter" %}}


### PR DESCRIPTION
Please only review for mistakes (wrong information or accidentally deleting anything that shouldn't be deleted or things like that). I'm not fixing missing parameter descriptions or similar here. We'll need to do that upstream when we're adding code samples.

Note: This doesn't output code samples right now, I will need to add that logic once we have code samples in the sdk docs.