### PR TITLE
Manage data: fix broken Python SDK, SQL timestamp bug, and tutorial nav

### DIFF
--- a/docs/data/capture-sync/capture-and-sync-data.md
+++ b/docs/data/capture-sync/capture-and-sync-data.md
@@ -81,14 +81,12 @@ If you want to keep a local copy, copy the data to a new folder and sync that fo
 
 Wait 30 seconds to a minute for data to accumulate and sync, then:
 
-1. In the Viam app, click the **DATA** tab in the top navigation.
-2. You should see captured data appearing. For camera captures, you will see
-   image thumbnails. For sensor data, you will see tabular entries.
+1. In the Viam app, click the **DATA** tab in the top navigation. The tab opens on the **Images** view by default.
+2. For camera captures, you should see image thumbnails appearing. For sensor data, click the **Sensors** tab to see the latest readings from each machine and resource. To see historical rows of tabular data, click the small search icon next to a resource on the Sensors tab to open the query editor.
 3. Use the filters on the left to narrow by:
    - **Machine** -- select your specific machine
    - **Component** -- select the component you configured
    - **Time range** -- pick a recent window
-   - **Data type** -- Images or Tabular
 
 If you see data flowing in, capture and sync are working correctly.
 
@@ -127,8 +125,9 @@ If you see data flowing in, capture and sync are working correctly.
 
 {{< expand "Local disk filling up" >}}
 
-- By default, captured data is stored in `~/.viam/capture` before syncing. If
-  sync is disabled or the machine is offline for an extended period, this
+- By default, captured data is stored in `$HOME/.viam/capture` before syncing
+  (`/root/.viam/capture` when `viam-server` runs as root through `viam-agent`).
+  If sync is disabled or the machine is offline for an extended period, this
   directory can grow large.
 - Re-enable sync or manually clear the capture directory if needed.
 - Check that the **Syncing** toggle is on in the data management service

--- a/docs/data/capture-sync/conditional-sync.md
+++ b/docs/data/capture-sync/conditional-sync.md
@@ -34,12 +34,12 @@ If `selective_syncer_name` is configured but the sensor cannot be found, **sched
 
 ## Configure conditional sync
 
-This example uses the [`sync-at-time:timesyncsensor`](https://app.viam.com/module/naomi/sync-at-time) module to sync data only during a configured time window. You can substitute any sensor that returns `should_sync`.
+This example uses the [`sync-at-time/timesyncsensor`](https://app.viam.com/module/naomi/sync-at-time) component to sync data only during a configured time window. You can substitute any sensor that returns `should_sync`.
 
 ### 1. Add the sync sensor
 
 1. On your machine's **CONFIGURE** tab, click **+** next to your machine part and select **Component or service**.
-2. Search for **sync-at-time** and select the `naomi:sync-at-time:timesyncsensor` component.
+2. Search for **sync-at-time/timesyncsensor** and select the result.
 3. Click **Add module**, enter a name (for example, `timesensor`), and click **Create**.
 4. Configure the time window in the sensor's attributes:
 

--- a/docs/data/capture-sync/conditional-sync.md
+++ b/docs/data/capture-sync/conditional-sync.md
@@ -39,7 +39,7 @@ This example uses the [`sync-at-time:timesyncsensor`](https://app.viam.com/modul
 ### 1. Add the sync sensor
 
 1. On your machine's **CONFIGURE** tab, click **+** next to your machine part and select **Component or service**.
-2. Search for and select the `sync-at-time:timesyncsensor` model.
+2. Search for **sync-at-time** and select the `naomi:sync-at-time:timesyncsensor` component.
 3. Click **Add module**, enter a name (for example, `timesensor`), and click **Create**.
 4. Configure the time window in the sensor's attributes:
 

--- a/docs/data/capture-sync/conditional-sync.md
+++ b/docs/data/capture-sync/conditional-sync.md
@@ -34,7 +34,7 @@ If `selective_syncer_name` is configured but the sensor cannot be found, **sched
 
 ## Configure conditional sync
 
-This example uses the [`sync-at-time/timesyncsensor`](https://app.viam.com/module/naomi/sync-at-time) component to sync data only during a configured time window. You can substitute any sensor that returns `should_sync`.
+This example uses the [`sync-at-time/timesyncsensor`](https://app.viam.com/module/naomi/sync-at-time) sensor module to sync data only during a configured time window. You can substitute any sensor that returns `should_sync`.
 
 ### 1. Add the sync sensor
 

--- a/docs/data/data-management-tutorial.md
+++ b/docs/data/data-management-tutorial.md
@@ -23,16 +23,20 @@ We will use a fake sensor so this tutorial works without any physical hardware.
 
 ## 1. Add a fake sensor
 
-We need a component that produces data. A fake sensor generates random readings, which is perfect for learning the data pipeline without physical hardware.
+We need a component that produces data. The built-in `sensor/fake` component returns a fixed set of readings every time it is polled, which is enough to exercise the capture, sync, and query pipeline end to end.
 
 1. Go to your machine's page in the Viam app.
 2. Click the **+** button in the left sidebar.
 3. Select **Configuration block**.
-4. Search for **fake** and select the **sensor** type.
+4. Search for **sensor/fake** and select the result.
 5. Name it `test-sensor` and click **Create**.
 6. Click **Save** in the upper right.
 
-Expand the **test** section on the sensor's component card. You should see readings updating. This confirms the sensor is working.
+Expand the **test** section on the sensor's component card. You should see `{"a": 1, "b": 2, "c": 3}` returned from `GetReadings`. This confirms the sensor is working.
+
+{{< alert title="Note" color="note" >}}
+`sensor/fake` always returns the same values. As you capture data in the next steps, every row will have identical `data` but a fresh `time_received` timestamp. That is enough to verify the full pipeline. With a real sensor, the values would change each reading.
+{{< /alert >}}
 
 ## 2. Enable data capture
 
@@ -54,19 +58,20 @@ The data management service captures readings to local disk, then syncs them to 
 
 Wait about 30 seconds, then:
 
-1. Click the **DATA** tab in the top navigation of the Viam app.
-2. You should see tabular data entries appearing from `test-sensor`.
+1. Click the **DATA** tab in the top navigation of the Viam app. The tab opens on the **Images** view by default.
+2. Click the **Sensors** tab.
+3. You should see a machine card for your machine with `test-sensor` listed and its most recent reading displayed.
 
-Each entry shows the sensor name, the capture method (`Readings`), timestamps, and the reading values.
+The Sensors tab shows the latest reading per resource per machine, not a table of historical rows. You will query the historical rows from the query editor in the next step.
 
-If you don't see data yet, wait another 30 seconds. The first sync can take a moment as the service initializes.
+If you don't see your machine or sensor yet, wait another 30 seconds. The first sync can take a moment as the service initializes.
 
 {{< alert title="What just happened?" color="info" >}}
 
 Behind the scenes:
 
 1. `viam-server` called `test-sensor.Readings()` every 5 seconds.
-2. Each reading was written to a capture file in `~/.viam/capture` on your machine.
+2. Each reading was appended to a `.capture` file (length-delimited binary protobuf) in `$HOME/.viam/capture` on your machine. When `viam-server` runs as root through `viam-agent`, that path is `/root/.viam/capture`.
 3. The sync process uploaded those files to Viam's cloud storage.
 4. The local files were deleted after successful sync.
 
@@ -78,25 +83,33 @@ Your data is now stored in MongoDB (tabular data) in the cloud, queryable and ex
 
 Now that data is in the cloud, you can query it.
 
-1. In the **DATA** tab, click **Query**.
+1. On the **Sensors** tab, find your `test-sensor` and click the small search icon next to it to jump to the query editor. (If you don't see the icon, it is in the same row as the sensor name. Its tooltip reads "Query historical data".) You can also click **Query** in the data tab navigation to open the editor manually.
 2. The query editor opens. Paste this SQL query:
 
    ```sql
    SELECT time_received, data
    FROM readings
    WHERE component_name = 'test-sensor'
+     AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)
    ORDER BY time_received DESC
    LIMIT 5
    ```
 
+   {{< alert title="Known issue" color="caution" >}}
+   The `AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)` clause is a workaround for APP-10891: SQL queries against `readings` currently return no rows unless the `WHERE` clause includes an explicit lower bound on `time_received`. Include it on every SQL query on this page.
+   {{< /alert >}}
+
 3. Click **Run query**.
 
-You should see your most recent 5 readings with timestamps and the sensor's data values.
+The results appear as a list of JSON rows by default. Click the **table view** toggle (the small table icon in the results area) to see the rows as columns. You should see 5 rows with `time_received` values a few seconds apart and identical `data` values (`{"a": 1, "b": 2, "c": 3}`, because `sensor/fake` returns constant readings).
 
 To understand the structure, try this:
 
 ```sql
-SELECT data FROM readings WHERE component_name = 'test-sensor' LIMIT 1
+SELECT data FROM readings
+WHERE component_name = 'test-sensor'
+  AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)
+LIMIT 1
 ```
 
 Switch to **table view** (the table icon in the results area). You'll see nested fields flattened into column headers like `data.readings.x`. These dot-notation paths are what you use to extract specific values in queries. For the full schema, see the [readings table schema](/data/reference/#column-reference).
@@ -107,6 +120,7 @@ Try one more query:
 SELECT COUNT(*) as total_readings
 FROM readings
 WHERE component_name = 'test-sensor'
+  AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)
 ```
 
 This tells you how many readings have been captured so far.
@@ -132,11 +146,11 @@ from viam.app.viam_client import ViamClient
 
 
 async def main():
-    opts = ViamClient.Options.with_api_key(
+    dial_options = DialOptions.with_api_key(
         api_key="YOUR-API-KEY",
-        api_key_id="YOUR-API-KEY-ID"
+        api_key_id="YOUR-API-KEY-ID",
     )
-    client = await ViamClient.create_from_dial_options(opts)
+    client = await ViamClient.create_from_dial_options(dial_options)
     data_client = client.data_client
 
     # Query the 5 most recent readings from test-sensor
@@ -146,6 +160,7 @@ async def main():
             "SELECT time_received, data "
             "FROM readings "
             "WHERE component_name = 'test-sensor' "
+            "  AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP) "
             "ORDER BY time_received DESC "
             "LIMIT 5"
         ),

--- a/docs/data/filter-at-the-edge.md
+++ b/docs/data/filter-at-the-edge.md
@@ -98,7 +98,7 @@ The filtered camera wraps an existing camera and only outputs frames that match 
 ### Prerequisites
 
 - A configured camera component on your machine. See [Configure a camera](/reference/components/camera/) if you need to set one up.
-- The data management service configured. See [Capture and sync edge data](/data/) for instructions.
+- The data management service configured. See [Start data capture](/data/capture-sync/capture-and-sync-data/) for instructions.
 
 ### Instructions
 
@@ -219,9 +219,9 @@ helps you avoid filling the disk.
 
 ### How local storage works
 
-- Captured data is written to `~/.viam/capture` by default.
-- Each capture creates a file (JPEG for images, JSON for tabular data).
-- The sync process uploads files and deletes them after successful upload.
+- Captured data is written to the capture directory (default: `$HOME/.viam/capture`). When `viam-server` is installed through `viam-agent` it runs as root, so the path is `/root/.viam/capture`. See [Capture directories](/data/reference/#capture-directories) for the full per-platform breakdown.
+- Each capture is written as a `.capture` file: length-delimited binary protobuf. The first message is metadata describing the capture; the remaining messages hold the captured data. Images and tabular readings use the same container format.
+- The sync process uploads `.capture` files and deletes them after successful upload.
 - If sync is disabled or the network is down, files accumulate locally.
 
 ### Configure storage limits
@@ -231,16 +231,16 @@ your data management service configuration, set the `maximum_capture_file_size_b
 attribute to limit the size of individual capture files, and monitor the overall
 capture directory size.
 
-To check current disk usage of the capture directory:
+To check current disk usage of the capture directory (substitute `/root/.viam/capture` if `viam-server` runs as root through `viam-agent`):
 
 ```bash
-du -sh ~/.viam/capture
+du -sh "$HOME/.viam/capture"
 ```
 
 To monitor it over time:
 
 ```bash
-watch -n 60 du -sh ~/.viam/capture
+watch -n 60 du -sh "$HOME/.viam/capture"
 ```
 
 ### Best practices for constrained machines
@@ -314,7 +314,7 @@ watch -n 60 du -sh ~/.viam/capture
   management service configuration.
 - Check the sync interval. A very long sync interval combined with high capture
   frequency can cause the local buffer to grow between sync cycles.
-- Run `du -sh ~/.viam/capture` to check current usage.
+- Run `du -sh "$HOME/.viam/capture"` to check current usage (or `/root/.viam/capture` when `viam-server` runs as root).
 
 {{< /expand >}}
 

--- a/docs/data/pipelines/create-a-pipeline.md
+++ b/docs/data/pipelines/create-a-pipeline.md
@@ -91,6 +91,7 @@ Where `my-pipeline.json` contains:
 
 ```python
 import asyncio
+from viam.rpc.dial import DialOptions
 from viam.app.viam_client import ViamClient
 from viam.gen.app.data.v1.data_pb2 import TabularDataSourceType
 
@@ -100,11 +101,11 @@ ORG_ID = "YOUR-ORGANIZATION-ID"
 
 
 async def main():
-    opts = ViamClient.Options.with_api_key(
+    dial_options = DialOptions.with_api_key(
         api_key=API_KEY,
-        api_key_id=API_KEY_ID
+        api_key_id=API_KEY_ID,
     )
-    client = await ViamClient.create_from_dial_options(opts)
+    client = await ViamClient.create_from_dial_options(dial_options)
     data_client = client.data_client
 
     # Returns the pipeline ID

--- a/docs/data/query-data-from-code.md
+++ b/docs/data/query-data-from-code.md
@@ -13,7 +13,20 @@ aliases:
 Pull captured data into your own programs using the Viam data client API. You can run the same SQL and MQL queries available in the app's query editor from Python or Go code.
 
 {{< alert title="Tip: discover your data structure" color="tip" >}}
-Not sure what fields to query? Run `SELECT data FROM readings WHERE component_name = 'YOUR-COMPONENT' LIMIT 1` in the [query editor](/data/query-data/) first. Switch to **table view** to see nested fields as dot-notation column headers. Use those paths in your code. See the [readings table schema](/data/reference/#column-reference) for the full reference.
+Not sure what fields to query? Run this in the [query editor](/data/query-data/) first:
+
+```sql
+SELECT data FROM readings
+WHERE component_name = 'YOUR-COMPONENT'
+  AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)
+LIMIT 1
+```
+
+Switch to **table view** to see nested fields as dot-notation column headers. Use those paths in your code. See the [readings table schema](/data/reference/#column-reference) for the full reference.
+{{< /alert >}}
+
+{{< alert title="Known issue: SQL queries need an explicit lower time bound" color="caution" >}}
+SQL queries against `readings` currently return no rows unless the `WHERE` clause includes an explicit lower bound on `time_received`. Include `AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)` in any SQL example on this page if you copy it. MQL queries are not affected. Tracked as APP-10891.
 {{< /alert >}}
 
 ## Set up a connection
@@ -38,11 +51,11 @@ ORG_ID = "YOUR-ORGANIZATION-ID"
 
 
 async def main():
-    opts = ViamClient.Options.with_api_key(
+    dial_options = DialOptions.with_api_key(
         api_key=API_KEY,
-        api_key_id=API_KEY_ID
+        api_key_id=API_KEY_ID,
     )
-    client = await ViamClient.create_from_dial_options(opts)
+    client = await ViamClient.create_from_dial_options(dial_options)
     data_client = client.data_client
 
     # ... your queries here ...
@@ -109,6 +122,7 @@ results = await data_client.tabular_data_by_sql(
         "  data.readings.temperature AS temperature "
         "FROM readings "
         "WHERE component_name = 'my-sensor' "
+        "  AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP) "
         "ORDER BY time_received DESC "
         "LIMIT 5"
     ),
@@ -128,6 +142,7 @@ results, err := dataClient.TabularDataBySQL(ctx, orgID,
         "data.readings.temperature AS temperature "+
         "FROM readings "+
         "WHERE component_name = 'my-sensor' "+
+        "  AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP) "+
         "ORDER BY time_received DESC LIMIT 5")
 if err != nil {
     logger.Fatal(err)

--- a/docs/data/query-data.md
+++ b/docs/data/query-data.md
@@ -16,6 +16,10 @@ Explore and analyze your captured data using SQL or MQL queries. You can run que
 
 Tabular data (sensor readings, motor positions, encoder ticks, and other structured key-value data) is queryable through SQL and MQL. Binary data (images, point clouds) is stored separately and accessible through the [data client API](/dev/reference/apis/data-client/).
 
+{{< alert title="Known issue: SQL queries need an explicit lower time bound" color="caution" >}}
+SQL queries against `readings` currently return no rows unless the `WHERE` clause includes an explicit lower bound on `time_received`. Add `AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)` to any SQL example on this page if you copy it. MQL queries are not affected. Tracked as APP-10891.
+{{< /alert >}}
+
 ## Open the query editor
 
 1. Go to [app.viam.com](https://app.viam.com).
@@ -36,6 +40,7 @@ Start with a broad query to see what data you have:
 ```sql
 SELECT time_received, component_name, component_type, data
 FROM readings
+WHERE time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)
 ORDER BY time_received DESC
 LIMIT 10
 ```
@@ -46,7 +51,10 @@ Most of the interesting values are in the `data` column, which contains your act
 To see the structure of your data, run this query for a specific component:
 
 ```sql
-SELECT data FROM readings WHERE component_name = 'my-sensor' LIMIT 1
+SELECT data FROM readings
+WHERE component_name = 'my-sensor'
+  AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)
+LIMIT 1
 ```
 
 Switch to **table view** (the table icon in the results area) to see nested fields automatically flattened into dot-notation column headers like `data.readings.temperature`. These dot-notation paths are exactly what you use in your queries to extract specific values.
@@ -59,6 +67,7 @@ To narrow to a specific component:
 SELECT time_received, data
 FROM readings
 WHERE component_name = 'my-sensor'
+  AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)
 ORDER BY time_received DESC
 LIMIT 10
 ```
@@ -85,6 +94,7 @@ SELECT
   data.readings.humidity AS humidity
 FROM readings
 WHERE component_name = 'my-sensor'
+  AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)
 ORDER BY time_received DESC
 LIMIT 20
 ```
@@ -98,6 +108,7 @@ SELECT
 FROM readings
 WHERE component_name = 'my-detector'
   AND component_type = 'rdk:service:vision'
+  AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)
 ORDER BY time_received DESC
 LIMIT 10
 ```
@@ -108,6 +119,7 @@ To filter by a specific machine:
 SELECT time_received, component_name, data
 FROM readings
 WHERE robot_id = 'YOUR-MACHINE-ID'
+  AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)
 ORDER BY time_received DESC
 LIMIT 10
 ```

--- a/docs/data/query-data.md
+++ b/docs/data/query-data.md
@@ -17,7 +17,7 @@ Explore and analyze your captured data using SQL or MQL queries. You can run que
 Tabular data (sensor readings, motor positions, encoder ticks, and other structured key-value data) is queryable through SQL and MQL. Binary data (images, point clouds) is stored separately and accessible through the [data client API](/dev/reference/apis/data-client/).
 
 {{< alert title="Known issue: SQL queries need an explicit lower time bound" color="caution" >}}
-SQL queries against `readings` currently return no rows unless the `WHERE` clause includes an explicit lower bound on `time_received`. Add `AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)` to any SQL example on this page if you copy it. MQL queries are not affected. Tracked as APP-10891.
+SQL queries against `readings` currently return no rows unless the `WHERE` clause includes an explicit lower bound on `time_received`. Every SQL example and troubleshooting step on this page (including short inline examples) includes `AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)` for this reason. When troubleshooting, do not remove the lower-bound filter entirely: widen it by using this broad lower bound. MQL queries are not affected. Tracked as APP-10891.
 {{< /alert >}}
 
 ## Open the query editor
@@ -252,8 +252,22 @@ You can run the same SQL and MQL queries from Python or Go using the data client
 
 To get oriented with your own data:
 
-1. Open the query editor and run `SELECT DISTINCT component_name FROM readings` to see what components have captured data.
-2. Pick a component and run `SELECT data FROM readings WHERE component_name = 'YOUR-COMPONENT' LIMIT 1` to see the JSON structure of its readings.
+1. Open the query editor and run the following to see what components have captured data:
+
+   ```sql
+   SELECT DISTINCT component_name FROM readings
+   WHERE time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)
+   ```
+
+2. Pick a component and run the following to see the JSON structure of its readings:
+
+   ```sql
+   SELECT data FROM readings
+   WHERE component_name = 'YOUR-COMPONENT'
+     AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)
+   LIMIT 1
+   ```
+
 3. Use the field names from step 2 to write a query that extracts a specific value with dot notation (for example, `data.readings.temperature`).
 
 For the full schema of the readings table, see [Query reference](/data/reference/#column-reference).
@@ -263,11 +277,18 @@ For the full schema of the readings table, see [Query reference](/data/reference
 {{< expand "Query returns empty results" >}}
 
 - **Check the component name.** Component names are case-sensitive and must match
-  exactly. Run `SELECT DISTINCT component_name FROM readings` to see all
-  available component names.
-- **Check the time range.** If you're filtering by time, make sure your range
-  covers a period when data was actually captured. Remove the time filter first
-  to confirm data exists, then add it back.
+  exactly. Run the following to see all available component names:
+
+  ```sql
+  SELECT DISTINCT component_name FROM readings
+  WHERE time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)
+  ```
+
+- **Check the time range.** If you narrowed the time range, widen it back to the
+  broad lower bound `time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)`
+  to confirm data exists, then tighten the range back down. Do not remove the
+  `time_received` filter entirely: under APP-10891, SQL queries without an
+  explicit lower bound on `time_received` return no rows.
 - **Verify data has synced.** Data must sync from the machine to the cloud before
   it is queryable. Check the **DATA** tab to confirm entries are visible.
 
@@ -276,9 +297,15 @@ For the full schema of the readings table, see [Query reference](/data/reference
 {{< expand "Query returns data but fields are null" >}}
 
 - **Check the JSON path.** The nested path must match the actual structure of
-  your data. Run `SELECT data FROM readings LIMIT 1` to see the raw JSON, then
-  build your dot-notation path to match. A common mistake is using
-  `data.temperature` when the actual path is `data.readings.temperature`.
+  your data. Run the following to see the raw JSON, then build your dot-notation
+  path to match. A common mistake is using `data.temperature` when the actual
+  path is `data.readings.temperature`.
+
+  ```sql
+  SELECT data FROM readings
+  WHERE time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)
+  LIMIT 1
+  ```
 
 {{< /expand >}}
 

--- a/docs/data/reference.md
+++ b/docs/data/reference.md
@@ -188,8 +188,22 @@ To query: `data.position`
 
 If you're unsure what fields your component produces:
 
-1. Run `SELECT DISTINCT component_name FROM readings` to see what components have captured data.
-2. Pick one and run `SELECT data FROM readings WHERE component_name = 'YOUR-COMPONENT' LIMIT 1`.
+1. Run the following to see what components have captured data:
+
+   ```sql
+   SELECT DISTINCT component_name FROM readings
+   WHERE time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)
+   ```
+
+2. Pick one and run the following:
+
+   ```sql
+   SELECT data FROM readings
+   WHERE component_name = 'YOUR-COMPONENT'
+     AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)
+   LIMIT 1
+   ```
+
 3. Look at the JSON structure in the result. The keys you see are the fields you can query with dot notation.
 4. Build your query using `data.` followed by the path to the field you want (for example, `data.readings.temperature`).
 

--- a/docs/data/reference.md
+++ b/docs/data/reference.md
@@ -78,10 +78,17 @@ The `readings` table does not include `robot_name` or `part_name` columns. These
 The `data` column contains your actual captured values as nested JSON. Its structure depends on what component and method captured the data. To find out what's inside `data` for your specific components, run:
 
 ```sql
-SELECT data FROM readings WHERE component_name = 'my-sensor' LIMIT 1
+SELECT data FROM readings
+WHERE component_name = 'my-sensor'
+  AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)
+LIMIT 1
 ```
 
 Then use the field names you see to build more specific queries.
+
+{{< alert title="Known issue: SQL queries need an explicit lower time bound" color="caution" >}}
+SQL queries against `readings` currently return no rows unless the `WHERE` clause includes an explicit lower bound on `time_received`. Include `AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)` in any SQL example on this page if you copy it. MQL queries are not affected. Tracked as APP-10891.
+{{< /alert >}}
 
 **Common data structures:**
 
@@ -109,6 +116,7 @@ SELECT time_received,
   data.readings.humidity AS humidity
 FROM readings
 WHERE component_name = 'my-sensor'
+  AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)
 ORDER BY time_received DESC
 LIMIT 10
 ```


### PR DESCRIPTION
## Summary

Critical fixes from an external review of the Manage Data section. Every item is a verified bug, not a judgment call — content restructuring is deferred to follow-up PRs.

- **Python SDK** — the three Python examples (`data-management-tutorial.md`, `query-data-from-code.md`, `pipelines/create-a-pipeline.md`) used `ViamClient.Options.with_api_key(...)`, which does not exist in any published `viam-sdk`. Verified against PyPI `viam-sdk 0.73.1` runtime, SDK source at `viam_client.py`, and full git history. Replaced with the canonical `DialOptions.with_api_key(...)` form.
- **SQL timestamp bug (APP-10891)** — SQL queries against the `readings` table currently return no rows unless the `WHERE` clause has an explicit lower bound on `time_received`. Added `AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)` to affected examples in `query-data.md`, `query-data-from-code.md`, `reference.md`, and the tutorial, with a known-issue alert explaining the workaround.
- **Capture file format** — `filter-at-the-edge.md` claimed captures are "JPEG for images, JSON for tabular data". Both are actually length-delimited binary protobuf `.capture` files. Verified against `rdk/data/capture_file.go`. Rewritten accordingly.
- **Capture directory path** — `~/.viam/capture` was misleading on the majority of installs. When `viam-server` runs as root through `viam-agent` (the default systemd install), the path is `/root/.viam/capture`. Verified against `rdk/utils/env.go`. Updated prose in `filter-at-the-edge.md`, `capture-sync/capture-and-sync-data.md`, and the tutorial to explain the `$HOME`-dependent path.
- **Tutorial step 4 navigation** — the Data tab defaults to Images (not a tabular list), the Sensors tab shows machine cards with latest readings, and historical rows require jumping to the query editor through a small search icon. Verified against `app/frontend/src/components/data-management/machine/helpers.ts`, `app/ui/src/lib/components/data/view/sensors/sensors.svelte`, and `query-link.svelte`. Step 4 of the tutorial and step 5 of `capture-and-sync-data.md` rewritten to match.
- **`sensor/fake` disambiguation** — the built-in `sensor/fake` returns constant `{"a":1,"b":2,"c":3}` (verified at `rdk/components/sensor/fake/sensor.go:47`). Tutorial now uses `sensor/fake` (the literal UI label, which is also a valid search term given the backend splits on `/`) and an honest note explaining that rows will have identical `data` but fresh timestamps — which is enough to verify the pipeline.
- **`sync-at-time/timesyncsensor`** — fixed the conditional-sync page to use the slash form that the config block UI actually displays, rather than the colon-delimited module triplet.
- **Stale links and UI filters** — `/data/` → `/data/capture-sync/capture-and-sync-data/` in `filter-at-the-edge.md`; dropped the "Data type – Images or Tabular" filter from the capture-sync verify step (the filter no longer exists in the UI).

Replaces "model" with "component" in user-facing prose where the registry sense of "model" was being used in a way that could be confused with ML models.

## Test plan

- [ ] Netlify deploy preview builds
- [ ] Tutorial preview: step 4 flow matches the Sensors tab + query-editor navigation
- [ ] `filter-at-the-edge.md` preview: capture file and capture directory wording reads correctly
- [ ] `query-data.md` preview: known-issue alert renders, SQL examples include the timestamp guard
- [ ] `pipelines/create-a-pipeline.md` Python example: `DialOptions` import + usage matches the SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)