### PR TITLE
Update link to new arm motion page

### DIFF
--- a/docs/operate/reference/services/motion/_index.md
+++ b/docs/operate/reference/services/motion/_index.md
@@ -60,6 +60,6 @@ The `plan_deviation_m` for `MoveOnMap()` on calls issued from the **CONTROL** ta
 The following tutorials contain complete example code for interacting with a robot arm through the arm component API, and with the motion service API, respectively:
 
 {{< cards >}}
-{{% card link="/operate/mobility/move-arm/" %}}
+{{% card link="/operate/mobility/move-arm/arm-motion" %}}
 {{% card link="/tutorials/services/plan-motion-with-arm-gripper" %}}
 {{< /cards >}}


### PR DESCRIPTION
Since the docs for working with arms and motion planning have been updated, old links to the previous "move an arm" index page no longer resolve correctly. This is just the first instance I found while using the docs. Here's a rough search for the others: https://github.com/search?q=repo%3Aviamrobotics%2Fdocs%20move-arm&type=code


