### PR TITLE
Document parenting components to intermediate arm frames

### DIFF
--- a/docs/motion-planning/frame-system.md
+++ b/docs/motion-planning/frame-system.md
@@ -64,6 +64,30 @@ world
 └── table-surface
 ```
 
+### Parent to an intermediate arm link
+
+If you mount a component on an intermediate link of an arm rather than on the
+end effector, set the parent to `<arm-name>:<link-name>`. The link name is the
+`id` of a link in the arm's kinematic model. For example, if you have an arm
+named `my-arm` with a UR5e kinematic model and you strap a camera to the
+forearm, set the camera's parent to `my-arm:forearm_link`.
+
+```json
+{
+  "parent": "my-arm:forearm_link",
+  "translation": { "x": 0, "y": 0, "z": 30 },
+  "orientation": {
+    "type": "ov_degrees",
+    "value": { "x": 0, "y": 0, "z": 1, "th": 0 }
+  }
+}
+```
+
+The motion service plans around components attached to intermediate links the
+same way it plans for components attached to the arm's end effector. To find
+the link names for an arm, inspect its kinematic model file or run
+`viam machines motion print-config` and look for frames under the arm's name.
+
 ### Translation
 
 Translation is the offset in millimeters from the parent frame's origin to the

--- a/docs/motion-planning/frame-system.md
+++ b/docs/motion-planning/frame-system.md
@@ -86,7 +86,7 @@ forearm, set the camera's parent to `my-arm:forearm_link`.
 The motion service plans around components attached to intermediate links the
 same way it plans for components attached to the arm's end effector. To find
 the link names for an arm, inspect its kinematic model file or run
-`viam machines motion print-config` and look for frames under the arm's name.
+`viam machines part motion print-config` and look for frames under the arm's name.
 
 ### Translation
 
@@ -145,10 +145,10 @@ You can inspect your frame system from the command line without writing code:
 
 ```sh
 # Print the frame system configuration
-viam machines motion print-config --part "my-machine-main"
+viam machines part motion print-config --part "my-machine-main"
 
 # Print the current pose of every component relative to world
-viam machines motion print-status --part "my-machine-main"
+viam machines part motion print-status --part "my-machine-main"
 ```
 
 If a component's pose looks wrong, check the translation and orientation values

--- a/docs/motion-planning/motion-how-to/move-arm-to-pose.md
+++ b/docs/motion-planning/motion-how-to/move-arm-to-pose.md
@@ -239,10 +239,10 @@ You can move the arm and check poses without writing code:
 
 ```sh
 # Check the arm's current pose
-viam machines motion get-pose --part "my-machine-main" --component "my-arm"
+viam machines part motion get-pose --part "my-machine-main" --component "my-arm"
 
 # Move the arm to a new position (only specified values change)
-viam machines motion set-pose --part "my-machine-main" --component "my-arm" \
+viam machines part motion set-pose --part "my-machine-main" --component "my-arm" \
   --x 300 --y 200 --z 400
 ```
 

--- a/docs/motion-planning/reference/motion-service.md
+++ b/docs/motion-planning/reference/motion-service.md
@@ -135,7 +135,7 @@ All commands require the `--part` flag to identify the machine part.
 Prints the frame system configuration for all parts.
 
 ```sh
-viam machines motion print-config --part "my-machine-main"
+viam machines part motion print-config --part "my-machine-main"
 ```
 
 ### print-status
@@ -143,7 +143,7 @@ viam machines motion print-config --part "my-machine-main"
 Prints the current pose of every component relative to the world frame.
 
 ```sh
-viam machines motion print-status --part "my-machine-main"
+viam machines part motion print-status --part "my-machine-main"
 ```
 
 Output shows X, Y, Z position (mm) and orientation (OX, OY, OZ, Theta in

--- a/docs/motion-planning/reference/motion-service.md
+++ b/docs/motion-planning/reference/motion-service.md
@@ -132,7 +132,7 @@ All commands require the `--part` flag to identify the machine part.
 
 ### print-config
 
-Prints the frame system configuration for all parts.
+Prints the frame system configuration for the specified machine part.
 
 ```sh
 viam machines part motion print-config --part "my-machine-main"
@@ -154,7 +154,7 @@ degrees) for each frame.
 Gets the current pose of a specific component in the world frame.
 
 ```sh
-viam machines motion get-pose --part "my-machine-main" --component "my-arm"
+viam machines part motion get-pose --part "my-machine-main" --component "my-arm"
 ```
 
 ### set-pose
@@ -164,7 +164,7 @@ position and orientation values you provide are changed; the rest are kept from
 the component's current pose.
 
 ```sh
-viam machines motion set-pose --part "my-machine-main" --component "my-arm" \
+viam machines part motion set-pose --part "my-machine-main" --component "my-arm" \
   --x 300 --y 200 --z 400
 ```
 


### PR DESCRIPTION
## Source changes

- viamrobotics/rdk#5910: Enables parenting components to internal (intermediate) frames of arms, such as a camera strapped to the forearm of a UR5e. Users can now set the `parent` field in a frame configuration to `<arm-name>:<link-name>`, where the link name is an id from the arm's kinematic model. Public APIs are unchanged — the motion service plans around the component as if it were attached anywhere else.

## Docs changes

- `docs/motion-planning/frame-system.md`: add a short "Parent to an intermediate arm link" subsection under Parent-child hierarchy that explains the `<arm-name>:<link-name>` syntax, shows a JSON example, and points to the kinematic model file and the CLI as sources for link names.

## How I found these

- Read the RDK diff (referenceframe/frame_system.go) and the PR description, which calls out the new capability explicitly.
- Grep for `upper_arm_link`, `forearm_link`, `base_link`, `my-arm:`, etc. across the docs repo. Only `docs/motion-planning/constraints.md` mentioned the namespaced link naming (in the context of `CollisionSpecification`), but no page explained how to set the `parent` field to an intermediate link.

---
Generated by daily docs change agent