### PR TITLE
Move vale vocab `main` to dir that vale >=3.0.0 expects

### DIFF
--- a/.github/vale/styles/Vocab/main/accept.txt
+++ b/.github/vale/styles/Vocab/main/accept.txt
@@ -1,2 +1,0 @@
-Python
-Golang

--- a/.github/vale/styles/config/vocabularies/main/accept.txt
+++ b/.github/vale/styles/config/vocabularies/main/accept.txt
@@ -1,0 +1,2 @@
+Python
+Golang

--- a/.github/workflows/vale-lint.yml
+++ b/.github/workflows/vale-lint.yml
@@ -29,7 +29,7 @@ jobs:
           source env/bin/activate
       - uses: errata-ai/vale-action@reviewdog
         with:
-          version: 2.30.0
+          version: 3.12.0
           reporter: github-check
           filter_mode: file
           fail_on_error: true


### PR DESCRIPTION
Per https://vale.sh/docs/keys/vocab:

>In versions of Vale prior to 3.0, vocabularies were stored in <StylesPath>/Vocab. When upgrading from an older version of Vale, you'll need to move your vocabularies to the new <StylesPath>/config/vocabularies location.

Tested: successfully ran Vale 3.11.2 (latest) locally using the Viam vale.ini located in this repo.