### PR TITLE
Fix broken landing page image on Safari

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -2486,7 +2486,6 @@ h3.body-header[style] {
   margin-top: 3rem;
   min-width: 500px;
   max-width: 500px;
-  height: fit-content;
   margin-top: 9rem;
 }
 


### PR DESCRIPTION
The image on the right side of the landing page is awfully distorted on Safari on the production site right now, stretched vertically to roughly the page height. I believe the landing page is the only page that uses this style, and it displays nicely in Firefox and Chrome and Safari after this fix. But let me know if we have other ways to test and validate style changes.
