### PR TITLE
RSDK-10583 - Add macos webcam permissions section

### DIFF
--- a/docs/operate/reference/components/camera/webcam.md
+++ b/docs/operate/reference/components/camera/webcam.md
@@ -151,7 +151,7 @@ system_profiler SPCameraDataType
 
 The Unique ID displayed for each camera is the `video_path`.
 
-If you are using macOS version 14.0.0 Sonoma or later, you need to give `viam-server` permissions to access webcams.
+If you are using macOS version 15.x.x Sequoia or later, you need to give `viam-server` permissions to access webcams.
 When you run `viam-server` for the first time, a pop-up message will ask for camera access.
 Click **Allow**.
 Go to **System Settings** > **Privacy & Security** > **Camera** and check the toggle next to `viam-server`.

--- a/docs/operate/reference/components/camera/webcam.md
+++ b/docs/operate/reference/components/camera/webcam.md
@@ -151,9 +151,9 @@ system_profiler SPCameraDataType
 
 The Unique ID displayed for each camera is the `video_path`.
 
-If you are using MacOS version 14.0.0 Sonoma or later, you will need to give viam-server permissions to access webcams.
+If you are using macOS version 14.0.0 Sonoma or later, you need to give `viam-server` permissions to access webcams.
 After running viam-server for the first time, check for a pop-up message asking for Camera permissions.
-You can then go to `System Settings` > `Privacy & Security` > `Camera` and check the toggle next to `viam-server`.
+Go to **System Settings** > **Privacy & Security** > **Camera** and check the toggle next to `viam-server`.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/docs/operate/reference/components/camera/webcam.md
+++ b/docs/operate/reference/components/camera/webcam.md
@@ -154,7 +154,7 @@ The Unique ID displayed for each camera is the `video_path`.
 If you are using macOS version 15.x.x Sequoia or later, you need to give `viam-server` permissions to access webcams.
 When you run `viam-server` for the first time, a pop-up message will ask for camera access.
 Click **Allow**.
-Go to **System Settings** > **Privacy & Security** > **Camera** and check the toggle next to `viam-server`.
+To confirm settings, you can go to **System Settings** > **Privacy & Security** > **Camera** and check that the toggle next to `viam-server` is set to enable access.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/docs/operate/reference/components/camera/webcam.md
+++ b/docs/operate/reference/components/camera/webcam.md
@@ -151,7 +151,6 @@ system_profiler SPCameraDataType
 
 The Unique ID displayed for each camera is the `video_path`.
 
-
 If you are using MacOS version 14.0.0 Sonoma or later, you will need to give viam-server permissions to access webcams.
 After running viam-server for the first time, check for a pop-up message asking for Camera permissions.
 You can then go to `System Settings` > `Privacy & Security` > `Camera` and check the toggle next to `viam-server`.

--- a/docs/operate/reference/components/camera/webcam.md
+++ b/docs/operate/reference/components/camera/webcam.md
@@ -151,6 +151,11 @@ system_profiler SPCameraDataType
 
 The Unique ID displayed for each camera is the `video_path`.
 
+
+If you are using MacOS version 14.0.0 Sonoma or later, you will need to give viam-server permissions to access webcams.
+After running viam-server for the first time, check for a pop-up message asking for Camera permissions.
+You can then go to `System Settings` > `Privacy & Security` > `Camera` and check the toggle next to `viam-server`.
+
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/docs/operate/reference/components/camera/webcam.md
+++ b/docs/operate/reference/components/camera/webcam.md
@@ -152,7 +152,8 @@ system_profiler SPCameraDataType
 The Unique ID displayed for each camera is the `video_path`.
 
 If you are using macOS version 14.0.0 Sonoma or later, you need to give `viam-server` permissions to access webcams.
-After running viam-server for the first time, check for a pop-up message asking for Camera permissions.
+When you run `viam-server` for the first time, a pop-up message will ask for camera access.
+Click **Allow**.
 Go to **System Settings** > **Privacy & Security** > **Camera** and check the toggle next to `viam-server`.
 
 {{% /tab %}}


### PR DESCRIPTION
Newer MacOS versions require manual Camera permission approval.
Just adding a small section to the webcam docs here.
