### PR TITLE
"machine-to-cloud" should be hyphenated since it's a compound modifier

### DIFF
--- a/docs/operate/hello-world/first-project/part-2.md
+++ b/docs/operate/hello-world/first-project/part-2.md
@@ -8,7 +8,7 @@ description: "Configure automatic image capture and cloud sync for your inspecti
 date: "2025-01-30"
 ---
 
-**Goal:** Configure and use a machine to cloud data capture pipeline.
+**Goal:** Configure and use a machine-to-cloud data capture pipeline.
 
 **Skills:** Data capture configuration, cloud sync, browsing captured data.
 


### PR DESCRIPTION
Camila caught that "Configure and use a machine to cloud data capture pipeline." sounds confusing. We should add hyphens in "machine-to-cloud" since it's a compound modifier.

Please include a summary of the change and what is does. Please also include relevant motivation and context.

Review process:

- No need to request review from any specific docs team members; we will see your PR and one of us will review.
- If you need technical review from engineering, please request review from the relevant person.
- Docs team might commit styling nit fixes to save you the trouble :)
- You can merge after approval from one docs team member (as well as any necessary technical review).
