### PR TITLE
Fix tooltips

### DIFF
--- a/assets/js/base.js
+++ b/assets/js/base.js
@@ -1,3 +1,5 @@
+$('[data-toggle="tooltip"]').tooltip()
+
 function handleAnchorClick(event, anchor) {
    // write the full anchor URL to the clipboard
    navigator.clipboard.writeText(location.href.split('#')[0] + '#' + anchor ); 


### PR DESCRIPTION
It seems that the default `base.js` file in Docsy included tooltip initialization (see https://github.com/google/docsy/blob/a053131a4ebf6a59e4e8834a42368e248d98c01d/assets/js/base.js for an example of how they might have done this; unfortunately it's tricky to get the specific version of base.js used in our docsy version).

This adds a single line that initializes JQuery tooltips used in Docsy.

https://deploy-preview-4441--viam-docs.netlify.app/dev/reference/glossary/ provides proof that this approach works.

We could also try refactoring everything out of base.js and rely on the default behavior instead, but:
- that would take more time, and this works
- i'm not 100% comfortable with reliance on that default behavior -- what if we do want to use base.js in the future, and don't remember this issue from before? Better to hang a sign on this Chesterton's fence.