### PR TITLE
fix: wrap app.viam.com link in anchor tag

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1233,6 +1233,10 @@ td > ul, td > ol {
   color: #282829;
 }
 
+#navsearch > #appButton a {
+  color: #282829;
+}
+
 #navsearch > #appButton > span > span > i {
   color: #9C9CA4;
 }

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -76,7 +76,7 @@
       </button>
       <button class="docsbutton" id="appButton" title="Viam app">
         <span id="appButtonContent">
-          <span>app.viam.com <i class="fas fa-external-link-alt fa-sm" style="margin-left: 0.5rem;"></i></span>
+          <a href="https://app.viam.com" target="_blank">app.viam.com <i class="fas fa-external-link-alt fa-sm" style="margin-left: 0.5rem;"></i></a>
         </span>
       </button>
     </div>


### PR DESCRIPTION
The link to the Viam app in the docs navbar doesn't appear to work anymore. I'm not sure how it was working in the past since it was only a button with no anchor tag. To keep this from being interrupted by JS issues, I've updated the button to wrap the `app.viam.com` and icon in an anchor tag instead of a span to make it a working link. 

