### PR TITLE
DOCS-3814: Expand left sidenav one level down by default to improve navigation and discoverability

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -117,7 +117,7 @@ navbar_logo = true
 navbar_translucent_over_cover_disable = false
 sidebar_menu_compact = true  # When true, the section headings work like an accordian.
 sidebar_search_disable = true
-ul_show = 3  # Show only the first level of the sidenav by default
+ul_show = 3  # Always expand every first level section of the sidenav -- due to tabs, our 'first level' is 3
 
 [params.ui.feedback]
 enable = true

--- a/config.toml
+++ b/config.toml
@@ -117,6 +117,7 @@ navbar_logo = true
 navbar_translucent_over_cover_disable = false
 sidebar_menu_compact = true  # When true, the section headings work like an accordian.
 sidebar_search_disable = true
+ul_show = 3  # Show only the first level of the sidenav by default
 
 [params.ui.feedback]
 enable = true

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -94,7 +94,7 @@
       {{- if (or $hideChildren $treeRoot) -}}
       {{- else -}}
           <span class="menu-toggle">
-          {{ if (or $activePath $active) }}
+          {{ if (or $activePath $active (eq $ulNr 2)) }}
             <i class="fas fa-chevron-down"></i>
           {{ else }}
             <i class="fas fa-chevron-right"></i>


### PR DESCRIPTION
Given our tabbed configuration, the 'first level' is actually the third in configuration.
Much AI ink was spilled to discover this one-line change.