### PR TITLE
Manage data: restructure filtered camera and multi-part capture pages

### DIFF
--- a/docs/data/capture-sync/remote-parts-capture.md
+++ b/docs/data/capture-sync/remote-parts-capture.md
@@ -1,74 +1,105 @@
 ---
-linkTitle: "Capture from remote parts"
-title: "Capture from remote parts"
+linkTitle: "Multi-part capture"
+title: "Capture data from multi-part machines"
 weight: 15
 layout: "docs"
 type: "docs"
-description: "Capture data from components on a remote machine part and sync it through the main part."
+description: "Capture and sync data from components on sub-parts and remote parts of a multi-part machine."
 date: "2025-02-10"
 ---
 
-Capture data from components on a machine part that you can't or don't want to run data capture on directly. You add the remote part to your main machine, then configure data capture on the main part for resources on the remote. The main part handles capture and sync; the remote part just provides access to its components.
+Viam machines can be split across multiple computers. When that happens, data capture behaves differently depending on whether the additional computer is a [sub-part](/operate/reference/architecture/parts/#configure-a-sub-part) or a [remote part](/operate/reference/architecture/parts/#configure-a-remote-part). Understanding which pattern you have is the key to configuring capture correctly.
 
-This is useful when:
+## Terminology
 
-- You want to centralize data capture on your main compute instead of configuring it on every part
-- The remote part is a Raspberry Pi with a camera at a different location, and your main machine handles capture and sync
-- The remote part has limited resources or unreliable connectivity
+- **Sub-part**: an additional part of the _same_ machine. Each sub-part runs its own `viam-server` with its own configuration and its own filesystem.
+- **Remote part**: a part of a _different_ machine that yours accesses over the network. A remote part is itself a separate machine in the Viam app.
 
-## Prerequisites
+For the full architectural picture, including when to pick one over the other, see [Machine architecture: parts](/operate/reference/architecture/parts/).
 
-- A main machine with `viam-server` running and connected to the Viam app
-- A remote machine part running `viam-server` or `viam-micro-server` with at least one configured component
-- Both parts must be able to reach each other over the network
+## How capture differs
 
-## 1. Add the remote part to your main machine
+|                                       | Sub-part                                     | Remote part                |
+| ------------------------------------- | -------------------------------------------- | -------------------------- |
+| Data manager lives on                 | The sub-part itself                          | The main part              |
+| `.capture` files are written to       | The sub-part's filesystem                    | The main part's filesystem |
+| Sync uploads from                     | The sub-part                                 | The main part              |
+| Where you configure capture           | The sub-part's section of the machine config | The main machine's config  |
+| Captured metadata `part_id` is set to | The sub-part's `part_id`                     | The main part's `part_id`  |
 
-1. In the [Viam app](https://app.viam.com), go to your main machine's **CONFIGURE** tab.
+All captured data from a multi-part _machine_ shares the same `robot_id` (machine UUID), so you can query across all parts of one multi-part machine in a single SQL or MQL query. Data from a remote part that belongs to a different machine has a different `robot_id`.
+
+## Sub-parts
+
+Each sub-part is an independent `viam-server` instance with its own configuration and dependency graph. The main part's data manager cannot reach into a sub-part to capture its resources; the sub-part needs its own data manager service.
+
+### Configure data capture on a sub-part
+
+1. In the Viam app, navigate to the sub-part's section of your machine's **CONFIGURE** tab.
+2. Find the component on the sub-part that you want to capture from.
+3. In the component's **Data capture** section, click **+ Add method**.
+4. If the sub-part does not already have a data management service, Viam prompts you to enable one. Click to enable it.
+5. Select the capture method and frequency as you would for a local component.
+6. Click **Save**.
+
+The sub-part's `viam-server` writes `.capture` files to its own local capture directory and syncs them to the cloud from there. In the **DATA** tab, the rows appear under the main machine, but the captured metadata carries the sub-part's `part_id`.
+
+## Remote parts
+
+Remote parts appear in the main part's dependency graph, and the main part's data manager can be configured to capture from them exactly like local resources. All capture and sync happens on the main part's host.
+
+### 1. Add the remote part to your main machine
+
+1. In the Viam app, navigate to your main machine's **CONFIGURE** tab.
 2. Click the **+** button next to the main part's name.
 3. Select **Remote part**.
-4. Select the machine and part you want to add as a remote. The Viam app shows available parts automatically.
+4. Select the machine and part you want to add as a remote. The Viam app lists parts you have access to.
 5. Click **Save**.
 
-The main machine can now access all components on the remote part. You can verify this on the **CONTROL** tab, where the remote's components should appear.
+The main machine can now access all components on the remote part. You can verify this on the **CONTROL** tab, where the remote's components appear under the remote's section.
 
-For more details on configuring remotes, including authentication and manual JSON configuration, see [Machine architecture: parts](/operate/reference/architecture/parts/).
+For more details on remote part configuration, including authentication and manual JSON, see [Configure a remote part](/operate/reference/architecture/parts/#configure-a-remote-part).
 
-## 2. Configure data capture on the remote's components
+### 2. Configure data capture on the remote's components
 
-Once the remote part is added, its components appear on the main machine's **CONFIGURE** tab. Configure data capture on them the same way you would for local components:
+Once the remote part is added, its components appear on the main machine's **CONFIGURE** tab under the remote's section. Configure data capture through the main machine's config, not through the remote machine's config:
 
-1. Find the remote component in the **CONFIGURE** tab (it appears under the remote part's section).
+1. Find the remote component in the main machine's **CONFIGURE** tab.
 2. Scroll to the **Data capture** section on the component card.
 3. Click **+ Add method**.
 4. Select the capture method (for example, **GetImages** for a camera, **Readings** for a sensor).
 5. Set the capture frequency.
 6. Click **Save**.
 
-The main part handles capture and sync for the remote component. Data is written to the main part's capture directory and synced from there.
+The main part captures and syncs the remote's data. Files are written to the main part's capture directory and uploaded to the cloud from there.
 
-## 3. Verify data is being captured
+{{< alert title="Do not configure capture on both parts" color="caution" >}}
+If the remote part also has its own data management service with capture enabled on the same components, you will get duplicate `.capture` files and duplicate rows in the cloud. Configure capture on the main part only, and confirm that the remote machine's data manager does not have overlapping capture methods.
+{{< /alert >}}
+
+### 3. Verify data is being captured
 
 Wait 30 seconds to a minute, then:
 
 1. Click the **DATA** tab in the Viam app.
 2. Filter by the main machine's name.
-3. You should see data appearing from the remote part's components. The `component_name` will match the name on the remote part.
+3. For cameras, captured images appear under **Images**. For sensors, click **Sensors** to see the latest reading per resource.
+4. The captured `component_name` matches the name the component has on the remote part.
 
 If no data appears, check:
 
-- The remote part is online and accessible from the main part (verify on the **CONTROL** tab).
-- The fully qualified resource name in the capture config matches the component exactly.
-- The data management service is enabled with sync turned on.
+- The remote part is online and reachable from the main part (verify on the **CONTROL** tab).
+- The data management service on the main part has capture and sync enabled.
+- The capture method is configured on the remote component in the **main machine's** config, not the remote machine's config.
 
 ## Example: capture camera images from a remote Pi
 
-Your main machine runs an arm for pick-and-place operations. A Raspberry Pi at a different location has a camera monitoring the workspace. You want to capture images from the Pi's camera through the main machine so all data flows through one capture pipeline.
+Your main machine runs an arm for pick-and-place operations. A Raspberry Pi at a different location has a camera monitoring the workspace and is registered as its own Viam machine. You want to capture images from the Pi's camera through the main arm machine so all data flows through one capture pipeline.
 
-1. Configure the Pi with a webcam component.
-2. On your main arm machine, add the Pi as a remote part (step 1 above).
+1. Configure the Pi as its own Viam machine with a webcam component.
+2. On your main arm machine, add the Pi's machine part as a remote part (see [Add the remote part](#1-add-the-remote-part-to-your-main-machine)).
 3. On the main machine's **CONFIGURE** tab, find the Pi's `workspace-cam` component under the remote part section.
 4. Add data capture on `workspace-cam` with method **GetImages** at 0.5 Hz (one image every 2 seconds).
-5. Save.
+5. Click **Save**.
 
-The main machine captures images from the Pi's camera and syncs them to the cloud alongside any data captured from local components.
+The main machine captures images from the Pi's camera and syncs them to the cloud alongside any data captured from its own local components. The Pi itself does not need a data management service for this flow.

--- a/docs/data/filter-at-the-edge.md
+++ b/docs/data/filter-at-the-edge.md
@@ -179,7 +179,7 @@ You can configure more than one `vision_services` entry to trigger on multiple c
 {{% tablestep %}}
 **Configure data capture on the filtered camera**
 
-Configure data capture on the **filtered camera**, not on the raw camera, following the same process as [Start data capture](/data/capture-sync/capture-and-sync-data/). Use the `ReadImage` capture method and choose a capture frequency.
+Configure data capture on the **filtered camera**, not on the raw camera, following the same process as [Start data capture](/data/capture-sync/capture-and-sync-data/). Use the `GetImages` capture method and choose a capture frequency.
 
 If the raw camera already has data capture configured, remove it. Otherwise you will capture both the unfiltered stream and the filtered stream.
 

--- a/docs/data/filter-at-the-edge.md
+++ b/docs/data/filter-at-the-edge.md
@@ -49,8 +49,9 @@ increase it later once you understand your data volume and bandwidth budget.
 {{< /alert >}}
 
 This approach works well when you need periodic snapshots but not continuous
-monitoring. It does not help when you need to capture specific events -- for
-that, continue to the next techniques.
+monitoring. It does not help when you need to capture specific events, like
+"only save images when there is a person in the frame". For event-based
+capture, skip ahead to [Use a filtered camera with ML](#use-a-filtered-camera-with-ml).
 
 ## Configure conditional sync
 
@@ -92,8 +93,21 @@ machine has enough local storage for the capture buffer (see
 
 ## Use a filtered camera with ML
 
-You can use the [`filtered_camera`](https://app.viam.com/module/viam/filtered-camera) registry module to selectively capture only images that contain certain objects or people, using a machine learning (ML) model.
-The filtered camera wraps an existing camera and only outputs frames that match your ML model's criteria, so only interesting frames are ever written to disk.
+The [`filtered-camera`](https://app.viam.com/module/viam/filtered-camera) registry module captures only the images you actually care about by running an ML vision model on each frame and gating capture on the result. It wraps an existing camera and a vision service so data capture sees a pre-filtered stream.
+
+### How it works
+
+The filtered camera sits between a raw camera and the data manager:
+
+1. A raw **camera** component (for example, a USB webcam) provides the image stream.
+2. A **vision service** runs an ML classifier or detector against each image and returns classifications or detections with confidence scores.
+3. A **`filtered-camera`** component wraps the camera and the vision service. It continuously pulls frames from the camera into an in-memory ring buffer, asks the vision service to score each frame, and marks a frame as "interesting" when a classification or detection passes a confidence threshold you configure.
+4. **Data capture** is configured on the `filtered-camera` component, not on the raw camera. Because the filtered camera is itself a camera component, the data manager captures from it the same way it would from any other camera. Only frames that passed the filter are ever written to disk.
+5. The normal sync pipeline uploads the captured files to the cloud.
+
+The raw camera's image stream is unchanged: the CONTROL tab, other services, and anything else on the machine still see every frame. Only the filtered camera, and therefore only data capture, sees the filtered subset.
+
+Optionally, you can configure a pre-trigger buffer with `window_seconds_before` and a post-trigger buffer with `window_seconds_after`. When a frame triggers the filter, the module includes the buffered frames from those windows alongside the trigger frame. Use this when you need context leading up to or after an event.
 
 ### Prerequisites
 
@@ -119,7 +133,7 @@ If you're not sure which model to use, you can use [`EfficientDet-COCO`](https:/
 {{% tablestep %}}
 **Add a vision service to use with the ML model**
 
-You can think of the vision service as the bridge between the ML model service and the output from your camera.
+The vision service is the bridge between the ML model service and the camera images. It loads the ML model and exposes classifier or detector methods that the filtered camera calls on each frame.
 
 Add and configure the `vision / ML model` service on your machine.
 From the **Select model** dropdown, select the name of your ML model service (for example, `mlmodel-1`).
@@ -128,13 +142,9 @@ From the **Select model** dropdown, select the name of your ML model service (fo
 {{% tablestep %}}
 **Configure the filtered camera**
 
-The `filtered-camera` {{< glossary_tooltip term_id="modular-resource" text="modular component" >}} pulls the stream of images from your camera component and applies the vision service to it.
+Add a `camera / filtered-camera` component on your machine. Set `camera` to the name of the raw camera you want to filter, and add a `vision_services` entry that references the vision service you just configured, along with the classification labels or detection classes you want to capture.
 
-Configure a `filtered-camera` component on your machine, following the [attribute guide in the module listing](https://app.viam.com/module/viam/filtered-camera).
-Use the name of your camera component as the `"camera"` to pull images from, and select the name of the vision service you just configured as your `"vision"` service.
-Then add all or some of the labels your ML model uses as classifications or detections in `"classifications"` or `"objects"`.
-
-For example, if you are using the `EfficientDet-COCO` model, you could use a configuration like the following to only capture images when a person is detected with more than 80% confidence in your camera stream.
+For example, to capture images only when a person is detected with at least 80% confidence:
 
 ```json {class="line-numbers linkable-line-numbers"}
 {
@@ -147,55 +157,56 @@ For example, if you are using the `EfficientDet-COCO` model, you could use a con
       }
     }
   ],
-  "window_seconds": 0
+  "window_seconds_before": 0,
+  "window_seconds_after": 0
 }
 ```
 
-You can also add a buffer window with `window_seconds`, which controls the duration of a buffer of images captured before a successful match.
-If you were to set `window_seconds` to `3`, the camera would also capture and sync images from the 3 seconds before a person appeared in the camera stream.
+Key attributes:
+
+| Attribute               | Required | Description                                                                                                                                                                             |
+| ----------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `camera`                | Yes      | Name of the camera to filter.                                                                                                                                                           |
+| `vision_services`       | Yes      | List of vision services with their trigger criteria. Each entry needs a `vision` (the service name) and one of `classifications` or `objects` (a map of label to confidence threshold). |
+| `window_seconds_before` | Yes      | Seconds of buffered frames to include before a trigger. Set to `0` for no pre-buffer.                                                                                                   |
+| `window_seconds_after`  | Yes      | Seconds of buffered frames to include after a trigger. Set to `0` for no post-buffer.                                                                                                   |
+| `image_frequency`       | No       | Rate in Hz at which the filtered camera pulls frames from the raw camera into its buffer. Default: `1.0`.                                                                               |
+| `cooldown_s`            | No       | Seconds to suppress new triggers after a capture window ends. Useful when events happen in bursts. Default: `0`.                                                                        |
+
+You can configure more than one `vision_services` entry to trigger on multiple conditions. Use `"*"` as a label to match any classification or detection above the confidence threshold. For the full attribute reference, see the [module README on GitHub](https://github.com/viam-modules/filtered_camera#attributes).
 
 {{% /tablestep %}}
 {{% tablestep %}}
-**Configure data capture and sync on the filtered camera**
+**Configure data capture on the filtered camera**
 
-Configure data capture and sync on the filtered camera following the same process as described in [Capture and sync data](/data/capture-sync/capture-and-sync-data/).
-The filtered camera will only capture image data that passes the filters you configured in the previous step.
+Configure data capture on the **filtered camera**, not on the raw camera, following the same process as [Start data capture](/data/capture-sync/capture-and-sync-data/). Use the `ReadImage` capture method and choose a capture frequency.
 
-Turn off data capture on your original camera component if you haven't already, so that you don't capture duplicate or unfiltered images.
-
-{{% /tablestep %}}
-{{% tablestep %}}
-**Save to start capturing**
-
-Save the config.
-With cloud sync enabled, captured data is automatically uploaded to Viam after a short delay.
+If the raw camera already has data capture configured, remove it. Otherwise you will capture both the unfiltered stream and the filtered stream.
 
 {{% /tablestep %}}
 {{% tablestep %}}
-**View filtered data on Viam**
+**Save and verify**
 
-Once you save your configuration, place an object that your ML model can detect within view of your camera.
+Save the config. Place an object your ML model can detect in front of the camera and wait for the next sync interval.
 
-Images that pass your filter will be captured and will sync at the specified sync interval, which may mean you have to wait and then refresh the page for data to appear.
-Your images will begin to appear under the **DATA** tab.
+On the **DATA** tab in the Viam app, click **Images** (the default view). You should see frames appear only when the trigger condition was met. If no frames appear:
 
-If no data appears after the sync interval, check the [**Logs**](/manage/troubleshoot/troubleshoot/#check-logs) and ensure that the condition for filtering is met.
-You can test the vision service from the [**CONTROL** tab](/manage/troubleshoot/teleoperate/default-interface/) to see its classifications and detections live.
+- **Test the vision service directly.** On the machine's **CONTROL** tab, open the vision service panel and point the camera at a known object. The panel shows live classifications and detections with their confidence scores. If no classifications or detections reach your threshold, the filtered camera has nothing to capture.
+- **Check the logs.** The machine's **LOGS** tab shows the filtered camera's filtering decisions if you set `"debug": true` in its config.
+- **Confirm capture is on the filtered camera.** Data capture must be on the `filtered-camera` component, not the underlying camera.
 
 {{% /tablestep %}}
 {{% tablestep %}}
 **(Optional) Trigger sync with custom logic**
 
-By default, the captured data syncs at the regular interval you specified in the data capture config.
-If you need to trigger sync in a different way, see [Conditional cloud sync](/data/capture-sync/conditional-sync/) for a documented example of syncing data only at certain times of day.
+By default, captured data syncs at the interval you set on the data management service. If you need to sync only at certain times or when other conditions are met, see [Conditional sync](/data/capture-sync/conditional-sync/).
 
 {{% /tablestep %}}
 {{< /table >}}
 
 {{< alert title="Build your own filtering module" color="tip" >}}
 
-If the `filtered_camera` registry module doesn't meet your needs, you can build a custom filtering module.
-See [Create a data filtering module](/tutorials/configure/pet-photographer/) for a full walkthrough, or [Write a module](/build-modules/write-a-driver-module/) for general module development guidance.
+If the `filtered-camera` module does not meet your needs, you can build a custom filtering module. See [Write a module](/build-modules/write-a-driver-module/) for the general module development guide. The next section covers the pattern.
 
 {{< /alert >}}
 

--- a/docs/data/pipelines/reference.md
+++ b/docs/data/pipelines/reference.md
@@ -1,5 +1,5 @@
 ---
-linkTitle: "Reference"
+linkTitle: "Pipeline reference"
 title: "Data pipelines reference"
 weight: 30
 layout: "docs"

--- a/docs/data/reference.md
+++ b/docs/data/reference.md
@@ -1,5 +1,5 @@
 ---
-linkTitle: "Reference"
+linkTitle: "Data reference"
 title: "Data management reference"
 weight: 999
 layout: "docs"


### PR DESCRIPTION
## Summary

Restructuring follow-up to #4901. Addresses the three Step 2 decisions from the Manage Data section review: filtered camera clarity, multi-part data capture gap, and the duplicate "Reference" sidebar labels.

> **Note:** this PR is stacked on #4901. The diff against \`new-docs-site\` includes #4901's commits until that PR merges. Merge #4901 first.

### 1. Filtered camera rewrite — \`docs/data/filter-at-the-edge.md\`

The reviewer said the filtered camera section "felt very undocumented and hand wavy" even though they got it working.

- Added a new **"How it works"** subsection with a 5-step prose walkthrough of the data flow: raw camera → vision service → filtered camera → data capture → sync. Explicitly explains that the filtered camera is itself a camera component, so the data manager captures from it like any other camera.
- Dropped the confusing inline \`modular-resource\` glossary tooltip.
- Replaced the deprecated \`"window_seconds": 0\` config example with the current \`"window_seconds_before": 0\` / \`"window_seconds_after": 0\` fields. Verified against the module README at \`github.com/viam-modules/filtered_camera\`.
- Added an attribute reference table (\`camera\`, \`vision_services\`, \`window_seconds_before\`, \`window_seconds_after\`, \`image_frequency\`, \`cooldown_s\`) so readers do not have to rely on the sparse module listing page.
- Rewrote the verify step with concrete troubleshooting pointers: test the vision service directly on the CONTROL tab, enable \`"debug": true\` and check logs, confirm capture is configured on the filtered camera and not the raw camera.
- The "Configure data capture" step now explicitly says "on the filtered camera, not on the raw camera" and warns about duplicate captures.
- Removed the orphaned \`/tutorials/configure/pet-photographer/\` link from the "Build your own filtering module" alert.
- Fixed the "continue to the next techniques" hand-off at the end of "Reduce capture frequency" to point at the filtered camera section instead of conditional sync (the old text implied conditional sync helps with event-based capture, which it does not).

### 2. Multi-part capture rewrite — \`docs/data/capture-sync/remote-parts-capture.md\`

The reviewer confused sub-parts with remote parts, and the old page only covered one of the two cases. Verified actual RDK behavior against source (\`rdk/services/datamanager/builtin/builtin.go:366-394\`, \`capture.go:353-375\`, test \`builtin_capture_test.go:83-159\`) before rewriting.

- Retitled to **"Capture data from multi-part machines"** (\`linkTitle: Multi-part capture\`). Filename unchanged, so the URL \`/data/capture-sync/remote-parts-capture/\` is preserved.
- Added a **Terminology** block with one-line definitions of sub-part and remote part, with links to \`/operate/reference/architecture/parts/\` for the full architectural context.
- Added a **"How capture differs"** comparison table covering: where the data manager lives, where \`.capture\` files are written, where sync uploads from, where you configure capture, and \`part_id\` attribution.
- Added a new **Sub-parts** section covering the case the old page did not: each sub-part is an independent \`viam-server\` instance with its own data manager, data lives on the sub-part's local filesystem, and the main part's data manager cannot reach into it.
- Kept the **Remote parts** walkthrough (the RDK research confirmed the old content was substantively correct). Added a caution against configuring overlapping capture on both parts, which produces duplicate rows. Rewrote the verify step to match the current Data tab UI.
- Kept the "capture camera images from a remote Pi" example with minor edits for terminology consistency.

### 3. Reference page naming collision

Both \`docs/data/reference.md\` and \`docs/data/pipelines/reference.md\` had \`linkTitle: "Reference"\`, producing two identical sidebar entries.

- \`docs/data/reference.md\` → \`linkTitle: "Data reference"\`
- \`docs/data/pipelines/reference.md\` → \`linkTitle: "Pipeline reference"\`

Titles, URLs, and aliases unchanged.

## Test plan

- [ ] Netlify deploy preview builds
- [ ] Filtered camera section preview: "How it works" subsection reads cleanly, attribute table renders, verify step reads as actionable
- [ ] Multi-part capture preview: both sub-part and remote-part sections are present and clearly labeled, terminology block is at the top
- [ ] Sidebar: "Data reference" and "Pipeline reference" are distinguishable in the nav
- [ ] \`linkTitle: "Multi-part capture"\` appears in the capture-sync section of the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)