### PR TITLE
docs(hello-world): use correct tflite module name

### DIFF
--- a/docs/operate/hello-world/first-project/part-1.md
+++ b/docs/operate/hello-world/first-project/part-1.md
@@ -131,7 +131,7 @@ You'll configure two services:
 1. Click **+** next to your machine part
 2. Select **Configuration block**
 3. Search for `tflite`
-4. Select `tflight_cpu/tflight_cpu`
+4. Select `tflite_cpu/tflite_cpu`
 5. Click **Add component**
 6. Name it `model-service`
 7. Click **Add component**


### PR DESCRIPTION
While going through the new hello world guide (very neat setup with the simulator!), I noticed the naming for the tflite_cpu module was incorrect. This is a quick PR to use the correct naming. 
