### PR TITLE
DOCS-3797: Modernize the Micro-RDK platform

### DIFF
--- a/docs/operate/get-started/other-hardware/micro-module.md
+++ b/docs/operate/get-started/other-hardware/micro-module.md
@@ -97,7 +97,7 @@ To be able to develop for the Micro-RDK on macOS and Linux systems, you must ins
 1. Use `espup` to download and install the ESP Rust toolchain:
 
    ```sh { class="command-line" data-prompt="$"}
-   espup install -s -f /dev/null -v 1.83.0
+   espup install -s -f /dev/null -v 1.85.0
    ```
 
 {{< alert title="Note" color="tip" >}}

--- a/docs/operate/reference/components/board/esp32.md
+++ b/docs/operate/reference/components/board/esp32.md
@@ -151,7 +151,7 @@ The following properties are available for `digital_interrupts`:
 ### PWM signals on `esp32` pins
 
 You can set PWM frequencies with Viam through the [`GPIOPin` API](/dev/reference/apis/components/board/#api).
-Refer to the [Espressif documentation for valid frequencies and duty resolutions](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/ledc.html#supported-range-of-frequency-and-duty-resolutions).
+Refer to the [Espressif documentation for valid frequencies and duty resolutions](https://docs.espressif.com/projects/esp-idf/en/release-v5.4/esp32/api-reference/peripherals/ledc.html#supported-range-of-frequency-and-duty-resolutions).
 A configured `esp32` board can support a maximum of four different PWM frequencies simultaneously, as the boards only have four available timers.
 
 For example:

--- a/docs/operate/reference/components/board/esp32.md
+++ b/docs/operate/reference/components/board/esp32.md
@@ -151,7 +151,7 @@ The following properties are available for `digital_interrupts`:
 ### PWM signals on `esp32` pins
 
 You can set PWM frequencies with Viam through the [`GPIOPin` API](/dev/reference/apis/components/board/#api).
-Refer to the [Espressif documentation for valid frequencies and duty resolutions](https://docs.espressif.com/projects/esp-idf/en/v4.4/esp32/api-reference/peripherals/ledc.html?#supported-range-of-frequency-and-duty-resolutions).
+Refer to the [Espressif documentation for valid frequencies and duty resolutions](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/ledc.html#supported-range-of-frequency-and-duty-resolutions).
 A configured `esp32` board can support a maximum of four different PWM frequencies simultaneously, as the boards only have four available timers.
 
 For example:

--- a/docs/operate/reference/components/board/esp32.md
+++ b/docs/operate/reference/components/board/esp32.md
@@ -151,7 +151,7 @@ The following properties are available for `digital_interrupts`:
 ### PWM signals on `esp32` pins
 
 You can set PWM frequencies with Viam through the [`GPIOPin` API](/dev/reference/apis/components/board/#api).
-Refer to the [Espressif documentation for valid frequencies and duty resolutions](https://docs.espressif.com/projects/esp-idf/en/release-v5.4/esp32/api-reference/peripherals/ledc.html#supported-range-of-frequency-and-duty-resolutions).
+Refer to the [Espressif documentation for valid frequencies and duty resolutions](https://docs.espressif.com/projects/esp-idf/en/v5.4/esp32/api-reference/peripherals/ledc.html#supported-range-of-frequency-and-duty-resolutions).
 A configured `esp32` board can support a maximum of four different PWM frequencies simultaneously, as the boards only have four available timers.
 
 For example:


### PR DESCRIPTION
Swept for instances of related versions and just found these two. We of course point to https://github.com/viamrobotics/micro-rdk/tree/main/templates/project but that is being updated.

Don't merge until https://viam.atlassian.net/browse/RSDK-8990 is released.