### PR TITLE
Fix tflite_cpu module name typo in hello world guide

### DIFF
--- a/docs/operate/hello-world/first-project/part-1.md
+++ b/docs/operate/hello-world/first-project/part-1.md
@@ -131,7 +131,7 @@ You'll configure two services:
 1. Click **+** next to your machine part
 2. Select **Configuration block**
 3. Search for `tflite`
-4. Select `tflight_cpu/tflight_cpu`
+4. Select `tflite_cpu/tflite_cpu`
 5. Click **Add component**
 6. Name it `model-service`
 7. Click **Add component**


### PR DESCRIPTION
Backport of #4897 (merged to main) to `new-docs-site`.

Fixes `tflight_cpu/tflight_cpu` → `tflite_cpu/tflite_cpu` in the hello world guide.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)