### PR TITLE
DOCS-4034: Add information disambiguating between getImages and readImage

### DIFF
--- a/docs/data-ai/capture-data/capture-sync.md
+++ b/docs/data-ai/capture-data/capture-sync.md
@@ -63,12 +63,16 @@ For more information, see [How sync works](/data-ai/capture-data/advanced/how-sy
 
 1. If you see a **Capture disabled on data management service** warning, click **Enable capture on data management service**.
 1. Select a **Method** to capture data from.
+
    {{< alert title="Camera capture methods" color="note" >}}
    Camera components provide two similar, but distinct capture methods:
+
    - **GetImages** (recommended): Returns one image for each camera sensor as a JPEG (for color sensors) or point cloud (for depth sensors).
    - **ReadImage**: Returns a single image in the specified MIME type, if the camera component supports that MIME type.
      Prefer GetImages unless your use case requires a specific MIME type other than JPEG.
+
    {{< /alert >}}
+
 1. Set the capture **Frequency** in hertz, for example to `0.2` with `ReadImage` on a camera to capture an image every 5 seconds.
 1. **Save** your config.
 


### PR DESCRIPTION
* Recommends getImage since it:
  * separates the concern of MIME types from the user entirely
  * guarantees that users will always get an image from every sensor, so they don't lose out on information if their camera has multiple sensors 