### PR TITLE
Fix broken newlines, remove duplicate example

### DIFF
--- a/docs/operate/get-started/other-hardware/manage-modules.md
+++ b/docs/operate/get-started/other-hardware/manage-modules.md
@@ -111,15 +111,11 @@ then
     echo "Installing venv on Linux"
     sudo apt-get install -y python3-venv
 fi
-if [ "$UNAME" = "Darwin" ]
-then
-    echo "Installing venv on Darwin"
-    brew install python3-venv
-fi
 
 python3 -m venv .venv
 . .venv/bin/activate
 pip3 install -r requirements.txt
+
 ```
 
 {{% /expand%}}
@@ -128,33 +124,6 @@ pip3 install -r requirements.txt
 
 ```sh { class="command-line" data-prompt="$"}
 #!/bin/bash
-pip3 install -r requirements.txt
-python3 -m PyInstaller --onefile --hidden-import="googleapiclient" src/main.py
-tar -czvf dist/archive.tar.gz <PATH-TO-EXECUTABLE>
-```
-
-{{% /expand%}}
-
-{{%expand "Click to view example build.sh (without setup.sh) for a Python module" %}}
-
-```sh { class="command-line" data-prompt="$"}
-#!/bin/bash
-set -e
-UNAME=$(uname -s)
-
-if [ "$UNAME" = "Linux" ]
-then
-    echo "Installing venv on Linux"
-    sudo apt-get install -y python3-venv
-fi
-if [ "$UNAME" = "Darwin" ]
-then
-    echo "Installing venv on Darwin"
-    brew install python3-venv
-fi
-
-python3 -m venv .venv
-. .venv/bin/activate
 pip3 install -r requirements.txt
 python3 -m PyInstaller --onefile --hidden-import="googleapiclient" src/main.py
 tar -czvf dist/archive.tar.gz <PATH-TO-EXECUTABLE>


### PR DESCRIPTION
For some reason, the newlines at the bottom of setup.sh aren't rendering in prod, shoving all of the python3 and pip commands into one non-functional line. I'm trying to fix that (will check the preview to see if it's fixed).

Also, removed the 'brew install python3-venv` command and the Darwin check because on macOS, Python3 always comes bundled with venv, and that package doesn't exist anyway.

And I removed the third code sample from this section because it's just a combination of the previous two samples and I think including it is likely to cause more confusion than anything else.
