### PR TITLE
Clean up build reference

### DIFF
--- a/docs/operate/reference/kinematic-chain-config.md
+++ b/docs/operate/reference/kinematic-chain-config.md
@@ -15,11 +15,11 @@ aliases:
 
 If you are developing a new {{< glossary_tooltip term_id="modular-resource" text="modular resource" >}} to support a component with a complex kinematic chain (for example, a new robotic arm model), you need to add a file to your driver that details the attachment of the intermediate reference frames on the component.
 
-Components with complex kinematic chains require an additional set of intermediate reference frames to use the [motion service](/operate/reference/services/motion/).
+The [motion service](/operate/reference/services/motion/) uses these intermediate reference frames when calculating movements.
 
 For example, an [arm](/operate/reference/components/arm/) has a reference frame originating where the arm is attached to a surface, but it also has links and joints whose frames of reference matter when attempting to move the arm to a [pose](/operate/reference/orientation-vector/) with [`MoveToPosition()`](/dev/reference/apis/components/arm/#movetoposition).
 
-This file can be a JSON file like [the one for the xArm6](https://github.com/viam-modules/viam-ufactory-xarm/blob/main/arm/xarm6_kinematics.json), or a [<file>.URDF</file> file](https://industrial-training-master.readthedocs.io/en/melodic/_source/session3/Intro-to-URDF.html).
+This file can be a JSON file like [this xArm6 file](https://github.com/viam-modules/viam-ufactory-xarm/blob/main/arm/xarm6_kinematics.json), or a [<file>.URDF</file> file](https://industrial-training-master.readthedocs.io/en/melodic/_source/session3/Intro-to-URDF.html).
 
 ## Kinematic parameters
 

--- a/docs/operate/reference/kinematic-chain-config.md
+++ b/docs/operate/reference/kinematic-chain-config.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure Complex Kinematic Chains"
+title: "Configure complex kinematic chains"
 linkTitle: "Complex Kinematic Chains"
 weight: 200
 type: "docs"
@@ -13,13 +13,13 @@ aliases:
 # SMEs: Motion
 ---
 
-Many components have complex kinematic chains and require an additional set of intermediate reference frames to use the [motion service](/operate/reference/services/motion/).
+If you are developing a new {{< glossary_tooltip term_id="modular-resource" text="modular resource" >}} to support a component with a complex kinematic chain (for example, a new robotic arm model), you need to add a file to your driver that details the attachment of the intermediate reference frames on the component.
+
+Components with complex kinematic chains require an additional set of intermediate reference frames to use the [motion service](/operate/reference/services/motion/).
 
 For example, an [arm](/operate/reference/components/arm/) has a reference frame originating where the arm is attached to a surface, but it also has links and joints whose frames of reference matter when attempting to move the arm to a [pose](/operate/reference/orientation-vector/) with [`MoveToPosition()`](/dev/reference/apis/components/arm/#movetoposition).
 
-If you want to implement a {{< glossary_tooltip term_id="modular-resource" text="modular resource" >}} with a complex kinematic chain, you need to add a file to your driver that details the attachment of the intermediate reference frames on the component.
-
-This file can be a JSON file like [The one for the xArm6](https://github.com/viam-modules/viam-ufactory-xarm/blob/main/arm/xarm6_kinematics.json), or a [<file>.URDF</file> file](https://industrial-training-master.readthedocs.io/en/melodic/_source/session3/Intro-to-URDF.html).
+This file can be a JSON file like [the one for the xArm6](https://github.com/viam-modules/viam-ufactory-xarm/blob/main/arm/xarm6_kinematics.json), or a [<file>.URDF</file> file](https://industrial-training-master.readthedocs.io/en/melodic/_source/session3/Intro-to-URDF.html).
 
 ## Kinematic parameters
 

--- a/docs/operate/reference/module-configuration.md
+++ b/docs/operate/reference/module-configuration.md
@@ -1,7 +1,7 @@
 ---
 title: "Modular Resource and Module Configuration Details"
 linkTitle: "Module Configuration"
-weight: 20
+weight: 40
 no_list: true
 type: docs
 icon: true

--- a/docs/operate/reference/viam-micro-server/_index.md
+++ b/docs/operate/reference/viam-micro-server/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "The Micro-RDK and viam-micro-server"
 linkTitle: "viam-micro-server"
-weight: 90
+weight: 30
 type: docs
 images: ["/installation/thumbnails/esp32-espressif.png"]
 imageAlt: "E S P 32 - espressif"

--- a/docs/operate/reference/viam-server/_index.md
+++ b/docs/operate/reference/viam-server/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "viam-server"
 linkTitle: "viam-server"
-weight: 80
+weight: 20
 type: "docs"
 description: "viam-server is the open-source, on-machine portion of the Viam platform."
 tags: ["server", "rdk"]


### PR DESCRIPTION
With reference open now, really needed some cleanup:
- Put things in an order that matches Build and Integrate overall
- Try to tell people immediately that they do *not* need to read about complex kinematic chains