### PR TITLE
Redirect Admin and access section header to overview page

### DIFF
--- a/docs/organization/_index.md
+++ b/docs/organization/_index.md
@@ -5,18 +5,6 @@ weight: 225
 layout: "docs"
 type: "docs"
 no_list: true
+manualLink: "/organization/overview/"
 description: "Manage access, roles, authentication, data regions, and billing for your organization."
 ---
-
-Manage who has access to your machines, configure authentication, and set up billing.
-
-{{< cards >}}
-{{% card link="/organization/overview/" %}}
-{{% card link="/organization/access/" %}}
-{{% card link="/organization/rbac/" %}}
-{{% card link="/organization/api-keys/" %}}
-{{% card link="/organization/oauth/" %}}
-{{% card link="/organization/data-regions/" %}}
-{{% card link="/organization/billing/" %}}
-{{% card link="/organization/white-labeled-billing/" %}}
-{{< /cards >}}


### PR DESCRIPTION
## Summary

Clicking the "Admin and access" section header in the nav now goes directly to the overview page instead of showing a cards landing page.

Adds `manualLink: "/organization/overview/"` to the section `_index.md`, matching the pattern used by Fleet deployment, Manage data, and Monitor and operate sections.

## Test plan

- [ ] Clicking "Admin and access" in the nav goes to the overview page
- [ ] Section still expands to show child pages in the nav sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)