### PR TITLE
Ask AI feedback: Fix package version configuration example

### DIFF
--- a/docs/manage/fleet/reuse-configuration.md
+++ b/docs/manage/fleet/reuse-configuration.md
@@ -314,8 +314,8 @@ This example uses [`$set`](https://www.mongodb.com/docs/manual/reference/operato
 ```
 
 {{< /expand >}}
-{{< expand "Pin a module version" >}}
-This example uses [`$set`](https://www.mongodb.com/docs/manual/reference/operator/update/set/#mongodb-update-up.-set) to set [version update settings for a module](/operate/reference/module-configuration/#module-configuration-details) named `custom-sensor` in the fragment:
+{{< expand "Set a module version" >}}
+This example uses [`$set`](https://www.mongodb.com/docs/manual/reference/operator/update/set/#mongodb-update-up.-set) to configure [version update settings for a module](/operate/reference/module-configuration/#module-configuration-details) named `custom-sensor` from the fragment:
 
 ```json {class="line-numbers linkable-line-numbers"}
 "fragment_mods": [
@@ -332,7 +332,7 @@ This example uses [`$set`](https://www.mongodb.com/docs/manual/reference/operato
 ],
 ```
 
-Here are the version options:
+The `version` field supports the following values:
 
 - To update with new minor releases of the same major release branch, use `"^<major version number>"`, for example `"^1"`
 - To update with new patch releases of the same minor release branch, use `"~<minor version number>"`, for example `"~1.8"`
@@ -340,8 +340,8 @@ Here are the version options:
 - To pin to a specific release, use `"<version number>"`, for example `"1.8.3"`
 
 {{< /expand >}}
-{{< expand "Change a package version" >}}
-This example uses [`$set`](https://www.mongodb.com/docs/manual/reference/operator/update/set/#mongodb-update-up.-set) to modify [version update settings for the first package in the packages array](/data-ai/ai/deploy/#deploy-a-specific-version-of-an-ml-model) from the fragment:
+{{< expand "Set a package version" >}}
+This example uses [`$set`](https://www.mongodb.com/docs/manual/reference/operator/update/set/#mongodb-update-up.-set) to configure [version update settings for a package](/data-ai/ai/deploy/#deploy-a-specific-version-of-an-ml-model) named `package_name` from the fragment:
 
 ```json {class="line-numbers linkable-line-numbers"}
 "fragment_mods": [
@@ -350,13 +350,20 @@ This example uses [`$set`](https://www.mongodb.com/docs/manual/reference/operato
     "mods": [
       {
         "$set": {
-          "packages.0.version": "latest"
+          "packages.package_name.version": "latest"
         }
       }
     ]
   }
 ],
 ```
+
+The `version` field supports the following values:
+
+- To update with new minor releases of the same major release branch, use `"^<major version number>"`, for example `"^1"`
+- To update with new patch releases of the same minor release branch, use `"~<minor version number>"`, for example `"~1.8"`
+- To always update with the latest release, use `"latest"`
+- To pin to a specific release, use `"<version number>"`, for example `"1.8.3"`
 
 {{< /expand >}}
 {{< expand "Change the log level of a resource" >}}


### PR DESCRIPTION
* fixes an issue seen in the Ask AI slack channel.
  Question:
  How would a fragment override for an ml_model package version look like?

  Answer:
  Here's how you can override an ML model package version in a fragment:

  ```
  "fragment_mods": [
  {
    "fragment_id": "abcd7ef8-fa88-1234-b9a1-123z987e55aa",
    "mods": [
      {
        "$set": {
          "packages.0.version": "latest"
        }
      }
    ]
  }
  ]
  ```

  You can set the version to:

  - "^<major version number>" (e.g. "^1") for updates within the same major release
  - "~<minor version number>" (e.g. "~1.8") for updates within the same minor release
  - "latest" to always update to the latest release
  - "<version number>" (e.g. "1.8.3") to pin to a specific version

  Remember to check your machine's LOGS tab after configuring fragment overwrites to ensure there are no issues with the configuration.

  Update:
  It should be `packages.<package_name>.version`
* I noticed that the preceding section contained very similar content, so I adjusted the language in both sections for consistency and added the list of possible version values/explanations to the package section, since the other section may be hidden for users linked to the page.

I couldn't get the `0` syntax to work, but if someone else knows how to get it to work, happy to add an example for that if we want to document it. I'm guessing that syntax was removed at some point?

