### PR TITLE
DOCS-3895: Add meta.json to tarball

### DIFF
--- a/docs/operate/get-started/other-hardware/_index.md
+++ b/docs/operate/get-started/other-hardware/_index.md
@@ -1142,7 +1142,7 @@ You can use the following package and upload method if you opted not to enable c
 1.  To package the module as an archive, run the following command from inside the module directory:
 
     ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-    tar -czf module.tar.gz run.sh setup.sh requirements.txt src
+    tar -czf module.tar.gz run.sh setup.sh requirements.txt src meta.json
     ```
 
     where `run.sh` is your entrypoint file, `requirements.txt` is your pip dependency list file, and `src` is the directory that contains the source code of your module.

--- a/docs/operate/get-started/other-hardware/hello-world-module.md
+++ b/docs/operate/get-started/other-hardware/hello-world-module.md
@@ -733,7 +733,7 @@ To package (for Python) and upload your module and make it available to configur
 1. Package the module as an archive, run the following command from inside the <file>hello-world</file> directory:
 
    ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
-   tar -czf module.tar.gz run.sh setup.sh requirements.txt src
+   tar -czf module.tar.gz run.sh setup.sh requirements.txt src meta.json
    ```
 
    This creates a tarball called <file>module.tar.gz</file>.

--- a/docs/operate/get-started/other-hardware/manage-modules.md
+++ b/docs/operate/get-started/other-hardware/manage-modules.md
@@ -247,7 +247,7 @@ Use the [Viam CLI](/dev/tools/cli/) to manually update your module:
 2. For Python modules only, package your files as an archive, for example:
 
    ```sh {class="command-line" data-prompt="$"}
-   tar -czf module.tar.gz run.sh requirements.txt src
+   tar -czf module.tar.gz run.sh requirements.txt src meta.json
    ```
 
    Supply the path to the resulting archive file in the next step.


### PR DESCRIPTION
A user asked about what files to scp to a pi when testing a local module on a separate computer. I tested both this and scp'ing the tarball plus the meta.json (with a generated Python module), and both work. I'm thinking meta.json should be in the tarball so it's all together, but is there a reason that'd actually not be preferred?