### PR TITLE
Update train docs for deprecated TRAINING tab

### DIFF
--- a/docs/data-ai/train/train-tf-tflite.md
+++ b/docs/data-ai/train/train-tf-tflite.md
@@ -106,9 +106,9 @@ Click **Train model**.
 {{% tablestep %}}
 **Wait for your model to train**
 
-The model now starts training and you can follow its process on the [**TRAINING** tab](https://app.viam.com/training).
+The model now starts training and you can follow its progress on the [**MODELS** tab](https://app.viam.com/models) by expanding the **Active Training** section.
 
-Once the model has finished training, it becomes visible on the [**MODELS** tab](https://app.viam.com/models).
+Once the model has finished training, it appears in the models list on the [**MODELS** tab](https://app.viam.com/models).
 
 You will receive an email when your model finishes training.
 
@@ -116,7 +116,7 @@ You will receive an email when your model finishes training.
 {{% tablestep %}}
 **Debug your training job**
 
-From the [**TRAINING** tab](https://app.viam.com/training), click on your training job's ID to see its logs.
+From the [**MODELS** tab](https://app.viam.com/models), expand **Active Training** and click your training job's ID to see its logs.
 
 {{< alert title="Note" color="note" >}}
 

--- a/docs/data-ai/train/train.md
+++ b/docs/data-ai/train/train.md
@@ -824,9 +824,9 @@ You can get the dataset ID from the **DATASET** tab of the **DATA** page or by r
 {{% tablestep %}}
 **Check on training job progress**
 
-You can view your training job on the **DATA** page's [**TRAINING** tab](https://app.viam.com/training).
+You can view your training job on the **DATA** page's [**MODELS** tab](https://app.viam.com/models) by expanding the **Active Training** section.
 
-Once the model has finished training, it becomes visible on the **DATA** page's [**MODELS** tab](https://app.viam.com/models).
+Once the model has finished training, it appears in the models list on the **DATA** page's [**MODELS** tab](https://app.viam.com/models).
 
 You will receive an email when your training job completes.
 
@@ -840,7 +840,7 @@ viam train list --org-id=<INSERT ORG ID> --job-status=unspecified
 {{% tablestep %}}
 **Debug your training job**
 
-From the **DATA** page's [**TRAINING** tab](https://app.viam.com/training), click your training job ID to see its logs.
+From the **DATA** page's [**MODELS** tab](https://app.viam.com/models), expand **Active Training** and click your training job ID to see its logs.
 
 {{< alert title="Note" color="note" >}}
 

--- a/docs/train/custom-training-scripts.md
+++ b/docs/train/custom-training-scripts.md
@@ -289,7 +289,7 @@ Use the [ML Training Client API](/dev/reference/apis/ml-training-client/#submitt
 {{< tabs >}}
 {{% tab name="Web UI" %}}
 
-In the Viam app, go to the **DATA** page and click the [**TRAINING** tab](https://app.viam.com/training).
+In the Viam app, go to the **DATA** page, click the [**MODELS** tab](https://app.viam.com/models), and expand **Active Training**.
 Click a job ID to view its logs.
 
 {{% /tab %}}

--- a/docs/train/train-a-model.md
+++ b/docs/train/train-a-model.md
@@ -74,7 +74,7 @@ The command returns a training job ID that you can use to check status.
 **Web UI:**
 
 1. In the Viam app, click the **DATA** tab.
-2. Click the **TRAINING** subtab.
+2. Click the **MODELS** subtab, then expand **Active Training**.
 3. You will see a list of training jobs with their status:
    - **Pending** -- the job is queued
    - **In Progress** -- training is running
@@ -208,8 +208,9 @@ for _, job := range jobs {
 
 {{< expand "Training job fails" >}}
 
-- **Check the training logs.** In the **TRAINING** tab, click the failed job ID
-  to view logs. The error message usually indicates the problem.
+- **Check the training logs.** In the **MODELS** tab, expand **Active Training**
+  and click the failed job ID to view logs. The error message usually indicates
+  the problem.
 - **Dataset too small.** Training requires at least 15 images with at least 80%
   labeled. Check your dataset in the **DATASETS** tab.
 - **No labels selected.** You must select at least two labels. A model cannot


### PR DESCRIPTION
## Source changes

- viamrobotics/app#11649 (APP-15716, commit `8ae21e6`): The Viam app UI deprecated the `TRAINING` tab on the DATA page and removed the `/training` route. Training jobs now appear in an **Active Training** expandable section on the **MODELS** tab (`/models`). The `DataTabLabel.Training`, `DataURL.Training`, and the `/training` +page route were all deleted in `ui/src/lib/data-tabs.ts`, `ui/src/lib/layout/nav/pages.ts`, and `ui/src/routes/(auth-required)/training/`.

## Docs changes

- `docs/train/train-a-model.md`: Replaced two references to the **TRAINING** subtab/tab with the **MODELS** subtab/tab plus the **Active Training** expandable section (one in the monitoring step, one in the troubleshooting expand).
- `docs/train/custom-training-scripts.md`: Replaced the **TRAINING** tab reference in "Monitor and debug" with the **MODELS** tab and **Active Training** section.
- `docs/data-ai/train/train.md`: Replaced two **TRAINING** tab references in the training job progress and debug steps with the **MODELS** tab and **Active Training** section. The follow-up "Once the model has finished training..." sentence was also reworded to distinguish active training (in the expandable section) from completed models (in the models list).
- `docs/data-ai/train/train-tf-tflite.md`: Same pattern as `train.md`: replaced two **TRAINING** tab references and reworded the follow-up sentence.

After editing, re-grepped the entire docs repo for `app.viam.com/training`, `**TRAINING** tab`, and `TRAINING subtab` to confirm zero remaining instances.

## How I found these

- Grep matches: `Grep /training` returned four files; `Grep '\*\*TRAINING\*\*'` returned five files. All references were in training how-to content. After deduplication, four files needed edits.
- No xref file maps directly to the removed tab; the app UI xref does not yet cover data/ML tab labels.

## Validation

- `prettier@3.2.5 --write` — no changes.
- `markdownlint-cli --config .markdownlint.yaml` — clean.
- `vale` — 0 errors, 0 warnings, 0 suggestions across all four files.

---
Generated by daily docs change agent