### PR TITLE
migrate gazebo to hosted simulation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ serve-dev-future: setup
 	hugo server -F $(DEV_OPTIONS) $(SERVE_OPTIONS)
 
 prettierfix: setup
-	./node_modules/prettier/bin/prettier.cjs --check docs/**/*.md --fix --write
+	./node_modules/prettier/bin/prettier.cjs --check 'docs/**/*.md' --fix --write
 
 test-code-snippets: test-python-snippets test-go-snippets test-typescript-snippets
 

--- a/docs/operate/hello-world/first-project/part-1.md
+++ b/docs/operate/hello-world/first-project/part-1.md
@@ -19,16 +19,16 @@ date: "2025-01-30"
 Before starting this tutorial, you need the can inspection simulation running.
 Follow the **[Gazebo Simulation Setup Guide](../gazebo-setup/)** to:
 
-1. Build the Docker image with Gazebo Harmonic
+1. Boot a simulation environment on Viam's cloud
 2. Create a machine in Viam and get credentials
 3. Start the container with your Viam credentials
 
 Once you see "Can Inspection Simulation Running!" in the container logs and your machine shows **Live** in the Viam app, return here to continue.
 
 {{< alert title="What you're working with" color="info" >}}
-The simulation runs Gazebo Harmonic inside a Docker container.
+The simulation runs Gazebo Harmonic inside a sandbox.
 It simulates a conveyor belt with cans (some dented) passing under an inspection camera.
-viam-server runs on the Linux virtual machine inside the container and connects to Viam's cloud, just like it would on a physical machine.
+viam-server runs inside the sandbox and connects to Viam's cloud, just like it would on a physical machine.
 Everything you configure in the Viam app applies to the simulated hardware.
 {{< /alert >}}
 
@@ -76,7 +76,7 @@ To add the camera component to your machine part:
 To configure your camera component to work with the camera in the simulation, you need to specify the correct camera ID.
 Most components require a few configuration parameters.
 
-1. In the **JSON Configuration** section, add:
+1. In the **JSON Configuration** section, set:
 
    ```json
    {
@@ -164,7 +164,7 @@ Now add a vision service that connects your camera to the ML model service.
 1. Click **+** next to your machine part
 2. Select **Configuration block**
 3. Search for `vision`
-4. Select **mlmodel**
+4. Select **vision/mlmodel**
 5. Click **Add component**
 6. Name it `vision-service`
 7. Click **Add component**

--- a/docs/operate/hello-world/first-project/part-1.md
+++ b/docs/operate/hello-world/first-project/part-1.md
@@ -17,7 +17,7 @@ date: "2025-01-30"
 ## Prerequisites
 
 Before starting this tutorial, you need the can inspection simulation running.
-Follow the **[Gazebo Simulation Setup Guide](../gazebo-setup/)** to:
+Follow the **[Simulation Setup Guide](../sim-setup/)** to:
 
 1. Boot a simulation environment on Viam's cloud
 2. Create a machine in Viam and get credentials

--- a/docs/operate/hello-world/first-project/sim-setup.md
+++ b/docs/operate/hello-world/first-project/sim-setup.md
@@ -7,7 +7,7 @@ type: "docs"
 description: "Set up the hosted simulation environment for the inspection tutorial."
 date: "2025-01-30"
 aliases:
-- gazebo-setup
+  - gazebo-setup
 ---
 
 This guide walks you through setting up the Gazebo simulation used in the [Your First Project](../) tutorial.

--- a/docs/operate/hello-world/first-project/sim-setup.md
+++ b/docs/operate/hello-world/first-project/sim-setup.md
@@ -6,6 +6,8 @@ layout: "docs"
 type: "docs"
 description: "Set up the hosted simulation environment for the inspection tutorial."
 date: "2025-01-30"
+aliases:
+- gazebo-setup
 ---
 
 This guide walks you through setting up the Gazebo simulation used in the [Your First Project](../) tutorial.

--- a/docs/operate/hello-world/first-project/sim-setup.md
+++ b/docs/operate/hello-world/first-project/sim-setup.md
@@ -14,7 +14,7 @@ If you run into trouble getting this working, reach out on discord or at **TODO*
 
 ## Step 1: Start a Simulation Environment
 
-Visit https://cans.viam-labs.com/, and follow the prompts to log in. Wait for your instance to start.
+Visit [cans.viam-labs.com](https://cans.viam-labs.com), and follow the prompts to log in. Wait for your instance to start.
 
 ## Step 2: Verify the Simulation
 

--- a/docs/operate/hello-world/first-project/sim-setup.md
+++ b/docs/operate/hello-world/first-project/sim-setup.md
@@ -1,47 +1,28 @@
 ---
-linkTitle: "Gazebo Simulation Setup"
-title: "Gazebo Simulation Setup"
+linkTitle: "Simulation Setup"
+title: "Simulation Setup"
 weight: 100
 layout: "docs"
 type: "docs"
-description: "Set up the Gazebo simulation environment for the inspection tutorial."
+description: "Set up the hosted simulation environment for the inspection tutorial."
 date: "2025-01-30"
 ---
 
 This guide walks you through setting up the Gazebo simulation used in the [Your First Project](../) tutorial.
 
-## Prerequisites
+If you run into trouble getting this working, reach out on discord or at **TODO**@viam.com.
 
-- **Docker Desktop** installed and running
-- ~5GB disk space for the Docker image
+## Step 1: Start a Simulation Environment
 
-## Step 1: Pull the Docker Image
+Visit https://cans.viam-labs.com/, and follow the prompts to log in. Wait for your instance to start.
 
-The simulation runs in a Docker container with Gazebo Harmonic and viam-server pre-installed.
+## Step 2: Verify the Simulation
 
-```bash
-docker pull ghcr.io/viamrobotics/can-inspection-simulation:latest-local
-```
-
-This downloads the pre-built image, which takes about a minute depending on your internet connection.
-
-## Step 2: Start the Container
-
-```bash
-docker run --name gz-station1 -d \
-  -p 8080:8080 -p 8081:8081 -p 8443:8443 \
-  ghcr.io/viamrobotics/can-inspection-simulation:latest-local
-```
-
-## Step 3: Verify the Simulation
-
-Open your browser to `http://localhost:8081`
-
-You should see two live camera feeds from the inspection station:
+When your instance is finished starting, you should see two live camera feeds from the inspection station:
 
 {{<imgproc src="/tutorials/first-project/sim-viewer.png" resize="x1100" declaredimensions=true alt="Simulation web viewer showing the Can Inspection Station with Overview Camera and Inspection Camera feeds." class="imgzoom shadow">}}
 
-## Step 4: Create a Machine in Viam
+## Step 3: Create a Machine in Viam
 
 1. Go to [app.viam.com](https://app.viam.com) and create a free account or log in
 2. Click the **Locations** tab
@@ -49,7 +30,7 @@ You should see two live camera feeds from the inspection station:
 
    {{<imgproc src="/tutorials/first-project/fleet-add-machine.png" resize="x1100" declaredimensions=true alt="Viam app Fleet page showing First Location with no machines and the Add machine button." class="imgzoom shadow">}}
 
-## Step 5: Configure Machine Credentials
+## Step 4: Configure Machine Credentials
 
 1. In the Viam app, click the **Awaiting setup** button on your new machine and click **Machine cloud credentials** to copy the credentials JSON
 
@@ -67,7 +48,7 @@ You should see two live camera feeds from the inspection station:
 
    {{<imgproc src="/tutorials/first-project/sim-config-running.png" resize="x1100" declaredimensions=true alt="Simulation configuration page after restart, showing a green 'Configuration updated successfully' banner and Viam Server Status: Running." class="imgzoom shadow">}}
 
-## Step 6: Verify Machine Connection
+## Step 5: Verify Machine Connection
 
 Go back to your machine's page in the Viam app.
 The status indicator should now show **Live**.


### PR DESCRIPTION
## What changed
- reworked the 'gazebo simulation setup' page to reflect the new hosted version (no more docker)
- minor copy edits from going through the instructions
## Why
We moved from docker to hosted sim so that users can get start without installing software on their computer.
## Todo
- [ ] fill in support email