### PR TITLE
Update machine settings card labels for new layout

### DIFF
--- a/docs/fleet/system-settings.md
+++ b/docs/fleet/system-settings.md
@@ -13,7 +13,7 @@ Configure system-level settings for deployed machines. These settings are manage
 
 Control which versions of `viam-agent` and `viam-server` run on the machine.
 
-In the machine settings card, under **Viam agent version control**:
+In the machine settings card, open **Settings** and expand **Software Updates**:
 
 | Field         | Type   | Default    | Description                                                                                            |
 | ------------- | ------ | ---------- | ------------------------------------------------------------------------------------------------------ |
@@ -22,7 +22,7 @@ In the machine settings card, under **Viam agent version control**:
 
 ## Agent advanced settings
 
-Under **Agent advanced settings**:
+In the machine settings card, open **Settings** and expand **Advanced**:
 
 | Field                               | Type    | Default | Description                                                                 |
 | ----------------------------------- | ------- | ------- | --------------------------------------------------------------------------- |
@@ -38,7 +38,7 @@ Under **Agent advanced settings**:
 
 Add WiFi or wired networks that the machine can connect to. Each network is a named entry with connection parameters.
 
-In the machine settings card under **Networks**, click **Add another network** and configure:
+In the machine settings card, open **Settings** and expand **Known Networks**. Click **Add another network** and configure:
 
 | Field               | Type    | Default  | Description                                                                                |
 | ------------------- | ------- | -------- | ------------------------------------------------------------------------------------------ |
@@ -108,7 +108,7 @@ By default, `viam-server` listens on `localhost:8080`. To change the bind addres
 
 Control automatic operating system package updates on the machine.
 
-Under **System configuration**, set `os_auto_upgrade_type`:
+In the machine settings card, open **Settings** and expand **System**. Set `os_auto_upgrade_type`:
 
 | Value        | Description                                                              |
 | ------------ | ------------------------------------------------------------------------ |
@@ -121,7 +121,7 @@ Under **System configuration**, set `os_auto_upgrade_type`:
 
 Forward operating system logs from the machine to Viam's cloud log viewer.
 
-Under **System configuration**:
+In the machine settings card, open **Settings** and expand **System**:
 
 | Field                                        | Type    | Default | Description                                                             |
 | -------------------------------------------- | ------- | ------- | ----------------------------------------------------------------------- |

--- a/docs/manage/reference/viam-agent/_index.md
+++ b/docs/manage/reference/viam-agent/_index.md
@@ -175,7 +175,7 @@ Your machine credentials file must be at <file>\etc\viam.json</file>.
 {{% /tab %}}
 {{< /tabs >}}
 
-## `version_control`: Version management for `viam-agent` and `viam-server`
+## `version_control`: Version management for `viam-agent` and `viam-server` {#version-control}
 
 By default, when a new version of `viam-server` becomes available, it will automatically download.
 When `viam-agent` next restarts, it installs and starts using the new version of `viam-server`.
@@ -213,7 +213,7 @@ To update the version of `viam-server` (or the RDK) update the machine settings.
 3. Change the specified `viam-server` version.
 4. Save your configuration.
 
-## `advanced_settings`
+## `advanced_settings` {#advanced-settings}
 
 <!-- prettier-ignore -->
 | Name       | Type | Required? | Description |

--- a/docs/manage/reference/viam-agent/_index.md
+++ b/docs/manage/reference/viam-agent/_index.md
@@ -175,6 +175,7 @@ Your machine credentials file must be at <file>\etc\viam.json</file>.
 {{% /tab %}}
 {{< /tabs >}}
 
+<a id="version_control-version-management-for-viam-agent-and-viam-server"></a>
 ## `version_control`: Version management for `viam-agent` and `viam-server` {#version-control}
 
 By default, when a new version of `viam-server` becomes available, it will automatically download.

--- a/docs/manage/reference/viam-agent/_index.md
+++ b/docs/manage/reference/viam-agent/_index.md
@@ -176,6 +176,7 @@ Your machine credentials file must be at <file>\etc\viam.json</file>.
 {{< /tabs >}}
 
 <a id="version_control-version-management-for-viam-agent-and-viam-server"></a>
+
 ## `version_control`: Version management for `viam-agent` and `viam-server` {#version-control}
 
 By default, when a new version of `viam-server` becomes available, it will automatically download.
@@ -215,6 +216,7 @@ To update the version of `viam-server` (or the RDK) update the machine settings.
 4. Save your configuration.
 
 <a id="advanced_settings"></a>
+
 ## `advanced_settings` {#advanced-settings}
 
 <!-- prettier-ignore -->

--- a/docs/manage/reference/viam-agent/_index.md
+++ b/docs/manage/reference/viam-agent/_index.md
@@ -214,6 +214,7 @@ To update the version of `viam-server` (or the RDK) update the machine settings.
 3. Change the specified `viam-server` version.
 4. Save your configuration.
 
+<a id="advanced_settings"></a>
 ## `advanced_settings` {#advanced-settings}
 
 <!-- prettier-ignore -->

--- a/docs/operate/reference/viam-server/_index.md
+++ b/docs/operate/reference/viam-server/_index.md
@@ -79,7 +79,7 @@ Alternatively, if you are having issues with a module, try the **Restart module*
 
 There are a few updates that may make your machine temporarily unavailable:
 
-- [`viam-agent` updating itself](/manage/reference/viam-agent/#version_control-version-management-for-viam-agent-and-viam-server)
+- [`viam-agent` updating itself](/manage/reference/viam-agent/#version-control)
 - [`viam-agent` updating `viam-server`](/manage/reference/viam-agent/#update-or-downgrade-viam-server-with-viam-agent)
 - configuration updates
 

--- a/docs/operate/reference/viam-server/manage-viam-server.md
+++ b/docs/operate/reference/viam-server/manage-viam-server.md
@@ -155,7 +155,7 @@ Follow the manual steps to update the standalone version.
 {{% tab name="Installed with viam-agent" %}}
 
 By default, `viam-agent` automatically upgrades to the latest stable version of `viam-server`.
-You can change this behavior in the [`version_control` settings of your machine](/manage/reference/viam-agent/#version_control-version-management-for-viam-agent-and-viam-server).
+You can change this behavior in the [`version_control` settings of your machine](/manage/reference/viam-agent/#version-control).
 For example, the following `version_control` configuration will always update to the latest stable release of `viam-agent` and the latest development release of `viam-server`:
 
 ```json {class="line-numbers linkable-line-numbers" data-line=""}
@@ -212,7 +212,7 @@ We recommend running `brew upgrade viam-server` on a regular basis.
 {{< tabs >}}
 {{% tab name="Installed with viam-agent" %}}
 
-To disable automatic updates, configure the [`version_control` settings of your machine](/manage/reference/viam-agent/#version_control-version-management-for-viam-agent-and-viam-server) to a specific version number.
+To disable automatic updates, configure the [`version_control` settings of your machine](/manage/reference/viam-agent/#version-control) to a specific version number.
 For example, the following `version_control` configuration pins `viam-server` to version `0.52.1`, preventing `viam-server` from updating to a more recent version:
 
 ```json {class="line-numbers linkable-line-numbers" data-line=""}


### PR DESCRIPTION
## Source changes

- viamrobotics/app#11640 (APP-15678): The Machine Settings card was redesigned. The flat `CardLayout` was replaced with a nested `CardSection` hierarchy. Settings are now collapsible subsections under a top-level **Settings** section, plus a separate **Details** section.
  - "Viam agent version control" → "Software Updates"
  - "Agent advanced settings" → "Advanced"
  - "Networks" → "Known Networks"
  - "System configuration" → "System"
  - "Network configuration" → "Server Connection"
  - New "Provisioning & Hotspot" subsection
- Each subsection also gained a "Docs" button linking into `/manage/reference/viam-agent/` at specific anchors (`#version-control`, `#system-configuration`, `#advanced-settings`).

## Docs changes

- `docs/fleet/system-settings.md`: update the five references to the old subsection labels to use the new labels and the **Settings > subsection** navigation path.
- `docs/manage/reference/viam-agent/_index.md`: add custom anchor IDs `{#version-control}` and `{#advanced-settings}` so the new UI "Docs" buttons land on the correct sections. The `#system-configuration` anchor already matches the existing heading slug and needs no change.
- `docs/operate/reference/viam-server/_index.md` and `docs/operate/reference/viam-server/manage-viam-server.md`: update the three existing internal links that used the long auto-generated slug to use the new `#version-control` anchor.

## How I found these

- Grep for `Viam agent version control`, `Agent advanced settings`, `Network management and hotspot`, `System configuration` across the docs repo.
- Followed the new UI docs links in the source diff to their anchor targets and verified the existing headings would not match.
- Cross-referenced existing internal links to `viam-agent/#version_control-...` so they could be updated at the same time.

---
Generated by daily docs change agent