### PR TITLE
Manage data: address Copilot follow-ups from PR 4901

### DIFF
--- a/docs/data/data-management-tutorial.md
+++ b/docs/data/data-management-tutorial.md
@@ -70,7 +70,7 @@ If you don't see your machine or sensor yet, wait another 30 seconds. The first 
 
 Behind the scenes:
 
-1. `viam-server` called `test-sensor.Readings()` every 5 seconds.
+1. `viam-server` called `test-sensor.GetReadings()` every 5 seconds.
 2. Each reading was appended to a `.capture` file (length-delimited binary protobuf) in `$HOME/.viam/capture` on your machine. When `viam-server` runs as root through `viam-agent`, that path is `/root/.viam/capture`.
 3. The sync process uploaded those files to Viam's cloud storage.
 4. The local files were deleted after successful sync.

--- a/docs/data/query-data.md
+++ b/docs/data/query-data.md
@@ -17,7 +17,7 @@ Explore and analyze your captured data using SQL or MQL queries. You can run que
 Tabular data (sensor readings, motor positions, encoder ticks, and other structured key-value data) is queryable through SQL and MQL. Binary data (images, point clouds) is stored separately and accessible through the [data client API](/dev/reference/apis/data-client/).
 
 {{< alert title="Known issue: SQL queries need an explicit lower time bound" color="caution" >}}
-SQL queries against `readings` currently return no rows unless the `WHERE` clause includes an explicit lower bound on `time_received`. Every SQL example and troubleshooting step on this page (including short inline examples) includes `AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)` for this reason. When troubleshooting, do not remove the lower-bound filter entirely: widen it by using this broad lower bound. MQL queries are not affected. Tracked as APP-10891.
+SQL queries against `readings` currently return no rows unless the `WHERE` clause includes an explicit lower bound on `time_received`. Every SQL example and troubleshooting step on this page (including short inline examples) includes an explicit lower bound on `time_received` for this reason. When troubleshooting, do not remove the lower-bound filter entirely: widen it by using a broad lower bound such as `AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)`. MQL queries are not affected. Tracked as APP-10891.
 {{< /alert >}}
 
 ## Open the query editor


### PR DESCRIPTION
## Summary

Two small follow-up fixes to content that landed in #4901. Both were flagged by Copilot review on #4902 but apply to files that aren't in that PR's diff, so they need a separate PR.

- **query-data.md alert:** the wording overstated things. It claimed every SQL example on the page includes the specific clause \`AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)\`, but the "filter by time range" example uses a different literal timestamp form (\`time_received > '2025-01-15T00:00:00Z'\`). Softened the alert to say "every SQL example includes an explicit lower bound on \`time_received\`" and kept the specific workaround clause as a concrete example in the troubleshooting advice.
- **data-management-tutorial.md "What just happened?" callout:** referred to \`test-sensor.Readings()\`, but the rest of the page (and the Viam app's CONTROL panel — verified at \`app/test-cards/src/lib/components/sensor-view.svelte:49\`) uses \`GetReadings\`. Aligned to \`GetReadings\`.

## Test plan

- [ ] Netlify deploy preview builds
- [ ] query-data.md preview: alert wording reads correctly
- [ ] data-management-tutorial.md preview: "What just happened?" step 1 says \`GetReadings()\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)