### PR TITLE
API reference: add missing cards, fix weight ordering

### DIFF
--- a/docs/reference/apis/_index.md
+++ b/docs/reference/apis/_index.md
@@ -53,6 +53,11 @@ Submit and manage ML training jobs running on Viam.
 Retrieve billing information from Viam.
 
 {{% /manualcard %}}
+{{% manualcard link="/reference/apis/sessions/" title="Session Management API" %}}
+
+Manage sessions, heartbeats, and safety timeouts for connected clients.
+
+{{% /manualcard %}}
 
 {{< /cards >}}
 
@@ -62,6 +67,8 @@ These APIs provide interfaces for controlling and getting information from the {
 
 {{< cards >}}
 {{< card link="/reference/apis/components/arm/" customTitle="Arm API" noimage="True" >}}
+{{< card link="/reference/apis/components/audio-in/" customTitle="Audio in API" noimage="True" >}}
+{{< card link="/reference/apis/components/audio-out/" customTitle="Audio out API" noimage="True" >}}
 {{< card link="/reference/apis/components/base/" customTitle="Base API" noimage="True" >}}
 {{< card link="/reference/apis/components/board/" customTitle="Board API" noimage="True" >}}
 {{< card link="/reference/apis/components/button/" customTitle="Button API" noimage="True" >}}
@@ -92,4 +99,5 @@ These APIs provide interfaces for controlling and getting information from the s
 {{% card link="/reference/apis/services/generic/" customTitle="Generic service API" noimage="True" %}}
 {{% card link="/reference/apis/services/base-rc/" customTitle="Base Remote Control service API" noimage="True" %}}
 {{% card link="/reference/apis/services/discovery/" customTitle="Discovery service API" noimage="True" %}}
+{{% card link="/reference/apis/services/world-state-store/" customTitle="World state store service API" noimage="True" %}}
 {{< /cards >}}

--- a/docs/reference/apis/billing-client.md
+++ b/docs/reference/apis/billing-client.md
@@ -1,7 +1,7 @@
 ---
 title: "Retrieve billing information with Viam's billing client API"
 linkTitle: "Billing client"
-weight: 90
+weight: 60
 type: "docs"
 description: "Use the billing client API to retrieve billing information from Viam."
 tags: ["cloud", "sdk", "viam-server", "networking", "apis", "robot api"]

--- a/docs/reference/apis/components/arm.md
+++ b/docs/reference/apis/components/arm.md
@@ -1,7 +1,7 @@
 ---
 title: "Arm API"
 linkTitle: "Arm"
-weight: 5
+weight: 10
 type: "docs"
 description: "Give commands to your arm components for linear motion planning."
 icon: true

--- a/docs/reference/apis/components/audio-in.md
+++ b/docs/reference/apis/components/audio-in.md
@@ -1,7 +1,7 @@
 ---
 title: "Audio in API"
 linkTitle: "Audio in"
-weight: 10
+weight: 20
 type: "docs"
 description: "Give commands to your audio in components."
 icon: true

--- a/docs/reference/apis/components/audio-out.md
+++ b/docs/reference/apis/components/audio-out.md
@@ -1,7 +1,7 @@
 ---
 title: "Audio out API"
 linkTitle: "Audio out"
-weight: 10
+weight: 30
 type: "docs"
 description: "Give commands to your audio out components."
 icon: true

--- a/docs/reference/apis/components/base.md
+++ b/docs/reference/apis/components/base.md
@@ -1,7 +1,7 @@
 ---
 title: "Base API"
 linkTitle: "Base"
-weight: 20
+weight: 40
 type: "docs"
 description: "Give commands for moving all configured components attached to a mobile platform as a whole without needing to send commands to individual components."
 icon: true

--- a/docs/reference/apis/components/board.md
+++ b/docs/reference/apis/components/board.md
@@ -1,7 +1,7 @@
 ---
 title: "Board API"
 linkTitle: "Board"
-weight: 30
+weight: 50
 type: "docs"
 description: "Give commands for setting GPIO pins to high or low, setting PWM, and working with analog and digital interrupts."
 icon: true

--- a/docs/reference/apis/components/button.md
+++ b/docs/reference/apis/components/button.md
@@ -1,7 +1,7 @@
 ---
 title: "Button API"
 linkTitle: "Button"
-weight: 35
+weight: 60
 type: "docs"
 description: "Give commands for getting presses from a physical button."
 icon: true

--- a/docs/reference/apis/components/camera.md
+++ b/docs/reference/apis/components/camera.md
@@ -1,7 +1,7 @@
 ---
 title: "Camera API"
 linkTitle: "Camera"
-weight: 40
+weight: 70
 type: "docs"
 description: "Give commands for getting images or point clouds."
 icon: true

--- a/docs/reference/apis/components/encoder.md
+++ b/docs/reference/apis/components/encoder.md
@@ -1,7 +1,7 @@
 ---
 title: "Encoder API"
 linkTitle: "Encoder"
-weight: 50
+weight: 80
 type: "docs"
 description: "Give commands for getting the position of a motor or a joint in ticks or degrees."
 icon: true

--- a/docs/reference/apis/components/gantry.md
+++ b/docs/reference/apis/components/gantry.md
@@ -1,7 +1,7 @@
 ---
 title: "Gantry API"
 linkTitle: "Gantry"
-weight: 60
+weight: 90
 type: "docs"
 description: "Give commands for coordinated control of one or more linear actuators."
 icon: true

--- a/docs/reference/apis/components/generic.md
+++ b/docs/reference/apis/components/generic.md
@@ -1,7 +1,7 @@
 ---
 title: "Control your generic component with the generic API"
 linkTitle: "Generic"
-weight: 70
+weight: 100
 type: "docs"
 description: "Give commands for running custom model-specific commands using DoCommand on your generic components."
 icon: true

--- a/docs/reference/apis/components/gripper.md
+++ b/docs/reference/apis/components/gripper.md
@@ -1,7 +1,7 @@
 ---
 title: "Control your gripper with the gripper API"
 linkTitle: "Gripper"
-weight: 80
+weight: 110
 type: "docs"
 description: "Give commands for opening and closing a gripper device."
 icon: true

--- a/docs/reference/apis/components/input-controller.md
+++ b/docs/reference/apis/components/input-controller.md
@@ -2,7 +2,7 @@
 title: "Input controller API"
 linkTitle: "Input controller"
 titleMustBeLong: true
-weight: 90
+weight: 120
 type: "docs"
 description: "Give commands to register callbacks for events, allowing you to use input devices to control your machines."
 icon: true

--- a/docs/reference/apis/components/motor.md
+++ b/docs/reference/apis/components/motor.md
@@ -1,7 +1,7 @@
 ---
 title: "Motor API"
 linkTitle: "Motor"
-weight: 100
+weight: 130
 type: "docs"
 description: "Give commands to operate a motor or get its current status."
 icon: true

--- a/docs/reference/apis/components/movement-sensor.md
+++ b/docs/reference/apis/components/movement-sensor.md
@@ -1,7 +1,7 @@
 ---
 title: "Movement sensor API"
 linkTitle: "Movement sensor"
-weight: 110
+weight: 140
 type: "docs"
 description: "Give commands for getting the current GPS location, linear velocity and acceleration, angular velocity and acceleration and heading."
 icon: true

--- a/docs/reference/apis/components/power-sensor.md
+++ b/docs/reference/apis/components/power-sensor.md
@@ -1,7 +1,7 @@
 ---
 title: "Power sensor API"
 linkTitle: "Power sensor"
-weight: 120
+weight: 150
 type: "docs"
 description: "Commands for getting measurements of voltage, current, and power consumption."
 icon: true

--- a/docs/reference/apis/components/sensor.md
+++ b/docs/reference/apis/components/sensor.md
@@ -1,7 +1,7 @@
 ---
 title: "Sensor API"
 linkTitle: "Sensor"
-weight: 130
+weight: 160
 type: "docs"
 description: "Give commands for getting sensor readings."
 icon: true

--- a/docs/reference/apis/components/servo.md
+++ b/docs/reference/apis/components/servo.md
@@ -1,7 +1,7 @@
 ---
 title: "Servo API"
 linkTitle: "Servo"
-weight: 140
+weight: 170
 type: "docs"
 description: "Give commands for controlling the angular position of a servo precisely or getting its current status."
 icon: true

--- a/docs/reference/apis/components/switch.md
+++ b/docs/reference/apis/components/switch.md
@@ -1,7 +1,7 @@
 ---
 title: "Switch API"
 linkTitle: "Switch"
-weight: 200
+weight: 180
 type: "docs"
 description: "Give commands for getting the state of a physical switch that has two or more discrete positions."
 icon: true

--- a/docs/reference/apis/data-client.md
+++ b/docs/reference/apis/data-client.md
@@ -1,7 +1,7 @@
 ---
 title: "Upload and retrieve data with Viam's data client API"
 linkTitle: "Data client"
-weight: 10
+weight: 30
 type: "docs"
 description: "Use the data client API to upload and retrieve data directly."
 icon: true

--- a/docs/reference/apis/fleet.md
+++ b/docs/reference/apis/fleet.md
@@ -1,7 +1,7 @@
 ---
 title: "Manage your fleet with Viam's fleet management API"
 linkTitle: "Fleet management"
-weight: 20
+weight: 10
 type: "docs"
 description: "Use the fleet management API with Viam's client SDKs to manage your machine fleet with code."
 tags:

--- a/docs/reference/apis/ml-training-client.md
+++ b/docs/reference/apis/ml-training-client.md
@@ -1,7 +1,7 @@
 ---
 title: "Work with ML training jobs with Viam's ML training API"
 linkTitle: "ML training client"
-weight: 10
+weight: 40
 type: "docs"
 description: "Use the ML training client API to manage ML training jobs taking place in Viam's cloud app."
 tags: ["cloud", "sdk", "viam-server", "networking", "apis", "ml model", "ml"]

--- a/docs/reference/apis/services/base-rc.md
+++ b/docs/reference/apis/services/base-rc.md
@@ -1,7 +1,7 @@
 ---
 title: "Base remote control service API"
 linkTitle: "Base remote control"
-weight: 70
+weight: 10
 type: "docs"
 tags: ["base", "services", "rover", "input controller", "remote control"]
 description: "Give commands to get a list of inputs from the controller that are being monitored for that control mode."

--- a/docs/reference/apis/services/data.md
+++ b/docs/reference/apis/services/data.md
@@ -1,7 +1,7 @@
 ---
 title: "Data management service API"
 linkTitle: "Data management"
-weight: 10
+weight: 20
 type: "docs"
 description: "Give commands to your data management service to sync data stored on the machine it is deployed on to the cloud."
 icon: true

--- a/docs/reference/apis/services/discovery.md
+++ b/docs/reference/apis/services/discovery.md
@@ -1,7 +1,7 @@
 ---
 title: "Discovery service API"
 linkTitle: "Discovery"
-weight: 80
+weight: 30
 type: "docs"
 tags: ["navigation", "services", "resources", "components"]
 description: "Reveal which resources are available to configure on a machine based on the hardware that is physically present."

--- a/docs/reference/apis/services/generic.md
+++ b/docs/reference/apis/services/generic.md
@@ -1,7 +1,7 @@
 ---
 title: "Generic service API"
 linkTitle: "Generic"
-weight: 60
+weight: 40
 type: "docs"
 tags: ["generic", "services"]
 description: "Give commands to your generic components for running model-specific commands using DoCommand."

--- a/docs/reference/apis/services/ml.md
+++ b/docs/reference/apis/services/ml.md
@@ -1,7 +1,7 @@
 ---
 title: "ML model service API"
 linkTitle: "ML model"
-weight: 30
+weight: 50
 type: "docs"
 tags: ["data management", "ml", "model training"]
 description: "Give commands to your ML model service to make inferences based on a provided ML model."

--- a/docs/reference/apis/services/motion.md
+++ b/docs/reference/apis/services/motion.md
@@ -1,7 +1,7 @@
 ---
 title: "Motion service API"
 linkTitle: "Motion"
-weight: 40
+weight: 60
 type: "docs"
 description: "Give commands to move a machine's components from one location or pose to another."
 icon: true

--- a/docs/reference/apis/services/navigation.md
+++ b/docs/reference/apis/services/navigation.md
@@ -1,7 +1,7 @@
 ---
 title: "Navigation service API"
 linkTitle: "Navigation"
-weight: 50
+weight: 70
 type: "docs"
 tags: ["navigation", "services", "base", "rover"]
 description: "Give commands to define waypoints and move your machine along those waypoints while avoiding obstacles."

--- a/docs/reference/apis/services/vision.md
+++ b/docs/reference/apis/services/vision.md
@@ -1,7 +1,7 @@
 ---
 title: "Vision service API"
 linkTitle: "Vision"
-weight: 20
+weight: 80
 type: "docs"
 description: "Give commands to get detections, classifications, or point cloud objects, depending on the ML model the vision service is using."
 aliases:

--- a/docs/reference/apis/services/world-state-store.md
+++ b/docs/reference/apis/services/world-state-store.md
@@ -1,7 +1,7 @@
 ---
 title: "World state store API"
 linkTitle: "World state store"
-weight: 70
+weight: 90
 type: "docs"
 tags: ["world_state_store", "services"]
 description: "Retrieve a list of world objects."

--- a/docs/reference/apis/sessions.md
+++ b/docs/reference/apis/sessions.md
@@ -1,7 +1,7 @@
 ---
 title: "Session management with Viam's client SDKs"
 linkTitle: "Session management"
-weight: 20
+weight: 50
 type: "docs"
 description: "Manage sessions between your machine and clients connected through Viam's SDKs."
 tags:


### PR DESCRIPTION
## Summary

Completes the API reference section review (Phase 2 recommendations).

## Changes

### Overview page (_index.md)
- Add missing component cards: audio-in, audio-out
- Add missing service card: world-state-store
- Add missing platform card: sessions

### Weight ordering (33 files)
- Fix all weight ties that caused undefined nav ordering
- Components: alphabetical at weights 10-180 (18 pages)
- Services: alphabetical at weights 10-90 (9 pages)
- Platform APIs: ordered by usage frequency at weights 10-60 (6 pages)

## Test plan

- [ ] All cards render on the APIs overview page
- [ ] Nav sidebar shows pages in correct alphabetical/frequency order
- [ ] No broken links from new cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)