### PR TITLE
Make 'connect devices' sidebar entry consistent with other Operate categories

### DIFF
--- a/docs/operate/get-started/_index.md
+++ b/docs/operate/get-started/_index.md
@@ -5,5 +5,6 @@ layout: "empty"
 type: "docs"
 empty_node: true
 open_on_desktop: true
+header_only: true
 canonical: "/operate/get-started/basics/"
 ---


### PR DESCRIPTION
Currently 'Connect devices' shows up at a different font size, which looks wonky; this resolves the issue.