### PR TITLE
Fix off-by-one rendering of all highlighted lines in the docs!

### DIFF
--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -3,7 +3,14 @@
 {{- $attributes = merge $attributes (dict "class" (delimit $classes " ")) }}
 <pre
   {{- range $k, $v := $attributes }}
-    {{- printf " %s=%q" $k $v | safeHTMLAttr }}
+    {{- if eq $k "data-line-offset" -}}
+      data-line-offset="{{ int $v | add -1 }}"
+    {{- else -}}
+      {{- printf " %s=%q" $k $v | safeHTMLAttr -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if not (isset $attributes "data-line-offset") -}}
+    data-line-offset="0"
   {{- end -}}
 >
 <code>


### PR DESCRIPTION
All of the highlighted lines in the docs are rendered one line above where they ought to be. This PR fixes the issue.

A few examples:

* https://docs.viam.com/tutorials/projects/helmet/
* https://docs.viam.com/operate/get-started/other-hardware/hello-world-module/#implement-the-api-methods (open the Go tab and look at the example in step 2; this example notably uses the first branch of the conditional logic, which sets an offset starting line)
* https://docs.viam.com/dev/reference/sdks/connectivity/ (all tabs)

There is probably a better way to do this -- for instance, I'm not convinced we need so much custom logic for code examples at all -- but this fix fixes the problem without changing all of the variables we use to configure code snippets, and without ripping out any internals like prism.js. Once I have a little more experience with our infra, I'll give simplifying the code-block handling a shot... but for now, this fixes a very visible issue in the docs.

For more information about why data-line-offset fixes this issue, see the [prism.js line-highlight docs](https://prismjs.com/plugins/line-highlight/).