### PR TITLE
DOCS-4072: Redirect empty pages to top page of respective section

### DIFF
--- a/docs/dev/reference/_index.md
+++ b/docs/dev/reference/_index.md
@@ -1,10 +1,10 @@
 ---
 linkTitle: "Reference"
-title: "Reference"
 weight: 300
 layout: "empty"
 type: "docs"
 empty_node: true
 open_on_desktop: true
 header_only: true
+canonical: "/dev/reference/apis/"
 ---

--- a/docs/dev/tools/_index.md
+++ b/docs/dev/tools/_index.md
@@ -1,10 +1,10 @@
 ---
 linkTitle: "Tools"
-title: "Tools"
 weight: 100
 layout: "empty"
 type: "docs"
 empty_node: true
 open_on_desktop: true
 header_only: true
+canonical: "/dev/tools/cli/"
 ---

--- a/docs/manage/fleet/_index.md
+++ b/docs/manage/fleet/_index.md
@@ -1,10 +1,10 @@
 ---
 linkTitle: "Deploy fleet"
-title: "Deploy fleet"
 weight: 10
 layout: "empty"
 type: "docs"
 empty_node: true
 open_on_desktop: true
 header_only: true
+canonical: "/manage/fleet/reuse-configuration/"
 ---

--- a/docs/manage/fleet/provision/_index.md
+++ b/docs/manage/fleet/provision/_index.md
@@ -1,8 +1,8 @@
 ---
 linkTitle: "Provision devices"
-title: "Provision devices"
 weight: 68
 layout: "empty"
 type: "docs"
 empty_node: true
+canonical: "/manage/fleet/provision/setup/"
 ---

--- a/docs/manage/manage/_index.md
+++ b/docs/manage/manage/_index.md
@@ -1,10 +1,10 @@
 ---
 linkTitle: "Manage organization"
-title: "Manage and organize your organization"
 weight: 30
 layout: "empty"
 type: "docs"
 empty_node: true
 open_on_desktop: true
 header_only: true
+canonical: "/manage/manage/access/"
 ---

--- a/docs/manage/reference/_index.md
+++ b/docs/manage/reference/_index.md
@@ -6,4 +6,5 @@ layout: "empty"
 type: "docs"
 empty_node: true
 header_only: true
+canonical: "/manage/reference/viam-agent/"
 ---

--- a/docs/manage/software/_index.md
+++ b/docs/manage/software/_index.md
@@ -6,4 +6,5 @@ type: "docs"
 empty_node: true
 open_on_desktop: true
 header_only: true
+canonical: "/manage/software/control-logic/"
 ---

--- a/docs/manage/troubleshoot/_index.md
+++ b/docs/manage/troubleshoot/_index.md
@@ -1,10 +1,10 @@
 ---
 linkTitle: "Monitor & Troubleshoot"
-title: "Monitor and Troubleshoot"
 weight: 30
 layout: "empty"
 type: "docs"
 empty_node: true
 open_on_desktop: true
 header_only: true
+canonical: "/manage/troubleshoot/monitor/"
 ---

--- a/docs/operate/control/_index.md
+++ b/docs/operate/control/_index.md
@@ -1,10 +1,10 @@
 ---
 linkTitle: "Build apps"
-title: "Build apps"
 weight: 200
 layout: "empty"
 type: "docs"
 empty_node: true
 open_on_desktop: true
 header_only: true
+canonical: "/operate/control/web-app/"
 ---

--- a/docs/operate/get-started/_index.md
+++ b/docs/operate/get-started/_index.md
@@ -1,10 +1,9 @@
 ---
 linkTitle: "Connect devices"
-title: "Get Started"
 weight: 100
 layout: "empty"
 type: "docs"
 empty_node: true
 open_on_desktop: true
-header_only: true
+canonical: "/operate/get-started/basics/"
 ---

--- a/docs/operate/mobility/_index.md
+++ b/docs/operate/mobility/_index.md
@@ -1,10 +1,10 @@
 ---
 linkTitle: "Plan motion"
-title: "Plan motion"
 weight: 200
 layout: "empty"
 type: "docs"
 empty_node: true
 open_on_desktop: true
 header_only: true
+canonical: "/operate/mobility/motion-concepts/"
 ---

--- a/docs/operate/reference/_index.md
+++ b/docs/operate/reference/_index.md
@@ -1,9 +1,9 @@
 ---
 linkTitle: "Reference"
-title: "Reference"
 weight: 300
 layout: "empty"
 type: "docs"
 empty_node: true
 header_only: true
+canonical: "/operate/reference/architecture/"
 ---

--- a/docs/operate/reference/components/_index.md
+++ b/docs/operate/reference/components/_index.md
@@ -4,7 +4,7 @@ linkTitle: "Components"
 weight: 20
 type: docs
 layout: "empty"
-canonical: "/operate/get-started/supported-hardware/"
+canonical: "/operate/reference/components/arm/"
 no_component: true
 empty_node: true
 toc_hide: false

--- a/docs/operate/reference/services/_index.md
+++ b/docs/operate/reference/services/_index.md
@@ -4,7 +4,7 @@ linkTitle: "Services"
 weight: 30
 type: docs
 layout: "empty"
-canonical: "/dev/reference/apis/#service-apis"
+canonical: "/operate/reference/services/generic/"
 no_component: true
 empty_node: true
 toc_hide: false


### PR DESCRIPTION
So that if someone somehow lands on one of these, they at least stay in the same section

Oddly, with non-reference ones specifically, if `title` is in the frontmatter the canonical link doesn't work. But in reference it doesn't matter. Not going to dig at all since it seems irrelevant to this quick fix.