### PR TITLE
Manage data overview: add data flow diagram

### DIFF
--- a/docs/data/overview.md
+++ b/docs/data/overview.md
@@ -13,6 +13,8 @@ Your robot's sensors, cameras, and other components produce data you need to rec
 
 Data moves through four stages, from your robot to actionable insights:
 
+<img src="/data/data-flow-overview.svg" alt="Data flow: capture on the machine writes .capture files to local disk, sync uploads to cloud, cloud stores tabular data in MongoDB and binary data in blob storage, and from there you can query, export, train ML models, build dashboards, and trigger alerts." style="width:100%;max-width:720px;height:auto;display:block" >
+
 1. **Capture on the machine.** You configure which components to record from and at what frequency. Captured data is written to local disk. Nothing is captured until you configure it.
 2. **Sync to the cloud.** A separate process uploads captured data to Viam's cloud at a configurable interval, then deletes local files. If the machine goes offline, data buffers locally and syncs when connectivity returns.
 3. **Store.** In the cloud, tabular data (sensor readings, motor positions, encoder ticks) is stored in MongoDB. Binary data (images, point clouds, audio) is stored in blob storage. Both are indexed and queryable.

--- a/static/data/data-flow-overview.svg
+++ b/static/data/data-flow-overview.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 190" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif">
+  <defs>
+    <style>
+      .stage-label { font-size: 13px; font-weight: 600; fill: #252525; }
+      .detail { font-size: 10px; fill: #808080; }
+      .layer-label { font-size: 11px; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase; fill: #252525; }
+    </style>
+  </defs>
+
+  <!-- Layer boundaries -->
+  <rect x="0" y="0" width="310" height="190" rx="6" fill="none" stroke="#252525" stroke-width="1.5"/>
+  <text x="12" y="18" class="layer-label">On the machine</text>
+
+  <rect x="320" y="0" width="400" height="190" rx="6" fill="none" stroke="#252525" stroke-width="1.5"/>
+  <text x="332" y="18" class="layer-label">In the cloud</text>
+
+  <!-- Stage 1: Capture -->
+  <rect x="12" y="30" width="135" height="146" rx="4" fill="#fff" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="79.5" y="52" text-anchor="middle" class="stage-label">Capture</text>
+  <line x1="20" y1="58" x2="139" y2="58" stroke="#e0e0e0" stroke-width="0.5"/>
+  <text x="79.5" y="76" text-anchor="middle" class="detail">viam-server records</text>
+  <text x="79.5" y="92" text-anchor="middle" class="detail">component data at a</text>
+  <text x="79.5" y="108" text-anchor="middle" class="detail">configured frequency</text>
+  <line x1="20" y1="116" x2="139" y2="116" stroke="#e0e0e0" stroke-width="0.5"/>
+  <text x="79.5" y="134" text-anchor="middle" class="detail">Saves to .capture</text>
+  <text x="79.5" y="150" text-anchor="middle" class="detail">files on local disk</text>
+
+  <!-- Arrow 1→2 -->
+  <line x1="147" y1="103" x2="163" y2="103" stroke="#252525" stroke-width="1.2"/>
+  <polygon points="160,99 169,103 160,107" fill="#252525"/>
+
+  <!-- Stage 2: Sync -->
+  <rect x="169" y="30" width="130" height="146" rx="4" fill="#fff" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="234" y="52" text-anchor="middle" class="stage-label">Sync</text>
+  <line x1="177" y1="58" x2="291" y2="58" stroke="#e0e0e0" stroke-width="0.5"/>
+  <text x="234" y="76" text-anchor="middle" class="detail">Uploads captured</text>
+  <text x="234" y="92" text-anchor="middle" class="detail">data to Viam cloud</text>
+  <line x1="177" y1="100" x2="291" y2="100" stroke="#e0e0e0" stroke-width="0.5"/>
+  <text x="234" y="118" text-anchor="middle" class="detail">Deletes local files</text>
+  <text x="234" y="134" text-anchor="middle" class="detail">after upload</text>
+  <line x1="177" y1="142" x2="291" y2="142" stroke="#e0e0e0" stroke-width="0.5"/>
+  <text x="234" y="160" text-anchor="middle" class="detail">Default: every 6s</text>
+
+  <!-- Arrow 2→3 (dashed, crosses machine-to-cloud boundary) -->
+  <line x1="299" y1="103" x2="329" y2="103" stroke="#252525" stroke-width="1.2" stroke-dasharray="4,3"/>
+  <polygon points="326,99 335,103 326,107" fill="#252525"/>
+
+  <!-- Stage 3: Store -->
+  <rect x="335" y="30" width="145" height="146" rx="4" fill="#fff" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="407.5" y="52" text-anchor="middle" class="stage-label">Store</text>
+  <line x1="343" y1="58" x2="472" y2="58" stroke="#e0e0e0" stroke-width="0.5"/>
+  <text x="407.5" y="76" text-anchor="middle" class="detail">Tabular data</text>
+  <text x="407.5" y="92" text-anchor="middle" class="detail">(readings, positions)</text>
+  <text x="407.5" y="108" text-anchor="middle" class="detail">→ MongoDB</text>
+  <line x1="343" y1="116" x2="472" y2="116" stroke="#e0e0e0" stroke-width="0.5"/>
+  <text x="407.5" y="134" text-anchor="middle" class="detail">Binary data</text>
+  <text x="407.5" y="150" text-anchor="middle" class="detail">(images, point clouds)</text>
+  <text x="407.5" y="166" text-anchor="middle" class="detail">→ Blob storage</text>
+
+  <!-- Arrow 3→4 -->
+  <line x1="480" y1="103" x2="496" y2="103" stroke="#252525" stroke-width="1.2"/>
+  <polygon points="493,99 502,103 493,107" fill="#252525"/>
+
+  <!-- Stage 4: Use -->
+  <rect x="502" y="30" width="206" height="146" rx="4" fill="#fff" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="605" y="52" text-anchor="middle" class="stage-label">Use</text>
+  <line x1="510" y1="58" x2="700" y2="58" stroke="#e0e0e0" stroke-width="0.5"/>
+  <text x="605" y="78" text-anchor="middle" class="detail">Query with SQL or MQL</text>
+  <text x="605" y="98" text-anchor="middle" class="detail">Export to your tools</text>
+  <text x="605" y="118" text-anchor="middle" class="detail">Build ML datasets</text>
+  <text x="605" y="138" text-anchor="middle" class="detail">Visualize in dashboards</text>
+  <text x="605" y="158" text-anchor="middle" class="detail">Trigger alerts</text>
+</svg>


### PR DESCRIPTION
## Summary

The reviewer's first comment on the overview page was: "Could use a 10,000' view image with How data flows." This PR adds it.

### Diagram

New SVG at `static/data/data-flow-overview.svg` showing the four-stage data pipeline:

**Capture** → **Sync** → **Store** → **Use**

Split into two labeled regions ("On the machine" and "In the cloud") with a dashed arrow at the boundary crossing, matching the convention in the existing `what-is-viam-technical.svg` architecture diagram.

Each stage box contains a brief description:
- **Capture**: viam-server records component data at a configured frequency, saves to .capture files on local disk
- **Sync**: uploads captured data to Viam cloud, deletes local files after upload, default every 6s
- **Store**: tabular data (readings, positions) → MongoDB; binary data (images, point clouds) → Blob storage
- **Use**: query with SQL or MQL, export, build ML datasets, visualize in dashboards, trigger alerts

### Style

Matches `what-is-viam-technical.svg`:
- Layer boundaries: `#252525` stroke at 1.5px
- Interior boxes: `#fff` fill, `#e0e0e0` stroke at 1px
- Internal dividers: `#e0e0e0` at 0.5px
- Arrows: `#252525` at 1.2px (dashed for cloud crossing)
- Typography: Inter font, 13px bold labels, 10px gray detail text, 11px uppercase layer labels

### Integration

Placed on the overview page between "Data moves through four stages" and the numbered list, using a plain `<img>` tag (SVGs cannot use Hugo's `imgproc` shortcode).

## Test plan

- [ ] Netlify deploy preview builds
- [ ] Overview preview: diagram renders between the intro sentence and the numbered list
- [ ] Diagram is readable at mobile widths (SVG scales via viewBox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)