### PR TITLE
DOCS-4042: Clarify Micro-RDK 32-bit support

### DIFF
--- a/docs/operate/get-started/setup-micro/_index.md
+++ b/docs/operate/get-started/setup-micro/_index.md
@@ -36,7 +36,7 @@ The following microcontrollers have been tested with Viam:
 - [ESP32-WROVER Series](https://www.espressif.com/en/products/modules/esp32)
 
 {{% hiddencontent %}}
-The Micro-RDK does not support 32-bit Linux.
+The Micro-RDK and `viam-micro-server` do not support 32-bit Linux.
 {{% /hiddencontent %}}
 
 ## About ESP32 microcontroller setup

--- a/docs/operate/get-started/setup-micro/_index.md
+++ b/docs/operate/get-started/setup-micro/_index.md
@@ -35,6 +35,10 @@ The following microcontrollers have been tested with Viam:
 
 - [ESP32-WROVER Series](https://www.espressif.com/en/products/modules/esp32)
 
+{{% hiddencontent %}}
+The Micro-RDK does not support 32-bit Linux.
+{{% /hiddencontent %}}
+
 ## About ESP32 microcontroller setup
 
 Microcontrollers do not run operating systems and are instead flashed with dedicated firmware.


### PR DESCRIPTION
To get AI to stop saying "For 32-bit systems, you can use viam-micro-server which is specifically built for microcontrollers."