### PR TITLE
Update configure tab UI labels for new attributes section layout

### DIFF
--- a/docs/build-modules/write-a-driver-module.md
+++ b/docs/build-modules/write-a-driver-module.md
@@ -620,7 +620,7 @@ Configure the module on your machine and verify it works.
 
 7. Click **Save**.
 
-**Test using the TEST card:**
+**Test using the Test section:**
 
 1. Find your sensor component and expand the **Test** section.
 2. Your temperature and humidity values appear automatically under

--- a/docs/build-modules/write-a-driver-module.md
+++ b/docs/build-modules/write-a-driver-module.md
@@ -622,7 +622,7 @@ Configure the module on your machine and verify it works.
 
 **Test using the TEST card:**
 
-1. Find your sensor component and expand the **TEST** section.
+1. Find your sensor component and expand the **Test** section.
 2. Your temperature and humidity values appear automatically under
    **GetReadings**.
 
@@ -977,7 +977,7 @@ Each model needs its own `init()` function calling `resource.RegisterComponent`
 2. Open the generated resource file and implement your config validation and
    `GetReadings` method.
 3. Configure the module on your machine as a local module.
-4. Expand the **TEST** section on your sensor. Verify readings appear
+4. Expand the **Test** section on your sensor. Verify readings appear
    automatically under **GetReadings**.
 5. Enable data capture on the sensor. Wait one minute, then check the **DATA**
    tab to confirm readings are flowing to the cloud.

--- a/docs/build-modules/write-a-logic-module.md
+++ b/docs/build-modules/write-a-logic-module.md
@@ -559,8 +559,7 @@ func (s *TempAlert) Reconfigure(
 
 **Test with DoCommand:**
 
-On the **CONFIGURE** tab, expand your service's card and find the **DO COMMAND**
-section. Send a command:
+On the **CONFIGURE** tab, expand your service's **Test** section and then expand **DoCommand**. Send a command:
 
 ```json
 { "command": "get_alerts" }

--- a/docs/build-modules/write-an-inline-module.md
+++ b/docs/build-modules/write-an-inline-module.md
@@ -434,8 +434,8 @@ added.
 
 #### Send test commands
 
-1. On the **CONFIGURE** tab, expand your generic service's card.
-2. Find the **DO COMMAND** section.
+1. On the **CONFIGURE** tab, expand your generic service's **Test** section.
+2. Expand **DoCommand**.
 3. Enter a command (or an empty map `{}` if your DoCommand does not use the
    payload):
 

--- a/docs/dev/reference/try-viam/try-viam-tutorial.md
+++ b/docs/dev/reference/try-viam/try-viam-tutorial.md
@@ -168,9 +168,9 @@ Both [motors](/operate/reference/components/motor/) on this rover use the model 
 
 The attributes section lists the board the motor is wired to, and since the rover's motors are encoded the user interface also shows the encoded motor attributes: the encoder name, motor ramp rate limit, encoder ticks per rotation, and max RPM limit.
 
-You can click **{}** (Switch to Advanced) on the top right of the component's card to view the attributes field in raw JSON format.
+You can click **JSON** on the top right of the component's card to view the attributes field in raw JSON format.
 The attributes pane contains the current JSON configuration for this component.
-Click **Switch to Builder** to return to the default graphical user interface.
+Click **Builder** to return to the default graphical user interface.
 
 ### Base configuration
 

--- a/docs/hardware/common-components/add-a-base.md
+++ b/docs/hardware/common-components/add-a-base.md
@@ -76,7 +76,7 @@ motor names for that side:
 
 ### 4. Save and test
 
-Click **Save**, then expand the **TEST** section.
+Click **Save**, then expand the **Test** section.
 
 - Use the directional controls to drive the base forward, backward, left,
   and right.

--- a/docs/hardware/common-components/add-a-board.md
+++ b/docs/hardware/common-components/add-a-board.md
@@ -85,7 +85,7 @@ immediately. No restart needed.
 ### 5. Test the board
 
 1. Find your board in the configuration view.
-2. Expand the **TEST** section.
+2. Expand the **Test** section.
 3. Try setting a GPIO pin high or low, or read an analog value.
 
 If you have an LED wired to a GPIO pin, setting the pin high should light

--- a/docs/hardware/common-components/add-a-button.md
+++ b/docs/hardware/common-components/add-a-button.md
@@ -54,7 +54,7 @@ attributes.
 
 ### 3. Save and test
 
-Click **Save**, then expand the **TEST** section.
+Click **Save**, then expand the **Test** section.
 
 - Click **Push** to simulate pressing the button.
 

--- a/docs/hardware/common-components/add-a-camera.md
+++ b/docs/hardware/common-components/add-a-camera.md
@@ -89,7 +89,7 @@ Every component in Viam has a built-in **test panel** in the Configure tab.
 The test panel uses the exact same APIs your code will use, so if the camera works here, it will work in your programs.
 
 1. Find your camera component in the configuration view.
-2. Expand the **TEST** section at the bottom of the component panel.
+2. Expand the **Test** section at the bottom of the component panel.
 3. Click **Toggle stream** to see a live video feed from the camera.
 4. Click **Get image** to capture a single frame.
 

--- a/docs/hardware/common-components/add-a-gantry.md
+++ b/docs/hardware/common-components/add-a-gantry.md
@@ -93,7 +93,7 @@ them:
 
 ### 4. Save and test
 
-Click **Save**, then expand the **TEST** section.
+Click **Save**, then expand the **Test** section.
 
 - Read the current position.
 - Command a short move and verify the axis travels the correct distance.

--- a/docs/hardware/common-components/add-a-gripper.md
+++ b/docs/hardware/common-components/add-a-gripper.md
@@ -70,7 +70,7 @@ define the gripper's position relative to the arm:
 
 ### 4. Save and test
 
-Click **Save**, then expand the **TEST** section.
+Click **Save**, then expand the **Test** section.
 
 - Click **Open** to open the gripper.
 - Click **Grab** to close the gripper and check if it grabbed something.

--- a/docs/hardware/common-components/add-a-motor.md
+++ b/docs/hardware/common-components/add-a-motor.md
@@ -96,7 +96,7 @@ If you have an encoder attached, also set:
 
 ### 4. Save and test
 
-Click **Save**, then expand the **TEST** section for the motor.
+Click **Save**, then expand the **Test** section for the motor.
 
 - Use the power slider to spin the motor at different speeds.
 - Toggle direction to verify forward and backward.

--- a/docs/hardware/common-components/add-a-movement-sensor.md
+++ b/docs/hardware/common-components/add-a-movement-sensor.md
@@ -106,7 +106,7 @@ you build a complete spatial picture from multiple hardware sources.
 
 ### Save and test
 
-Click **Save**, then expand the **TEST** section.
+Click **Save**, then expand the **Test** section.
 
 - The test panel shows all available data: position, velocity, orientation,
   and heading.

--- a/docs/hardware/common-components/add-a-power-sensor.md
+++ b/docs/hardware/common-components/add-a-power-sensor.md
@@ -69,7 +69,7 @@ Additional models are available as modules in the
 
 ### 4. Save and test
 
-Click **Save**, then expand the **TEST** section.
+Click **Save**, then expand the **Test** section.
 
 - The test panel shows voltage, current, and power readings.
 - Verify the voltage matches what you expect from your power supply or

--- a/docs/hardware/common-components/add-a-sensor.md
+++ b/docs/hardware/common-components/add-a-sensor.md
@@ -75,7 +75,7 @@ sensor needs.
 
 ### 3. Save and test
 
-Click **Save**, then expand the **TEST** section.
+Click **Save**, then expand the **Test** section.
 
 - The test panel shows the output of `GetReadings`, a table of named values.
 - Verify the readings make sense (for example, room temperature should be roughly

--- a/docs/hardware/common-components/add-a-servo.md
+++ b/docs/hardware/common-components/add-a-servo.md
@@ -66,7 +66,7 @@ the pulse width:
 
 ### 4. Save and test
 
-Click **Save**, then expand the **TEST** section.
+Click **Save**, then expand the **Test** section.
 
 - Use the angle slider to move the servo to different positions.
 - The servo should move smoothly and hold its position.

--- a/docs/hardware/common-components/add-a-switch.md
+++ b/docs/hardware/common-components/add-a-switch.md
@@ -58,7 +58,7 @@ for required attributes.
 
 ### 3. Save and test
 
-Click **Save**, then expand the **TEST** section.
+Click **Save**, then expand the **Test** section.
 
 - Read the current position.
 - Set the switch to different positions and verify it responds correctly.

--- a/docs/hardware/common-components/add-an-arm.md
+++ b/docs/hardware/common-components/add-an-arm.md
@@ -95,7 +95,7 @@ See [Frame System](/motion-planning/frame-system/) for details on configuring fr
 
 ### 4. Save and test
 
-Click **Save**, then expand the **TEST** section.
+Click **Save**, then expand the **Test** section.
 
 - Use the joint position controls to move individual joints.
 - Verify each joint moves in the expected direction.

--- a/docs/hardware/common-components/add-an-encoder.md
+++ b/docs/hardware/common-components/add-an-encoder.md
@@ -101,7 +101,7 @@ the motor shaft. Check your encoder's datasheet. Common values are 12, 48,
 
 ### 5. Save and test
 
-Click **Save**, then expand the **TEST** section for the encoder.
+Click **Save**, then expand the **Test** section for the encoder.
 
 - Manually rotate the motor shaft. The tick count should change.
 - Rotating in one direction should increase the count; the other direction

--- a/docs/hardware/common-components/add-an-input-controller.md
+++ b/docs/hardware/common-components/add-an-input-controller.md
@@ -96,7 +96,7 @@ and works with browser-compatible game controllers or on-screen controls.
 
 ### Save and test
 
-Click **Save**, then expand the **TEST** section.
+Click **Save**, then expand the **Test** section.
 
 - The test panel shows all available controls (buttons, axes).
 - Press buttons or move joystick axes. Events should appear in real time.

--- a/docs/manage/fleet/reuse-configuration.md
+++ b/docs/manage/fleet/reuse-configuration.md
@@ -52,7 +52,7 @@ If you already created a machine to test your configuration, you can **Switch to
 
 Fragments support variable substitution, allowing you to use the same fragment for multiple use cases even if there are small differences in configuration.
 
-When configuring resources, click the **{} JSON** button to switch to advanced view.
+When configuring resources, click the **JSON** button to switch to the JSON editor.
 Instead of a key value, add a variable in the form `"$variable": { "name": "placeholder" } }}`.
 For example:
 
@@ -177,7 +177,7 @@ For example if you changed the default camera configuration in the fragment to b
 {{< tabs >}}
 {{% tab name="Config Builder" %}}
 
-You can click the **{}** button to switch to advanced view and see the changes.
+You can click the **JSON** button to switch to the JSON editor and see the changes.
 
 Click **Save**.
 

--- a/docs/operate/hello-world/first-project/part-1.md
+++ b/docs/operate/hello-world/first-project/part-1.md
@@ -176,7 +176,7 @@ Now add a vision service that connects your camera to the ML model service.
 1. Select the `vision-service` service in your machine's configuration
 2. Find the **ML Model** dropdown and select `model-service` (the ML model service you just created)
 3. Find the **Default Camera** dropdown and select `inspection-cam`
-4. Find the **Attributes** section and set **Minimum confidence threshold** to 0.75
+4. In the **Attributes** section, set **Minimum confidence threshold** to 0.75
 5. Click **Save** in the upper right corner
 
 {{<imgproc src="/tutorials/first-project/vision-service-config.png" resize="x1100" declaredimensions=true alt="Vision service configuration panel showing ML Model set to model-service, Default Camera set to inspection-cam, and confidence threshold at 0.75." class="imgzoom shadow">}}

--- a/docs/operate/reference/architecture/parts.md
+++ b/docs/operate/reference/architecture/parts.md
@@ -110,7 +110,7 @@ To establish a connection between a part of one machine and a part of a second m
 1. Select the remote part from the list of parts.
 
    Alternatively, click **Add empty remote** and then scroll to the newly-created remote part configuration card.
-   Click on **{}** (Switch to advanced) and replace the JSON object with a remote config.
+   Click on **JSON** and replace the JSON object with a remote config.
 
    {{<imgproc src="/build/configure/parts/remote-config.png" resize="x1100" declaredimensions=true alt="The configured remote." style="width:700px" class="shadow" >}}
 

--- a/docs/operate/reference/components/camera/_index.md
+++ b/docs/operate/reference/components/camera/_index.md
@@ -80,7 +80,7 @@ If none of these steps work, reach out to us on the [Community Discord](https://
 When working with a [camera](/operate/reference/components/camera/) component, depending on the camera, you may need to explicitly provide some camera-specific configuration parameters.
 
 Check the specifications for your camera, and manually provide configuration parameters such as width and height to the camera component configuration panel.
-On the **CONFIGURE** page, find your camera, then fill in your camera's specific configuration either using the **Show more** button to show the relevant configuration options, or the **{}** (Switch to Advanced) button in the top right of the component panel to enter these attributes manually.
+On the **CONFIGURE** page, find your camera, then fill in your camera's specific configuration either using the **Show more** button to show the relevant configuration options, or the **JSON** button to enter these attributes manually.
 Provide at least the width and height values to start.
 
 {{% /expand%}}

--- a/docs/operate/reference/components/camera/webcam.md
+++ b/docs/operate/reference/components/camera/webcam.md
@@ -115,9 +115,7 @@ To add and use the service:
    {{<imgproc src="/components/camera/webcam-discovery-test.png" alt="The test panel for the find-webcams service." resize="1100x" style="max-width:600px" class="shadow imgzoom" >}}
 
 1. Click the **Copy attributes** button for the camera you want to use.
-1. Click the **{}** icon in the upper right corner of the camera component configuration.
-
-   {{<imgproc src="/components/camera/advanced-config.png" resize="x1100" declaredimensions=true alt="The switch to advanced button." style="width:200px" class="shadow" >}}
+1. Click the **JSON** button in the upper right corner of the camera component configuration.
 
 1. Paste the copied attributes.
 1. Click **Save**.

--- a/docs/operate/reference/components/component/board1.md
+++ b/docs/operate/reference/components/component/board1.md
@@ -34,7 +34,7 @@ Enter a name or use the suggested name for your board and click **Create**.
 
 ![An example configuration for a <board-model> board.](/components/board/pi-ui-config.png)
 
-Click the **{}** (Switch to Advanced) button in the top right of the component panel to edit your board's attributes with JSON, according to the following table.
+Click the **JSON** button in the top right of the component panel to edit your board's attributes with JSON, according to the following table.
 
 {{% /tab %}}
 {{% tab name="JSON Template" %}}

--- a/docs/operate/reference/components/input-controller/gpio.md
+++ b/docs/operate/reference/components/input-controller/gpio.md
@@ -28,8 +28,8 @@ Enter a name or use the suggested name for your input controller and click **Cre
 
 ![An example configuration for a GPIO input controller component](/components/input-controller/gpio-input-controller-ui-config.png)
 
-Click **{}** (Switch to advanced) to edit buttons and axes.
-Copy and paste the following attribute template into your input controller's **Attributes** box.
+Click **JSON** to edit buttons and axes.
+Copy and paste the following attribute template into the JSON editor.
 Then remove and fill in the attributes as applicable to your input controller, according to the table below.
 
 {{< tabs >}}

--- a/docs/operate/reference/services/slam/cartographer/_index.md
+++ b/docs/operate/reference/services/slam/cartographer/_index.md
@@ -125,7 +125,7 @@ To create a new map, follow the instructions below.
 
 3. (Optional) Configure cartographer to use cloudSLAM:
 
-   On the `SLAM` service configuration pane, click the **JSON** button to switch to the JSON editor and set the `use_cloud_slam` field to **true**. This setting disables local mapping to limit cpu usage in favor of using cloudSLAM.
+   On the `SLAM` service configuration pane, click the **JSON** button to switch to the JSON editor and set the `use_cloud_slam` field to **true**. This setting disables local mapping to limit CPU usage in favor of using cloudSLAM.
 
    In addition, your configured LiDAR camera and movement sensor must have data capture enabled. See the [cloudSLAM](../cloudslam/) documentation for more information on how to configure the feature on your machine and how to use cloudSLAM.
 

--- a/docs/operate/reference/services/slam/cartographer/_index.md
+++ b/docs/operate/reference/services/slam/cartographer/_index.md
@@ -116,7 +116,7 @@ To create a new map, follow the instructions below.
    - **Maximum range (meters)**: Set the maximum range of your `rplidar`.
      See [config params](#config_params) for suggested values for RPLidar A1 and A3.
 
-   If you would like to tune additional Cartographer parameters, you can the click **{}** button to switch to the advanced view, then edit the `config_params` from there.
+   If you would like to tune additional Cartographer parameters, click the **JSON** button to switch to the JSON editor, then edit the `config_params` from there.
    See the [`config_params`](#config_params) section for more information on the other parameters.
 
    To save your changes, click the **Save** button in the top right corner of the page.
@@ -125,7 +125,7 @@ To create a new map, follow the instructions below.
 
 3. (Optional) Configure cartographer to use cloudSLAM:
 
-   On the `SLAM` service configuration pane, click the **{}** button to switch to advanced views and set the `use_cloud_slam` field to **true**. This setting disables local mapping to limit cpu usage in favor of using cloudSLAM.
+   On the `SLAM` service configuration pane, click the **JSON** button to switch to the JSON editor and set the `use_cloud_slam` field to **true**. This setting disables local mapping to limit cpu usage in favor of using cloudSLAM.
 
    In addition, your configured LiDAR camera and movement sensor must have data capture enabled. See the [cloudSLAM](../cloudslam/) documentation for more information on how to configure the feature on your machine and how to use cloudSLAM.
 

--- a/docs/operate/reference/services/slam/cloudslam/_index.md
+++ b/docs/operate/reference/services/slam/cloudslam/_index.md
@@ -175,7 +175,7 @@ You _do not_ need to configure data capture on the individual IMU and odometer.
 
 5. Configure Cartographer to use cloudslam.
 
-   In your `cartographer` config card, click the **{}** button to switch to advanced views and set the `use_cloud_slam` field to **true**. This setting disables local mapping to limit cpu usage in favor of using cloudslam.
+   In your `cartographer` config card, click the **JSON** button to switch to the JSON editor and set the `use_cloud_slam` field to **true**. This setting disables local mapping to limit cpu usage in favor of using cloudslam.
 
 {{% /tab %}}
 {{% tab name="JSON Example" %}}

--- a/docs/operate/reference/services/slam/cloudslam/_index.md
+++ b/docs/operate/reference/services/slam/cloudslam/_index.md
@@ -175,7 +175,7 @@ You _do not_ need to configure data capture on the individual IMU and odometer.
 
 5. Configure Cartographer to use cloudslam.
 
-   In your `cartographer` config card, click the **JSON** button to switch to the JSON editor and set the `use_cloud_slam` field to **true**. This setting disables local mapping to limit cpu usage in favor of using cloudslam.
+   In your `cartographer` config card, click the **JSON** button to switch to the JSON editor and set the `use_cloud_slam` field to **true**. This setting disables local mapping to limit CPU usage in favor of using cloudslam.
 
 {{% /tab %}}
 {{% tab name="JSON Example" %}}

--- a/docs/operate/reference/services/vision/mlmodel.md
+++ b/docs/operate/reference/services/vision/mlmodel.md
@@ -58,7 +58,7 @@ Select the ML model service your model is deployed on from the **ML Model** drop
 Add a default camera for the vision service to use.
 
 Edit other attributes as applicable according to the table below.
-You can edit optional attributes in raw JSON by clicking **{}** (Switch to advanced) on the right side of your service panel.
+You can edit optional attributes in raw JSON by clicking **JSON** on the right side of your service panel.
 
 {{% /tab %}}
 {{% tab name="JSON Template" %}}

--- a/docs/try/part-1.md
+++ b/docs/try/part-1.md
@@ -80,7 +80,7 @@ After adding the camera component, you will see two items appear under your mach
 
 To configure your camera component to work with the camera in the simulation, you need to specify the correct camera ID. Most components require a few configuration parameters.
 
-1. In the **ATTRIBUTES** section, add:
+1. In the **Attributes** section, add:
 
    ```json
    {
@@ -101,8 +101,8 @@ Verify the camera is working. Every component in Viam has a built-in test card r
 ### Open the test panel
 
 1. You should still be on the **CONFIGURE** tab with your `inspection-cam` selected
-2. Look for the **TEST** section at the bottom of the camera's configuration panel
-3. Click **TEST** to expand the camera's test card
+2. Look for the **Test** section at the bottom of the camera's configuration panel
+3. Click **Test** to expand the camera's test card
 
 The camera component test card uses the camera API to add an image feed to the Viam app, enabling you to determine whether your camera is working. You should see a live video feed from the simulated camera. This is an overhead view of the conveyor/staging area.
 
@@ -168,8 +168,8 @@ This fragment works with any camera. If you were using a USB webcam instead of t
 
 ### Test the vision service
 
-1. Find the **TEST** section at the bottom of the `vision-service` configuration panel
-2. Expand the **TEST** card
+1. Find the **Test** section at the bottom of the `vision-service` configuration panel
+2. Expand the **Test** card
 3. If not already selected, select `inspection-cam` as the camera source
 4. Set **Detections/Classifications** to `Live`
 5. Check that detection and labeling are working

--- a/docs/try/part-4.md
+++ b/docs/try/part-4.md
@@ -238,8 +238,8 @@ Click **Save**.
 **Test the inspector:**
 
 1. In the **CONFIGURE** tab, click on `inspector-service` to open its configuration panel
-2. Expand **TEST** card at the bottom
-3. In the **DO COMMAND** section, enter `{"detect": true}`
+2. Expand the **Test** section at the bottom
+3. Expand **DoCommand** and enter `{"detect": true}`
 4. Click **Execute**
 5. You should see a response with `label` and `confidence` values
 6. Click **Execute** several more times to see different detections as cans pass beneath the inspection-cam

--- a/docs/tutorials/configure/pet-photographer.md
+++ b/docs/tutorials/configure/pet-photographer.md
@@ -892,7 +892,7 @@ If you have a different item you want to use, or want to match to a color that m
 1. Enter a name or use the suggested name for your color detector.
    This tutorial uses the name 'my_color_detector' in all example code.
 1. click **Create**.
-1. In the vision service's **Attributes** section, click the color selection box to set the color to be detected.
+1. In the vision service's **Attributes** section, click the color selection box to set the color to detect.
    For this tutorial, set the color to `#43A1D0` or `rgb(67, 161, 208)`.
    Alternatively, you can provide the color of your pet, or use a different brightly-colored collar or ribbon.
 1. Set **Hue Tolerance** to `0.06` and **Segment size px** to `100`.

--- a/docs/tutorials/services/navigate-with-rover-base.md
+++ b/docs/tutorials/services/navigate-with-rover-base.md
@@ -105,7 +105,7 @@ We used a [`jetson` board](https://github.com/viam-modules/nvidia/tree/main/jets
 
 2. Configure [digital interrupts](https://github.com/viam-modules/nvidia/blob/main/README.md#digital-interrupt-configuration) on your board to signal precise GPIO state changes to the [encoders](/operate/reference/components/encoder/) on your rover base.
    Find your board on the **CONFIGURE** tab in **Builder** mode.
-   Click the **{}** (Switch to advanced) button on the right side of your board's card to switch to JSON attributes editing mode.
+   Click the **JSON** button on the right side of your board's card to switch to JSON attributes editing mode.
    Copy and paste the following JSON into your board's attributes field to add [digital interrupts](https://github.com/viam-modules/nvidia/blob/main/README.md#digital-interrupt-configuration) on pins `31`, `29`, `23`, and `21`:
 
 ```json {class="line-numbers linkable-line-numbers"}

--- a/static/include/components/troubleshoot/camera.md
+++ b/static/include/components/troubleshoot/camera.md
@@ -2,7 +2,7 @@ If your camera is not working as expected, follow these steps:
 
 1. Check your machine logs on the **LOGS** tab to check for errors.
 1. Review this camera model's documentation to ensure you have configured all required attributes.
-1. Click on the **TEST** panel on the **CONFIGURE** or **CONTROL** tab and test if you can use the camera there.
+1. Click on the **Test** panel on the **CONFIGURE** or **CONTROL** tab and test if you can use the camera there.
 
 If none of these steps work, reach out to us on the [Community Discord](https://discord.gg/viam) and we will be happy to help.
 
@@ -13,6 +13,6 @@ If none of these steps work, reach out to us on the [Community Discord](https://
 When working with a [camera](/operate/reference/components/camera/) component, depending on the camera, you may need to explicitly provide some camera-specific configuration parameters.
 
 **Solution:** Check the specifications for your camera, and manually provide configuration parameters such as width and height to the camera component configuration panel.
-On the **CONFIGURE** page, find your camera, then fill in your camera's specific configuration either using the **Show more** button to show the relevant configuration options, or the **{}** (Switch to Advanced) button in the top right of the component panel to enter these attributes manually.
+On the **CONFIGURE** page, find your camera, then fill in your camera's specific configuration either using the **Show more** button to show the relevant configuration options, or the **JSON** button to enter these attributes manually.
 Provide at least the width and height values to start.
 {{% /expand%}}


### PR DESCRIPTION
## Source changes

- viamrobotics/app#11648 (APP-15892): Restructured component and service cards on the configure tab. The old `SectionGroup title="configure"` with a nested `Section title="Attributes"` was replaced by a `CardSection title="Attributes"` with a Builder/JSON toggle. The old `{}` (Switch to advanced) button was replaced by explicit **Builder** and **JSON** toggle buttons. The **DO COMMAND** section was moved inside the **Test** section as a nested subsection. Section headings no longer use CSS `text-transform: uppercase`.

## Docs changes

- **34 files**: Replace `**{}** (Switch to advanced)` with `**JSON**` button references (12 pages)
- Replace `**Switch to Builder**` with `**Builder**` (1 page)
- Update `**DO COMMAND**` section references to note it is now nested inside the **Test** section (3 pages)
- Fix section label casing from uppercase (`**TEST**`, `**ATTRIBUTES**`) to title case (`**Test**`, `**Attributes**`) to match new CardSection rendering (20+ pages)
- Remove outdated screenshot reference for the old `{}` button (1 page)

## How I found these

- Xref lookup: `flows.md` and Playbook 5 (UI verification)
- Grep matches: searched for `**{}**`, `Switch to advanced`, `Switch to Builder`, `**TEST**`, `**ATTRIBUTES**`, `**DO COMMAND**` across entire docs repo; found 40+ matching locations across 34 files

---
Generated by daily docs change agent