### PR TITLE
DOCS-3198: offline data pipelines, SDK docs, hot data store fixes

### DIFF
--- a/.github/workflows/sdk_protos_map.csv
+++ b/.github/workflows/sdk_protos_map.csv
@@ -425,6 +425,11 @@ data,GetDatabaseConnection,,get_database_connection,,getDatabaseConnection,getDa
 data,ConfigureDatabaseUser,,configure_database_user,,configureDatabaseUser,configureDatabaseUser
 data,AddBinaryDataToDatasetByIDs,,add_binary_data_to_dataset_by_ids,,addBinaryDataToDatasetByIds,addBinaryDataToDatasetByIds
 data,RemoveBinaryDataFromDatasetByIDs,,remove_binary_data_from_dataset_by_ids,,removeBinaryDataFromDatasetByIds,removeBinaryDataFromDatasetByIds
+data,GetDataPipeline,,get_data_pipeline,,,getDataPipeline
+data,ListDataPipelines,,list_data_pipelines,,,listDataPipelines
+data,CreateDataPipeline,,create_data_pipeline,,,createDataPipeline
+data,DeleteDataPipeline,,delete_data_pipeline,,,deleteDataPipeline
+data,ListDataPipelineRuns,,list_data_pipeline_runs,,,listDataPipelineRuns
 
 ## Dataset
 dataset,CreateDataset,,create_dataset,,createDataset,createDataset

--- a/docs/data-ai/capture-data/advanced/advanced-data-capture-sync.md
+++ b/docs/data-ai/capture-data/advanced/advanced-data-capture-sync.md
@@ -15,7 +15,25 @@ Some data use cases require advanced configuration beyond the attributes accessi
 You can use raw JSON to configure additional attributes for both data management and data capture.
 You can also configure data capture for remote parts.
 
-### Advanced data management service configurations
+## Cloud data retention
+
+Configure how long your synced data remains stored in the cloud:
+
+- **Retain data up to a certain size (for example, 100GB) or for a specific length of time (for example, 14 days):** Set `retention_policies` at the resource level.
+  See the `retention_policy` field in [data capture configuration attributes](/data-ai/capture-data/advanced/advanced-data-capture-sync/#click-to-view-data-capture-attributes).
+- **Delete data captured by a machine when you delete the machine:** Control whether your cloud data is deleted when a machine or machine part is removed.
+  See the `delete_data_on_part_deletion` field in the [data management service configuration attributes](/data-ai/capture-data/advanced/advanced-data-capture-sync/#click-to-view-data-management-attributes).
+
+## Sync optimization
+
+**Configurable sync threads:** You can control how many concurrent sync operations occur by adjusting the `maximum_num_sync_threads` setting.
+Higher values may improve throughput on more powerful hardware, but raising it too high may introduce instability on resource-constrained devices.
+
+**Wait time before syncing arbitrary files:** If you choose to sync arbitrary files (beyond those captured by the data management service), the `file_last_modified_millis` configuration attribute specifies how long a file must remain unmodified before the data manager considers it for syncing.
+The default is 10 seconds.
+
+
+## Advanced data management service configuration
 
 To configure the data manager in JSON, see the following example configurations:
 
@@ -96,7 +114,7 @@ The following attributes are available for the data management service:
 
 You can edit the JSON directly by switching to **JSON** mode in the UI.
 
-### Advanced data capture configurations
+## Advanced data capture configuration
 
 {{< alert title="Caution" color="caution" >}}
 
@@ -531,55 +549,7 @@ The following attributes are available for data capture configuration:
 
 You can edit the JSON directly by switching to **JSON** mode in the UI.
 
-### Capture to the hot data store
-
-If you want faster access to your most recent sensor readings, you can configure hot data storage.
-The hot data store keeps a rolling window of hot data for faster queries.
-All historical data remains in your default storage.
-
-To configure the hot data store:
-
-1. Use the `recent_data_store` attribute on each capture method in your data manager service.
-2. Configure your queries' data source to the hot data store by passing the `use_recent_data` boolean argument to [tabularDataByMQL](/dev/reference/apis/data-client/#tabulardatabymql).
-
-{{% expand "Click to view a sample configuration" %}}
-
-The following sample configuration captures data from a sensor at 0.5 Hz.
-`viam-server` stores the last 24 hours of data in a shared recent-data database, while continuing to write all data to blob storage:
-
-```json {class="line-numbers linkable-line-numbers" data-line="17-19"}
-{
-  "components": [
-    {
-      "name": "sensor-1",
-      "api": "rdk:component:sensor",
-      "model": "rdk:builtin:fake",
-      "attributes": {},
-      "service_configs": [
-        {
-          "type": "data_manager",
-          "attributes": {
-            "capture_methods": [
-              {
-                "method": "Readings",
-                "capture_frequency_hz": 0.5,
-                "additional_params": {},
-                "recent_data_store": {
-                  "stored_hours": 24
-                }
-              }
-            ]
-          }
-        }
-      ]
-    }
-  ]
-}
-```
-
-{{% /expand%}}
-
-### Capture directly to your own MongoDB cluster
+## Capture directly to your own MongoDB cluster
 
 You can configure direct capture of tabular data to a MongoDB instance alongside disk storage on your edge device.
 This can be useful for powering real-time dashboards before data is synced from the edge to the cloud.
@@ -699,20 +669,3 @@ Failing to write to MongoDB doesn't affect capturing and syncing data to cloud s
   If your use case needs to support very high capture rates, this feature may not be appropriate.
 
 {{< /alert >}}
-
-### Cloud data retention
-
-Configure how long your synced data remains stored in the cloud:
-
-- **Retain data up to a certain size (for example, 100GB) or for a specific length of time (for example, 14 days):** Set `retention_policies` at the resource level.
-  See the `retention_policy` field in [data capture configuration attributes](/data-ai/capture-data/advanced/advanced-data-capture-sync/#click-to-view-data-capture-attributes).
-- **Delete data captured by a machine when you delete the machine:** Control whether your cloud data is deleted when a machine or machine part is removed.
-  See the `delete_data_on_part_deletion` field in the [data management service configuration attributes](/data-ai/capture-data/advanced/advanced-data-capture-sync/#click-to-view-data-management-attributes).
-
-### Sync optimization
-
-**Configurable sync threads:** You can control how many concurrent sync operations occur by adjusting the `maximum_num_sync_threads` setting.
-Higher values may improve throughput on more powerful hardware, but raising it too high may introduce instability on resource-constrained devices.
-
-**Wait time before syncing arbitrary files:** If you choose to sync arbitrary files (beyond those captured by the data management service), the `file_last_modified_millis` configuration attribute specifies how long a file must remain unmodified before the data manager considers it for syncing.
-The default is 10 seconds.

--- a/docs/data-ai/capture-data/advanced/advanced-data-capture-sync.md
+++ b/docs/data-ai/capture-data/advanced/advanced-data-capture-sync.md
@@ -32,7 +32,6 @@ Higher values may improve throughput on more powerful hardware, but raising it t
 **Wait time before syncing arbitrary files:** If you choose to sync arbitrary files (beyond those captured by the data management service), the `file_last_modified_millis` configuration attribute specifies how long a file must remain unmodified before the data manager considers it for syncing.
 The default is 10 seconds.
 
-
 ## Advanced data management service configuration
 
 To configure the data manager in JSON, see the following example configurations:

--- a/docs/data-ai/data/data-pipelines.md
+++ b/docs/data-ai/data/data-pipelines.md
@@ -1,0 +1,758 @@
+---
+linkTitle: "Aggregate data automatically"
+title: "Aggregate data automatically"
+weight: 25
+description: "Make processed data automatically available for faster, simpler queries."
+type: "docs"
+tags: ["data pipelines", "aggregation", "materialized views"]
+icon: true
+images: ["/services/icons/data-capture.svg"]
+viamresources: ["sensor", "data_manager"]
+platformarea: ["data", "cli"]
+date: "2025-07-02"
+---
+
+Data pipelines automatically transform raw sensor readings into summaries and insights at a schedule that you choose.
+Viam stores the output of these pipelines in a cache so that you can access complex aggregation results more efficiently.
+When late-arriving data syncs to Viam, pipelines automatically re-run to keep summaries accurate.
+
+For example, you could use a data pipeline to pre-calculate results like "average temperature per hour".
+If you query that information frequently, this can save significant computational resources.
+
+## Prerequisites
+
+Before creating a data pipeline, you must enable data capture from at least one component and begin syncing data with Viam.
+
+Only users with organization owner permissions can create a data pipeline.
+
+## Pipeline management
+
+### Create a pipeline
+
+To define a data pipeline, specify a name, organization, schedule, data source type, and query:
+
+{{< tabs >}}
+{{% tab name="CLI" %}}
+
+Use [`datapipelines create`](/dev/tools/cli/#datapipelines) to create your pipeline:
+
+```sh {class="command-line" data-prompt="$" class="command-line" data-continuation-prompt="2-5"}
+viam datapipelines create \
+  --org-id=<org-id> \
+  --name=sensor-counts \
+  --schedule="0 * * * *" \
+  --data-source-type="standard" \
+  --mql='[{"$match": {"component_name": "sensor"}}, {"$group": {"_id": "$location_id", "avg": {"$avg": "$data.readings.value"}}}]'
+```
+
+To pass your query from a file instead of from inline MQL, pass the `--mql-path` flag instead of `--mql`.
+To query data from the [hot data store](/data-ai/data/hot-data-store/), specify `--data-source-type hotstorage`.
+
+{{% /tab %}}
+{{% tab name="Python" %}}
+
+Use [`DataClient.CreateDataPipeline`](/dev/reference/apis/data-client/#createdatapipeline) to define a new pipeline:
+
+```python
+data_client = DataClient.from_api_key(
+    api_key="<api-key>",
+    api_key_id="<api-key-id>"
+)
+
+request = data_client.create_data_pipeline(
+    organization_id="<org-id>",
+    name="hourly-temp-average",
+    mql_binary=[
+        bson.encode({"$match": {"component_name": "temperature-sensor"}}),
+        bson.encode({
+            "$group": {
+                "_id": "$location_id",
+                "avg_temp": {"$avg": "$data.readings.temperature"},
+                "count": {"$sum": 1}
+            }
+        })
+    ],
+    schedule="0 * * * *"  # Run hourly
+)
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+Use [`DataClient.CreateDataPipeline`](https://pkg.go.dev/go.viam.com/rdk/app#DataClient.CreateDataPipeline) to define a new pipeline:
+
+```go
+client, err := utils.NewViamClient(context.Background(), utils.WithAPIKey("<api-key>", "<api-key-id>"))
+if err != nil {
+    panic(err)
+}
+defer client.Close()
+
+dataClient := client.DataClient()
+
+pipeline := [][]byte{
+    bson.Marshal(bson.M{"$match": bson.M{"component_name": "temperature-sensor"}}),
+    bson.Marshal(bson.M{
+        "$group": bson.M{
+            "_id": "$location_id",
+            "avg_temp": bson.M{"$avg": "$data.readings.temperature"},
+            "count": bson.M{"$sum": 1},
+        },
+    }),
+}
+
+resp, err := dataClient.CreateDataPipeline(context.Background(), &datapb.CreateDataPipelineRequest{
+    OrganizationId: "<org-id>",
+    Name: "hourly-temp-average",
+    MqlBinary: pipeline,
+    Schedule: "0 * * * *", // Run hourly
+})
+```
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+Use [`dataClient.CreateDataPipeline`](/dev/reference/apis/data-client/#createdatapipeline) to define a new pipeline:
+
+```typescript
+const apiKey = '<api-key>';
+const apiKeyID = '<api-key-id>';
+
+const client = await createViamClient({
+  credential: {
+    type: 'api-key',
+    payload: { key: apiKey, keyId: apiKeyID }
+  }
+});
+
+const dataClient = client.dataClient;
+
+const pipeline = [
+  BSON.serialize({ $match: { component_name: "temperature-sensor" } }),
+  BSON.serialize({
+    $group: {
+      _id: "$location_id",
+      avg_temp: { $avg: "$data.readings.temperature" },
+      count: { $sum: 1 }
+    }
+  })
+];
+
+const response = await dataClient.createDataPipeline({
+  organizationId: "<org-id>",
+  name: "hourly-temp-average",
+  mqlBinary: pipeline,
+  schedule: "0 * * * *" // Run hourly
+});
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+To create a pipeline that reads data from the [hot data store](/data-ai/data/hot-data-store/), specify a `dataSourceType` in your pipeline configuration.
+
+#### Schedule format
+
+To create a schedule for your pipeline, specify a [cron expression](https://en.wikipedia.org/wiki/Cron) in UTC.
+The schedule determines both execution frequency and input time window.
+The following table contains some common schedules, which correspond to the listed execution frequencies and input time windows:
+
+| Schedule            | Frequency        | Time Window         |
+|---------------------|------------------|---------------------|
+| `0 * * * *`         | Hourly           | Previous hour       |
+| `0 0 * * *`         | Daily            | Previous day        |
+| `*/15 * * * *`      | Every 15 minutes | Previous 15 minutes |
+
+### List pipelines
+
+{{< tabs >}}
+{{% tab name="CLI" %}}
+
+Use [`datapipelines list`](/dev/tools/cli/#datapipelines) to see a summary of all pipelines in an organization:
+
+```sh {class="command-line" data-prompt="$" class="command-line"}
+viam datapipelines list --org-id=<org-id>
+```
+
+{{% /tab %}}
+{{% tab name="Python" %}}
+
+Use [`DataClient.ListDataPipelines`](/dev/reference/apis/data-client/#listdatapipelines) to fetch a summary of all pipelines in an organization:
+
+```python
+data_client = DataClient.from_api_key(
+    api_key="<api-key>",
+    api_key_id="<api-key-id>"
+)
+
+pipelines = data_client.list_data_pipelines(organization_id="<org-id>")
+
+for pipeline in pipelines:
+    print(f"{pipeline.name} (id: {pipeline.id})")
+    print(f"Schedule: {pipeline.schedule}")
+    print(f"Enabled: {pipeline.enabled}")
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+Use [`DataClient.ListDataPipelines`](https://pkg.go.dev/go.viam.com/rdk/app#DataClient.ListDataPipelines) to fetch a summary of all pipelines in an organization:
+
+```go
+client, err := utils.NewViamClient(context.Background(), utils.WithAPIKey("<api-key>", "<api-key-id>"))
+if err != nil {
+    panic(err)
+}
+defer client.Close()
+
+dataClient := client.DataClient()
+
+resp, err := dataClient.ListDataPipelines(context.Background(), &datapb.ListDataPipelinesRequest{
+    OrganizationId: "<org-id>",
+})
+
+for _, pipeline := range resp.DataPipelines {
+    fmt.Printf("%s (id: %s)\n", pipeline.Name, pipeline.Id)
+    fmt.Printf("Schedule: %s\n", pipeline.Schedule)
+    fmt.Printf("Enabled: %v\n", pipeline.Enabled)
+}
+```
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+Use [`dataClient.ListDataPipelines`](/dev/reference/apis/data-client/#listdatapipelines) to fetch a summary of all pipelines in an organization:
+
+```typescript
+const apiKey = '<api-key>';
+const apiKeyID = '<api-key-id>';
+
+const client = await createViamClient({
+  credential: {
+    type: 'api-key',
+    payload: { key: apiKey, keyId: apiKeyID }
+  }
+});
+
+const dataClient = client.dataClient;
+
+const response = await dataClient.listDataPipelines({
+  organizationId: "<org-id>"
+});
+
+response.dataPipelines.forEach(pipeline => {
+  console.log(`${pipeline.name} (id: ${pipeline.id})`);
+  console.log(`Schedule: ${pipeline.schedule}`);
+  console.log(`Enabled: ${pipeline.enabled}`);
+});
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### Update a pipeline
+
+{{< tabs >}}
+{{% tab name="CLI" %}}
+
+Use [`datapipelines update`](/dev/tools/cli/#datapipelines) to alter an existing data pipeline:
+
+```sh {class="command-line" data-prompt="$" class="command-line" data-continuation-prompt="2-5"}
+viam datapipelines update \
+  --org-id=<org-id> \
+  --id=<pipeline-id> \
+  --schedule="0 * * * *" \
+  --mql='[{"$match": {"component_name": "sensor"}}, {"$group": {"_id": "$location_id", "avg": {"$avg": "$data.readings.value"}}}]'
+```
+
+To pass your query from a file instead of from inline MQL, pass the `--mql-path` flag instead of `--mql`.
+
+{{% /tab %}}
+{{% tab name="Python" %}}
+
+Use [`DataClient.UpdateDataPipeline`](/dev/reference/apis/data-client/#updatedatapipeline) to alter an existing data pipeline:
+
+```python
+data_client = DataClient.from_api_key(
+    api_key="<api-key>",
+    api_key_id="<api-key-id>"
+)
+
+data_client.update_data_pipeline(
+    id="<pipeline-id>",
+    name="updated-name",
+    mql_binary=[
+        bson.encode({"$match": {"component_name": "sensor"}}),
+        bson.encode({"$group": {"_id": "$part_id", "total": {"$sum": 1}}})
+    ],
+    schedule="0 * * * *"
+)
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+Use [`DataClient.UpdateDataPipeline`](https://pkg.go.dev/go.viam.com/rdk/app#DataClient.UpdateDataPipeline) to alter an existing data pipeline:
+
+```go
+client, err := utils.NewViamClient(context.Background(), utils.WithAPIKey("<api-key>", "<api-key-id>"))
+if err != nil {
+    panic(err)
+}
+defer client.Close()
+
+dataClient := client.DataClient()
+
+pipeline := [][]byte{
+    bson.Marshal(bson.M{"$match": bson.M{"component_name": "sensor"}}),
+    bson.Marshal(bson.M{
+        "$group": bson.M{
+            "_id": "$part_id",
+            "total": bson.M{"$sum": 1},
+        },
+    }),
+}
+
+_, err := dataClient.UpdateDataPipeline(context.Background(), &datapb.UpdateDataPipelineRequest{
+    Id: "<pipeline-id>",
+    Name: "updated-name",
+    MqlBinary: pipeline,
+    Schedule: "0 * * * *",
+})
+```
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+Use [`dataClient.UpdateDataPipeline`](/dev/reference/apis/data-client/#updatedatapipeline) to alter an existing data pipeline:
+
+```typescript
+const apiKey = '<api-key>';
+const apiKeyID = '<api-key-id>';
+
+const client = await createViamClient({
+  credential: {
+    type: 'api-key',
+    payload: { key: apiKey, keyId: apiKeyID }
+  }
+});
+
+const dataClient = client.dataClient;
+
+const pipeline = [
+  BSON.serialize({ $match: { component_name: "sensor" } }),
+  BSON.serialize({
+    $group: {
+      _id: "$part_id",
+      total: { $sum: 1 }
+    }
+  })
+];
+
+await dataClient.updateDataPipeline({
+  id: "<pipeline-id>",
+  name: "updated-name",
+  mqlBinary: pipeline,
+  schedule: "0 0 * * *" // Change to daily
+});
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### Enable a pipeline
+
+{{< tabs >}}
+{{% tab name="CLI" %}}
+
+Use [`datapipelines enable`](/dev/tools/cli/#datapipelines) to enable a disabled data pipeline:
+
+```sh {class="command-line" data-prompt="$"}
+viam datapipelines enable --id=<pipeline-id>
+```
+
+{{% /tab %}}
+{{% tab name="Python" %}}
+
+Use [`DataClient.EnableDataPipeline`](/dev/reference/apis/data-client/#enabledatapipeline) to enable a disabled data pipeline:
+
+```python
+data_client = DataClient.from_api_key(
+    api_key="<api-key>",
+    api_key_id="<api-key-id>"
+)
+
+data_client.enable_data_pipeline(id="<pipeline-id>")
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+Use [`DataClient.EnableDataPipeline`](https://pkg.go.dev/go.viam.com/rdk/app#DataClient.EnableDataPipeline) to enable a disabled data pipeline:
+
+```go
+client, err := utils.NewViamClient(context.Background(), utils.WithAPIKey("<api-key>", "<api-key-id>"))
+if err != nil {
+    panic(err)
+}
+defer client.Close()
+
+dataClient := client.DataClient()
+
+_, err := dataClient.EnableDataPipeline(context.Background(), &datapb.EnableDataPipelineRequest{
+    Id: "<pipeline-id>",
+})
+```
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+Use [`dataClient.EnableDataPipeline`](/dev/reference/apis/data-client/#enabledatapipeline) to enable a disabled data pipeline:
+
+```typescript
+const apiKey = '<api-key>';
+const apiKeyID = '<api-key-id>';
+
+const client = await createViamClient({
+  credential: {
+    type: 'api-key',
+    payload: { key: apiKey, keyId: apiKeyID }
+  }
+});
+
+const dataClient = client.dataClient;
+
+const pipeline = [
+
+await dataClient.enableDataPipeline({ id: "<pipeline-id>" });
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### Disable a pipeline
+
+Disabling a data pipeline lets you pause data pipeline execution without fully deleting the pipeline configuration from your organization.
+
+{{< tabs >}}
+{{% tab name="CLI" %}}
+
+Use [`datapipelines disable`](/dev/tools/cli/#datapipelines) to disable a data pipeline:
+
+```sh {class="command-line" data-prompt="$"}
+viam datapipelines disable --id=<pipeline-id>
+```
+
+{{% /tab %}}
+{{% tab name="Python" %}}
+
+Use [`DataClient.DisableDataPipeline`](/dev/reference/apis/data-client/#disabledatapipeline) to disable a data pipeline:
+
+```python
+data_client = DataClient.from_api_key(
+    api_key="<api-key>",
+    api_key_id="<api-key-id>"
+)
+
+data_client.disable_data_pipeline(id="<pipeline-id>")
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+Use [`DataClient.DisableDataPipeline`](https://pkg.go.dev/go.viam.com/rdk/app#DataClient.DisableDataPipeline) to disable a data pipeline:
+
+```go
+client, err := utils.NewViamClient(context.Background(), utils.WithAPIKey("<api-key>", "<api-key-id>"))
+if err != nil {
+    panic(err)
+}
+defer client.Close()
+
+dataClient := client.DataClient()
+
+_, err := dataClient.DisableDataPipeline(context.Background(), &datapb.DisableDataPipelineRequest{
+    Id: "<pipeline-id>",
+})
+```
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+Use [`dataClient.DisableDataPipeline`](/dev/reference/apis/data-client/#disabledatapipeline) to disable a data pipeline:
+
+```typescript
+const apiKey = '<api-key>';
+const apiKeyID = '<api-key-id>';
+
+const client = await createViamClient({
+  credential: {
+    type: 'api-key',
+    payload: { key: apiKey, keyId: apiKeyID }
+  }
+});
+
+const dataClient = client.dataClient;
+
+await dataClient.disableDataPipeline({ id: "<pipeline-id>" });
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### Delete a pipeline
+
+{{< tabs >}}
+{{% tab name="CLI" %}}
+
+Use [`datapipelines delete`](/dev/tools/cli/#datapipelines) to delete a data pipeline:
+
+```sh {class="command-line" data-prompt="$"}
+viam datapipelines delete --id=<pipeline-id>
+```
+
+{{% /tab %}}
+{{% tab name="Python" %}}
+
+Use [`DataClient.DeleteDataPipeline`](/dev/reference/apis/data-client/#deletedatapipeline) to delete a data pipeline:
+
+```python
+data_client = DataClient.from_api_key(
+    api_key="<api-key>",
+    api_key_id="<api-key-id>"
+)
+
+data_client.delete_data_pipeline(id="<pipeline-id>")
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+Use [`DataClient.DeleteDataPipeline`](https://pkg.go.dev/go.viam.com/rdk/app#DataClient.DeleteDataPipeline) to delete a data pipeline:
+
+```go
+client, err := utils.NewViamClient(context.Background(), utils.WithAPIKey("<api-key>", "<api-key-id>"))
+if err != nil {
+    panic(err)
+}
+defer client.Close()
+
+dataClient := client.DataClient()
+
+_, err := dataClient.DeleteDataPipeline(context.Background(), &datapb.DeleteDataPipelineRequest{
+    Id: "<pipeline-id>",
+})
+```
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+Use [`dataClient.DeleteDataPipeline`](/dev/reference/apis/data-client/#deletedatapipeline) to delete a data pipeline:
+
+```typescript
+const apiKey = '<api-key>';
+const apiKeyID = '<api-key-id>';
+
+const client = await createViamClient({
+  credential: {
+    type: 'api-key',
+    payload: { key: apiKey, keyId: apiKeyID }
+  }
+});
+
+const dataClient = client.dataClient;
+
+await dataClient.deleteDataPipeline({ id: "<pipeline-id>" });
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### Check pipeline execution history
+
+Data pipeline executions may have any of the following statuses:
+
+- `SCHEDULED`: pending execution
+- `STARTED`: currently processing
+- `COMPLETED`: successfully finished
+- `FAILED`: execution error
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+Use [`DataClient.ListDataPipelineRuns`](/dev/reference/apis/data-client/#listdatapipelineruns) to view the statuses of past executions of a pipeline:
+
+```python
+data_client = DataClient.from_api_key(
+    api_key="<api-key>",
+    api_key_id="<api-key-id>"
+)
+
+runs = data_client.list_data_pipeline_runs(
+    id="<pipeline-id>",
+    page_size=10
+)
+
+for run in runs:
+    print(f"Run {run.id}: {run.status}")
+    print(f"Data window: {run.data_start_time} to {run.data_end_time}")
+    print(f"Started: {run.started}, Ended: {run.ended}")
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+Use [`DataClient.ListDataPipelineRuns`](https://pkg.go.dev/go.viam.com/rdk/app#DataClient.ListDataPipelineRuns) to view the statuses of past executions of a pipeline:
+
+```go
+client, err := utils.NewViamClient(context.Background(), utils.WithAPIKey("<api-key>", "<api-key-id>"))
+if err != nil {
+    panic(err)
+}
+defer client.Close()
+
+dataClient := client.DataClient()
+
+resp, err := dataClient.ListDataPipelineRuns(context.Background(), &datapb.ListDataPipelineRunsRequest{
+    Id: "<pipeline-id>",
+    PageSize: 10,
+})
+
+for _, run := range resp.Executions {
+    fmt.Printf("Run %s: %s\n", run.Id, run.Status)
+    fmt.Printf("Data window: %s to %s\n", run.DataStartTime, run.DataEndTime)
+    fmt.Printf("Started: %s, Ended: %s\n", run.Started, run.Ended)
+}
+```
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+Use [`dataClient.ListDataPipelineRuns`](/dev/reference/apis/data-client/#listdatapipelineruns) to view the statuses of past executions of a pipeline:
+
+```typescript
+const apiKey = '<api-key>';
+const apiKeyID = '<api-key-id>';
+
+const client = await createViamClient({
+  credential: {
+    type: 'api-key',
+    payload: { key: apiKey, keyId: apiKeyID }
+  }
+});
+
+const dataClient = client.dataClient;
+
+const response = await dataClient.listDataPipelineRuns({
+  id: "<pipeline-id>",
+  pageSize: 10
+});
+
+response.executions.forEach(run => {
+  console.log(`Run ${run.id}: ${run.status}`);
+  console.log(`Data window: ${run.dataStartTime} to ${run.dataEndTime}`);
+  console.log(`Started: ${run.started}, Ended: ${run.ended}`);
+});
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### Query pipeline results
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+Use [`DataClient.TabularDataByMQL`](/dev/reference/apis/data-client/#tabulardatabymql) to query the results of your data pipeline:
+
+```python
+data_client = DataClient.from_api_key(
+    api_key="<api-key>",
+    api_key_id="<api-key-id>"
+)
+
+results = data_client.tabular_data_by_mql(
+    organization_id="<org-id>",
+    mql_binary=[
+        bson.encode({}),
+    ],
+    data_source=TabularDataSource(
+        type=TabularDataSourceType.TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK,
+        pipeline_id="<pipeline-id>"
+    )
+)
+
+for document in results:
+    print(document)
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+Use [`DataClient.TabularDataByMQL`](https://pkg.go.dev/go.viam.com/rdk/app#DataClient.TabularDataByMQL) to query the results of your data pipeline:
+
+```go
+client, err := utils.NewViamClient(context.Background(), utils.WithAPIKey("<api-key>", "<api-key-id>"))
+if err != nil {
+    panic(err)
+}
+defer client.Close()
+
+dataClient := client.DataClient()
+
+query := [][]byte{
+    bson.Marshal(bson.M{}),
+}
+
+resp, err := dataClient.TabularDataByMQL(context.Background(), &datapb.TabularDataByMQLRequest{
+    OrganizationId: "<org-id>",
+    MqlBinary: query,
+    DataSource: &datapb.TabularDataSource{
+        Type: datapb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK,
+        PipelineId: proto.String("<pipeline-id>"),
+    },
+})
+
+for _, doc := range resp.Data {
+    fmt.Println(doc)
+}
+```
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+Use [`dataClient.TabularDataByMQL`](/dev/reference/apis/data-client/#tabulardatabymql) to query the results of your data pipeline:
+
+```typescript
+const apiKey = '<api-key>';
+const apiKeyID = '<api-key-id>';
+
+const client = await createViamClient({
+  credential: {
+    type: 'api-key',
+    payload: { key: apiKey, keyId: apiKeyID }
+  }
+});
+
+const dataClient = client.dataClient;
+
+const query = [
+  BSON.serialize({}),
+];
+
+const response = await dataClient.tabularDataByMQL({
+  organizationId: "<org-id>",
+  mqlBinary: query,
+  dataSource: {
+    type: TabularDataSourceType.TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK,
+    pipelineId: "<pipeline-id>"
+  }
+});
+
+response.data.forEach(doc => {
+  console.log(BSON.deserialize(doc));
+});
+```
+
+{{% /tab %}}
+{{< /tabs >}}

--- a/docs/data-ai/data/data-pipelines.md
+++ b/docs/data-ai/data/data-pipelines.md
@@ -115,14 +115,14 @@ resp, err := dataClient.CreateDataPipeline(context.Background(), &datapb.CreateD
 Use [`dataClient.CreateDataPipeline`](/dev/reference/apis/data-client/#createdatapipeline) to define a new pipeline:
 
 ```typescript
-const apiKey = '<api-key>';
-const apiKeyID = '<api-key-id>';
+const apiKey = "<api-key>";
+const apiKeyID = "<api-key-id>";
 
 const client = await createViamClient({
   credential: {
-    type: 'api-key',
-    payload: { key: apiKey, keyId: apiKeyID }
-  }
+    type: "api-key",
+    payload: { key: apiKey, keyId: apiKeyID },
+  },
 });
 
 const dataClient = client.dataClient;
@@ -133,16 +133,16 @@ const pipeline = [
     $group: {
       _id: "$location_id",
       avg_temp: { $avg: "$data.readings.temperature" },
-      count: { $sum: 1 }
-    }
-  })
+      count: { $sum: 1 },
+    },
+  }),
 ];
 
 const response = await dataClient.createDataPipeline({
   organizationId: "<org-id>",
   name: "hourly-temp-average",
   mqlBinary: pipeline,
-  schedule: "0 * * * *" // Run hourly
+  schedule: "0 * * * *", // Run hourly
 });
 ```
 
@@ -157,11 +157,11 @@ To create a schedule for your pipeline, specify a [cron expression](https://en.w
 The schedule determines both execution frequency and input time window.
 The following table contains some common schedules, which correspond to the listed execution frequencies and input time windows:
 
-| Schedule            | Frequency        | Time Window         |
-|---------------------|------------------|---------------------|
-| `0 * * * *`         | Hourly           | Previous hour       |
-| `0 0 * * *`         | Daily            | Previous day        |
-| `*/15 * * * *`      | Every 15 minutes | Previous 15 minutes |
+| Schedule       | Frequency        | Time Window         |
+| -------------- | ---------------- | ------------------- |
+| `0 * * * *`    | Hourly           | Previous hour       |
+| `0 0 * * *`    | Daily            | Previous day        |
+| `*/15 * * * *` | Every 15 minutes | Previous 15 minutes |
 
 ### List pipelines
 
@@ -224,23 +224,23 @@ for _, pipeline := range resp.DataPipelines {
 Use [`dataClient.ListDataPipelines`](/dev/reference/apis/data-client/#listdatapipelines) to fetch a summary of all pipelines in an organization:
 
 ```typescript
-const apiKey = '<api-key>';
-const apiKeyID = '<api-key-id>';
+const apiKey = "<api-key>";
+const apiKeyID = "<api-key-id>";
 
 const client = await createViamClient({
   credential: {
-    type: 'api-key',
-    payload: { key: apiKey, keyId: apiKeyID }
-  }
+    type: "api-key",
+    payload: { key: apiKey, keyId: apiKeyID },
+  },
 });
 
 const dataClient = client.dataClient;
 
 const response = await dataClient.listDataPipelines({
-  organizationId: "<org-id>"
+  organizationId: "<org-id>",
 });
 
-response.dataPipelines.forEach(pipeline => {
+response.dataPipelines.forEach((pipeline) => {
   console.log(`${pipeline.name} (id: ${pipeline.id})`);
   console.log(`Schedule: ${pipeline.schedule}`);
   console.log(`Enabled: ${pipeline.enabled}`);
@@ -327,14 +327,14 @@ _, err := dataClient.UpdateDataPipeline(context.Background(), &datapb.UpdateData
 Use [`dataClient.UpdateDataPipeline`](/dev/reference/apis/data-client/#updatedatapipeline) to alter an existing data pipeline:
 
 ```typescript
-const apiKey = '<api-key>';
-const apiKeyID = '<api-key-id>';
+const apiKey = "<api-key>";
+const apiKeyID = "<api-key-id>";
 
 const client = await createViamClient({
   credential: {
-    type: 'api-key',
-    payload: { key: apiKey, keyId: apiKeyID }
-  }
+    type: "api-key",
+    payload: { key: apiKey, keyId: apiKeyID },
+  },
 });
 
 const dataClient = client.dataClient;
@@ -344,16 +344,16 @@ const pipeline = [
   BSON.serialize({
     $group: {
       _id: "$part_id",
-      total: { $sum: 1 }
-    }
-  })
+      total: { $sum: 1 },
+    },
+  }),
 ];
 
 await dataClient.updateDataPipeline({
   id: "<pipeline-id>",
   name: "updated-name",
   mqlBinary: pipeline,
-  schedule: "0 0 * * *" // Change to daily
+  schedule: "0 0 * * *", // Change to daily
 });
 ```
 
@@ -482,14 +482,14 @@ _, err := dataClient.DisableDataPipeline(context.Background(), &datapb.DisableDa
 Use [`dataClient.DisableDataPipeline`](/dev/reference/apis/data-client/#disabledatapipeline) to disable a data pipeline:
 
 ```typescript
-const apiKey = '<api-key>';
-const apiKeyID = '<api-key-id>';
+const apiKey = "<api-key>";
+const apiKeyID = "<api-key-id>";
 
 const client = await createViamClient({
   credential: {
-    type: 'api-key',
-    payload: { key: apiKey, keyId: apiKeyID }
-  }
+    type: "api-key",
+    payload: { key: apiKey, keyId: apiKeyID },
+  },
 });
 
 const dataClient = client.dataClient;
@@ -550,14 +550,14 @@ _, err := dataClient.DeleteDataPipeline(context.Background(), &datapb.DeleteData
 Use [`dataClient.DeleteDataPipeline`](/dev/reference/apis/data-client/#deletedatapipeline) to delete a data pipeline:
 
 ```typescript
-const apiKey = '<api-key>';
-const apiKeyID = '<api-key-id>';
+const apiKey = "<api-key>";
+const apiKeyID = "<api-key-id>";
 
 const client = await createViamClient({
   credential: {
-    type: 'api-key',
-    payload: { key: apiKey, keyId: apiKeyID }
-  }
+    type: "api-key",
+    payload: { key: apiKey, keyId: apiKeyID },
+  },
 });
 
 const dataClient = client.dataClient;
@@ -631,24 +631,24 @@ for _, run := range resp.Executions {
 Use [`dataClient.ListDataPipelineRuns`](/dev/reference/apis/data-client/#listdatapipelineruns) to view the statuses of past executions of a pipeline:
 
 ```typescript
-const apiKey = '<api-key>';
-const apiKeyID = '<api-key-id>';
+const apiKey = "<api-key>";
+const apiKeyID = "<api-key-id>";
 
 const client = await createViamClient({
   credential: {
-    type: 'api-key',
-    payload: { key: apiKey, keyId: apiKeyID }
-  }
+    type: "api-key",
+    payload: { key: apiKey, keyId: apiKeyID },
+  },
 });
 
 const dataClient = client.dataClient;
 
 const response = await dataClient.listDataPipelineRuns({
   id: "<pipeline-id>",
-  pageSize: 10
+  pageSize: 10,
 });
 
-response.executions.forEach(run => {
+response.executions.forEach((run) => {
   console.log(`Run ${run.id}: ${run.status}`);
   console.log(`Data window: ${run.dataStartTime} to ${run.dataEndTime}`);
   console.log(`Started: ${run.started}, Ended: ${run.ended}`);
@@ -724,32 +724,30 @@ for _, doc := range resp.Data {
 Use [`dataClient.TabularDataByMQL`](/dev/reference/apis/data-client/#tabulardatabymql) to query the results of your data pipeline:
 
 ```typescript
-const apiKey = '<api-key>';
-const apiKeyID = '<api-key-id>';
+const apiKey = "<api-key>";
+const apiKeyID = "<api-key-id>";
 
 const client = await createViamClient({
   credential: {
-    type: 'api-key',
-    payload: { key: apiKey, keyId: apiKeyID }
-  }
+    type: "api-key",
+    payload: { key: apiKey, keyId: apiKeyID },
+  },
 });
 
 const dataClient = client.dataClient;
 
-const query = [
-  BSON.serialize({}),
-];
+const query = [BSON.serialize({})];
 
 const response = await dataClient.tabularDataByMQL({
   organizationId: "<org-id>",
   mqlBinary: query,
   dataSource: {
     type: TabularDataSourceType.TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK,
-    pipelineId: "<pipeline-id>"
-  }
+    pipelineId: "<pipeline-id>",
+  },
 });
 
-response.data.forEach(doc => {
+response.data.forEach((doc) => {
   console.log(BSON.deserialize(doc));
 });
 ```

--- a/docs/data-ai/data/hot-data-store.md
+++ b/docs/data-ai/data/hot-data-store.md
@@ -57,7 +57,6 @@ Set the value of the `stored_hours` field to the number of hours of recent data 
 Queries typically execute on blog storage.
 To query data from hot data store instead of blob storage, specify hot storage as your data source in your query.
 
-
 {{< tabs >}}
 {{% tab name="Python" %}}
 
@@ -120,14 +119,14 @@ for _, doc := range resp.Data {
 Use [`dataClient.TabularDataByMQL`](/dev/reference/apis/data-client/#tabulardatabymql) with `dataSource` set to `TabularDataSourceType.TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE` to query your hot data store:
 
 ```typescript
-const apiKey = '<api-key>';
-const apiKeyID = '<api-key-id>';
+const apiKey = "<api-key>";
+const apiKeyID = "<api-key-id>";
 
 const client = await createViamClient({
   credential: {
-    type: 'api-key',
-    payload: { key: apiKey, keyId: apiKeyID }
-  }
+    type: "api-key",
+    payload: { key: apiKey, keyId: apiKeyID },
+  },
 });
 
 const dataClient = client.dataClient;
@@ -135,16 +134,16 @@ const dataClient = client.dataClient;
 const query = [
   BSON.serialize({ $match: { location_id: "warehouse-1" } }),
   BSON.serialize({ $sort: { _id: -1 } }),
-  BSON.serialize({ $limit: 100 })
+  BSON.serialize({ $limit: 100 }),
 ];
 
 const response = await dataClient.tabularDataByMQL({
   organizationId: "<org-id>",
   mqlBinary: query,
-  dataSource: TabularDataSourceType.TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE
+  dataSource: TabularDataSourceType.TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE,
 });
 
-response.data.forEach(doc => {
+response.data.forEach((doc) => {
   console.log(BSON.deserialize(doc));
 });
 ```

--- a/docs/data-ai/data/hot-data-store.md
+++ b/docs/data-ai/data/hot-data-store.md
@@ -1,0 +1,162 @@
+---
+linkTitle: "Cache recent data"
+title: "Cache recent data"
+weight: 25
+description: "Make processed automatically available for faster, simpler queries."
+type: "docs"
+tags: ["hot data store", "aggregation", "materialized views"]
+icon: true
+images: ["/services/icons/data-capture.svg"]
+viamresources: ["sensor", "data_manager"]
+platformarea: ["data", "cli"]
+date: "2024-12-03"
+aliases:
+  - /data-ai/capture-data/advanced/advanced-data-capture-sync/#capture-to-the-hot-data-store
+---
+
+The hot data store enables faster queries on recent sensor data.
+
+## Configure
+
+To configure a rolling window of recent data, add the `recent_data_store` configuration to your component's data capture settings:
+
+```json {class="line-numbers linkable-line-numbers" data-line="17-19"}
+{
+  "components": [
+    {
+      "name": "sensor-1",
+      "api": "rdk:component:sensor",
+      "model": "rdk:builtin:fake",
+      "attributes": {},
+      "service_configs": [
+        {
+          "type": "data_manager",
+          "attributes": {
+            "capture_methods": [
+              {
+                "method": "Readings",
+                "capture_frequency_hz": 0.5,
+                "additional_params": {},
+                "recent_data_store": {
+                  "stored_hours": 24
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Set the value of the `stored_hours` field to the number of hours of recent data you would like to cache in the hot data store.
+
+## Query
+
+Queries typically execute on blog storage.
+To query data from hot data store instead of blob storage, specify hot storage as your data source in your query.
+
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+Use [`DataClient.TabularDataByMQL`](/dev/reference/apis/data-client/#tabulardatabymql) with `data_source` set to `TabularDataSourceType.TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE` to query your hot data store:
+
+```python
+data_client = DataClient.from_api_key(
+    api_key="<api-key>",
+    api_key_id="<api-key-id>"
+)
+
+results = data_client.tabular_data_by_mql(
+    organization_id="<org-id>",
+    mql_binary=[
+        bson.encode({"$match": {"location_id": "warehouse-1"}}),
+        bson.encode({"$sort": {"_id": -1}}),
+        bson.encode({"$limit": 100})
+    ],
+    data_source=TabularDataSourceType.TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE
+)
+
+for document in results:
+    print(document)
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+Use [`DataClient.TabularDataByMQL`](https://pkg.go.dev/go.viam.com/rdk/app#DataClient.TabularDataByMQL) with `DataSource` set to `datapb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE` to query your hot data store:
+
+```go
+client, err := utils.NewViamClient(context.Background(), utils.WithAPIKey("<api-key>", "<api-key-id>"))
+if err != nil {
+    panic(err)
+}
+defer client.Close()
+
+dataClient := client.DataClient()
+
+query := [][]byte{
+    bson.Marshal(bson.M{"$match": bson.M{"location_id": "warehouse-1"}}),
+    bson.Marshal(bson.M{"$sort": bson.M{"_id": -1}}),
+    bson.Marshal(bson.M{"$limit": 100}),
+}
+
+resp, err := dataClient.TabularDataByMQL(context.Background(), &datapb.TabularDataByMQLRequest{
+    OrganizationId: "<org-id>",
+    MqlBinary: query,
+    DataSource: datapb.TabularDataSourceType_TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE,
+})
+
+for _, doc := range resp.Data {
+    fmt.Println(doc)
+}
+```
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+Use [`dataClient.TabularDataByMQL`](/dev/reference/apis/data-client/#tabulardatabymql) with `dataSource` set to `TabularDataSourceType.TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE` to query your hot data store:
+
+```typescript
+const apiKey = '<api-key>';
+const apiKeyID = '<api-key-id>';
+
+const client = await createViamClient({
+  credential: {
+    type: 'api-key',
+    payload: { key: apiKey, keyId: apiKeyID }
+  }
+});
+
+const dataClient = client.dataClient;
+
+const query = [
+  BSON.serialize({ $match: { location_id: "warehouse-1" } }),
+  BSON.serialize({ $sort: { _id: -1 } }),
+  BSON.serialize({ $limit: 100 })
+];
+
+const response = await dataClient.tabularDataByMQL({
+  organizationId: "<org-id>",
+  mqlBinary: query,
+  dataSource: TabularDataSourceType.TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE
+});
+
+response.data.forEach(doc => {
+  console.log(BSON.deserialize(doc));
+});
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+All queries that omit `use_recent_data` or explicitly set the value to `false` continue to use blob storage.
+
+### Query limitations
+
+You cannot use the following MongoDB aggregation operators when querying your hot data store:
+
+- `$lookup`
+- `$unionWith`

--- a/docs/data-ai/data/hot-data-store.md
+++ b/docs/data-ai/data/hot-data-store.md
@@ -152,7 +152,7 @@ response.data.forEach(doc => {
 {{% /tab %}}
 {{< /tabs >}}
 
-All queries that omit `use_recent_data` or explicitly set the value to `false` continue to use blob storage.
+All queries that omit `DataSource` will continue to use blob storage.
 
 ### Query limitations
 

--- a/docs/data-ai/data/query.md
+++ b/docs/data-ai/data/query.md
@@ -1,7 +1,7 @@
 ---
 linkTitle: "Query data"
 title: "Query data"
-weight: 20
+weight: 30
 layout: "docs"
 type: "docs"
 aliases:

--- a/docs/dev/tools/cli.md
+++ b/docs/dev/tools/cli.md
@@ -398,7 +398,7 @@ The `datapipelines` command provides access to data pipelines for processing mac
 Data pipelines help you optimize query performance for frequently accessed complex data transformations.
 
 ```sh {class="command-line" data-prompt="$"}
-viam datapipelines create --org-id=<org-id> --name=<name> --schedule=<schedule> --mql=<mql-query> [--data-source-type=<type>]
+viam datapipelines create --org-id=<org-id> --name=<name> --schedule=<schedule> --mql=<mql-query> --data-source-type=<type>
 viam datapipelines update --id=<pipeline-id> --name=<name> --schedule=<schedule> --mql=<mql-query> [--data-source-type=<type>]
 viam datapipelines list --org-id=<org-id>
 viam datapipelines describe --id=<pipeline-id>
@@ -409,10 +409,10 @@ Examples:
 
 ```sh {class="command-line" data-prompt="$"}
 # create a new data pipeline with standard data source type (default)
-viam datapipelines create --org-id=123 --name="Daily Sensor Summary" --schedule="0 9 * * *" --mql='[{"$match": {"component_name": "sensor1"}}]'
+viam datapipelines create --org-id=123 --name="Daily Sensor Summary" --schedule="0 9 * * *" --data-source-type=standard --mql='[{"$match": {"component_name": "sensor1"}}]'
 
 # create a data pipeline with hot storage data source type for faster access
-viam datapipelines create --org-id=123 --name="Real-time Analytics" --schedule="*/5 * * * *" --mql='[{"$match": {"component_name": "camera1"}}]' --data-source-type=hotstorage
+viam datapipelines create --org-id=123 --name="Real-time Analytics" --schedule="*/5 * * * *" --data-source-type=hotstorage --mql='[{"$match": {"component_name": "camera1"}}]'
 
 # disable a pipeline
 viam datapipelines disable --id=abc123
@@ -453,11 +453,11 @@ viam datapipelines delete --id=abc123
 | Argument | Description | Applicable commands | Required? |
 | -------- | ----------- | ------------------- | --------- |
 | `--org-id` | ID of the organization that owns the data pipeline. | `create`, `list` | **Required** |
-| `--name` | Name of the data pipeline. | `create`, `update` | **Required** |
-| `--schedule` | Cron schedule that expresses when the pipeline should run, for example `0 9 * * *` for daily at 9 AM. | `create`, `update` | **Required** |
+| `--name` | Name of the data pipeline. | `create`, `update` | **Required** for `create` |
+| `--schedule` | Cron schedule that expresses when the pipeline should run, for example `0 9 * * *` for daily at 9 AM. | `create`, `update` | **Required** for `create` |
 | `--mql` | MQL (MongoDB Query Language) query as a JSON string for data processing. You must specify either `--mql` or `--mql-path` when creating a pipeline. | `create`, `update` | Optional |
 | `--mql-path` | Path to a JSON file containing the MQL query for the data pipeline. You must specify either `--mql` or `--mql-path` when creating a pipeline. | `create`, `update` | Optional |
-| `--data-source-type` | Data source type for the pipeline. Options: `standard` (default), `hotstorage`. `standard` provides typical analytics storage; `hotstorage` offers faster access for real-time processing. | `create`, `update` | Optional |
+| `--data-source-type` | Data source type for the pipeline. Options: `standard` (default), `hotstorage`. `standard` provides typical analytics storage; `hotstorage` offers faster access for real-time processing. | `create`, `update` | **Required** for `create` |
 | `--id` | ID of the data pipeline to update, describe, or delete. | `enable`, `delete`, `describe`, `disable`, `update` | **Required** |
 
 ### `dataset`

--- a/static/include/app/apis/generated/app.md
+++ b/static/include/app/apis/generated/app.md
@@ -37,7 +37,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 ```ts {class="line-numbers linkable-line-numbers"}
 // This method is used internally only. To obtain a user's ID, use the listOrganizationsByUser method.
 const members = await appClient.listOrganizationMembers(
-  "<YOUR-ORGANIZATION-ID>",
+  '<YOUR-ORGANIZATION-ID>'
 );
 ```
 
@@ -168,7 +168,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const organizations =
-  await appClient.getOrganizationsWithAccessToLocation("<YOUR-LOCATION-ID>");
+  await appClient.getOrganizationsWithAccessToLocation(
+    '<YOUR-LOCATION-ID>'
+  );
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getorganizationswithaccesstolocation).
@@ -256,7 +258,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const organization = await appClient.getOrganization("<YOUR-ORGANIZATION-ID>");
+const organization = await appClient.getOrganization(
+  '<YOUR-ORGANIZATION-ID>'
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getorganization).
@@ -307,7 +311,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const isAvailable =
-  await appClient.getOrganizationNamespaceAvailability("name");
+  await appClient.getOrganizationNamespaceAvailability('name');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getorganizationnamespaceavailability).
@@ -369,8 +373,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const organization = await appClient.updateOrganization(
-  "<YOUR-ORGANIZATION-ID>",
-  "newName",
+  '<YOUR-ORGANIZATION-ID>',
+  'newName'
 );
 ```
 
@@ -387,7 +391,7 @@ Delete an organization.
 
 **Parameters:**
 
-- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization. You can obtain your organization ID from your organizations settings page.
+- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization. You can obtain your organization ID from the organization settings page.
 
 **Returns:**
 
@@ -415,7 +419,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.deleteOrganization("<YOUR-ORGANIZATION-ID>");
+await appClient.deleteOrganization('<YOUR-ORGANIZATION-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deleteorganization).
@@ -432,7 +436,7 @@ List the members and invites of the {{< glossary_tooltip term_id="organization" 
 
 **Parameters:**
 
-- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to list members of. You can obtain your organization ID from your organizations settings page.
+- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to list members of. You can obtain your organization ID from the organization settings page.
 
 **Returns:**
 
@@ -456,13 +460,13 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Returns:**
 
 - (Promise<[ListOrganizationMembersResponse](https://ts.viam.dev/classes/appApi.ListOrganizationMembersResponse.html)>): An object containing organization members, pending invites, and
-  org ID.
+org ID.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const members = await appClient.listOrganizationMembers(
-  "<YOUR-ORGANIZATION-ID>",
+  '<YOUR-ORGANIZATION-ID>'
 );
 ```
 
@@ -480,7 +484,7 @@ Create an {{< glossary_tooltip term_id="organization" text="organization" >}} in
 
 **Parameters:**
 
-- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to create an invite for. You can obtain your organization ID from your organizations settings page.
+- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to create an invite for. You can obtain your organization ID from the organization settings page.
 - `email` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The email address to send the invite to.
 - `authorizations` ([List[viam.proto.app.Authorization]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Authorization)) (optional): Specifications of the authorizations to include in the invite. If not provided, full owner permissions will be granted.
 - `send_email_invite` ([bool](https://docs.python.org/3/library/stdtypes.html#boolean-type-bool)) (required): Whether or not an email should be sent to the recipient of an invite. The user must accept the email to be added to the associated authorizations. When set to false, the user automatically receives the associated authorization on the next login of the user with the associated email address.
@@ -520,20 +524,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const auth = new VIAM.appApi.Authorization({
-  authorizationType: "role",
-  authorizationId: "organization_operator",
-  organizationId: "<YOUR-ORGANIZATION-ID>",
-  resourceId: "<YOUR-RESOURCE-ID>", // The resource to grant access to
-  resourceType: "organization", // The type of resource to grant access to
-  identityId: "<YOUR-USER-ID>", // The user id of the user to grant access to (optional)
-  roleId: "owner", // The role to grant access to
-  identityType: "user",
+  authorizationType: 'role',
+  authorizationId: 'organization_operator',
+  organizationId: '<YOUR-ORGANIZATION-ID>',
+  resourceId: '<YOUR-RESOURCE-ID>', // The resource to grant access to
+  resourceType: 'organization', // The type of resource to grant access to
+  identityId: '<YOUR-USER-ID>', // The user id of the user to grant access to (optional)
+  roleId: 'owner', // The role to grant access to
+  identityType: 'user',
 });
 
 const invite = await appClient.createOrganizationInvite(
-  "<YOUR-ORGANIZATION-ID>",
-  "youremail@email.com",
-  [auth],
+  '<YOUR-ORGANIZATION-ID>',
+  'youremail@email.com',
+  [auth]
 );
 ```
 
@@ -552,7 +556,7 @@ If an invitation has only one authorization and you want to remove it, delete th
 
 **Parameters:**
 
-- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization that the invite is for. You can obtain your organization ID from your organizations settings page.
+- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization that the invite is for. You can obtain your organization ID from the organization settings page.
 - `email` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): Email of the user the invite was sent to.
 - `add_authorizations` ([List[viam.proto.app.Authorization]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Authorization)) (optional): Optional list of authorizations to add to the invite.
 - `remove_authorizations` ([List[viam.proto.app.Authorization]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Authorization)) (optional): Optional list of authorizations to remove from the invite.
@@ -607,20 +611,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const auth = new VIAM.appApi.Authorization({
-  authorizationType: "role",
-  authorizationId: "organization_operator",
-  organizationId: "<YOUR-ORGANIZATION-ID>",
-  resourceId: "<YOUR-RESOURCE-ID>", // The resource to grant access to
-  resourceType: "organization", // The type of resource to grant access to
-  identityId: "<YOUR-USER-ID>", // The user id of the user to grant access to (optional)
-  roleId: "owner", // The role to grant access to
-  identityType: "user",
+  authorizationType: 'role',
+  authorizationId: 'organization_operator',
+  organizationId: '<YOUR-ORGANIZATION-ID>',
+  resourceId: '<YOUR-RESOURCE-ID>', // The resource to grant access to
+  resourceType: 'organization', // The type of resource to grant access to
+  identityId: '<YOUR-USER-ID>', // The user id of the user to grant access to (optional)
+  roleId: 'owner', // The role to grant access to
+  identityType: 'user',
 });
 const invite = await appClient.updateOrganizationInviteAuthorizations(
-  "<YOUR-ORGANIZATION-ID>",
-  "youremail@email.com",
+  '<YOUR-ORGANIZATION-ID>',
+  'youremail@email.com',
   [auth],
-  [],
+  []
 );
 ```
 
@@ -638,7 +642,7 @@ Remove a member from the {{< glossary_tooltip term_id="organization" text="organ
 
 **Parameters:**
 
-- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the org to remove the user from. You can obtain your organization ID from your organizations settings page.
+- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the org to remove the user from. You can obtain your organization ID from the organization settings page.
 - `user_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the user to remove.
 
 **Returns:**
@@ -672,8 +676,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 await appClient.deleteOrganizationMember(
-  "<YOUR-ORGANIZATION-ID>",
-  "<YOUR-USER-ID>",
+  '<YOUR-ORGANIZATION-ID>',
+  '<YOUR-USER-ID>'
 );
 ```
 
@@ -691,7 +695,7 @@ Delete a pending organization invite to the organization you are currently authe
 
 **Parameters:**
 
-- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization that the invite to delete was for. You can obtain your organization ID from your organizations settings page.
+- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization that the invite to delete was for. You can obtain your organization ID from the organization settings page.
 - `email` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The email address the pending invite was sent to.
 
 **Returns:**
@@ -726,8 +730,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 await appClient.deleteOrganizationInvite(
-  "<YOUR-ORGANIZATION-ID>",
-  "youremail@email.com",
+  '<YOUR-ORGANIZATION-ID>',
+  'youremail@email.com'
 );
 ```
 
@@ -745,7 +749,7 @@ Resend a pending organization invite email.
 
 **Parameters:**
 
-- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization that the invite to resend was for. You can obtain your organization ID from your organizations settings page.
+- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization that the invite to resend was for. You can obtain your organization ID from the organization settings page.
 - `email` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The email address associated with the invite.
 
 **Returns:**
@@ -780,8 +784,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const invite = await appClient.resendOrganizationInvite(
-  "<YOUR-ORGANIZATION-ID>",
-  "youremail@email.com",
+  '<YOUR-ORGANIZATION-ID>',
+  'youremail@email.com'
 );
 ```
 
@@ -799,7 +803,7 @@ Gets the user-defined metadata for an organization.
 
 **Parameters:**
 
-- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization with which the user-defined metadata is associated. You can obtain your organization ID from your organizations settings page.
+- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization with which the user-defined metadata is associated. You can obtain your organization ID from the organization settings page.
 
 **Returns:**
 
@@ -828,7 +832,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const metadata = await appClient.getOrganizationMetadata(
-  "<YOUR-ORGANIZATION-ID>",
+  '<YOUR-ORGANIZATION-ID>'
 );
 ```
 
@@ -877,8 +881,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.updateOrganizationMetadata("<YOUR-ORGANIZATION-ID>", {
-  key: "value",
+await appClient.updateOrganizationMetadata('<YOUR-ORGANIZATION-ID>', {
+  key: 'value',
 });
 ```
 
@@ -897,7 +901,7 @@ Optionally, put the new location under a specified parent location.
 
 **Parameters:**
 
-- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to create the location under. You can obtain your organization ID from your organizations settings page.
+- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to create the location under. You can obtain your organization ID from the organization settings page.
 - `name` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): Name of the location.
 - `parent_location_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (optional): Optional parent location to put the location under. Defaults to a root-level location if no location ID is provided.
 
@@ -936,8 +940,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const location = await appClient.createLocation(
-  "<YOUR-ORGANIZATION-ID>",
-  "name",
+  '<YOUR-ORGANIZATION-ID>',
+  'name'
 );
 ```
 
@@ -987,7 +991,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const location = await appClient.getLocation("<YOUR-LOCATION-ID>");
+const location = await appClient.getLocation('<YOUR-LOCATION-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getlocation).
@@ -1062,8 +1066,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const location = await appClient.updateLocation(
-  "<YOUR-LOCATION-ID>",
-  "newName",
+  '<YOUR-LOCATION-ID>',
+  'newName'
 );
 ```
 
@@ -1113,7 +1117,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.deleteLocation("<YOUR-LOCATION-ID>");
+await appClient.deleteLocation('<YOUR-LOCATION-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deletelocation).
@@ -1130,7 +1134,7 @@ Get a list of all {{< glossary_tooltip term_id="location" text="locations" >}} u
 
 **Parameters:**
 
-- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the org to list locations for. You can obtain your organization ID from your organizations settings page.
+- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the org to list locations for. You can obtain your organization ID from the organization settings page.
 
 **Returns:**
 
@@ -1158,7 +1162,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const locations = await appClient.listLocations("<YOUR-ORGANIZATION-ID>");
+const locations = await appClient.listLocations(
+  '<YOUR-ORGANIZATION-ID>'
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listlocations).
@@ -1205,7 +1211,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.shareLocation("<OTHER-ORGANIZATION-ID>", "<YOUR-LOCATION-ID>");
+await appClient.shareLocation(
+  '<OTHER-ORGANIZATION-ID>',
+  '<YOUR-LOCATION-ID>'
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#sharelocation).
@@ -1253,8 +1262,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 await appClient.unshareLocation(
-  "<OTHER-ORGANIZATION-ID>",
-  "<YOUR-LOCATION-ID>",
+  '<OTHER-ORGANIZATION-ID>',
+  '<YOUR-LOCATION-ID>'
 );
 ```
 
@@ -1304,7 +1313,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const locationAuth = await appClient.locationAuth("<YOUR-LOCATION-ID>");
+const locationAuth = await appClient.locationAuth(
+  '<YOUR-LOCATION-ID>'
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#locationauth).
@@ -1353,7 +1364,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const locationAuth = await appClient.createLocationSecret("<YOUR-LOCATION-ID>");
+const locationAuth = await appClient.createLocationSecret(
+  '<YOUR-LOCATION-ID>'
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createlocationsecret).
@@ -1407,7 +1420,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.deleteLocationSecret("<YOUR-LOCATION-ID>", "<YOUR-SECRET-ID>");
+await appClient.deleteLocationSecret(
+  '<YOUR-LOCATION-ID>',
+  '<YOUR-SECRET-ID>'
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deletelocationsecret).
@@ -1424,7 +1440,7 @@ Get the user-defined metadata for a location.
 
 **Parameters:**
 
-- `location_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the location with which the user-defined metadata is associated. You can obtain your location ID from your location's page.
+- `location_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the location with which the user-defined metadata is associated. You can obtain your location ID from the locations page.
 
 **Returns:**
 
@@ -1452,7 +1468,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const metadata = await appClient.getLocationMetadata("<YOUR-LOCATION-ID>");
+const metadata = await appClient.getLocationMetadata(
+  '<YOUR-LOCATION-ID>'
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getlocationmetadata).
@@ -1469,7 +1487,7 @@ Update the user-defined metadata for a location.
 
 **Parameters:**
 
-- `location_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the location with which to associate the user-defined metadata. You can obtain your location ID from your location's page.
+- `location_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the location with which to associate the user-defined metadata. You can obtain your location ID from the locations page.
 - `metadata` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (required): The user-defined metadata converted from JSON to a Python dictionary.
 
 **Returns:**
@@ -1499,8 +1517,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.updateLocationMetadata("<YOUR-LOCATION-ID>", {
-  key: "value",
+await appClient.updateLocationMetadata('<YOUR-LOCATION-ID>', {
+  key: 'value',
 });
 ```
 
@@ -1550,7 +1568,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const robot = await appClient.getRobot("<YOUR-ROBOT-ID>");
+const robot = await appClient.getRobot('<YOUR-ROBOT-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getrobot).
@@ -1595,7 +1613,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const robotAPIKeys = await appClient.getRobotAPIKeys("<YOUR-ROBOT-ID>");
+const robotAPIKeys =
+  await appClient.getRobotAPIKeys('<YOUR-ROBOT-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getrobotapikeys).
@@ -1646,7 +1665,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const robotParts = await appClient.getRobotParts("<YOUR-ROBOT-ID>");
+const robotParts = await appClient.getRobotParts('<YOUR-ROBOT-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getrobotparts).
@@ -1704,12 +1723,15 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const robotPart = await appClient.getRobotPart("<YOUR-ROBOT-PART-ID>");
+const robotPart = await appClient.getRobotPart('<YOUR-ROBOT-PART-ID>');
 // Get the part's address
 const address = robotPart.part.fqdn;
 // Check if machine is live (last access time less than 10 sec ago)
-if (Date.now() - Number(robotPart.part.lastAccess.seconds) * 1000 <= 10000) {
-  console.log("Machine is live");
+if (
+  Date.now() - Number(robotPart.part.lastAccess.seconds) * 1000 <=
+  10000
+) {
+  console.log('Machine is live');
 }
 ```
 
@@ -1767,12 +1789,14 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Returns:**
 
 - (Promise<[GetRobotPartLogsResponse](https://ts.viam.dev/classes/appApi.GetRobotPartLogsResponse.html)>): The robot requested logs and the page token for the next page of
-  logs.
+logs.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const robotPartLogs = await appClient.getRobotPartLogs("<YOUR-ROBOT-PART-ID>");
+const robotPartLogs = await appClient.getRobotPartLogs(
+  '<YOUR-ROBOT-PART-ID>'
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getrobotpartlogs).
@@ -1795,7 +1819,7 @@ Get an asynchronous iterator that receives live machine part logs.
 
 **Returns:**
 
-- ([viam.app.\_logs.\_LogsStream[List[LogEntry]]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.LogEntry)): The asynchronous iterator receiving live machine part logs.
+- ([viam.app._logs._LogsStream[List[LogEntry]]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.LogEntry)): The asynchronous iterator receiving live machine part logs.
 
 **Example:**
 
@@ -1815,7 +1839,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - `id` (string) (required): The ID of the requested robot part.
 - `queue` ([LogEntry](https://ts.viam.dev/classes/commonApi.LogEntry.html)) (required): A queue to put the log entries into.
 - `filter` (string) (optional): Optional string to filter logs on.
-- `errorsOnly` (boolean) (optional): Optional bool to indicate whether or not only error\-level
+- `errorsOnly` (boolean) (optional): Optional bool to indicate whether or not only error-level
   logs should be returned. Defaults to true.
 
 **Returns:**
@@ -1825,7 +1849,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const robotPartLogs = await appClient.tailRobotPartLogs("<YOUR-ROBOT-PART-ID>");
+const robotPartLogs = await appClient.tailRobotPartLogs(
+  '<YOUR-ROBOT-PART-ID>'
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#tailrobotpartlogs).
@@ -1877,7 +1903,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const robotPartHistory = await appClient.getRobotPartHistory(
-  "<YOUR-ROBOT-PART-ID>",
+  '<YOUR-ROBOT-PART-ID>'
 );
 ```
 
@@ -1936,8 +1962,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const robotPart = await appClient.updateRobotPart(
-  "<YOUR-ROBOT-PART-ID>",
-  "newName",
+  '<YOUR-ROBOT-PART-ID>',
+  'newName'
 );
 ```
 
@@ -1986,12 +2012,15 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<string>): The ID of the newly\-created robot part.
+- (Promise<string>): The ID of the newly-created robot part.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const robotPartId = await appClient.newRobotPart("<YOUR-ROBOT-ID>", "newPart");
+const robotPartId = await appClient.newRobotPart(
+  '<YOUR-ROBOT-ID>',
+  'newPart'
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#newrobotpart).
@@ -2042,7 +2071,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.deleteRobotPart("<YOUR-ROBOT-PART-ID>");
+await appClient.deleteRobotPart('<YOUR-ROBOT-PART-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deleterobotpart).
@@ -2092,7 +2121,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.markPartAsMain("<YOUR-ROBOT-PART-ID>");
+await appClient.markPartAsMain('<YOUR-ROBOT-PART-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#markpartasmain).
@@ -2142,7 +2171,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.markPartForRestart("<YOUR-ROBOT-PART-ID>");
+await appClient.markPartForRestart('<YOUR-ROBOT-PART-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#markpartforrestart).
@@ -2192,7 +2221,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const robotPart = await appClient.createRobotPartSecret("<YOUR-ROBOT-PART-ID>");
+const robotPart = await appClient.createRobotPartSecret(
+  '<YOUR-ROBOT-PART-ID>'
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createrobotpartsecret).
@@ -2246,8 +2277,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 await appClient.deleteRobotPartSecret(
-  "<YOUR-ROBOT-PART-ID>",
-  "<YOUR-SECRET-ID>",
+  '<YOUR-ROBOT-PART-ID>',
+  '<YOUR-SECRET-ID>'
 );
 ```
 
@@ -2297,7 +2328,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const robots = await appClient.listRobots("<YOUR-LOCATION-ID>");
+const robots = await appClient.listRobots('<YOUR-LOCATION-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listrobots).
@@ -2348,7 +2379,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const robotId = await appClient.newRobot("<YOUR-LOCATION-ID>", "newRobot");
+const robotId = await appClient.newRobot(
+  '<YOUR-LOCATION-ID>',
+  'newRobot'
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#newrobot).
@@ -2372,13 +2406,12 @@ You can change:
 - The destination location must be within the same organization
 - No other machine in the destination location can have the same name
 
-{{< alert title="Important considerations" color="caution" >}}
+{{< alert title="Important" color="note" >}}
 Moving a machine has several important implications:
 
 - **Machine address changes**: The machine's network address will change to `<machine-main-part-name>.<new-location-id>.viam.cloud`. You'll need to update any code that references the old address.
 - **Permission changes**: Access permissions will be updated. Users with access to the current location lose access, and users with access to the new location gain access to the machine.
 - **Data access**: Users in the new location cannot access historical data from when the machine was in the previous location.
-
 {{< /alert >}}
 
 {{< tabs >}}
@@ -2421,15 +2454,15 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- (Promise<undefined | [appApi](https://ts.viam.dev/modules/appApi.html).[Robot](https://ts.viam.dev/classes/appApi.Robot.html)>): The newly\-modified robot object.
+- (Promise<undefined | [appApi](https://ts.viam.dev/modules/appApi.html).[Robot](https://ts.viam.dev/classes/appApi.Robot.html)>): The newly-modified robot object.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const robot = await appClient.updateRobot(
-  "<YOUR-ROBOT-ID>",
-  "<YOUR-LOCATION-ID>",
-  "newName",
+  '<YOUR-ROBOT-ID>',
+  '<YOUR-LOCATION-ID>',
+  'newName'
 );
 ```
 
@@ -2479,7 +2512,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.deleteRobot("<YOUR-ROBOT-ID>");
+await appClient.deleteRobot('<YOUR-ROBOT-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deleterobot).
@@ -2496,7 +2529,7 @@ Gets the user-defined metadata for a machine.
 
 **Parameters:**
 
-- `robot_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the robot with which the user-defined metadata is associated. You can obtain your robot ID from your machine's page.
+- `robot_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the robot with which the user-defined metadata is associated. You can obtain your robot ID from the machine page.
 
 **Returns:**
 
@@ -2524,7 +2557,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const metadata = await appClient.getRobotMetadata("<YOUR-ROBOT-ID>");
+const metadata = await appClient.getRobotMetadata('<YOUR-ROBOT-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getrobotmetadata).
@@ -2541,7 +2574,7 @@ Gets the user-defined metadata for a machine part.
 
 **Parameters:**
 
-- `robot_part_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the robot part with which the user-defined metadata is associated. You can obtain your robot part ID from your machine's page.
+- `robot_part_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the robot part with which the user-defined metadata is associated. You can obtain your robot part ID from the machine page.
 
 **Returns:**
 
@@ -2569,7 +2602,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const metadata = await appClient.getRobotPartMetadata("<YOUR-ROBOT-PART-ID>");
+const metadata = await appClient.getRobotPartMetadata(
+  '<YOUR-ROBOT-PART-ID>'
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getrobotpartmetadata).
@@ -2587,7 +2622,7 @@ User-defined metadata is billed as data.
 
 **Parameters:**
 
-- `robot_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the robot with which to associate the user-defined metadata. You can obtain your robot ID from your machine's page.
+- `robot_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the robot with which to associate the user-defined metadata. You can obtain your robot ID from the machine page.
 - `metadata` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (required): The user-defined metadata converted from JSON to a Python dictionary.
 
 **Returns:**
@@ -2617,8 +2652,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.updateRobotMetadata("<YOUR-ROBOT-ID>", {
-  key: "value",
+await appClient.updateRobotMetadata('<YOUR-ROBOT-ID>', {
+  key: 'value',
 });
 ```
 
@@ -2667,8 +2702,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.updateRobotPartMetadata("<YOUR-ROBOT-PART-ID>", {
-  key: "value",
+await appClient.updateRobotPartMetadata('<YOUR-ROBOT-PART-ID>', {
+  key: 'value',
 });
 ```
 
@@ -2686,8 +2721,8 @@ Get a list of {{< glossary_tooltip term_id="fragment" text="fragments" >}} in th
 
 **Parameters:**
 
-- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to list fragments for. You can obtain your organization ID from your organizations settings page.
-- `show_public` ([bool](https://docs.python.org/3/library/stdtypes.html#boolean-type-bool)) (required): Optional boolean specifying whether or not to only show public fragments. If True, only public fragments will return. If False, only private fragments will return. Defaults to True. Deprecated since version 0.25.0: Use visibilities instead.
+- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to list fragments for. You can obtain your organization ID from the organization settings page.
+- `show_public` ([bool](https://docs.python.org/3/library/stdtypes.html#boolean-type-bool)) (required): Optional boolean specifying whether or not to only show public fragments. If True, only public fragments will return. If False, only private fragments will return. Defaults to True.  Deprecated since version 0.25.0: Use visibilities instead.
 - `visibilities` ([List[Fragment]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.Fragment.Visibility)) (optional): List of FragmentVisibilities specifying which types of fragments to include in the results. If empty, by default only public fragments will be returned.
 
 **Returns:**
@@ -2720,7 +2755,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const fragments = await appClient.listFragments("<YOUR-ORGANIZATION-ID>");
+const fragments = await appClient.listFragments(
+  '<YOUR-ORGANIZATION-ID>'
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listfragments).
@@ -2747,12 +2784,14 @@ Get a list of top level and nested {{< glossary_tooltip term_id="fragment" text=
 **Returns:**
 
 - (Promise<[Fragment](https://ts.viam.dev/classes/appApi.Fragment.html)[]>): The list of top level and nested fragments for a machine, as well
-  as additionally specified fragment IDs.
+as additionally specified fragment IDs.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const fragments = await appClient.listMachineFragments("<YOUR-MACHINE-ID>");
+const fragments = await appClient.listMachineFragments(
+  '<YOUR-MACHINE-ID>'
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listmachinefragments).
@@ -2805,7 +2844,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const fragment = await appClient.getFragment(
-  "12a12ab1-1234-5678-abcd-abcd01234567",
+  '12a12ab1-1234-5678-abcd-abcd01234567'
 );
 ```
 
@@ -2823,7 +2862,7 @@ Create a new private {{< glossary_tooltip term_id="fragment" text="fragment" >}}
 
 **Parameters:**
 
-- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to create the fragment within. You can obtain your organization ID from your organizations settings page.
+- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to create the fragment within. You can obtain your organization ID from the organization settings page.
 - `name` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): Name of the fragment.
 - `config` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (optional): Optional Dictionary representation of new config to assign to specified fragment. Can be assigned by updating the fragment.
 
@@ -2861,8 +2900,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const fragment = await appClient.createFragment(
-  "<YOUR-ORGANIZATION-ID>",
-  "newFragment",
+  '<YOUR-ORGANIZATION-ID>',
+  'newFragment'
 );
 ```
 
@@ -2883,7 +2922,7 @@ Update a {{< glossary_tooltip term_id="fragment" text="fragment" >}} name and it
 - `fragment_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): ID of the fragment to update.
 - `name` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): New name to associate with the fragment.
 - `config` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (optional): Optional Dictionary representation of new config to assign to specified fragment. Not passing this parameter will leave the fragment’s config unchanged.
-- `public` ([bool](https://docs.python.org/3/library/stdtypes.html#boolean-type-bool)) (optional): Boolean specifying whether the fragment is public. Not passing this parameter will leave the fragment’s visibility unchanged. A fragment is private by default when created. Deprecated since version 0.25.0: Use visibility instead.
+- `public` ([bool](https://docs.python.org/3/library/stdtypes.html#boolean-type-bool)) (optional): Boolean specifying whether the fragment is public. Not passing this parameter will leave the fragment’s visibility unchanged. A fragment is private by default when created.  Deprecated since version 0.25.0: Use visibility instead.
 - `visibility` ([Fragment](https://python.viam.dev/autoapi/viam/gen/app/v1/app_pb2/index.html#viam.gen.app.v1.app_pb2.FragmentVisibility)) (optional): Optional FragmentVisibility list specifying who should be allowed to view the fragment. Not passing this parameter will leave the fragment’s visibility unchanged. A fragment is private by default when created.
 - `last_known_update` ([datetime.datetime](https://docs.python.org/3/library/datetime.html)) (optional): Optional time of the last known update to this fragment’s config. If provided, this will result in a GRPCError if the upstream config has changed since this time, indicating that the local config is out of date. Omitting this parameter will result in an overwrite of the upstream config.
 
@@ -2930,8 +2969,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const fragment = await appClient.updateFragment(
-  "12a12ab1-1234-5678-abcd-abcd01234567",
-  "better_name",
+  '12a12ab1-1234-5678-abcd-abcd01234567',
+  'better_name'
 );
 ```
 
@@ -2982,7 +3021,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.deleteFragment("12a12ab1-1234-5678-abcd-abcd01234567");
+await appClient.deleteFragment('12a12ab1-1234-5678-abcd-abcd01234567');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deletefragment).
@@ -3034,7 +3073,7 @@ Add a role under the organization you are currently authenticated to.
 
 **Parameters:**
 
-- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to create the role in. You can obtain your organization ID from your organizations settings page.
+- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to create the role in. You can obtain your organization ID from the organization settings page.
 - `identity_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): ID of the entity the role belongs to (for example, a user ID).
 - `role` (Literal['owner'] | Literal['operator']) (required): The role to add (either `"owner"` or `"operator"`).
 - `resource_type` (Literal['organization'] | Literal['location'] | Literal['robot']) (required): The type of the resource to add the role to (either `"organization"`, `"location"`, or `"robot"`). Must match the type of the `resource_id`'s resource.
@@ -3083,11 +3122,11 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 await appClient.addRole(
-  "<YOUR-ORGANIZATION-ID>",
-  "<YOUR-USER-ID>",
-  "owner",
-  "robot",
-  "<YOUR-ROBOT-ID>",
+  '<YOUR-ORGANIZATION-ID>',
+  '<YOUR-USER-ID>',
+  'owner',
+  'robot',
+  '<YOUR-ROBOT-ID>'
 );
 ```
 
@@ -3105,7 +3144,7 @@ Remove a role under the organization you are currently authenticated to.
 
 **Parameters:**
 
-- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization the role exists in. You can obtain your organization ID from your organizations settings page.
+- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization the role exists in. You can obtain your organization ID from the organization settings page.
 - `identity_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): ID of the entity the role belongs to (for example, a user ID).
 - `role` (Literal['owner'] | Literal['operator']) (required): The role to remove.
 - `resource_type` (Literal['organization'] | Literal['location'] | Literal['robot']) (required): Type of the resource the role is being removed from. Must match resource_id.
@@ -3154,11 +3193,11 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 await appClient.removeRole(
-  "<YOUR-ORGANIZATION-ID>",
-  "<YOUR-USER-ID>",
-  "owner",
-  "robot",
-  "<YOUR-ROBOT-ID>",
+  '<YOUR-ORGANIZATION-ID>',
+  '<YOUR-USER-ID>',
+  'owner',
+  'robot',
+  '<YOUR-ROBOT-ID>'
 );
 ```
 
@@ -3224,24 +3263,24 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const oldAuth = new VIAM.appApi.Authorization({
-  authorizationType: "role",
-  authorizationId: "organization_owner",
-  organizationId: "<YOUR-ORGANIZATION-ID>",
-  resourceId: "<YOUR-RESOURCE-ID>", // The resource to grant access to
-  resourceType: "organization", // The type of resource to grant access to
-  identityId: "<USER-ID>", // The user id of the user to grant access to (optional)
-  roleId: "owner", // The role to grant access to
-  identityType: "user",
+  authorizationType: 'role',
+  authorizationId: 'organization_owner',
+  organizationId: '<YOUR-ORGANIZATION-ID>',
+  resourceId: '<YOUR-RESOURCE-ID>', // The resource to grant access to
+  resourceType: 'organization', // The type of resource to grant access to
+  identityId: '<USER-ID>', // The user id of the user to grant access to (optional)
+  roleId: 'owner', // The role to grant access to
+  identityType: 'user',
 });
 const newAuth = new VIAM.appApi.Authorization({
-  authorizationType: "role",
-  authorizationId: "organization_operator",
-  organizationId: "<YOUR-ORGANIZATION-ID>",
-  resourceId: "<YOUR-RESOURCE-ID>", // The resource to grant access to
-  resourceType: "organization", // The type of resource to grant access To
-  identityId: "<USER-ID>", // The user id of the user to grant access to (optional)
-  roleId: "operator", // The role to grant access to
-  identityType: "user",
+  authorizationType: 'role',
+  authorizationId: 'organization_operator',
+  organizationId: '<YOUR-ORGANIZATION-ID>',
+  resourceId: '<YOUR-RESOURCE-ID>', // The resource to grant access to
+  resourceType: 'organization', // The type of resource to grant access To
+  identityId: '<USER-ID>', // The user id of the user to grant access to (optional)
+  roleId: 'operator', // The role to grant access to
+  identityType: 'user',
 });
 await appClient.changeRole(oldAuth, newAuth);
 ```
@@ -3448,7 +3487,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const registryItem = await appClient.getRegistryItem("<YOUR-REGISTRY-ITEM-ID>");
+const registryItem = await appClient.getRegistryItem(
+  '<YOUR-REGISTRY-ITEM-ID>'
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getregistryitem).
@@ -3501,9 +3542,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 await appClient.createRegistryItem(
-  "<YOUR-ORGANIZATION-ID>",
-  "newRegistryItemName",
-  5,
+  '<YOUR-ORGANIZATION-ID>',
+  'newRegistryItemName',
+  5
 );
 ```
 
@@ -3564,10 +3605,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 await appClient.updateRegistryItem(
-  "<YOUR-REGISTRY-ITEM-ID>",
+  '<YOUR-REGISTRY-ITEM-ID>',
   5, // Package: ML Model
-  "new description",
-  1, // Private
+  'new description',
+  1 // Private
 );
 ```
 
@@ -3650,11 +3691,11 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const registryItems = await appClient.listRegistryItems(
-  "<YOUR-ORGANIZATION-ID>",
+  '<YOUR-ORGANIZATION-ID>',
   [], // All package types
   [1], // Private packages
   [],
-  [1], // Active packages
+  [1] // Active packages
 );
 ```
 
@@ -3700,7 +3741,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.deleteRegistryItem("<YOUR-REGISTRY-ITEM-ID>");
+await appClient.deleteRegistryItem('<YOUR-REGISTRY-ITEM-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deleteregistryitem).
@@ -3717,7 +3758,7 @@ Create a {{< glossary_tooltip term_id="module" text="module" >}} under the organ
 
 **Parameters:**
 
-- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to create the module under. You can obtain your organization ID from your organizations settings page.
+- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to create the module under. You can obtain your organization ID from the organization settings page.
 - `name` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The name of the module. Must be unique within your organization.
 
 **Returns:**
@@ -3753,8 +3794,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const module = await appClient.createModule(
-  "<YOUR-ORGANIZATION-ID>",
-  "newModule",
+  '<YOUR-ORGANIZATION-ID>',
+  'newModule'
 );
 ```
 
@@ -3828,12 +3869,12 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const module = await appClient.updateModule(
-  "<YOUR-MODULE-ID>",
+  '<YOUR-MODULE-ID>',
   1,
-  "https://example.com",
-  "new description",
-  [{ model: "namespace:group:model1", api: "rdk:component:generic" }],
-  "entrypoint",
+  'https://example.com',
+  'new description',
+  [{ model: 'namespace:group:model1', api: 'rdk:component:generic' }],
+  'entrypoint'
 );
 ```
 
@@ -3921,7 +3962,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const module = await appClient.getModule("<YOUR-MODULE-ID>");
+const module = await appClient.getModule('<YOUR-MODULE-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#getmodule).
@@ -3938,7 +3979,7 @@ List the {{< glossary_tooltip term_id="module" text="modules" >}} under the orga
 
 **Parameters:**
 
-- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to list modules for. You can obtain your organization ID from your organizations settings page.
+- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to list modules for. You can obtain your organization ID from the organization settings page.
 
 **Returns:**
 
@@ -3966,7 +4007,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const modules = await appClient.listModules("<YOUR-ORGANIZATION-ID>");
+const modules = await appClient.listModules('<YOUR-ORGANIZATION-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listmodules).
@@ -3983,7 +4024,7 @@ Create a new [API key](/operate/control/api-keys/).
 
 **Parameters:**
 
-- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to create the key for. You can obtain your organization ID from your organizations settings page.
+- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to create the key for. You can obtain your organization ID from the organization settings page.
 - `authorizations` ([List[APIKeyAuthorization]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Authorization)) (required): A list of authorizations to associate with the key.
 - `name` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (optional): A name for the key. If None, defaults to the current timestamp.
 
@@ -4070,7 +4111,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.deleteKey("<YOUR-KEY-ID>");
+await appClient.deleteKey('<YOUR-KEY-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#deletekey).
@@ -4115,7 +4156,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const key = await appClient.rotateKey("<YOUR-KEY-ID>");
+const key = await appClient.rotateKey('<YOUR-KEY-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#rotatekey).
@@ -4132,7 +4173,7 @@ List all keys for the {{< glossary_tooltip term_id="organization" text="organiza
 
 **Parameters:**
 
-- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to list API keys for. You can obtain your organization ID from your organizations settings page.
+- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to list API keys for. You can obtain your organization ID from the organization settings page.
 
 **Returns:**
 
@@ -4160,7 +4201,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const keys = await appClient.listKeys("<YOUR-ORGANIZATION-ID>");
+const keys = await appClient.listKeys('<YOUR-ORGANIZATION-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#listkeys).
@@ -4207,7 +4248,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const key =
-  await appClient.createKeyFromExistingKeyAuthorizations("<YOUR-KEY-ID>");
+  await appClient.createKeyFromExistingKeyAuthorizations(
+    '<YOUR-KEY-ID>'
+  );
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AppClient.html#createkeyfromexistingkeyauthorizations).
@@ -4235,8 +4278,8 @@ Retrieve the app content for an organization.
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const appContent = await appClient.getAppContent(
-  "<YOUR-PUBLIC-NAMESPACE>",
-  "<YOUR-APP-NAME>",
+  '<YOUR-PUBLIC-NAMESPACE>',
+  '<YOUR-APP-NAME>'
 );
 ```
 

--- a/static/include/app/apis/generated/data-table.md
+++ b/static/include/app/apis/generated/data-table.md
@@ -7,7 +7,7 @@
 | [`TabularDataBySQL`](/dev/reference/apis/data-client/#tabulardatabysql) | Obtain unified tabular data and metadata, queried with SQL. Make sure your API key has permissions at the organization level in order to use this. |
 | [`TabularDataByMQL`](/dev/reference/apis/data-client/#tabulardatabymql) | Obtain unified tabular data and metadata, queried with MQL. |
 | [`BinaryDataByFilter`](/dev/reference/apis/data-client/#binarydatabyfilter) | Retrieve optionally filtered binary data from Viam. |
-| [`BinaryDataByIDs`](/dev/reference/apis/data-client/#binarydatabyids) | Retrieve binary data from Viam by `BinaryID`. |
+| [`BinaryDataByIDs`](/dev/reference/apis/data-client/#binarydatabyids) | Retrieve binary data from the Viam by `BinaryID`. |
 | [`DeleteTabularData`](/dev/reference/apis/data-client/#deletetabulardata) | Delete tabular data older than a specified number of days. |
 | [`DeleteBinaryDataByFilter`](/dev/reference/apis/data-client/#deletebinarydatabyfilter) | Filter and delete binary data. |
 | [`DeleteBinaryDataByIDs`](/dev/reference/apis/data-client/#deletebinarydatabyids) | Filter and delete binary data by ids. |
@@ -23,3 +23,8 @@
 | [`ConfigureDatabaseUser`](/dev/reference/apis/data-client/#configuredatabaseuser) | Configure a database user for the Viam organization’s MongoDB Atlas Data Federation instance. |
 | [`AddBinaryDataToDatasetByIDs`](/dev/reference/apis/data-client/#addbinarydatatodatasetbyids) | Add the `BinaryData` to the provided dataset. |
 | [`RemoveBinaryDataFromDatasetByIDs`](/dev/reference/apis/data-client/#removebinarydatafromdatasetbyids) | Remove the BinaryData from the provided dataset. |
+| [`GetDataPipeline`](/dev/reference/apis/data-client/#getdatapipeline) | Get the configuration of a data pipeline. |
+| [`ListDataPipelines`](/dev/reference/apis/data-client/#listdatapipelines) | Get the configuration for multiple data pipelines. |
+| [`CreateDataPipeline`](/dev/reference/apis/data-client/#createdatapipeline) | Create a data pipeline. |
+| [`DeleteDataPipeline`](/dev/reference/apis/data-client/#deletedatapipeline) | Delete a data pipeline. |
+| [`ListDataPipelineRuns`](/dev/reference/apis/data-client/#listdatapipelineruns) | List the statuses of individual executions of a data pipeline. |

--- a/static/include/app/apis/generated/data.md
+++ b/static/include/app/apis/generated/data.md
@@ -14,7 +14,7 @@ Gets the most recent tabular data captured from the specified data source, as lo
 
 **Returns:**
 
-- (Tuple[[datetime.datetime](https://docs.python.org/3/library/datetime.html), [datetime.datetime](https://docs.python.org/3/library/datetime.html), Dict[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), viam.utils.ValueTypes]] | None): A return value of None means that this data source has not synced data in the last year. Otherwise, the data source has synced some data in the last year, so the returned tuple contains the following: time_captured (datetime): The time captured. time_synced (datetime): The time synced. payload (Dict[str, ValueTypes]): The latest tabular data captured from the specified data source. .
+- (Tuple[[datetime.datetime](https://docs.python.org/3/library/datetime.html), [datetime.datetime](https://docs.python.org/3/library/datetime.html), Dict[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), viam.utils.ValueTypes]] | None): A return value of None means that this data source has not synced data in the last year. Otherwise, the data source has synced some data in the last year, so the returned tuple contains the following:   time_captured (datetime): The time captured. time_synced (datetime): The time synced. payload (Dict[str, ValueTypes]): The latest tabular data captured from the specified data source.   .
 
 **Example:**
 
@@ -44,25 +44,25 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 - `partId` (string) (required): The ID of the part that owns the data.
 - `resourceName` (string) (required): The name of the requested resource that captured the
-  data. Ex: "my\-sensor".
+  data. Ex: "my-sensor".
 - `resourceSubtype` (string) (required): The subtype of the requested resource that captured
   the data. Ex: "rdk:component:sensor".
 - `methodName` (string) (required): The data capture method name. Ex: "Readings".
 
 **Returns:**
 
-- (Promise<null | [Date, Date, Record<string, [JsonValue](https://ts.viam.dev/types/JsonValue.html)>]>): A tuple containing \[timeCaptured, timeSynced, payload] or null if
-  no data has been synced for the specified resource OR the most recently
-  captured data was over a year ago.
+- (Promise<null | [Date, Date, Record<string, [JsonValue](https://ts.viam.dev/types/JsonValue.html)>]>): A tuple containing [timeCaptured, timeSynced, payload] or null if
+no data has been synced for the specified resource OR the most recently
+captured data was over a year ago.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const data = await dataClient.getLatestTabularData(
-  "123abc45-1234-5678-90ab-cdef12345678",
-  "my-sensor",
-  "rdk:component:sensor",
-  "Readings",
+  '123abc45-1234-5678-90ab-cdef12345678',
+  'my-sensor',
+  'rdk:component:sensor',
+  'Readings'
 );
 ```
 
@@ -80,7 +80,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<({[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\> payload, [DateTime](https://api.flutter.dev/flutter/dart-core/DateTime-class.html) timeCaptured, [DateTime](https://api.flutter.dev/flutter/dart-core/DateTime-class.html) timeSynced})?\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<({[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic> payload, [DateTime](https://api.flutter.dev/flutter/dart-core/DateTime-class.html) timeCaptured, [DateTime](https://api.flutter.dev/flutter/dart-core/DateTime-class.html) timeSynced})?>
 
 **Example:**
 
@@ -171,12 +171,12 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const data = await dataClient.exportTabularData(
-  "123abc45-1234-5678-90ab-cdef12345678",
-  "my-sensor",
-  "rdk:component:sensor",
-  "Readings",
-  new Date("2025-03-25"),
-  new Date("2024-03-27"),
+  '123abc45-1234-5678-90ab-cdef12345678',
+  'my-sensor',
+  'rdk:component:sensor',
+  'Readings',
+  new Date('2025-03-25'),
+  new Date('2024-03-27')
 );
 ```
 
@@ -196,7 +196,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[TabularDataPoint](https://flutter.viam.dev/viam_sdk/TabularDataPoint-class.html)\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[TabularDataPoint](https://flutter.viam.dev/viam_sdk/TabularDataPoint-class.html)>\>
 
 **Example:**
 
@@ -241,9 +241,8 @@ For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_s
 
 ### TabularDataByFilter
 
-Retrieve optionally filtered tabular data from the Viam.
-You can also find your tabular data under the **Sensors** subtab of the app's [**Data** tab](https://app.viam.com/data).
-
+Retrieve optionally filtered tabular data from [Viam](https://app.viam.com).
+You can also find your tabular data under the **Sensors** subtab of the [**Data** tab](https://app.viam.com/data).
 {{< tabs >}}
 {{% tab name="Python" %}}
 
@@ -259,7 +258,7 @@ You can also find your tabular data under the **Sensors** subtab of the app's [*
 
 **Returns:**
 
-- (Tuple[List[TabularData], [int](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex), [str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]): A tuple containing the following: tabular_data (List[TabularData]): The tabular data. count (int): The count (number of entries). last (str): The last-returned page ID. .
+- (Tuple[List[TabularData], [int](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex), [str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]): A tuple containing the following:   tabular_data (List[TabularData]): The tabular data. count (int): The count (number of entries). last (str): The last-returned page ID.   .
 
 **Example:**
 
@@ -290,28 +289,28 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - `limit` (number) (optional): The maximum number of entries to include in a page. Defaults
   to 50 if unspecfied.
 - `sortOrder` ([Order](https://ts.viam.dev/enums/dataApi.Order.html)) (optional): The desired sort order of the data.
-- `last` (string) (optional): Optional string indicating the ID of the last\-returned data. If
+- `last` (string) (optional): Optional string indicating the ID of the last-returned data. If
   provided, the server will return the next data entries after the `last`
   ID.
 - `countOnly` (boolean) (optional): Whether to return only the total count of entries.
 - `includeInternalData` (boolean) (optional): Whether to retun internal data. Internal data is
-  used for Viam\-specific data ingestion, like cloud SLAM. Defaults to
+  used for Viam-specific data ingestion, like cloud SLAM. Defaults to
   `false`.
 
 **Returns:**
 
 - (Promise<{ count: bigint; data: TabularData[]; last: string }>): An array of data objects, the count (number of entries), and the
-  last\-returned page ID.
+last-returned page ID.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const data = await dataClient.tabularDataByFilter(
   {
-    componentName: "sensor-1",
-    componentType: "rdk:component:sensor",
+    componentName: 'sensor-1',
+    componentType: 'rdk:component:sensor',
   } as Filter,
-  5,
+  5
 );
 ```
 
@@ -330,7 +329,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[TabularDataByFilterResponse](https://flutter.viam.dev/viam_protos.app.data/TabularDataByFilterResponse-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[TabularDataByFilterResponse](https://flutter.viam.dev/viam_protos.app.data/TabularDataByFilterResponse-class.html)>
 
 **Example:**
 
@@ -380,7 +379,7 @@ Obtain unified tabular data and metadata, queried with SQL. Make sure your API k
 
 **Parameters:**
 
-- `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization that owns the data. To find your organization ID, visit the organization settings page on Viam.
+- `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization that owns the data. To find your organization ID, visit the organization settings page.
 - `sql_query` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The SQL query to run.
 
 **Returns:**
@@ -414,8 +413,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const data = await dataClient.tabularDataBySQL(
-  "123abc45-1234-5678-90ab-cdef12345678",
-  "SELECT * FROM readings LIMIT 5",
+  '123abc45-1234-5678-90ab-cdef12345678',
+  'SELECT * FROM readings LIMIT 5'
 );
 ```
 
@@ -431,7 +430,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>\>>
 
 **Example:**
 
@@ -467,7 +466,7 @@ Obtain unified tabular data and metadata, queried with MQL.
 
 **Parameters:**
 
-- `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization that owns the data. To find your organization ID, visit the organization settings page on Viam.
+- `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization that owns the data. To find your organization ID, visit the organization settings page.
 - `query` (List[[bytes](https://docs.python.org/3/library/stdtypes.html#bytes-objects)] | List[Dict[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]]) (required): The MQL query to run, as a list of MongoDB aggregation pipeline stages. Each stage can be provided as either a dictionary or raw BSON bytes, but support for bytes will be removed in the future, so prefer the dictionary option.
 - `use_recent_data` ([bool](https://docs.python.org/3/library/stdtypes.html#boolean-type-bool)) (optional): Whether to query blob storage or your recent data store. Defaults to False.. Deprecated, use tabular_data_source_type instead.
 - `tabular_data_source_type` ([viam.proto.app.data.TabularDataSourceType.ValueType](https://python.viam.dev/autoapi/viam/proto/app/data/index.html#viam.proto.app.data.TabularDataSourceType)) (required): The data source to query. Defaults to TABULAR_DATA_SOURCE_TYPE_STANDARD.
@@ -500,7 +499,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - `organizationId` (string) (required): The ID of the organization that owns the data.
 - `query` (Uint8Array) (required): The MQL query to run as a list of BSON documents.
 - `useRecentData` (boolean) (optional): Whether to query blob storage or your recent data
-  store. Defaults to false. Deprecated \- use dataSource instead.
+  store. Defaults to false. Deprecated - use dataSource instead.
 - `tabularDataSource` ([TabularDataSource](https://ts.viam.dev/classes/dataApi.TabularDataSource.html)) (optional)
 
 **Returns:**
@@ -514,7 +513,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 const mqlQuery: Record<string, JsonValue>[] = [
   {
     $match: {
-      component_name: "sensor-1",
+      component_name: 'sensor-1',
     },
   },
   {
@@ -523,8 +522,8 @@ const mqlQuery: Record<string, JsonValue>[] = [
 ];
 
 const data = await dataClient.tabularDataByMQL(
-  "123abc45-1234-5678-90ab-cdef12345678",
-  mqlQuery,
+  '123abc45-1234-5678-90ab-cdef12345678',
+  mqlQuery
 );
 ```
 
@@ -541,7 +540,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>\>>
 
 **Example:**
 
@@ -583,9 +582,8 @@ For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_s
 
 ### BinaryDataByFilter
 
-Retrieve optionally filtered binary data from the Viam.
-You can also find your binary data under the **Images**, **Point clouds**, or **Files** subtab of the app's [**Data** tab](https://app.viam.com/data), depending on the type of data that you have uploaded.
-
+Retrieve optionally filtered binary data from [Viam](https://app.viam.com).
+You can also find your binary data under the **Images**, **Point clouds**, or **Files** subtab of the [**Data** tab](https://app.viam.com/data), depending on the type of data that you have uploaded.
 {{< tabs >}}
 {{% tab name="Python" %}}
 
@@ -602,7 +600,7 @@ You can also find your binary data under the **Images**, **Point clouds**, or **
 
 **Returns:**
 
-- (Tuple[List[viam.proto.app.data.BinaryData], [int](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex), [str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]): A tuple containing the following: data (List[ BinaryData ]): The binary data. count (int): The count (number of entries). last (str): The last-returned page ID. .
+- (Tuple[List[viam.proto.app.data.BinaryData], [int](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex), [str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]): A tuple containing the following:   data (List[ BinaryData ]): The binary data. count (int): The count (number of entries). last (str): The last-returned page ID.   .
 
 **Example:**
 
@@ -654,30 +652,30 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - `limit` (number) (optional): The maximum number of entries to include in a page. Defaults
   to 50 if unspecfied.
 - `sortOrder` ([Order](https://ts.viam.dev/enums/dataApi.Order.html)) (optional): The desired sort order of the data.
-- `last` (string) (optional): Optional string indicating the ID of the last\-returned data. If
+- `last` (string) (optional): Optional string indicating the ID of the last-returned data. If
   provided, the server will return the next data entries after the `last`
   ID.
 - `includeBinary` (boolean) (optional): Whether to include binary file data with each
   retrieved file.
 - `countOnly` (boolean) (optional): Whether to return only the total count of entries.
 - `includeInternalData` (boolean) (optional): Whether to retun internal data. Internal data is
-  used for Viam\-specific data ingestion, like cloud SLAM. Defaults to
+  used for Viam-specific data ingestion, like cloud SLAM. Defaults to
   `false`.
 
 **Returns:**
 
 - (Promise<{ count: bigint; data: [BinaryData](https://ts.viam.dev/classes/dataApi.BinaryData.html)[]; last: string }>): An array of data objects, the count (number of entries), and the
-  last\-returned page ID.
+last-returned page ID.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const data = await dataClient.binaryDataByFilter(
   {
-    componentName: "camera-1",
-    componentType: "rdk:component:camera",
+    componentName: 'camera-1',
+    componentType: 'rdk:component:camera',
   } as Filter,
-  1,
+  1
 );
 ```
 
@@ -697,7 +695,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[BinaryDataByFilterResponse](https://flutter.viam.dev/viam_protos.app.data/BinaryDataByFilterResponse-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[BinaryDataByFilterResponse](https://flutter.viam.dev/viam_protos.app.data/BinaryDataByFilterResponse-class.html)>
 
 **Example:**
 
@@ -736,7 +734,7 @@ For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_s
 
 ### BinaryDataByIDs
 
-Retrieve binary data from the [Viam app](https://app.viam.com) by `BinaryID`.
+Retrieve binary data from the Viam by `BinaryID`.
 You can also find your binary data under the **Images**, **Point clouds**, or **Files** subtab of the app's [**Data** tab](https://app.viam.com/data), depending on the type of data that you have uploaded.
 
 {{< tabs >}}
@@ -787,7 +785,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const data = await dataClient.binaryDataByIds([
-  "ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh",
+  'ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh',
 ]);
 ```
 
@@ -798,12 +796,12 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `binaryIds` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[BinaryID](https://flutter.viam.dev/viam_protos.app.data/BinaryID-class.html)\> (required)
+- `binaryIds` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[BinaryID](https://flutter.viam.dev/viam_protos.app.data/BinaryID-class.html)> (required)
 - `includeBinary` [bool](https://api.flutter.dev/flutter/dart-core/bool-class.html) (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[BinaryDataByIDsResponse](https://flutter.viam.dev/viam_protos.app.data/BinaryDataByIDsResponse-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[BinaryDataByIDsResponse](https://flutter.viam.dev/viam_protos.app.data/BinaryDataByIDsResponse-class.html)>
 
 **Example:**
 
@@ -850,7 +848,7 @@ Delete tabular data older than a specified number of days.
 
 **Parameters:**
 
-- `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to delete the data from. To find your organization ID, visit the organization settings page on Viam.
+- `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to delete the data from. To find your organization ID, visit the organization settings page.
 - `delete_older_than_days` ([int](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (required): Delete data that was captured up to this many days ago. For example, a value of 10 deletes any data that was captured up to 10 days ago. A value of 0 deletes all existing data.
 
 **Returns:**
@@ -887,8 +885,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const data = await dataClient.deleteTabularData(
-  "123abc45-1234-5678-90ab-cdef12345678",
-  10,
+  '123abc45-1234-5678-90ab-cdef12345678',
+  10
 );
 ```
 
@@ -904,7 +902,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)>
 
 **Example:**
 
@@ -938,7 +936,7 @@ Filter and delete binary data.
 
 **Parameters:**
 
-- `filter` ([viam.proto.app.data.Filter](https://python.viam.dev/autoapi/viam/proto/app/data/index.html#viam.proto.app.data.Filter)) (optional): Optional, specifies binary data to delete. CAUTION: Passing an empty Filter deletes all binary data! You must specify an organization ID with organization_ids when using this option. To find your organization ID, visit the organization settings page on Viam.
+- `filter` ([viam.proto.app.data.Filter](https://python.viam.dev/autoapi/viam/proto/app/data/index.html#viam.proto.app.data.Filter)) (optional): Optional, specifies binary data to delete. CAUTION: Passing an empty Filter deletes all binary data! You must specify an organization ID with organization_ids when using this option. To find your organization ID, visit the organization settings page.
 
 **Returns:**
 
@@ -974,11 +972,11 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const data = await dataClient.deleteBinaryDataByFilter({
-  componentName: "camera-1",
-  componentType: "rdk:component:camera",
-  organizationIds: ["123abc45-1234-5678-90ab-cdef12345678"],
-  startTime: new Date("2025-03-19"),
-  endTime: new Date("2025-03-20"),
+  componentName: 'camera-1',
+  componentType: 'rdk:component:camera',
+  organizationIds: ['123abc45-1234-5678-90ab-cdef12345678'],
+  startTime: new Date('2025-03-19'),
+  endTime: new Date('2025-03-20'),
 } as Filter);
 ```
 
@@ -994,7 +992,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)>
 
 **Example:**
 
@@ -1074,7 +1072,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Parameters:**
 
-- `ids` (string) (required): The IDs of the data to be deleted. Must be non\-empty.
+- `ids` (string) (required): The IDs of the data to be deleted. Must be non-empty.
 
 **Returns:**
 
@@ -1084,7 +1082,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const data = await dataClient.deleteBinaryDataByIds([
-  "ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh",
+  'ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh',
 ]);
 ```
 
@@ -1095,11 +1093,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `binaryDataIds` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\> (required)
+- `binaryDataIds` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)> (required)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)>
 
 **Example:**
 
@@ -1182,8 +1180,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Parameters:**
 
 - `tags` (string) (required): The list of tags to add to specified binary data. Must be
-  non\-empty.
-- `ids` (string) (required): The IDs of the data to be tagged. Must be non\-empty.
+  non-empty.
+- `ids` (string) (required): The IDs of the data to be tagged. Must be non-empty.
 
 **Returns:**
 
@@ -1193,10 +1191,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const data = await dataClient.addTagsToBinaryDataByIds(
-  ["tag1", "tag2"],
+  ['tag1', 'tag2'],
   [
-    "ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh",
-  ],
+    'ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh',
+  ]
 );
 ```
 
@@ -1207,12 +1205,12 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `tags` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\> (required)
-- `binaryDataIds` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\> (required)
+- `tags` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)> (required)
+- `binaryDataIds` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)> (required)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -1295,12 +1293,12 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const data = await dataClient.addTagsToBinaryDataByFilter(
-  ["tag1", "tag2"],
+  ['tag1', 'tag2'],
   [
     {
-      componentName: "camera-1",
+      componentName: 'camera-1',
     } as Filter,
-  ],
+  ]
 );
 ```
 
@@ -1311,12 +1309,12 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `tags` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\> (required)
+- `tags` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)> (required)
 - `filter` [Filter](https://flutter.viam.dev/viam_protos.app.data/Filter-class.html)? (required)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -1403,8 +1401,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Parameters:**
 
 - `tags` (string) (required): List of tags to remove from specified binary data. Must be
-  non\-empty.
-- `ids` (string) (required): The IDs of the data to be edited. Must be non\-empty.
+  non-empty.
+- `ids` (string) (required): The IDs of the data to be edited. Must be non-empty.
 
 **Returns:**
 
@@ -1414,10 +1412,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const data = await dataClient.removeTagsFromBinaryDataByIds(
-  ["tag1", "tag2"],
+  ['tag1', 'tag2'],
   [
-    "ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh",
-  ],
+    'ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh',
+  ]
 );
 ```
 
@@ -1428,12 +1426,12 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `tags` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\> (required)
-- `binaryDataIds` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\> (required)
+- `tags` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)> (required)
+- `binaryDataIds` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)> (required)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)>
 
 **Example:**
 
@@ -1505,7 +1503,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Parameters:**
 
 - `tags` (string) (required): List of tags to remove from specified binary data. Must be
-  non\-empty.
+  non-empty.
 - `filter` ([Filter](https://ts.viam.dev/classes/dataApi.Filter.html)) (optional): Optional `pb.Filter` specifying binary data to add tags to.
   No `filter` implies all binary data.
 
@@ -1517,14 +1515,14 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const data = await dataClient.removeTagsFromBinaryDataByFilter(
-  ["tag1", "tag2"],
+  ['tag1', 'tag2'],
   {
-    componentName: "camera-1",
-    componentType: "rdk:component:camera",
-    organizationIds: ["123abc45-1234-5678-90ab-cdef12345678"],
-    startTime: new Date("2025-03-19"),
-    endTime: new Date("2025-03-20"),
-  } as Filter,
+    componentName: 'camera-1',
+    componentType: 'rdk:component:camera',
+    organizationIds: ['123abc45-1234-5678-90ab-cdef12345678'],
+    startTime: new Date('2025-03-19'),
+    endTime: new Date('2025-03-20'),
+  } as Filter
 );
 ```
 
@@ -1535,12 +1533,12 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `tags` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\> (required)
+- `tags` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)> (required)
 - `filter` [Filter](https://flutter.viam.dev/viam_protos.app.data/Filter-class.html)? (required)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)>
 
 **Example:**
 
@@ -1615,7 +1613,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const data = await dataClient.tagsByFilter({
-  componentName: "camera-1",
+  componentName: 'camera-1',
 } as Filter);
 ```
 
@@ -1630,7 +1628,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)>\>
 
 **Example:**
 
@@ -1726,12 +1724,12 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const bboxId = await dataClient.addBoundingBoxToImageById(
-  "ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh",
-  "label1",
+  'ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh',
+  'label1',
   0.3,
   0.3,
   0.6,
-  0.6,
+  0.6
 );
 ```
 
@@ -1751,7 +1749,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)>
 
 **Example:**
 
@@ -1828,8 +1826,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 await dataClient.removeBoundingBoxFromImageById(
-  "ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh",
-  "5Z9ryhkW7ULaXROjJO6ghPYulNllnH20QImda1iZFroZpQbjahK6igQ1WbYigXED",
+  'ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh',
+  '5Z9ryhkW7ULaXROjJO6ghPYulNllnH20QImda1iZFroZpQbjahK6igQ1WbYigXED'
 );
 ```
 
@@ -1845,7 +1843,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -1923,7 +1921,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const data = await dataClient.boundingBoxLabelsByFilter({
-  componentName: "camera-1",
+  componentName: 'camera-1',
 } as Filter);
 ```
 
@@ -1938,7 +1936,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)>\>
 
 **Example:**
 
@@ -1978,7 +1976,7 @@ Get a connection to access a MongoDB Atlas Data federation instance.
 
 **Parameters:**
 
-- `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization you’d like to connect to. To find your organization ID, visit the organization settings page on Viam.
+- `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization you’d like to connect to. To find your organization ID, visit the organization settings page.
 
 **Returns:**
 
@@ -2007,7 +2005,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const hostname = await dataClient.getDatabaseConnection(
-  "123abc45-1234-5678-90ab-cdef12345678",
+  '123abc45-1234-5678-90ab-cdef12345678'
 );
 ```
 
@@ -2022,7 +2020,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[DatabaseConnection](https://flutter.viam.dev/viam_sdk/DatabaseConnection.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[DatabaseConnection](https://flutter.viam.dev/viam_sdk/DatabaseConnection.html)>
 
 **Example:**
 
@@ -2062,7 +2060,7 @@ It can also be used to reset the password of the existing database user.
 
 **Parameters:**
 
-- `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization you’d like to configure a database user for. To find your organization ID, visit the organization settings page on Viam.
+- `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization you’d like to configure a database user for. To find your organization ID, visit the organization settings page.
 - `password` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The password of the user.
 
 **Returns:**
@@ -2096,8 +2094,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 await dataClient.configureDatabaseUser(
-  "123abc45-1234-5678-90ab-cdef12345678",
-  "Password01!",
+  '123abc45-1234-5678-90ab-cdef12345678',
+  'Password01!'
 );
 ```
 
@@ -2113,7 +2111,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -2152,7 +2150,7 @@ This BinaryData will be tagged with the VIAM_DATASET\_{id} label.
 **Parameters:**
 
 - `binary_ids` ([List[viam.proto.app.data.BinaryID] | List[str]](https://python.viam.dev/autoapi/viam/proto/app/data/index.html#viam.proto.app.data.BinaryID)) (required): Unique identifiers for binary data to add to the dataset. To retrieve these IDs, navigate to the DATA page, click on an image, and copy its Binary Data ID from the details tab.
-- `dataset_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the dataset to be added to. To retrieve the dataset ID: Navigate to the DATASETS tab of the DATA page. Click on the dataset. Click the … menu. Select Copy dataset ID.
+- `dataset_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the dataset to be added to.  To retrieve the dataset ID:  Navigate to the DATASETS tab of the DATA page. Click on the dataset. Click the … menu. Select Copy dataset ID.
 
 **Returns:**
 
@@ -2197,9 +2195,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 ```ts {class="line-numbers linkable-line-numbers"}
 await dataClient.addBinaryDataToDatasetByIds(
   [
-    "ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh",
+    'ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh',
   ],
-  "12ab3de4f56a7bcd89ef0ab1",
+  '12ab3de4f56a7bcd89ef0ab1'
 );
 ```
 
@@ -2210,12 +2208,12 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `binaryDataIds` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\> (required)
+- `binaryDataIds` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)> (required)
 - `datasetId` [String](https://api.flutter.dev/flutter/dart-core/String-class.html) (required)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -2263,7 +2261,7 @@ This BinaryData will lose the VIAM_DATASET\_{id} tag.
 **Parameters:**
 
 - `binary_ids` ([List[viam.proto.app.data.BinaryID] | List[str]](https://python.viam.dev/autoapi/viam/proto/app/data/index.html#viam.proto.app.data.BinaryID)) (required): Unique identifiers for the binary data to remove from the dataset. To retrieve these IDs, navigate to the DATA page, click on an image and copy its Binary Data ID from the details tab. DEPRECATED: BinaryID is deprecated and will be removed in a future release. Instead, pass binary data IDs as a list of strings.
-- `dataset_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the dataset to be removed from. To retrieve the dataset ID: Navigate to the DATASETS tab of the DATA page. Click on the dataset. Click the … menu. Select Copy dataset ID.
+- `dataset_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the dataset to be removed from. To retrieve the dataset ID:  Navigate to the DATASETS tab of the DATA page. Click on the dataset. Click the … menu. Select Copy dataset ID.
 
 **Returns:**
 
@@ -2308,9 +2306,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 ```ts {class="line-numbers linkable-line-numbers"}
 await dataClient.removeBinaryDataFromDatasetByIds(
   [
-    "ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh",
+    'ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh',
   ],
-  "12ab3de4f56a7bcd89ef0ab1",
+  '12ab3de4f56a7bcd89ef0ab1'
 );
 ```
 
@@ -2321,12 +2319,12 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `binaryDataIds` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\> (required)
+- `binaryDataIds` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)> (required)
 - `datasetId` [String](https://api.flutter.dev/flutter/dart-core/String-class.html) (required)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -2359,6 +2357,276 @@ _viam = await Viam.withApiKey(
 ```
 
 For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/DataClient/removeBinaryDataFromDatasetByIds.html).
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### GetDataPipeline
+
+Get the configuration of a data pipeline.
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the data pipeline to get.
+
+**Returns:**
+
+- ([DataPipeline](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.DataPipeline)): The data pipeline with the given ID.
+
+**Example:**
+
+```python {class="line-numbers linkable-line-numbers"}
+data_pipeline = await data_client.get_data_pipeline(id="<YOUR-DATA-PIPELINE-ID>")
+```
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.get_data_pipeline).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `pipelineId` (string) (required): The ID of the data pipeline.
+
+**Returns:**
+
+- (Promise<null | DataPipeline>): The data pipeline configuration or null if it does not exist.
+
+**Example:**
+
+```ts {class="line-numbers linkable-line-numbers"}
+const pipeline = await dataClient.getPipeline(
+  '123abc45-1234-5678-90ab-cdef12345678'
+);
+```
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#getdatapipeline).
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### ListDataPipelines
+
+Get the configuration for multiple data pipelines.
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization that owns the pipelines. You can obtain your organization ID from the organization settings page.
+
+**Returns:**
+
+- ([List[DataPipeline]](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.DataPipeline)): A list of all of the data pipelines for the given organization.
+
+**Example:**
+
+```python {class="line-numbers linkable-line-numbers"}
+data_pipelines = await data_client.list_data_pipelines(organization_id="<YOUR-ORGANIZATION-ID>")
+```
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.list_data_pipelines).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization.
+
+**Returns:**
+
+- (Promise<DataPipeline[]>): The list of data pipelines.
+
+**Example:**
+
+```ts {class="line-numbers linkable-line-numbers"}
+const pipelines = await dataClient.listDataPipelines(
+  '123abc45-1234-5678-90ab-cdef12345678'
+);
+```
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#listdatapipelines).
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### CreateDataPipeline
+
+Create a data pipeline.
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization that will own the pipeline. You can obtain your organization ID from the organization settings page.
+- `name` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The name of the pipeline.
+- `mql_binary` (List[Dict[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]]) (required): The MQL pipeline to run, as a list of MongoDB aggregation pipeline stages.
+- `schedule` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): A cron expression representing the expected execution schedule in UTC (note this also defines the input time window; an hourly schedule would process 1 hour of data at a time).
+- `data_source_type` ([viam.proto.app.data.TabularDataSourceType.ValueType](https://python.viam.dev/autoapi/viam/gen/app/data/v1/data_pb2/index.html#viam.gen.app.data.v1.data_pb2.TabularDataSourceType)) (required): The type of data source to use for the pipeline. Defaults to TabularDataSourceType.TABULAR_DATA_SOURCE_TYPE_STANDARD.
+
+**Returns:**
+
+- ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)): The ID of the newly created pipeline.
+
+**Example:**
+
+```python {class="line-numbers linkable-line-numbers"}
+data_pipeline_id = await data_client.create_data_pipeline(
+    organization_id="<YOUR-ORGANIZATION-ID>",
+    name="<YOUR-PIPELINE-NAME>",
+    mql_binary=[<YOUR-MQL-PIPELINE-AGGREGATION>],
+    schedule="<YOUR-SCHEDULE>",
+    data_source_type=TabularDataSourceType.TABULAR_DATA_SOURCE_TYPE_STANDARD,
+)
+```
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.create_data_pipeline).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `organizationId` (string) (required): The ID of the organization.
+- `name` (string) (required): The name of the data pipeline.
+- `query` (Uint8Array) (required): The MQL query to run as a list of BSON documents.
+- `schedule` (string) (required): The schedule to run the query on (cron expression).
+- `dataSourceType` ([TabularDataSourceType](https://ts.viam.dev/enums/dataApi.TabularDataSourceType.html)) (optional): The type of data source to use for the data pipeline.
+
+**Returns:**
+
+- (Promise<string>): The ID of the created data pipeline.
+
+**Example:**
+
+```ts {class="line-numbers linkable-line-numbers"}
+// {@link JsonValue} is imported from @bufbuild/protobuf
+const mqlQuery: Record<string, JsonValue>[] = [
+  {
+    $match: {
+      component_name: 'sensor-1',
+    },
+  },
+  {
+    $limit: 5,
+  },
+];
+
+const pipelineId = await dataClient.createDataPipeline(
+  '123abc45-1234-5678-90ab-cdef12345678',
+  'my-pipeline',
+  mqlQuery,
+  '0 0 * * *'
+);
+```
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#createdatapipeline).
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### DeleteDataPipeline
+
+Delete a data pipeline.
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the data pipeline to delete.
+
+**Returns:**
+
+- None.
+
+**Example:**
+
+```python {class="line-numbers linkable-line-numbers"}
+await data_client.delete_data_pipeline(id="<YOUR-DATA-PIPELINE-ID>")
+```
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.delete_data_pipeline).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `pipelineId` (string) (required): The ID of the data pipeline.
+
+**Returns:**
+
+- (Promise<void>)
+
+**Example:**
+
+```ts {class="line-numbers linkable-line-numbers"}
+await dataClient.deleteDataPipeline(
+  '123abc45-1234-5678-90ab-cdef12345678'
+);
+```
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#deletedatapipeline).
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### ListDataPipelineRuns
+
+List the statuses of individual executions of a data pipeline.
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the pipeline to list runs for.
+- `page_size` ([int](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (required): The number of runs to return per page. Defaults to 10.
+
+**Returns:**
+
+- ([DataPipelineRunsPage](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.DataPipelineRunsPage)): A page of data pipeline runs with pagination support.
+
+**Example:**
+
+```python {class="line-numbers linkable-line-numbers"}
+data_pipeline_runs = await data_client.list_data_pipeline_runs(id="<YOUR-DATA-PIPELINE-ID>")
+while len(data_pipeline_runs.runs) > 0:
+    data_pipeline_runs = await data_pipeline_runs.next_page()
+```
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.list_data_pipeline_runs).
+
+{{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `pipelineId` (string) (required): The ID of the data pipeline.
+- `pageSize` (number) (optional): The number of runs to return per page.
+
+**Returns:**
+
+- (Promise<ListDataPipelineRunsPage>): A page of data pipeline runs.
+
+**Example:**
+
+```ts {class="line-numbers linkable-line-numbers"}
+const page = await dataClient.listDataPipelineRuns(
+  '123abc45-1234-5678-90ab-cdef12345678'
+);
+page.runs.forEach((run) => {
+  console.log(run);
+});
+page = await page.nextPage();
+page.runs.forEach((run) => {
+  console.log(run);
+});
+```
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#listdatapipelineruns).
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/static/include/app/apis/generated/data_sync.md
+++ b/static/include/app/apis/generated/data_sync.md
@@ -1,8 +1,7 @@
 ### BinaryDataCaptureUpload
 
-Upload binary data collected on your machine through a specific component and the relevant metadata to Viam.
-Uploaded binary data can be found under the **Images**, **Point clouds**, or **Files** subtab of the app's [**Data** tab](https://app.viam.com/data), depending on the type of data that you upload.
-
+Upload binary data collected on your machine through a specific component and the relevant metadata to [Viam](https://app.viam.com).
+Uploaded binary data can be found under the **Images**, **Point clouds**, or **Files** subtab of the [**Data** tab](https://app.viam.com/data), depending on the type of data that you upload.
 {{< tabs >}}
 {{% tab name="Python" %}}
 
@@ -63,9 +62,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
   binary to its corresponding mime type based on this extension. Files with
   a .jpeg, .jpg, or .png extension will be saved to the images tab.
 - `dataRequestTimes` (Date) (required): Tuple containing `Date` objects denoting the times
-  this data was requested\[0] by the robot and received\[1] from the
+  this data was requested[0] by the robot and received[1] from the
   appropriate sensor.
-- `tags` (string) (optional): The list of tags to allow for tag\-based filtering when
+- `tags` (string) (optional): The list of tags to allow for tag-based filtering when
   retrieving data.
 
 **Returns:**
@@ -77,12 +76,12 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 ```ts {class="line-numbers linkable-line-numbers"}
 const binaryDataId = await dataClient.binaryDataCaptureUpload(
   binaryData,
-  "123abc45-1234-5678-90ab-cdef12345678",
-  "rdk:component:camera",
-  "my-camera",
-  "ReadImage",
-  ".jpg",
-  [new Date("2025-03-19"), new Date("2025-03-19")],
+  '123abc45-1234-5678-90ab-cdef12345678',
+  'rdk:component:camera',
+  'my-camera',
+  'ReadImage',
+  '.jpg',
+  [new Date('2025-03-19'), new Date('2025-03-19')]
 );
 ```
 
@@ -93,19 +92,19 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `binaryData` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)\> (required)
+- `binaryData` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)> (required)
 - `partId` [String](https://api.flutter.dev/flutter/dart-core/String-class.html) (required)
 - `fileExtension` [String](https://api.flutter.dev/flutter/dart-core/String-class.html) (required)
 - `componentType` [String](https://api.flutter.dev/flutter/dart-core/String-class.html)? (optional)
 - `componentName` [String](https://api.flutter.dev/flutter/dart-core/String-class.html)? (optional)
 - `methodName` [String](https://api.flutter.dev/flutter/dart-core/String-class.html)? (optional)
-- `methodParameters` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), Any\>? (optional)
+- `methodParameters` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), Any>? (optional)
 - `dataRequestTimes` ([DateTime](https://api.flutter.dev/flutter/dart-core/DateTime-class.html), [DateTime](https://api.flutter.dev/flutter/dart-core/DateTime-class.html))? (optional)
-- `tags` [Iterable](https://api.flutter.dev/flutter/dart-core/Iterable-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\> (optional)
+- `tags` [Iterable](https://api.flutter.dev/flutter/dart-core/Iterable-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)> (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)>
 
 **Example:**
 
@@ -146,9 +145,8 @@ For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_s
 
 ### TabularDataCaptureUpload
 
-Upload tabular data collected on your machine through a specific {{< glossary_tooltip term_id="component" text="component" >}} to Viam.
-Uploaded tabular data can be found under the **Sensors** subtab of the app's [**Data** tab](https://app.viam.com/data).
-
+Upload tabular data collected on your machine through a specific {{< glossary_tooltip term_id="component" text="component" >}} to [Viam](https://app.viam.com).
+Uploaded tabular data can be found under the **Sensors** subtab of the [**Data** tab](https://app.viam.com/data).
 {{< tabs >}}
 {{% tab name="Python" %}}
 
@@ -210,11 +208,11 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - `componentName` (string) (required): The name of the component used to capture the data.
 - `methodName` (string) (required): The name of the method used to capture the data.
 - `dataRequestTimes` (Date) (required): Array of Date tuples, each containing two `Date`
-  objects denoting the times this data was requested\[0] by the robot and
-  received\[1] from the appropriate sensor. Passing a list of tabular data
-  and Timestamps with length n \> 1 will result in n datapoints being
+  objects denoting the times this data was requested[0] by the robot and
+  received[1] from the appropriate sensor. Passing a list of tabular data
+  and Timestamps with length n > 1 will result in n datapoints being
   uploaded, all tied to the same metadata.
-- `tags` (string) (optional): The list of tags to allow for tag\-based filtering when
+- `tags` (string) (optional): The list of tags to allow for tag-based filtering when
   retrieving data.
 
 **Returns:**
@@ -227,15 +225,20 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 const fileId = await dataClient.tabularDataCaptureUpload(
   [
     {
-      timestamp: "2025-03-26T10:00:00Z",
+      timestamp: '2025-03-26T10:00:00Z',
       value: 10,
     },
   ],
-  "123abc45-1234-5678-90ab-cdef12345678",
-  "rdk:component:sensor",
-  "my-sensor",
-  "Readings",
-  [[new Date("2025-03-26T10:00:00Z"), new Date("2025-03-26T10:00:00Z")]],
+  '123abc45-1234-5678-90ab-cdef12345678',
+  'rdk:component:sensor',
+  'my-sensor',
+  'Readings',
+  [
+    [
+      new Date('2025-03-26T10:00:00Z'),
+      new Date('2025-03-26T10:00:00Z'),
+    ],
+  ]
 );
 ```
 
@@ -246,18 +249,18 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `tabularData` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>\> (required)
+- `tabularData` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>> (required)
 - `partId` [String](https://api.flutter.dev/flutter/dart-core/String-class.html) (required)
 - `componentType` [String](https://api.flutter.dev/flutter/dart-core/String-class.html)? (optional)
 - `componentName` [String](https://api.flutter.dev/flutter/dart-core/String-class.html)? (optional)
 - `methodName` [String](https://api.flutter.dev/flutter/dart-core/String-class.html)? (optional)
-- `methodParameters` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), Any\>? (optional)
-- `dataRequestTimes` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<([DateTime](https://api.flutter.dev/flutter/dart-core/DateTime-class.html), [DateTime](https://api.flutter.dev/flutter/dart-core/DateTime-class.html))\>? (optional)
-- `tags` [Iterable](https://api.flutter.dev/flutter/dart-core/Iterable-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\> (optional)
+- `methodParameters` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), Any>? (optional)
+- `dataRequestTimes` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)<([DateTime](https://api.flutter.dev/flutter/dart-core/DateTime-class.html), [DateTime](https://api.flutter.dev/flutter/dart-core/DateTime-class.html))>? (optional)
+- `tags` [Iterable](https://api.flutter.dev/flutter/dart-core/Iterable-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)> (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)>
 
 **Example:**
 
@@ -359,12 +362,12 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - `componentType` [String](https://api.flutter.dev/flutter/dart-core/String-class.html)? (optional)
 - `componentName` [String](https://api.flutter.dev/flutter/dart-core/String-class.html)? (optional)
 - `methodName` [String](https://api.flutter.dev/flutter/dart-core/String-class.html)? (optional)
-- `methodParameters` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), Any\>? (optional)
-- `tags` [Iterable](https://api.flutter.dev/flutter/dart-core/Iterable-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\> (optional)
+- `methodParameters` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), Any>? (optional)
+- `tags` [Iterable](https://api.flutter.dev/flutter/dart-core/Iterable-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)> (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)>
 
 **Example:**
 
@@ -420,9 +423,8 @@ For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_s
 
 ### FileUploadFromPath
 
-Upload files stored on your machine to Viam by filepath.
-Uploaded files can be found under the **Files** subtab of the app's [**Data** tab](https://app.viam.com/data).
-
+Upload files stored on your machine to [Viam](https://app.viam.com) by filepath.
+Uploaded files can be found under the **Files** subtab of the [**Data** tab](https://app.viam.com/data).
 {{< tabs >}}
 {{% tab name="Python" %}}
 
@@ -462,7 +464,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ### StreamingDataCaptureUpload
 
-Upload the contents of streaming binary data and the relevant metadata to Viam.
+Upload the contents of streaming binary data and the relevant metadata to [Viam](https://app.viam.com).
 Uploaded streaming data can be found under the [**Data** tab](https://app.viam.com/data).
 
 {{< tabs >}}
@@ -513,19 +515,19 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Parameters:**
 
-- `bytes` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)\> (required)
+- `bytes` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)> (required)
 - `partId` [String](https://api.flutter.dev/flutter/dart-core/String-class.html) (required)
 - `fileExtension` [String](https://api.flutter.dev/flutter/dart-core/String-class.html) (required)
 - `componentType` [String](https://api.flutter.dev/flutter/dart-core/String-class.html)? (optional)
 - `componentName` [String](https://api.flutter.dev/flutter/dart-core/String-class.html)? (optional)
 - `methodName` [String](https://api.flutter.dev/flutter/dart-core/String-class.html)? (optional)
-- `methodParameters` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), Any\>? (optional)
+- `methodParameters` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), Any>? (optional)
 - `dataRequestTimes` ([DateTime](https://api.flutter.dev/flutter/dart-core/DateTime-class.html), [DateTime](https://api.flutter.dev/flutter/dart-core/DateTime-class.html))? (optional)
-- `tags` [Iterable](https://api.flutter.dev/flutter/dart-core/Iterable-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\> (optional)
+- `tags` [Iterable](https://api.flutter.dev/flutter/dart-core/Iterable-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)> (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)>
 
 **Example:**
 

--- a/static/include/app/apis/generated/dataset.md
+++ b/static/include/app/apis/generated/dataset.md
@@ -8,7 +8,7 @@ Create a new dataset.
 **Parameters:**
 
 - `name` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The name of the dataset being created.
-- `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization where the dataset is being created. To find your organization ID, visit the organization settings page on Viam.
+- `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization where the dataset is being created. To find your organization ID, visit the organization settings page.
 
 **Returns:**
 
@@ -43,8 +43,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const datasetId = await dataClient.createDataset(
-  "my-new-dataset",
-  "123abc45-1234-5678-90ab-cdef12345678",
+  'my-new-dataset',
+  '123abc45-1234-5678-90ab-cdef12345678'
 );
 ```
 
@@ -60,7 +60,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)>
 
 **Example:**
 
@@ -97,7 +97,7 @@ Delete a dataset.
 
 **Parameters:**
 
-- `id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the dataset. To retrieve the dataset ID: Navigate to the DATASETS tab of the DATA page. Click on the dataset. Click the … menu. Select Copy dataset ID.
+- `id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the dataset. To retrieve the dataset ID:  Navigate to the DATASETS tab of the DATA page. Click on the dataset. Click the … menu. Select Copy dataset ID.
 
 **Returns:**
 
@@ -127,7 +127,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await dataClient.deleteDataset("12ab3de4f56a7bcd89ef0ab1");
+await dataClient.deleteDataset('12ab3de4f56a7bcd89ef0ab1');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#deletedataset).
@@ -141,7 +141,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -178,7 +178,7 @@ Rename a dataset specified by the dataset ID.
 
 **Parameters:**
 
-- `id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the dataset. To retrieve the dataset ID: Navigate to the DATASETS tab of the DATA page. Click on the dataset. Click the … menu. Select Copy dataset ID.
+- `id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the dataset. To retrieve the dataset ID:  Navigate to the DATASETS tab of the DATA page. Click on the dataset. Click the … menu. Select Copy dataset ID.
 - `name` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The new name of the dataset.
 
 **Returns:**
@@ -211,7 +211,10 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await dataClient.renameDataset("12ab3de4f56a7bcd89ef0ab1", "my-new-dataset");
+await dataClient.renameDataset(
+  '12ab3de4f56a7bcd89ef0ab1',
+  'my-new-dataset'
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/DataClient.html#renamedataset).
@@ -226,7 +229,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -263,7 +266,7 @@ Get the datasets in an organization.
 
 **Parameters:**
 
-- `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization you’d like to retrieve datasets from. To find your organization ID, visit the organization settings page on Viam.
+- `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization you’d like to retrieve datasets from. To find your organization ID, visit the organization settings page.
 
 **Returns:**
 
@@ -295,7 +298,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const datasets = await dataClient.listDatasetsByOrganizationID(
-  "123abc45-1234-5678-90ab-cdef12345678",
+  '123abc45-1234-5678-90ab-cdef12345678'
 );
 ```
 
@@ -310,7 +313,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[Dataset](https://flutter.viam.dev/viam_protos.app.dataset/Dataset-class.html)\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[Dataset](https://flutter.viam.dev/viam_protos.app.dataset/Dataset-class.html)>\>
 
 **Example:**
 
@@ -347,7 +350,7 @@ Get a list of datasets using their IDs.
 
 **Parameters:**
 
-- `ids` (List[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]) (required): The IDs of the datasets that you would like to retrieve information about. To retrieve a dataset ID: Navigate to the DATASETS tab of the DATA page. Click on the dataset. Click the … menu. Select Copy dataset ID.
+- `ids` (List[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]) (required): The IDs of the datasets that you would like to retrieve information about. To retrieve a dataset ID:  Navigate to the DATASETS tab of the DATA page. Click on the dataset. Click the … menu. Select Copy dataset ID.
 
 **Returns:**
 
@@ -379,7 +382,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const datasets = await dataClient.listDatasetsByIds([
-  "12ab3de4f56a7bcd89ef0ab1",
+  '12ab3de4f56a7bcd89ef0ab1',
 ]);
 ```
 
@@ -390,11 +393,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `ids` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\> (required)
+- `ids` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)> (required)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[Dataset](https://flutter.viam.dev/viam_protos.app.dataset/Dataset-class.html)\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[Dataset](https://flutter.viam.dev/viam_protos.app.dataset/Dataset-class.html)>\>
 
 **Example:**
 

--- a/static/include/app/apis/generated/mltraining.md
+++ b/static/include/app/apis/generated/mltraining.md
@@ -7,7 +7,7 @@ Submit a training job.
 
 **Parameters:**
 
-- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to submit the training job to. To retrieve this, click on the organization in the top right corner, select **Settings**, and copy **Organization ID**.
+- `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to submit the training job to. To retrieve this, expand your organization's dropdown in the top right corner on [Viam](https://app.viam.com/), select **Settings**, and copy **Organization ID**.
 - `dataset_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the dataset to train the ML model on. To retrieve this, navigate to your [dataset's page](https://app.viam.com/data/datasets), click **...** in the left-hand menu, and click **Copy dataset ID**.
 - `model_name` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): the model name.
 - `model_version` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The version of the ML model you're training. This string must be unique from any previous versions you've set.
@@ -55,12 +55,12 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 await mlTrainingClient.submitTrainingJob(
-  "<organization-id>",
-  "<dataset-id>",
-  "<your-model-name>",
-  "1.0.0",
+  '<organization-id>',
+  '<dataset-id>',
+  '<your-model-name>',
+  '1.0.0',
   ModelType.SINGLE_LABEL_CLASSIFICATION,
-  ["tag1", "tag2"],
+  ['tag1', 'tag2']
 );
 ```
 
@@ -125,12 +125,12 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 await mlTrainingClient.submitCustomTrainingJob(
-  "<organization-id>",
-  "<dataset-id>",
-  "viam:classification-tflite",
-  "1.0.0",
-  "<your-model-name>",
-  "1.0.0",
+  '<organization-id>',
+  '<dataset-id>',
+  'viam:classification-tflite',
+  '1.0.0',
+  '<your-model-name>',
+  '1.0.0'
 );
 ```
 
@@ -177,7 +177,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const job = await mlTrainingClient.getTrainingJob("<training-job-id>");
+const job = await mlTrainingClient.getTrainingJob('<training-job-id>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MlTrainingClient.html#gettrainingjob).
@@ -228,8 +228,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const jobs = await mlTrainingClient.listTrainingJobs(
-  "<organization-id>",
-  TrainingStatus.RUNNING,
+  '<organization-id>',
+  TrainingStatus.RUNNING
 );
 ```
 
@@ -280,7 +280,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await mlTrainingClient.cancelTrainingJob("<training-job-id>");
+await mlTrainingClient.cancelTrainingJob('<training-job-id>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MlTrainingClient.html#canceltrainingjob).
@@ -326,7 +326,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await mlTrainingClient.deleteCompletedTrainingJob("<training-job-id>");
+await mlTrainingClient.deleteCompletedTrainingJob('<training-job-id>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MlTrainingClient.html#deletecompletedtrainingjob).

--- a/static/include/app/apis/overrides/protos/data.CreateDataPipeline.md
+++ b/static/include/app/apis/overrides/protos/data.CreateDataPipeline.md
@@ -1,0 +1,1 @@
+Create a data pipeline.

--- a/static/include/app/apis/overrides/protos/data.DeleteDataPipeline.md
+++ b/static/include/app/apis/overrides/protos/data.DeleteDataPipeline.md
@@ -1,0 +1,1 @@
+Delete a data pipeline.

--- a/static/include/app/apis/overrides/protos/data.GetDataPipeline.md
+++ b/static/include/app/apis/overrides/protos/data.GetDataPipeline.md
@@ -1,0 +1,1 @@
+Get the configuration of a data pipeline.

--- a/static/include/app/apis/overrides/protos/data.ListDataPipelineRuns.md
+++ b/static/include/app/apis/overrides/protos/data.ListDataPipelineRuns.md
@@ -1,0 +1,1 @@
+List the statuses of individual executions of a data pipeline.

--- a/static/include/app/apis/overrides/protos/data.ListDataPipelines.md
+++ b/static/include/app/apis/overrides/protos/data.ListDataPipelines.md
@@ -1,0 +1,1 @@
+Get the configuration for multiple data pipelines.

--- a/static/include/components/apis/generated/base.md
+++ b/static/include/components/apis/generated/base.md
@@ -74,7 +74,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const base = new VIAM.BaseClient(machine, "my_base");
+const base = new VIAM.BaseClient(machine, 'my_base');
 
 // Move forward 40mm at 90mm/s
 await base.moveStraight(40, 90);
@@ -92,11 +92,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 - `distance` [int](https://api.flutter.dev/flutter/dart-core/int-class.html) (required)
 - `velocity` [double](https://api.flutter.dev/flutter/dart-core/double-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -181,7 +181,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const base = new VIAM.BaseClient(machine, "my_base");
+const base = new VIAM.BaseClient(machine, 'my_base');
 
 // Spin 10 degrees clockwise at 15 degrees per second
 await base.spin(10, 15);
@@ -199,11 +199,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 - `angle` [double](https://api.flutter.dev/flutter/dart-core/double-class.html) (required)
 - `velocity` [double](https://api.flutter.dev/flutter/dart-core/double-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -311,8 +311,8 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Parameters:**
 
-- `linear` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required): Desired linear power percentage from \-1 to 1\.
-- `angular` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required): Desired angular power percentage from \-1 to 1\.
+- `linear` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required): Desired linear power percentage from -1 to 1.
+- `angular` ([PlainMessage](https://ts.viam.dev/types/PlainMessage.html)) (required): Desired angular power percentage from -1 to 1.
 - `extra` (None) (optional)
 - `callOptions` (CallOptions) (optional)
 
@@ -323,30 +323,30 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const base = new VIAM.BaseClient(machine, "my_base");
+const base = new VIAM.BaseClient(machine, 'my_base');
 
 // Move forward at 75% power
 await base.setPower(
   { x: 0, y: 0.75, z: 0 }, // linear power
-  { x: 0, y: 0, z: 0 }, // no rotation
+  { x: 0, y: 0, z: 0 } // no rotation
 );
 
 // Move straight back at 100% power
 await base.setPower(
   { x: 0, y: -1, z: 0 }, // linear power
-  { x: 0, y: 0, z: 0 }, // no rotation
+  { x: 0, y: 0, z: 0 } // no rotation
 );
 
 // Turn counter-clockwise at 50% power
 await base.setPower(
   { x: 0, y: 0, z: 0 }, // no linear movement
-  { x: 0, y: 0, z: 0.5 }, // rotate around z-axis
+  { x: 0, y: 0, z: 0.5 } // rotate around z-axis
 );
 
 // Turn clockwise at 60% power
 await base.setPower(
   { x: 0, y: 0, z: 0 }, // no linear movement
-  { x: 0, y: 0, z: -0.6 }, // rotate around z-axis
+  { x: 0, y: 0, z: -0.6 } // rotate around z-axis
 );
 ```
 
@@ -359,11 +359,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 - `linear` [Vector3](https://flutter.viam.dev/viam_sdk/Vector3-class.html) (required)
 - `angular` [Vector3](https://flutter.viam.dev/viam_sdk/Vector3-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -459,12 +459,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const base = new VIAM.BaseClient(machine, "my_base");
+const base = new VIAM.BaseClient(machine, 'my_base');
 
 // Move forward at 50mm/s while spinning 15 degrees per second to the left
 await base.setVelocity(
   { x: 0, y: 50, z: 0 }, // linear velocity in mm/s
-  { x: 0, y: 0, z: 15 }, // 15 degrees per second counter-clockwise
+  { x: 0, y: 0, z: 15 } // 15 degrees per second counter-clockwise
 );
 ```
 
@@ -477,11 +477,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 - `linear` [Vector3](https://flutter.viam.dev/viam_sdk/Vector3-class.html) (required)
 - `angular` [Vector3](https://flutter.viam.dev/viam_sdk/Vector3-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -581,7 +581,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const base = new VIAM.BaseClient(machine, "my_base");
+const base = new VIAM.BaseClient(machine, 'my_base');
 const properties = await base.getProperties();
 ```
 
@@ -592,11 +592,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[BaseProperties](https://flutter.viam.dev/viam_sdk/BaseProperties.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[BaseProperties](https://flutter.viam.dev/viam_sdk/BaseProperties.html)>
 
 **Example:**
 
@@ -678,7 +678,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const base = new VIAM.BaseClient(machine, "my_base");
+const base = new VIAM.BaseClient(machine, 'my_base');
 const moving = await base.isMoving();
 ```
 
@@ -693,7 +693,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[bool](https://api.flutter.dev/flutter/dart-core/bool-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[bool](https://api.flutter.dev/flutter/dart-core/bool-class.html)>
 
 **Example:**
 
@@ -776,7 +776,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const base = new VIAM.BaseClient(machine, "my_base");
+const base = new VIAM.BaseClient(machine, 'my_base');
 await base.stop();
 ```
 
@@ -787,11 +787,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -879,7 +879,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const base = new VIAM.BaseClient(machine, "my_base");
+const base = new VIAM.BaseClient(machine, 'my_base');
 const geometries = await base.getGeometries();
 ```
 
@@ -984,12 +984,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-import { Struct } from "@viamrobotics/sdk";
+import { Struct } from '@viamrobotics/sdk';
 
 const result = await resource.doCommand(
   Struct.fromJson({
-    myCommand: { key: "value" },
-  }),
+    myCommand: { key: 'value' },
+  })
 );
 ```
 
@@ -1000,11 +1000,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\> (required)
+- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic> (required)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>\>
 
 **Example:**
 

--- a/static/include/components/apis/generated/board.md
+++ b/static/include/components/apis/generated/board.md
@@ -75,10 +75,10 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const board = new VIAM.BoardClient(machine, "my_board");
+const board = new VIAM.BoardClient(machine, 'my_board');
 
 // Set the pin to high.
-await board.setGPIO("15", true);
+await board.setGPIO('15', true);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#setgpio).
@@ -90,11 +90,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 - `pin` [String](https://api.flutter.dev/flutter/dart-core/String-class.html) (required)
 - `high` [bool](https://api.flutter.dev/flutter/dart-core/bool-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -182,10 +182,10 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const board = new VIAM.BoardClient(machine, "my_board");
+const board = new VIAM.BoardClient(machine, 'my_board');
 
 // Get if it is true or false that the state of the pin is high.
-const high = await board.getGPIO("15");
+const high = await board.getGPIO('15');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#getgpio).
@@ -196,11 +196,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 **Parameters:**
 
 - `pin` [String](https://api.flutter.dev/flutter/dart-core/String-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[bool](https://api.flutter.dev/flutter/dart-core/bool-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[bool](https://api.flutter.dev/flutter/dart-core/bool-class.html)>
 
 **Example:**
 
@@ -291,15 +291,15 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Returns:**
 
-- (Promise<number>): The duty cycle, which is a value from 0 to 1\.
+- (Promise<number>): The duty cycle, which is a value from 0 to 1.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const board = new VIAM.BoardClient(machine, "my_board");
+const board = new VIAM.BoardClient(machine, 'my_board');
 
 // Get the duty cycle of this pin.
-const dutyCycle = await board.getPWM("15");
+const dutyCycle = await board.getPWM('15');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#getpwm).
@@ -310,11 +310,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 **Parameters:**
 
 - `pin` [String](https://api.flutter.dev/flutter/dart-core/String-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[double](https://api.flutter.dev/flutter/dart-core/double-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[double](https://api.flutter.dev/flutter/dart-core/double-class.html)>
 
 **Example:**
 
@@ -405,11 +405,11 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const board = new VIAM.BoardClient(machine, "my_board");
+const board = new VIAM.BoardClient(machine, 'my_board');
 
 // Set the duty cycle to 0.6, meaning that this pin will be in the high state for
 // 60% of the duration of the PWM interval period.
-await board.setPWM("15", 0.6);
+await board.setPWM('15', 0.6);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#setpwm).
@@ -421,11 +421,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 - `pin` [String](https://api.flutter.dev/flutter/dart-core/String-class.html) (required)
 - `dutyCyclePct` [double](https://api.flutter.dev/flutter/dart-core/double-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -513,10 +513,10 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const board = new VIAM.BoardClient(machine, "my_board");
+const board = new VIAM.BoardClient(machine, 'my_board');
 
 // Get the PWM frequency of this pin.
-const freq = await board.getPWMFrequency("15");
+const freq = await board.getPWMFrequency('15');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#getpwmfrequency).
@@ -527,11 +527,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 **Parameters:**
 
 - `pin` [String](https://api.flutter.dev/flutter/dart-core/String-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)>
 
 **Example:**
 
@@ -627,10 +627,10 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const board = new VIAM.BoardClient(machine, "my_board");
+const board = new VIAM.BoardClient(machine, 'my_board');
 
 // Set the PWM frequency of this pin to 1600 Hz.
-await board.setPWMFrequency("15", 1600);
+await board.setPWMFrequency('15', 1600);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#setpwmfrequency).
@@ -642,11 +642,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 - `pin` [String](https://api.flutter.dev/flutter/dart-core/String-class.html) (required)
 - `frequencyHz` [int](https://api.flutter.dev/flutter/dart-core/int-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -736,11 +736,11 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const board = new VIAM.BoardClient(machine, "my_board");
+const board = new VIAM.BoardClient(machine, 'my_board');
 
 // Get the number of times this DigitalInterrupt has been interrupted with a tick.
 const count = await board.getDigitalInterruptValue(
-  "my_example_digital_interrupt",
+  'my_example_digital_interrupt'
 );
 ```
 
@@ -752,11 +752,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 **Parameters:**
 
 - `digitalInterruptName` [String](https://api.flutter.dev/flutter/dart-core/String-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)>
 
 **Example:**
 
@@ -848,11 +848,13 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const board = new VIAM.BoardClient(machine, "my_board");
+const board = new VIAM.BoardClient(machine, 'my_board');
 
 // Get the value of the analog signal "my_example_analog_reader" has most
 // recently measured.
-const reading = await board.readAnalogReader("my_example_analog_reader");
+const reading = await board.readAnalogReader(
+  'my_example_analog_reader'
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#readanalogreader).
@@ -863,11 +865,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 **Parameters:**
 
 - `analogReaderName` [String](https://api.flutter.dev/flutter/dart-core/String-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[AnalogValue](https://flutter.viam.dev/viam_sdk/AnalogValue.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[AnalogValue](https://flutter.viam.dev/viam_sdk/AnalogValue.html)>
 
 **Example:**
 
@@ -957,10 +959,10 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const board = new VIAM.BoardClient(machine, "my_board");
+const board = new VIAM.BoardClient(machine, 'my_board');
 
 // Write the value 42 to "my_example_analog_writer".
-await board.writeAnalog("my_example_analog_writer", 42);
+await board.writeAnalog('my_example_analog_writer', 42);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/BoardClient.html#writeanalog).
@@ -972,11 +974,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 - `pin` [String](https://api.flutter.dev/flutter/dart-core/String-class.html) (required)
 - `value` [int](https://api.flutter.dev/flutter/dart-core/int-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -1074,14 +1076,14 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const board = new VIAM.BoardClient(machine, "my_board");
+const board = new VIAM.BoardClient(machine, 'my_board');
 
 // Stream ticks from pins 8 and 11.
-const ticks = await board.streamTicks(["8", "11"]);
+const ticks = await board.streamTicks(['8', '11']);
 
 for await (const tick of ticks) {
   console.log(
-    `Pin ${tick.pinName} changed to ${tick.high ? "high" : "low"} at ${tick.time}`,
+    `Pin ${tick.pinName} changed to ${tick.high ? 'high' : 'low'} at ${tick.time}`
   );
 }
 ```
@@ -1093,12 +1095,12 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `interrupts` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)\> (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `interrupts` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html)> (required)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Stream](https://api.flutter.dev/flutter/dart-async/Stream-class.html)\<[Tick](https://flutter.viam.dev/viam_sdk/Tick.html)\>
+- [Stream](https://api.flutter.dev/flutter/dart-async/Stream-class.html)<[Tick](https://flutter.viam.dev/viam_sdk/Tick.html)>
 
 **Example:**
 
@@ -1157,7 +1159,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 - `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
 - `mode` [(pb.PowerMode)](https://pkg.go.dev/go.viam.com/api/component/board/v1#PowerMode): Options to specify power usage of the board: `boardpb.PowerMode_POWER_MODE_UNSPECIFIED`, `boardpb.PowerMode_POWER_MODE_NORMAL`, and `boardpb.PowerMode_POWER_MODE_OFFLINE_DEEP`.
-- `duration` [(\*time.Duration)](https://pkg.go.dev/time#Duration): If provided, the board will exit the given power mode after the specified duration.
+- `duration` [(*time.Duration)](https://pkg.go.dev/time#Duration): If provided, the board will exit the given power mode after the specified duration.
 
 **Returns:**
 
@@ -1191,7 +1193,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const board = new VIAM.BoardClient(machine, "my_board");
+const board = new VIAM.BoardClient(machine, 'my_board');
 
 // Set the power mode of the board to OFFLINE_DEEP.
 const duration = new VIAM.Duration({ seconds: 10n });
@@ -1208,11 +1210,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 - `powerMode` [PowerMode](https://flutter.viam.dev/viam_protos.component.board/PowerMode-class.html) (required)
 - `seconds` [int](https://api.flutter.dev/flutter/dart-core/int-class.html) (required)
 - `nanos` [int](https://api.flutter.dev/flutter/dart-core/int-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -1513,12 +1515,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-import { Struct } from "@viamrobotics/sdk";
+import { Struct } from '@viamrobotics/sdk';
 
 const result = await resource.doCommand(
   Struct.fromJson({
-    myCommand: { key: "value" },
-  }),
+    myCommand: { key: 'value' },
+  })
 );
 ```
 
@@ -1529,11 +1531,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\> (required)
+- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic> (required)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>\>
 
 **Example:**
 

--- a/static/include/components/apis/generated/camera.md
+++ b/static/include/components/apis/generated/camera.md
@@ -125,22 +125,22 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const camera = new VIAM.CameraClient(machine, "my_camera");
+const camera = new VIAM.CameraClient(machine, 'my_camera');
 const image = await camera.getImage();
 
 // Convert Uint8Array to base64
 const base64Image = btoa(
   Array.from(image)
     .map((byte) => String.fromCharCode(byte))
-    .join(""),
+    .join('')
 );
 
 // Convert image to base64 and display it
-const imageElement = document.createElement("img");
+const imageElement = document.createElement('img');
 imageElement.src = `data:image/jpeg;base64,${base64Image}`;
-const imageContainer = document.getElementById("#imageContainer");
+const imageContainer = document.getElementById('#imageContainer');
 if (imageContainer) {
-  imageContainer.innerHTML = "";
+  imageContainer.innerHTML = '';
   imageContainer.appendChild(imageElement);
 }
 ```
@@ -153,11 +153,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 **Parameters:**
 
 - `mimeType` [MimeType](https://flutter.viam.dev/viam_sdk/MimeType-class.html)? (optional)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[ViamImage](https://flutter.viam.dev/viam_sdk/ViamImage-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[ViamImage](https://flutter.viam.dev/viam_sdk/ViamImage-class.html)>
 
 **Example:**
 
@@ -254,8 +254,8 @@ A specific MIME type can be requested but may not necessarily be the same one re
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const camera = new VIAM.CameraClient(machine, "my_camera");
-const mimeType = "image/jpeg";
+const camera = new VIAM.CameraClient(machine, 'my_camera');
+const mimeType = 'image/jpeg';
 const image = await camera.renderFrame(mimeType);
 ```
 
@@ -338,7 +338,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const camera = new VIAM.CameraClient(machine, "my_camera");
+const camera = new VIAM.CameraClient(machine, 'my_camera');
 const pointCloud = await camera.getPointCloud();
 ```
 
@@ -349,11 +349,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[ViamImage](https://flutter.viam.dev/viam_sdk/ViamImage-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[ViamImage](https://flutter.viam.dev/viam_sdk/ViamImage-class.html)>
 
 **Example:**
 
@@ -419,7 +419,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const camera = new VIAM.CameraClient(machine, "my_camera");
+const camera = new VIAM.CameraClient(machine, 'my_camera');
 const properties = await camera.getProperties();
 ```
 
@@ -434,7 +434,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[CameraProperties](https://flutter.viam.dev/viam_sdk/CameraProperties.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[CameraProperties](https://flutter.viam.dev/viam_sdk/CameraProperties.html)>
 
 **Example:**
 
@@ -519,12 +519,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-import { Struct } from "@viamrobotics/sdk";
+import { Struct } from '@viamrobotics/sdk';
 
 const result = await resource.doCommand(
   Struct.fromJson({
-    myCommand: { key: "value" },
-  }),
+    myCommand: { key: 'value' },
+  })
 );
 ```
 
@@ -535,11 +535,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\> (required)
+- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic> (required)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>\>
 
 **Example:**
 

--- a/static/include/components/apis/generated/encoder.md
+++ b/static/include/components/apis/generated/encoder.md
@@ -76,13 +76,13 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const encoder = new VIAM.EncoderClient(machine, "my_encoder");
+const encoder = new VIAM.EncoderClient(machine, 'my_encoder');
 
 // Get the position of the encoder in ticks
 const [position, posType] = await encoder.getPosition(
-  EncoderPositionType.POSITION_TYPE_TICKS_COUNT,
+  EncoderPositionType.POSITION_TYPE_TICKS_COUNT
 );
-console.log("The encoder position is currently", position, posType);
+console.log('The encoder position is currently', position, posType);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/EncoderClient.html#getposition).
@@ -158,7 +158,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const encoder = new VIAM.EncoderClient(machine, "my_encoder");
+const encoder = new VIAM.EncoderClient(machine, 'my_encoder');
 
 // Reset the zero position of the encoder
 await encoder.resetPosition();
@@ -236,7 +236,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const encoder = new VIAM.EncoderClient(machine, "my_encoder");
+const encoder = new VIAM.EncoderClient(machine, 'my_encoder');
 
 // Get whether the encoder returns position in ticks or degrees
 const properties = await encoder.getProperties();
@@ -376,12 +376,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-import { Struct } from "@viamrobotics/sdk";
+import { Struct } from '@viamrobotics/sdk';
 
 const result = await resource.doCommand(
   Struct.fromJson({
-    myCommand: { key: "value" },
-  }),
+    myCommand: { key: 'value' },
+  })
 );
 ```
 

--- a/static/include/components/apis/generated/gantry.md
+++ b/static/include/components/apis/generated/gantry.md
@@ -64,7 +64,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const gantry = new VIAM.GantryClient(machine, "my_gantry");
+const gantry = new VIAM.GantryClient(machine, 'my_gantry');
 
 // Get the current positions of the axes in millimeters
 const positions = await gantry.getPosition();
@@ -77,11 +77,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[double](https://api.flutter.dev/flutter/dart-core/double-class.html)\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[double](https://api.flutter.dev/flutter/dart-core/double-class.html)>\>
 
 **Example:**
 
@@ -179,7 +179,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const gantry = new VIAM.GantryClient(machine, "my_gantry");
+const gantry = new VIAM.GantryClient(machine, 'my_gantry');
 
 // Create positions for a 3-axis gantry
 const positions = [1, 2, 3];
@@ -196,13 +196,13 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `positions` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[double](https://api.flutter.dev/flutter/dart-core/double-class.html)\> (required)
-- `speeds` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[double](https://api.flutter.dev/flutter/dart-core/double-class.html)\> (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `positions` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[double](https://api.flutter.dev/flutter/dart-core/double-class.html)> (required)
+- `speeds` [List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[double](https://api.flutter.dev/flutter/dart-core/double-class.html)> (required)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -281,7 +281,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const gantry = new VIAM.GantryClient(machine, "my_gantry");
+const gantry = new VIAM.GantryClient(machine, 'my_gantry');
 
 // Get the lengths of the axes in millimeters
 const lengths = await gantry.getLengths();
@@ -294,11 +294,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[double](https://api.flutter.dev/flutter/dart-core/double-class.html)\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[double](https://api.flutter.dev/flutter/dart-core/double-class.html)>\>
 
 **Example:**
 
@@ -371,12 +371,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Returns:**
 
 - (Promise<boolean>): A bool representing whether the gantry has run the homing sequence
-  successfully.
+successfully.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const gantry = new VIAM.GantryClient(machine, "my_gantry");
+const gantry = new VIAM.GantryClient(machine, 'my_gantry');
 
 // Run the homing sequence
 const success = await gantry.home();
@@ -389,11 +389,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[bool](https://api.flutter.dev/flutter/dart-core/bool-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[bool](https://api.flutter.dev/flutter/dart-core/bool-class.html)>
 
 **Example:**
 
@@ -451,7 +451,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const gantry = new VIAM.GantryClient(machine, "my_gantry");
+const gantry = new VIAM.GantryClient(machine, 'my_gantry');
 
 // Get the geometries of this component
 const geometries = await gantry.getGeometries();
@@ -534,11 +534,11 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const gantry = new VIAM.GantryClient(machine, "my_gantry");
+const gantry = new VIAM.GantryClient(machine, 'my_gantry');
 
 // Check if the gantry is moving
 const moving = await gantry.isMoving();
-console.log("Moving:", moving);
+console.log('Moving:', moving);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GantryClient.html#ismoving).
@@ -552,7 +552,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[bool](https://api.flutter.dev/flutter/dart-core/bool-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[bool](https://api.flutter.dev/flutter/dart-core/bool-class.html)>
 
 **Example:**
 
@@ -632,7 +632,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const gantry = new VIAM.GantryClient(machine, "my_gantry");
+const gantry = new VIAM.GantryClient(machine, 'my_gantry');
 
 // Stop all motion of the gantry
 await gantry.stop();
@@ -645,11 +645,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -757,12 +757,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-import { Struct } from "@viamrobotics/sdk";
+import { Struct } from '@viamrobotics/sdk';
 
 const result = await resource.doCommand(
   Struct.fromJson({
-    myCommand: { key: "value" },
-  }),
+    myCommand: { key: 'value' },
+  })
 );
 ```
 
@@ -773,11 +773,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\> (required)
+- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic> (required)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>\>
 
 **Example:**
 

--- a/static/include/components/apis/generated/generic_component.md
+++ b/static/include/components/apis/generated/generic_component.md
@@ -69,12 +69,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-import { Struct } from "@viamrobotics/sdk";
+import { Struct } from '@viamrobotics/sdk';
 
 const result = await resource.doCommand(
   Struct.fromJson({
-    myCommand: { key: "value" },
-  }),
+    myCommand: { key: 'value' },
+  })
 );
 ```
 
@@ -85,11 +85,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\> (required)
+- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic> (required)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>\>
 
 **Example:**
 
@@ -151,12 +151,12 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 ```ts {class="line-numbers linkable-line-numbers"}
 const generic = new VIAM.GenericComponentClient(
   machine,
-  "my_generic_component",
+  'my_generic_component'
 );
 
 // Get the geometries of this component
 const geometries = await generic.getGeometries();
-console.log("Geometries:", geometries);
+console.log('Geometries:', geometries);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/GenericComponentClient.html#getgeometries).

--- a/static/include/components/apis/generated/input_controller.md
+++ b/static/include/components/apis/generated/input_controller.md
@@ -128,11 +128,14 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const controller = new VIAM.InputControllerClient(machine, "my_controller");
+const controller = new VIAM.InputControllerClient(
+  machine,
+  'my_controller'
+);
 
 // Get the most recent Event for each Control
 const recentEvents = await controller.getEvents();
-console.log("Recent events:", recentEvents);
+console.log('Recent events:', recentEvents);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/InputControllerClient.html#getevents).
@@ -210,13 +213,16 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const controller = new VIAM.InputControllerClient(machine, "my_controller");
+const controller = new VIAM.InputControllerClient(
+  machine,
+  'my_controller'
+);
 
 // Create a "Button is Pressed" event for the control BUTTON_START
 const buttonPressEvent = new VIAM.InputControllerEvent({
   time: { seconds: BigInt(Math.floor(Date.now() / 1000)) },
-  event: "ButtonPress",
-  control: "ButtonStart",
+  event: 'ButtonPress',
+  control: 'ButtonStart',
   value: 1.0,
 });
 // Trigger the event

--- a/static/include/components/apis/generated/motor.md
+++ b/static/include/components/apis/generated/motor.md
@@ -58,7 +58,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Parameters:**
 
-- `power` (number) (required): A value between \-1 and 1 where negative values indicate a
+- `power` (number) (required): A value between -1 and 1 where negative values indicate a
   backwards direction and positive values a forward direction.
 - `extra` (None) (optional)
 - `callOptions` (CallOptions) (optional)
@@ -84,11 +84,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 **Parameters:**
 
 - `powerPct` [double](https://api.flutter.dev/flutter/dart-core/double-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -182,11 +182,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 **Parameters:**
 
 - `rpm` [double](https://api.flutter.dev/flutter/dart-core/double-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -290,11 +290,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 - `rpm` [double](https://api.flutter.dev/flutter/dart-core/double-class.html) (required)
 - `revolutions` [double](https://api.flutter.dev/flutter/dart-core/double-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -395,11 +395,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 - `rpm` [double](https://api.flutter.dev/flutter/dart-core/double-class.html) (required)
 - `positionRevolutions` [double](https://api.flutter.dev/flutter/dart-core/double-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -493,11 +493,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 **Parameters:**
 
 - `offset` [double](https://api.flutter.dev/flutter/dart-core/double-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -596,11 +596,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[double](https://api.flutter.dev/flutter/dart-core/double-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[double](https://api.flutter.dev/flutter/dart-core/double-class.html)>
 
 **Example:**
 
@@ -702,11 +702,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[MotorProperties](https://flutter.viam.dev/viam_sdk/MotorProperties.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[MotorProperties](https://flutter.viam.dev/viam_sdk/MotorProperties.html)>
 
 **Example:**
 
@@ -808,11 +808,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[PowerState](https://flutter.viam.dev/viam_sdk/PowerState-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[PowerState](https://flutter.viam.dev/viam_sdk/PowerState-class.html)>
 
 **Example:**
 
@@ -913,11 +913,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[bool](https://api.flutter.dev/flutter/dart-core/bool-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[bool](https://api.flutter.dev/flutter/dart-core/bool-class.html)>
 
 **Example:**
 
@@ -1011,11 +1011,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -1140,11 +1140,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\> (required)
+- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic> (required)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>\>
 
 **Example:**
 

--- a/static/include/components/apis/generated/movement_sensor.md
+++ b/static/include/components/apis/generated/movement_sensor.md
@@ -68,7 +68,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 ```ts {class="line-numbers linkable-line-numbers"}
 const movementSensor = new VIAM.MovementSensorClient(
   machine,
-  "my_movement_sensor",
+  'my_movement_sensor'
 );
 const linearVelocity = await movementSensor.getLinearVelocity();
 ```
@@ -80,11 +80,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Vector3](https://flutter.viam.dev/viam_sdk/Vector3-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Vector3](https://flutter.viam.dev/viam_sdk/Vector3-class.html)>
 
 **Example:**
 
@@ -173,7 +173,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 ```ts {class="line-numbers linkable-line-numbers"}
 const movementSensor = new VIAM.MovementSensorClient(
   machine,
-  "my_movement_sensor",
+  'my_movement_sensor'
 );
 const angularVelocity = await movementSensor.getAngularVelocity();
 ```
@@ -185,11 +185,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Vector3](https://flutter.viam.dev/viam_sdk/Vector3-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Vector3](https://flutter.viam.dev/viam_sdk/Vector3-class.html)>
 
 **Example:**
 
@@ -204,7 +204,7 @@ For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_s
 
 ### GetCompassHeading
 
-Report the current [compass heading](<https://en.wikipedia.org/wiki/Heading_(navigation)>) in degrees.
+Report the current [compass heading](https://en.wikipedia.org/wiki/Heading_(navigation)) in degrees.
 
 Supported by GPS models.
 Supported by `viam-micro-server`.
@@ -272,7 +272,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 ```ts {class="line-numbers linkable-line-numbers"}
 const movementSensor = new VIAM.MovementSensorClient(
   machine,
-  "my_movement_sensor",
+  'my_movement_sensor'
 );
 const compassHeading = await movementSensor.getCompassHeading();
 ```
@@ -284,11 +284,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[double](https://api.flutter.dev/flutter/dart-core/double-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[double](https://api.flutter.dev/flutter/dart-core/double-class.html)>
 
 **Example:**
 
@@ -379,7 +379,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 ```ts {class="line-numbers linkable-line-numbers"}
 const movementSensor = new VIAM.MovementSensorClient(
   machine,
-  "my_movement_sensor",
+  'my_movement_sensor'
 );
 const orientation = await movementSensor.getOrientation();
 ```
@@ -391,11 +391,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Orientation](https://flutter.viam.dev/viam_sdk/Orientation-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Orientation](https://flutter.viam.dev/viam_sdk/Orientation-class.html)>
 
 **Example:**
 
@@ -450,7 +450,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(\*geo.Point)](https://pkg.go.dev/github.com/kellydunn/golang-geo#Point): Contains the current latitude and longitude as floats.
+- [(*geo.Point)](https://pkg.go.dev/github.com/kellydunn/golang-geo#Point): Contains the current latitude and longitude as floats.
 - [(float64)](https://pkg.go.dev/builtin#float64): The altitude in meters.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
@@ -480,7 +480,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 ```ts {class="line-numbers linkable-line-numbers"}
 const movementSensor = new VIAM.MovementSensorClient(
   machine,
-  "my_movement_sensor",
+  'my_movement_sensor'
 );
 const position = await movementSensor.getPosition();
 ```
@@ -492,11 +492,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Position](https://flutter.viam.dev/viam_sdk/Position-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Position](https://flutter.viam.dev/viam_sdk/Position-class.html)>
 
 **Example:**
 
@@ -550,7 +550,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(\*Properties)](https://pkg.go.dev/go.viam.com/rdk/components/movementsensor#Properties): The supported properties of the movement sensor.
+- [(*Properties)](https://pkg.go.dev/go.viam.com/rdk/components/movementsensor#Properties): The supported properties of the movement sensor.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**
@@ -579,7 +579,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 ```ts {class="line-numbers linkable-line-numbers"}
 const movementSensor = new VIAM.MovementSensorClient(
   machine,
-  "my_movement_sensor",
+  'my_movement_sensor'
 );
 const properties = await movementSensor.getProperties();
 ```
@@ -591,11 +591,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Properties](https://flutter.viam.dev/viam_sdk/Properties.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Properties](https://flutter.viam.dev/viam_sdk/Properties.html)>
 
 **Example:**
 
@@ -648,7 +648,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(\*Accuracy)](https://pkg.go.dev/go.viam.com/rdk/components/movementsensor#Accuracy): The precision and reliability metrics of the movement sensor, which vary depending on model.
+- [(*Accuracy)](https://pkg.go.dev/go.viam.com/rdk/components/movementsensor#Accuracy): The precision and reliability metrics of the movement sensor, which vary depending on model.
   This type contains the following fields:
 
   - `AccuracyMap` [(map[string]float32)](https://pkg.go.dev/builtin#string): A mapping of specific measurement parameters to their accuracy values.
@@ -664,7 +664,6 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
   - `CompassDegreeError` [(float32)](https://pkg.go.dev/builtin#float32): The estimated error in compass readings, measured in degrees.
     This signifies the deviation or uncertainty in the sensor's compass measurements.
     A lower value implies a more accurate compass direction.
-
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**
@@ -693,7 +692,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 ```ts {class="line-numbers linkable-line-numbers"}
 const movementSensor = new VIAM.MovementSensorClient(
   machine,
-  "my_movement_sensor",
+  'my_movement_sensor'
 );
 const accuracy = await movementSensor.getAccuracy();
 ```
@@ -705,11 +704,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Accuracy](https://flutter.viam.dev/viam_sdk/Accuracy.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Accuracy](https://flutter.viam.dev/viam_sdk/Accuracy.html)>
 
 **Example:**
 
@@ -795,9 +794,10 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 ```ts {class="line-numbers linkable-line-numbers"}
 const movementSensor = new VIAM.MovementSensorClient(
   machine,
-  "my_movement_sensor",
+  'my_movement_sensor'
 );
-const linearAcceleration = await movementSensor.getLinearAcceleration();
+const linearAcceleration =
+  await movementSensor.getLinearAcceleration();
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MovementSensorClient.html#getlinearacceleration).
@@ -807,11 +807,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Vector3](https://flutter.viam.dev/viam_sdk/Vector3-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Vector3](https://flutter.viam.dev/viam_sdk/Vector3-class.html)>
 
 **Example:**
 
@@ -927,7 +927,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 ```ts {class="line-numbers linkable-line-numbers"}
 const movementSensor = new VIAM.MovementSensorClient(
   machine,
-  "my_movement_sensor",
+  'my_movement_sensor'
 );
 const readings = await movementSensor.getReadings();
 ```
@@ -939,11 +939,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>\>
 
 **Example:**
 
@@ -1052,12 +1052,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-import { Struct } from "@viamrobotics/sdk";
+import { Struct } from '@viamrobotics/sdk';
 
 const result = await resource.doCommand(
   Struct.fromJson({
-    myCommand: { key: "value" },
-  }),
+    myCommand: { key: 'value' },
+  })
 );
 ```
 
@@ -1068,11 +1068,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\> (required)
+- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic> (required)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>\>
 
 **Example:**
 

--- a/static/include/components/apis/generated/power_sensor.md
+++ b/static/include/components/apis/generated/power_sensor.md
@@ -78,11 +78,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Voltage](https://flutter.viam.dev/viam_sdk/Voltage.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Voltage](https://flutter.viam.dev/viam_sdk/Voltage.html)>
 
 **Example:**
 
@@ -177,11 +177,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Current](https://flutter.viam.dev/viam_sdk/Current.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Current](https://flutter.viam.dev/viam_sdk/Current.html)>
 
 **Example:**
 
@@ -275,11 +275,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[double](https://api.flutter.dev/flutter/dart-core/double-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[double](https://api.flutter.dev/flutter/dart-core/double-class.html)>
 
 **Example:**
 
@@ -371,11 +371,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>\>
 
 **Example:**
 
@@ -499,11 +499,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\> (required)
+- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic> (required)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>\>
 
 **Example:**
 

--- a/static/include/components/apis/generated/sensor.md
+++ b/static/include/components/apis/generated/sensor.md
@@ -63,7 +63,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const sensor = new VIAM.SensorClient(machine, "my_sensor");
+const sensor = new VIAM.SensorClient(machine, 'my_sensor');
 
 // Get the readings of a sensor.
 const readings = await sensor.getReadings();
@@ -76,11 +76,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>\>
 
 **Example:**
 
@@ -221,12 +221,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-import { Struct } from "@viamrobotics/sdk";
+import { Struct } from '@viamrobotics/sdk';
 
 const result = await resource.doCommand(
   Struct.fromJson({
-    myCommand: { key: "value" },
-  }),
+    myCommand: { key: 'value' },
+  })
 );
 ```
 
@@ -237,11 +237,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\> (required)
+- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic> (required)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>\>
 
 **Example:**
 

--- a/static/include/components/apis/generated/servo.md
+++ b/static/include/components/apis/generated/servo.md
@@ -98,11 +98,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 **Parameters:**
 
 - `angle` [int](https://api.flutter.dev/flutter/dart-core/int-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -211,11 +211,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[int](https://api.flutter.dev/flutter/dart-core/int-class.html)>
 
 **Example:**
 
@@ -312,7 +312,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[bool](https://api.flutter.dev/flutter/dart-core/bool-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[bool](https://api.flutter.dev/flutter/dart-core/bool-class.html)>
 
 **Example:**
 
@@ -411,11 +411,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -539,11 +539,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\> (required)
+- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic> (required)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>\>
 
 **Example:**
 

--- a/static/include/components/apis/generated/switch.md
+++ b/static/include/components/apis/generated/switch.md
@@ -201,6 +201,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Returns:**
 
 - [(uint32)](https://pkg.go.dev/builtin#uint32)
+- [([]string)](https://pkg.go.dev/builtin#string)
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/switch#Switch).
@@ -215,7 +216,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 
 **Returns:**
 
-- (Promise<number>)
+- (Promise<[number, string[]]>)
 
 **Example:**
 

--- a/static/include/robot/apis/generated/robot.md
+++ b/static/include/robot/apis/generated/robot.md
@@ -239,7 +239,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await machine.cancelOperation("INSERT OPERATION ID");
+await machine.cancelOperation('INSERT OPERATION ID');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#canceloperation).
@@ -285,7 +285,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await machine.blockForOperation("INSERT OPERATION ID");
+await machine.blockForOperation('INSERT OPERATION ID');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#blockforoperation).
@@ -327,7 +327,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(\*framesystem.Config)](https://pkg.go.dev/go.viam.com/rdk/robot/framesystem#Config): The configuration of the given machine’s frame system.
+- [(*framesystem.Config)](https://pkg.go.dev/go.viam.com/rdk/robot/framesystem#Config): The configuration of the given machine’s frame system.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**
@@ -410,13 +410,13 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Parameters:**
 
 - `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
-- `pose` [(\*referenceframe.PoseInFrame)](https://pkg.go.dev/go.viam.com/rdk/referenceframe#PoseInFrame): The pose that should be transformed.
+- `pose` [(*referenceframe.PoseInFrame)](https://pkg.go.dev/go.viam.com/rdk/referenceframe#PoseInFrame): The pose that should be transformed.
 - `dst` [(string)](https://pkg.go.dev/builtin#string): The name of the reference pose to transform the given pose to.
-- `additionalTransforms` [([]\*referenceframe.LinkInFrame)](https://pkg.go.dev/go.viam.com/rdk/referenceframe#LinkInFrame): Any additional transforms.
+- `additionalTransforms` [([]*referenceframe.LinkInFrame)](https://pkg.go.dev/go.viam.com/rdk/referenceframe#LinkInFrame): Any additional transforms.
 
 **Returns:**
 
-- [(\*referenceframe.PoseInFrame)](https://pkg.go.dev/go.viam.com/rdk/referenceframe#PoseInFrame): Transformed pose in frame.
+- [(*referenceframe.PoseInFrame)](https://pkg.go.dev/go.viam.com/rdk/referenceframe#PoseInFrame): Transformed pose in frame.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**
@@ -480,8 +480,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Parameters:**
 
 - `pointCloudPCD` (Uint8Array) (required): The point clouds to transform. This should be in the
-  [PCD format encoded into bytes](https://pointclouds.org/documentation/tutorials/pcd_file_format.html).
-
+  [PCD format encoded into bytes](https://pointclouds.org/documentation/tutorials/pcd_file_format.html)
 - `source` (string) (required): The reference frame of the point cloud.
 - `destination` (string) (required): The reference frame into which the source data should
   be transformed, if unset this defaults to the "world" reference frame. Do
@@ -572,7 +571,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[ModuleModel](https://flutter.viam.dev/viam_protos.robot.robot/ModuleModel-class.html)\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[ModuleModel](https://flutter.viam.dev/viam_protos.robot.robot/ModuleModel-class.html)>\>
 
 **Example:**
 
@@ -675,7 +674,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
-- `moduleId` (string) (optional): The id matching the module_id field of the registry
+- `moduleId` (string) (optional): The id matching the module\_id field of the registry
   module in your part configuration.
 - `moduleName` (string) (optional): The name matching the name field of the local/registry
   module in your part configuration.
@@ -687,7 +686,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await machine.restartModule("namespace:module:model", "my_model_name");
+await machine.restartModule('namespace:module:model', 'my_model_name');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/RobotClient.html#restartmodule).
@@ -755,7 +754,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(cloud.Metadata)](https://pkg.go.dev/go.viam.com/rdk/cloud#Metadata): App-related metadata containing the primary organization ID, location ID, and robot part ID for a machine running on the Viam.
+- [(cloud.Metadata)](https://pkg.go.dev/go.viam.com/rdk/cloud#Metadata): App-related metadata containing the primary organization ID, location ID, and robot part ID for a machine running on Viam.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**
@@ -798,7 +797,7 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[CloudMetadata](https://flutter.viam.dev/viam_sdk/CloudMetadata.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[CloudMetadata](https://flutter.viam.dev/viam_sdk/CloudMetadata.html)>
 
 **Example:**
 
@@ -953,7 +952,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[RobotClient](https://flutter.viam.dev/viam_sdk/RobotClient-class.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[RobotClient](https://flutter.viam.dev/viam_sdk/RobotClient-class.html)>
 
 **Example:**
 
@@ -1047,7 +1046,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 
@@ -1163,7 +1162,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<void\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<void>
 
 **Example:**
 

--- a/static/include/services/apis/generated/data_manager.md
+++ b/static/include/services/apis/generated/data_manager.md
@@ -23,6 +23,7 @@ Sync data stored on the machine to the cloud.
 **Example:**
 
 ```go {class="line-numbers linkable-line-numbers"}
+data, err := datamanager.FromRobot(machine, "my_data_manager")
 // Sync data stored on the machine to the cloud.
 err := data.Sync(context.Background(), nil)
 ```

--- a/static/include/services/apis/generated/motion.md
+++ b/static/include/services/apis/generated/motion.md
@@ -37,7 +37,6 @@ The motion service takes the volumes associated with all configured machine comp
     Transforms can be used to account for geometries that are attached to the robot but not configured as robot components.
     For example, you could use a transform to represent the volume of a marker held in your machine's gripper.
     Transforms are not added to the config or carried into later processes.
-
 - `constraints` ([viam.proto.service.motion.Constraints](https://python.viam.dev/autoapi/viam/proto/service/motion/index.html#viam.proto.service.motion.Constraints)) (optional): Pass in [motion constraints](/operate/reference/services/motion/constraints/). By default, motion is unconstrained with the exception of obstacle avoidance.
 - `extra` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (optional): Extra options to pass to the underlying RPC call.
 - `timeout` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
@@ -130,14 +129,14 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const motion = new VIAM.MotionClient(machine, "builtin");
+const motion = new VIAM.MotionClient(machine, 'builtin');
 
 // Assumes a gripper configured with name "my_gripper"
 const gripperName = new VIAM.ResourceName({
-  name: "my_gripper",
-  namespace: "rdk",
-  type: "component",
-  subtype: "gripper",
+  name: 'my_gripper',
+  namespace: 'rdk',
+  type: 'component',
+  subtype: 'gripper',
 });
 
 const goalPose: VIAM.Pose = {
@@ -150,7 +149,7 @@ const goalPose: VIAM.Pose = {
   theta: 90,
 };
 const goalPoseInFrame = new VIAM.PoseInFrame({
-  referenceFrame: "world",
+  referenceFrame: 'world',
   pose: goalPose,
 });
 
@@ -198,8 +197,8 @@ Make sure the [SLAM service](/operate/reference/services/slam/) you use alongsid
 - `component_name` ([viam.proto.common.ResourceName](https://python.viam.dev/autoapi/viam/gen/common/v1/common_pb2/index.html#viam.gen.common.v1.common_pb2.ResourceName)) (required): The `ResourceName` of the base to move.
 - `destination` ([viam.proto.common.Pose](https://python.viam.dev/autoapi/viam/components/arm/index.html#viam.components.arm.Pose)) (required): The destination, which can be any [Pose](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.Pose) with respect to the SLAM map's origin.
 - `slam_service_name` ([viam.proto.common.ResourceName](https://python.viam.dev/autoapi/viam/gen/common/v1/common_pb2/index.html#viam.gen.common.v1.common_pb2.ResourceName)) (required): The `ResourceName` of the [SLAM service](/operate/reference/services/slam/) from which the SLAM map is requested.
-- `configuration` ([viam.proto.service.motion.MotionConfiguration](https://python.viam.dev/autoapi/viam/gen/service/motion/v1/motion_pb2/index.html#viam.gen.service.motion.v1.motion_pb2.MotionConfiguration)) (optional):
-  The configuration you want to set across this machine for this motion service. This parameter and each of its fields are optional.
+- `configuration` ([viam.proto.service.motion.MotionConfiguration](https://python.viam.dev/autoapi/viam/gen/service/motion/v1/motion_pb2/index.html#viam.gen.service.motion.v1.motion_pb2.MotionConfiguration)) (optional): 
+The configuration you want to set across this machine for this motion service. This parameter and each of its fields are optional.
 
 - `obstacle_detectors` [(Iterable[ObstacleDetector])](https://python.viam.dev/autoapi/viam/proto/service/motion/index.html#viam.proto.service.motion.ObstacleDetector): The names of each [vision service](/operate/reference/services/vision/) and [camera](/operate/reference/components/camera/) resource pair you want to use for transient obstacle avoidance.
 - `position_polling_frequency_hz` [(float)](https://docs.python.org/3/library/functions.html#float): The frequency in hz to poll the position of the machine.
@@ -242,8 +241,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Parameters:**
 
 - `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
-- `req` [(MoveOnMapReq)](https://pkg.go.dev/go.viam.com/rdk/services/motion#MoveOnMapReq):
-  A `MoveOnMapReq` which contains the following values:
+- `req` [(MoveOnMapReq)](https://pkg.go.dev/go.viam.com/rdk/services/motion#MoveOnMapReq): 
+A `MoveOnMapReq` which contains the following values:
 
 - `ComponentName` [(resource.Name)](https://pkg.go.dev/go.viam.com/rdk/resource#Name): The `resource.Name` of the base to move.
 - `Destination` [(spatialmath.Pose)](https://pkg.go.dev/go.viam.com/rdk/spatialmath#Pose): The destination, which can be any [Pose](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.Pose) with respect to the SLAM map's origin.
@@ -317,7 +316,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const motion = new VIAM.MotionClient(machine, "builtin");
+const motion = new VIAM.MotionClient(machine, 'builtin');
 
 // Define destination pose with respect to map origin
 const myPose: VIAM.Pose = {
@@ -331,20 +330,24 @@ const myPose: VIAM.Pose = {
 };
 
 const baseName = new VIAM.ResourceName({
-  name: "my_base",
-  namespace: "rdk",
-  type: "component",
-  subtype: "base",
+  name: 'my_base',
+  namespace: 'rdk',
+  type: 'component',
+  subtype: 'base',
 });
 const slamServiceName = new VIAM.ResourceName({
-  name: "my_slam_service",
-  namespace: "rdk",
-  type: "service",
-  subtype: "slam",
+  name: 'my_slam_service',
+  namespace: 'rdk',
+  type: 'service',
+  subtype: 'slam',
 });
 
 // Move the base to Y=10 (location of 0,10,0) relative to map origin
-const executionId = await motion.moveOnMap(myPose, baseName, slamServiceName);
+const executionId = await motion.moveOnMap(
+  myPose,
+  baseName,
+  slamServiceName
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotionClient.html#moveonmap).
@@ -399,8 +402,8 @@ Translation in obstacles is not supported by the [navigation service](/operate/r
 - `movement_sensor_name` ([viam.proto.common.ResourceName](https://python.viam.dev/autoapi/viam/gen/common/v1/common_pb2/index.html#viam.gen.common.v1.common_pb2.ResourceName)) (required): The `ResourceName` of the [movement sensor](/operate/reference/components/movement-sensor/) that you want to use to check the machine's location.
 - `obstacles` ([Sequence[viam.proto.common.GeoGeometry]](https://python.viam.dev/autoapi/viam/gen/common/v1/common_pb2/index.html#viam.gen.common.v1.common_pb2.GeoGeometry)) (optional): Obstacles to consider when planning the motion of the component, with each represented as a `GeoGeometry`. <ul><li> Default: `None` </li></ul>
 - `heading` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (optional): The compass heading, in degrees, that the machine's movement sensor should report at the `destination` point. <ul><li> Range: `[0-360)` `0`: North, `90`: East, `180`: South, `270`: West </li><li>Default: `None`</li></ul>
-- `configuration` ([viam.proto.service.motion.MotionConfiguration](https://python.viam.dev/autoapi/viam/gen/service/motion/v1/motion_pb2/index.html#viam.gen.service.motion.v1.motion_pb2.MotionConfiguration)) (optional):
-  The configuration you want to set across this machine for this motion service. This parameter and each of its fields are optional.
+- `configuration` ([viam.proto.service.motion.MotionConfiguration](https://python.viam.dev/autoapi/viam/gen/service/motion/v1/motion_pb2/index.html#viam.gen.service.motion.v1.motion_pb2.MotionConfiguration)) (optional): 
+The configuration you want to set across this machine for this motion service. This parameter and each of its fields are optional.
 
 - `obstacle_detectors` [(Iterable[ObstacleDetector])](https://python.viam.dev/autoapi/viam/proto/service/motion/index.html#viam.proto.service.motion.ObstacleDetector): The names of each [vision service](/operate/reference/services/vision/) and [camera](/operate/reference/components/camera/) resource pair you want to use for transient obstacle avoidance.
 - `position_polling_frequency_hz` [(float)](https://docs.python.org/3/library/functions.html#float): The frequency in hz to poll the position of the machine.
@@ -443,8 +446,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Parameters:**
 
 - `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
-- `req` [(MoveOnGlobeReq)](https://pkg.go.dev/go.viam.com/rdk/services/motion#MoveOnGlobeReq):
-  A `MoveOnGlobeReq` which contains the following values:
+- `req` [(MoveOnGlobeReq)](https://pkg.go.dev/go.viam.com/rdk/services/motion#MoveOnGlobeReq): 
+A `MoveOnGlobeReq` which contains the following values:
 
 - `componentName` [(resource.Name)](https://pkg.go.dev/go.viam.com/rdk/resource#Name): The `resource.Name` of the base to move.
 - `destination` [(\*geo.Point)](https://pkg.go.dev/github.com/kellydunn/golang-geo#Point): The location of the component's destination, represented in geographic notation as a [Point](https://pkg.go.dev/github.com/kellydunn/golang-geo#Point) _(lat, lng)_.
@@ -522,7 +525,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const motion = new VIAM.MotionClient(machine, "builtin");
+const motion = new VIAM.MotionClient(machine, 'builtin');
 
 // Define destination at GPS coordinates [0,0]
 const destination: VIAM.GeoPoint = {
@@ -531,23 +534,23 @@ const destination: VIAM.GeoPoint = {
 };
 
 const baseName = new VIAM.ResourceName({
-  name: "my_base",
-  namespace: "rdk",
-  type: "component",
-  subtype: "base",
+  name: 'my_base',
+  namespace: 'rdk',
+  type: 'component',
+  subtype: 'base',
 });
 const movementSensorName = new VIAM.ResourceName({
-  name: "my_movement_sensor",
-  namespace: "rdk",
-  type: "component",
-  subtype: "movement_sensor",
+  name: 'my_movement_sensor',
+  namespace: 'rdk',
+  type: 'component',
+  subtype: 'movement_sensor',
 });
 
 // Move the base to the geographic location
 const globeExecutionId = await motion.moveOnGlobe(
   destination,
   baseName,
-  movementSensorName,
+  movementSensorName
 );
 ```
 
@@ -580,7 +583,6 @@ You can use the `supplemental_transforms` argument to augment the machine's exis
   When `supplemental_transforms` are provided, a frame system is created within the context of the `GetPose` function.
   This new frame system builds off the machine's frame system and incorporates the `Transform`s provided.
   If the result of adding the `Transform`s results in a disconnected frame system, an error is thrown.
-
 - `extra` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (optional): Extra options to pass to the underlying RPC call.
 - `timeout` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
 
@@ -657,7 +659,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
 - `componentName` [(resource.Name)](https://pkg.go.dev/go.viam.com/rdk/resource#Name): The `resource.Name` of the piece of the machine whose pose is returned.
 - `destinationFrame` [(string)](https://pkg.go.dev/builtin#string): The name of the frame with respect to which the component's pose is reported.
-- `supplementalTransforms` [([]\*referenceframe.LinkInFrame)](https://pkg.go.dev/go.viam.com/rdk/referenceframe#LinkInFrame): An optional list of `LinkInFrame`s.
+- `supplementalTransforms` [([]*referenceframe.LinkInFrame)](https://pkg.go.dev/go.viam.com/rdk/referenceframe#LinkInFrame): An optional list of `LinkInFrame`s.
   A `LinkInFrame` represents an additional frame which is added to the machine's frame system.
   It consists of:
 
@@ -666,19 +668,18 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
     When `supplementalTransforms` are provided, a frame system is created within the context of the `GetPose` function.
     This new frame system builds off the machine's frame system and incorporates the `LinkInFrame`s provided.
     If the result of adding the `LinkInFrame`s results in a disconnected frame system, an error is thrown.
-
 - `extra` [(map[string]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
 
 **Returns:**
 
-- [(\*referenceframe.PoseInFrame)](https://pkg.go.dev/go.viam.com/rdk/referenceframe#PoseInFrame): The pose of the component.
+- [(*referenceframe.PoseInFrame)](https://pkg.go.dev/go.viam.com/rdk/referenceframe#PoseInFrame): The pose of the component.
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 **Example:**
 
 ```go {class="line-numbers linkable-line-numbers"}
 // Insert code to connect to your machine.
-// (see CONNECT tab of your machine's page)
+// (see CONNECT tab of your machine's page in the Viam app)
 
 // Assumes a gripper configured with name "my_gripper" on the machine
 gripperName := gripper.Named("my_gripper")
@@ -720,17 +721,21 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const motion = new VIAM.MotionClient(machine, "builtin");
+const motion = new VIAM.MotionClient(machine, 'builtin');
 
 const gripperName = new VIAM.ResourceName({
-  name: "my_gripper",
-  namespace: "rdk",
-  type: "component",
-  subtype: "gripper",
+  name: 'my_gripper',
+  namespace: 'rdk',
+  type: 'component',
+  subtype: 'gripper',
 });
 
 // Get the gripper's pose in world coordinates
-const gripperPoseInWorld = await motion.getPose(gripperName, "world", []);
+const gripperPoseInWorld = await motion.getPose(
+  gripperName,
+  'world',
+  []
+);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/MotionClient.html#getpose).
@@ -817,12 +822,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const motion = new VIAM.MotionClient(machine, "builtin");
+const motion = new VIAM.MotionClient(machine, 'builtin');
 const baseName = new VIAM.ResourceName({
-  name: "my_base",
-  namespace: "rdk",
-  type: "component",
-  subtype: "base",
+  name: 'my_base',
+  namespace: 'rdk',
+  type: 'component',
+  subtype: 'base',
 });
 
 // Stop the base component which was instructed to move
@@ -909,7 +914,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const motion = new VIAM.MotionClient(machine, "builtin");
+const motion = new VIAM.MotionClient(machine, 'builtin');
 
 // List plan statuses within the TTL
 const response = await motion.listPlanStatuses();
@@ -1014,12 +1019,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const motion = new VIAM.MotionClient(machine, "builtin");
+const motion = new VIAM.MotionClient(machine, 'builtin');
 const baseName = new VIAM.ResourceName({
-  name: "my_base",
-  namespace: "rdk",
-  type: "component",
-  subtype: "base",
+  name: 'my_base',
+  namespace: 'rdk',
+  type: 'component',
+  subtype: 'base',
 });
 
 // Get the plan(s) of the base component
@@ -1166,12 +1171,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-import { Struct } from "@viamrobotics/sdk";
+import { Struct } from '@viamrobotics/sdk';
 
 const result = await resource.doCommand(
   Struct.fromJson({
-    myCommand: { key: "value" },
-  }),
+    myCommand: { key: 'value' },
+  })
 );
 ```
 

--- a/static/include/services/apis/generated/navigation.md
+++ b/static/include/services/apis/generated/navigation.md
@@ -137,7 +137,6 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 - `mode` ([navigationApi](https://ts.viam.dev/modules/navigationApi.html)) (required): The mode for the service to operate in.
   
-  
   * 0: MODE\_UNSPECIFIED
   * 1: MODE\_MANUAL
   * 2: MODE\_WAYPOINT

--- a/static/include/services/apis/generated/slam.md
+++ b/static/include/services/apis/generated/slam.md
@@ -60,11 +60,11 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const slam = new VIAM.SlamClient(machine, "my_slam");
+const slam = new VIAM.SlamClient(machine, 'my_slam');
 
 // Get the current position of the robot in the SLAM map
 const position = await slam.getPosition();
-console.log("Current position:", position);
+console.log('Current position:', position);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/SlamClient.html#getposition).
@@ -128,7 +128,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const slam = new VIAM.SlamClient(machine, "my_slam");
+const slam = new VIAM.SlamClient(machine, 'my_slam');
 
 // Get the point cloud map
 const pointCloudMap = await slam.getPointCloudMap();
@@ -195,7 +195,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const slam = new VIAM.SlamClient(machine, "my_slam");
+const slam = new VIAM.SlamClient(machine, 'my_slam');
 
 // Get the internal state of the SLAM algorithm
 const internalState = await slam.getInternalState();
@@ -241,9 +241,9 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [(Properties)](https://pkg.go.dev/go.viam.com/rdk/services/slam#Properties):
-  Information about the current SLAM session.
-  An object containing four fields:
+- [(Properties)](https://pkg.go.dev/go.viam.com/rdk/services/slam#Properties): 
+Information about the current SLAM session.
+An object containing four fields:
 
 - `SensorInfo` [(SensorInfo[])](https://pkg.go.dev/go.viam.com/api/service/slam/v1#SensorInfo): Information about the sensors (camera and movement sensor) configured for your SLAM service, including the name and type of sensor.
 - `CloudSlam` [(bool)](https://pkg.go.dev/builtin#bool): A boolean which indicates whether the session is being run in the cloud.
@@ -274,11 +274,11 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const slam = new VIAM.SlamClient(machine, "my_slam");
+const slam = new VIAM.SlamClient(machine, 'my_slam');
 
 // Get the properties of the SLAM service
 const properties = await slam.getProperties();
-console.log("SLAM properties:", properties);
+console.log('SLAM properties:', properties);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/SlamClient.html#getproperties).
@@ -427,12 +427,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-import { Struct } from "@viamrobotics/sdk";
+import { Struct } from '@viamrobotics/sdk';
 
 const result = await resource.doCommand(
   Struct.fromJson({
-    myCommand: { key: "value" },
-  }),
+    myCommand: { key: 'value' },
+  })
 );
 ```
 

--- a/static/include/services/apis/generated/vision.md
+++ b/static/include/services/apis/generated/vision.md
@@ -93,11 +93,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 **Parameters:**
 
 - `cameraName` [String](https://api.flutter.dev/flutter/dart-core/String-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[Detection](https://flutter.viam.dev/viam_protos.service.vision/Detection-class.html)\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[Detection](https://flutter.viam.dev/viam_protos.service.vision/Detection-class.html)>\>
 
 **Example:**
 
@@ -231,11 +231,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 **Parameters:**
 
 - `image` [ViamImage](https://flutter.viam.dev/viam_sdk/ViamImage-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[Detection](https://flutter.viam.dev/viam_protos.service.vision/Detection-class.html)\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[Detection](https://flutter.viam.dev/viam_protos.service.vision/Detection-class.html)>\>
 
 **Example:**
 
@@ -348,11 +348,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 - `cameraName` [String](https://api.flutter.dev/flutter/dart-core/String-class.html) (required)
 - `count` [int](https://api.flutter.dev/flutter/dart-core/int-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[Classification](https://flutter.viam.dev/viam_protos.service.vision/Classification-class.html)\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[Classification](https://flutter.viam.dev/viam_protos.service.vision/Classification-class.html)>\>
 
 **Example:**
 
@@ -487,11 +487,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 - `image` [ViamImage](https://flutter.viam.dev/viam_sdk/ViamImage-class.html) (required)
 - `count` [int](https://api.flutter.dev/flutter/dart-core/int-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[Classification](https://flutter.viam.dev/viam_protos.service.vision/Classification-class.html)\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[Classification](https://flutter.viam.dev/viam_protos.service.vision/Classification-class.html)>\>
 
 **Example:**
 
@@ -604,11 +604,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 **Parameters:**
 
 - `cameraName` [String](https://api.flutter.dev/flutter/dart-core/String-class.html) (required)
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)\<[PointCloudObject](https://flutter.viam.dev/viam_protos.common.common/PointCloudObject-class.html)\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[List](https://api.flutter.dev/flutter/dart-core/List-class.html)<[PointCloudObject](https://flutter.viam.dev/viam_protos.common.common/PointCloudObject-class.html)>\>
 
 **Example:**
 
@@ -710,8 +710,8 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Returns:**
 
-- (Promise<    {        classifications: [visionApi](https://ts.viam.dev/modules/visionApi.html).[Classification](https://ts.viam.dev/classes/visionApi.Classification.html)[];        detections: [visionApi](https://ts.viam.dev/modules/visionApi.html).[Detection](https://ts.viam.dev/classes/visionApi.Detection.html)[];        extra: undefined        | [Struct](https://ts.viam.dev/classes/Struct.html);        image: undefined | [Image](https://ts.viam.dev/classes/cameraApi.Image.html);        objectPointClouds: [commonApi](https://ts.viam.dev/modules/commonApi.html).[PointCloudObject](https://ts.viam.dev/classes/commonApi.PointCloudObject.html)[];    },>): * The requested image, classifications, detections, and 3d point
-cloud objects.
+- (Promise<     {         classifications: [visionApi](https://ts.viam.dev/modules/visionApi.html).[Classification](https://ts.viam.dev/classes/visionApi.Classification.html)[];         detections: [visionApi](https://ts.viam.dev/modules/visionApi.html).[Detection](https://ts.viam.dev/classes/visionApi.Detection.html)[];         extra: undefined         | [Struct](https://ts.viam.dev/classes/Struct.html);         image: undefined | [Image](https://ts.viam.dev/classes/cameraApi.Image.html);         objectPointClouds: [commonApi](https://ts.viam.dev/modules/commonApi.html).[PointCloudObject](https://ts.viam.dev/classes/commonApi.PointCloudObject.html)[];     }, >): * The requested image, classifications, detections, and 3d point
+  cloud objects.
 
 **Example:**
 
@@ -842,11 +842,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\> (required)
+- `command` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic> (required)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>\>
 
 **Example:**
 
@@ -958,7 +958,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/s
 
 **Returns:**
 
-- (Promise<    {        classificationsSupported: boolean;        detectionsSupported: boolean;        objectPointCloudsSupported: boolean;    },>): * The properties of the vision service.
+- (Promise<     {         classificationsSupported: boolean;         detectionsSupported: boolean;         objectPointCloudsSupported: boolean;     }, >): * The properties of the vision service.
 
 **Example:**
 
@@ -974,11 +974,11 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 **Parameters:**
 
-- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic>? (optional)
 
 **Returns:**
 
-- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[VisionProperties](https://flutter.viam.dev/viam_sdk/VisionProperties.html)\>
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)<[VisionProperties](https://flutter.viam.dev/viam_sdk/VisionProperties.html)>
 
 **Example:**
 


### PR DESCRIPTION
- adds information about offline data pipelines (`docs/data-ai/data/data-pipelines.md`)
  - previously had no page in the docs besides some minimal CLI doc discussing pipelines; this introduces that missing page
  - includes examples in all supported languages (Python, Go, TypeScript) for basic data pipeline tasks
    - note that Go snippets link directly to Go API reference -- see SDK docs notes for more info
- updates generated SDK documentation to include Python and Typescript data pipelines APIs (no Flutter yet)
  - no Go because our data page doesn't seem to have or support any Go snippets (i'm guessing there's an out-of-scope story here)
- yanked hot data store out into its own page ((`docs/data-ai/data/hot-data-store.md`), since:
  - it has a lot in common with data pipelines, which could easily lead to user confusion
  - was very buried (increasing the likelihood of user confusion)
  - the recent API improvements for data pipelines broke our existing hot data store examples
- slight reorder of 'Advanced data capture and sync configurations' since some short-but-useful sections were buried all the way at the end of a very long page of complex, niche examples
- note that the alias for hot data store doesn't work -- leaving it for now in the hopes that someone can suggest a better alternative for relocating a _single section_ of a still-existing page to another page