### PR TITLE
Add information about training logs expiration after 7 days

### DIFF
--- a/docs/data-ai/train/train-tflite.md
+++ b/docs/data-ai/train/train-tflite.md
@@ -112,6 +112,8 @@ Your training script may output logs at the error level but still succeed.
 
 You can also view your training jobs' logs with the [`viam train logs`](/dev/tools/cli/#train) command.
 
+Training logs expire after 7 days.
+
 {{% /tablestep %}}
 {{< /table >}}
 

--- a/docs/data-ai/train/train.md
+++ b/docs/data-ai/train/train.md
@@ -842,6 +842,8 @@ Your training script may output logs at the error level but still succeed.
 
 You can also view your training jobs' logs with the [`viam train logs`](/dev/tools/cli/#train) command.
 
+Training logs expire after 7 days.
+
 {{% /tablestep %}}
 {{< /table >}}
 


### PR DESCRIPTION
Training job logs on Viam expire after 7 days. Relevant code here: https://github.com/viamrobotics/app/blob/1f820873c477c6c77703b51dc7d1acdb6df657d9/mltraining/logs/logs.go#L102

A user just ran into this and was confused as to why their logs weren't showing up. We should perhaps update app to have a "Logs expired" state (see screenshot below - just says "No logs to show"), but wanted to at least document this information as a backstop.


<img width="2548" height="1060" alt="image" src="https://github.com/user-attachments/assets/4982a5dd-72ab-4664-a68c-1c7fa3123f87" />
