### PR TITLE
Populate reference stubs: APIs, architecture, SDKs, platform

### DIFF
--- a/docs/reference/apis/_index.md
+++ b/docs/reference/apis/_index.md
@@ -53,6 +53,11 @@ Submit and manage ML training jobs running on Viam.
 Retrieve billing information from Viam.
 
 {{% /manualcard %}}
+{{% manualcard link="/reference/apis/sessions/" title="Session Management API" %}}
+
+Manage sessions, heartbeats, and safety timeouts for connected clients.
+
+{{% /manualcard %}}
 
 {{< /cards >}}
 
@@ -62,6 +67,8 @@ These APIs provide interfaces for controlling and getting information from the {
 
 {{< cards >}}
 {{< card link="/reference/apis/components/arm/" customTitle="Arm API" noimage="True" >}}
+{{< card link="/reference/apis/components/audio-in/" customTitle="Audio in API" noimage="True" >}}
+{{< card link="/reference/apis/components/audio-out/" customTitle="Audio out API" noimage="True" >}}
 {{< card link="/reference/apis/components/base/" customTitle="Base API" noimage="True" >}}
 {{< card link="/reference/apis/components/board/" customTitle="Board API" noimage="True" >}}
 {{< card link="/reference/apis/components/button/" customTitle="Button API" noimage="True" >}}
@@ -92,4 +99,5 @@ These APIs provide interfaces for controlling and getting information from the s
 {{% card link="/reference/apis/services/generic/" customTitle="Generic service API" noimage="True" %}}
 {{% card link="/reference/apis/services/base-rc/" customTitle="Base Remote Control service API" noimage="True" %}}
 {{% card link="/reference/apis/services/discovery/" customTitle="Discovery service API" noimage="True" %}}
+{{% card link="/reference/apis/services/world-state-store/" customTitle="World state store service API" noimage="True" %}}
 {{< /cards >}}

--- a/docs/reference/apis/billing-client.md
+++ b/docs/reference/apis/billing-client.md
@@ -1,7 +1,7 @@
 ---
 title: "Retrieve billing information with Viam's billing client API"
 linkTitle: "Billing client"
-weight: 90
+weight: 60
 type: "docs"
 description: "Use the billing client API to retrieve billing information from Viam."
 tags: ["cloud", "sdk", "viam-server", "networking", "apis", "robot api"]

--- a/docs/reference/apis/components/arm.md
+++ b/docs/reference/apis/components/arm.md
@@ -1,7 +1,7 @@
 ---
 title: "Arm API"
 linkTitle: "Arm"
-weight: 5
+weight: 10
 type: "docs"
 description: "Give commands to your arm components for linear motion planning."
 icon: true

--- a/docs/reference/apis/components/audio-in.md
+++ b/docs/reference/apis/components/audio-in.md
@@ -1,7 +1,7 @@
 ---
 title: "Audio in API"
 linkTitle: "Audio in"
-weight: 10
+weight: 20
 type: "docs"
 description: "Give commands to your audio in components."
 icon: true

--- a/docs/reference/apis/components/audio-out.md
+++ b/docs/reference/apis/components/audio-out.md
@@ -1,7 +1,7 @@
 ---
 title: "Audio out API"
 linkTitle: "Audio out"
-weight: 10
+weight: 30
 type: "docs"
 description: "Give commands to your audio out components."
 icon: true

--- a/docs/reference/apis/components/base.md
+++ b/docs/reference/apis/components/base.md
@@ -1,7 +1,7 @@
 ---
 title: "Base API"
 linkTitle: "Base"
-weight: 20
+weight: 40
 type: "docs"
 description: "Give commands for moving all configured components attached to a mobile platform as a whole without needing to send commands to individual components."
 icon: true

--- a/docs/reference/apis/components/board.md
+++ b/docs/reference/apis/components/board.md
@@ -1,7 +1,7 @@
 ---
 title: "Board API"
 linkTitle: "Board"
-weight: 30
+weight: 50
 type: "docs"
 description: "Give commands for setting GPIO pins to high or low, setting PWM, and working with analog and digital interrupts."
 icon: true

--- a/docs/reference/apis/components/button.md
+++ b/docs/reference/apis/components/button.md
@@ -1,7 +1,7 @@
 ---
 title: "Button API"
 linkTitle: "Button"
-weight: 35
+weight: 60
 type: "docs"
 description: "Give commands for getting presses from a physical button."
 icon: true

--- a/docs/reference/apis/components/camera.md
+++ b/docs/reference/apis/components/camera.md
@@ -1,7 +1,7 @@
 ---
 title: "Camera API"
 linkTitle: "Camera"
-weight: 40
+weight: 70
 type: "docs"
 description: "Give commands for getting images or point clouds."
 icon: true

--- a/docs/reference/apis/components/encoder.md
+++ b/docs/reference/apis/components/encoder.md
@@ -1,7 +1,7 @@
 ---
 title: "Encoder API"
 linkTitle: "Encoder"
-weight: 50
+weight: 80
 type: "docs"
 description: "Give commands for getting the position of a motor or a joint in ticks or degrees."
 icon: true

--- a/docs/reference/apis/components/gantry.md
+++ b/docs/reference/apis/components/gantry.md
@@ -1,7 +1,7 @@
 ---
 title: "Gantry API"
 linkTitle: "Gantry"
-weight: 60
+weight: 90
 type: "docs"
 description: "Give commands for coordinated control of one or more linear actuators."
 icon: true

--- a/docs/reference/apis/components/generic.md
+++ b/docs/reference/apis/components/generic.md
@@ -1,7 +1,7 @@
 ---
 title: "Control your generic component with the generic API"
 linkTitle: "Generic"
-weight: 70
+weight: 100
 type: "docs"
 description: "Give commands for running custom model-specific commands using DoCommand on your generic components."
 icon: true

--- a/docs/reference/apis/components/gripper.md
+++ b/docs/reference/apis/components/gripper.md
@@ -1,7 +1,7 @@
 ---
 title: "Control your gripper with the gripper API"
 linkTitle: "Gripper"
-weight: 80
+weight: 110
 type: "docs"
 description: "Give commands for opening and closing a gripper device."
 icon: true

--- a/docs/reference/apis/components/input-controller.md
+++ b/docs/reference/apis/components/input-controller.md
@@ -2,7 +2,7 @@
 title: "Input controller API"
 linkTitle: "Input controller"
 titleMustBeLong: true
-weight: 90
+weight: 120
 type: "docs"
 description: "Give commands to register callbacks for events, allowing you to use input devices to control your machines."
 icon: true

--- a/docs/reference/apis/components/motor.md
+++ b/docs/reference/apis/components/motor.md
@@ -1,7 +1,7 @@
 ---
 title: "Motor API"
 linkTitle: "Motor"
-weight: 100
+weight: 130
 type: "docs"
 description: "Give commands to operate a motor or get its current status."
 icon: true

--- a/docs/reference/apis/components/movement-sensor.md
+++ b/docs/reference/apis/components/movement-sensor.md
@@ -1,7 +1,7 @@
 ---
 title: "Movement sensor API"
 linkTitle: "Movement sensor"
-weight: 110
+weight: 140
 type: "docs"
 description: "Give commands for getting the current GPS location, linear velocity and acceleration, angular velocity and acceleration and heading."
 icon: true

--- a/docs/reference/apis/components/power-sensor.md
+++ b/docs/reference/apis/components/power-sensor.md
@@ -1,7 +1,7 @@
 ---
 title: "Power sensor API"
 linkTitle: "Power sensor"
-weight: 120
+weight: 150
 type: "docs"
 description: "Commands for getting measurements of voltage, current, and power consumption."
 icon: true

--- a/docs/reference/apis/components/sensor.md
+++ b/docs/reference/apis/components/sensor.md
@@ -1,7 +1,7 @@
 ---
 title: "Sensor API"
 linkTitle: "Sensor"
-weight: 130
+weight: 160
 type: "docs"
 description: "Give commands for getting sensor readings."
 icon: true

--- a/docs/reference/apis/components/servo.md
+++ b/docs/reference/apis/components/servo.md
@@ -1,7 +1,7 @@
 ---
 title: "Servo API"
 linkTitle: "Servo"
-weight: 140
+weight: 170
 type: "docs"
 description: "Give commands for controlling the angular position of a servo precisely or getting its current status."
 icon: true

--- a/docs/reference/apis/components/switch.md
+++ b/docs/reference/apis/components/switch.md
@@ -1,7 +1,7 @@
 ---
 title: "Switch API"
 linkTitle: "Switch"
-weight: 200
+weight: 180
 type: "docs"
 description: "Give commands for getting the state of a physical switch that has two or more discrete positions."
 icon: true

--- a/docs/reference/apis/data-client.md
+++ b/docs/reference/apis/data-client.md
@@ -1,7 +1,7 @@
 ---
 title: "Upload and retrieve data with Viam's data client API"
 linkTitle: "Data client"
-weight: 10
+weight: 30
 type: "docs"
 description: "Use the data client API to upload and retrieve data directly."
 icon: true

--- a/docs/reference/apis/fleet.md
+++ b/docs/reference/apis/fleet.md
@@ -1,7 +1,7 @@
 ---
 title: "Manage your fleet with Viam's fleet management API"
 linkTitle: "Fleet management"
-weight: 20
+weight: 10
 type: "docs"
 description: "Use the fleet management API with Viam's client SDKs to manage your machine fleet with code."
 tags:

--- a/docs/reference/apis/ml-training-client.md
+++ b/docs/reference/apis/ml-training-client.md
@@ -1,7 +1,7 @@
 ---
 title: "Work with ML training jobs with Viam's ML training API"
 linkTitle: "ML training client"
-weight: 10
+weight: 40
 type: "docs"
 description: "Use the ML training client API to manage ML training jobs taking place in Viam's cloud app."
 tags: ["cloud", "sdk", "viam-server", "networking", "apis", "ml model", "ml"]

--- a/docs/reference/apis/services/base-rc.md
+++ b/docs/reference/apis/services/base-rc.md
@@ -1,7 +1,7 @@
 ---
 title: "Base remote control service API"
 linkTitle: "Base remote control"
-weight: 70
+weight: 10
 type: "docs"
 tags: ["base", "services", "rover", "input controller", "remote control"]
 description: "Give commands to get a list of inputs from the controller that are being monitored for that control mode."

--- a/docs/reference/apis/services/data.md
+++ b/docs/reference/apis/services/data.md
@@ -1,7 +1,7 @@
 ---
 title: "Data management service API"
 linkTitle: "Data management"
-weight: 10
+weight: 20
 type: "docs"
 description: "Give commands to your data management service to sync data stored on the machine it is deployed on to the cloud."
 icon: true

--- a/docs/reference/apis/services/discovery.md
+++ b/docs/reference/apis/services/discovery.md
@@ -1,7 +1,7 @@
 ---
 title: "Discovery service API"
 linkTitle: "Discovery"
-weight: 80
+weight: 30
 type: "docs"
 tags: ["navigation", "services", "resources", "components"]
 description: "Reveal which resources are available to configure on a machine based on the hardware that is physically present."

--- a/docs/reference/apis/services/generic.md
+++ b/docs/reference/apis/services/generic.md
@@ -1,7 +1,7 @@
 ---
 title: "Generic service API"
 linkTitle: "Generic"
-weight: 60
+weight: 40
 type: "docs"
 tags: ["generic", "services"]
 description: "Give commands to your generic components for running model-specific commands using DoCommand."

--- a/docs/reference/apis/services/ml.md
+++ b/docs/reference/apis/services/ml.md
@@ -1,7 +1,7 @@
 ---
 title: "ML model service API"
 linkTitle: "ML model"
-weight: 30
+weight: 50
 type: "docs"
 tags: ["data management", "ml", "model training"]
 description: "Give commands to your ML model service to make inferences based on a provided ML model."

--- a/docs/reference/apis/services/motion.md
+++ b/docs/reference/apis/services/motion.md
@@ -1,7 +1,7 @@
 ---
 title: "Motion service API"
 linkTitle: "Motion"
-weight: 40
+weight: 60
 type: "docs"
 description: "Give commands to move a machine's components from one location or pose to another."
 icon: true

--- a/docs/reference/apis/services/navigation.md
+++ b/docs/reference/apis/services/navigation.md
@@ -1,7 +1,7 @@
 ---
 title: "Navigation service API"
 linkTitle: "Navigation"
-weight: 50
+weight: 70
 type: "docs"
 tags: ["navigation", "services", "base", "rover"]
 description: "Give commands to define waypoints and move your machine along those waypoints while avoiding obstacles."

--- a/docs/reference/apis/services/vision.md
+++ b/docs/reference/apis/services/vision.md
@@ -1,7 +1,7 @@
 ---
 title: "Vision service API"
 linkTitle: "Vision"
-weight: 20
+weight: 80
 type: "docs"
 description: "Give commands to get detections, classifications, or point cloud objects, depending on the ML model the vision service is using."
 aliases:

--- a/docs/reference/apis/services/world-state-store.md
+++ b/docs/reference/apis/services/world-state-store.md
@@ -1,7 +1,7 @@
 ---
 title: "World state store API"
 linkTitle: "World state store"
-weight: 70
+weight: 90
 type: "docs"
 tags: ["world_state_store", "services"]
 description: "Retrieve a list of world objects."

--- a/docs/reference/apis/sessions.md
+++ b/docs/reference/apis/sessions.md
@@ -1,7 +1,7 @@
 ---
 title: "Session management with Viam's client SDKs"
 linkTitle: "Session management"
-weight: 20
+weight: 50
 type: "docs"
 description: "Manage sessions between your machine and clients connected through Viam's SDKs."
 tags:

--- a/docs/reference/architecture/_index.md
+++ b/docs/reference/architecture/_index.md
@@ -161,7 +161,7 @@ Now imagine you want to run code to turn on a fan when the temperature sensor re
 - Write your script using one of the Viam [SDKs](/reference/sdks/), for example the Viam Python SDK, using the sensor API and motor API.
 - You then run this code either locally on the SBC, or on a separate server.
   See [Create a headless app](/operate/control/headless-app/) for more information.
-  Your code connects to the machine, authenticating with API keys, and uses the [sensor API](/reference/components/sensor/#api) to get readings and the [motor API](/reference/components/motor/#api) to turn the motor on and off.
+  Your code connects to the machine, authenticating with API keys, and uses the [sensor API](/reference/apis/components/sensor/) to get readings and the [motor API](/reference/apis/components/motor/) to turn the motor on and off.
 
   {{< imgproc src="/build/program/sdks/robot-client.png" resize="x400" declaredimensions=true alt="A desktop computer (client in this case) sends commands to robot 1 (server) with gRPC over wifi." >}}
 

--- a/docs/reference/architecture/_index.md
+++ b/docs/reference/architecture/_index.md
@@ -8,5 +8,209 @@ imageAlt: "Viam architecture"
 images: ["/viam/machine-components.png"]
 tags: ["components", "services", "communication"]
 date: "2024-08-13"
+aliases:
+  - /architecture/
+  - /operate/reference/architecture/
+  - /dev/reference/architecture/
 # updated: ""  # When the content was last entirely checked
 ---
+
+This page provides an overview of how a machine is structured, including on-device and cloud communications:
+
+- [`viam-server` and `viam-micro-server`](#viam-server-and-viam-micro-server)
+- [Components, services and modules](#components-services-modules)
+- [Communication flow and security](#communication)
+- [How data flows in Viam](#data-management-flow)
+- [Basic machine example](#basic-machine-example)
+- [Structure of more complex machines](#complex-machines-with-multiple-parts)
+
+{{<imgproc class="imgzoom" src="/architecture/architecture-diagram.svg" resize="x1100" declaredimensions=true alt="Viam-server runs on your machine and communicates with processes running on your machine, with the Viam Cloud, with API clients, and with other machines running viam-server." >}}
+
+## `viam-server` and `viam-micro-server`
+
+`viam-server` is the open-source executable binary that runs on your machine's SBC or other computer.
+
+`viam-server` does the following locally:
+
+- Runs drivers for your hardware
+- Runs motion planning and vision services
+- Runs {{< glossary_tooltip term_id="module" text="modules" >}}
+- Manages local connections between all these resources
+- Captures and stores data
+
+When `viam-server` can connect to the cloud, it also:
+
+- Automatically pulls configuration updates you make
+- Gets new versions of software packages
+- Uploads and syncs image and sensor data
+- Handles requests from client code you write with [SDKs](/reference/sdks/)
+- Allows you to remotely monitor and control your machine
+
+`viam-server` can use the internet, wide area networks (WAN) or local networks (LAN) to establish peer-to-peer connections between two {{< glossary_tooltip term_id="machine" text="machines" >}}, or to a client application.
+
+[`viam-micro-server`](/reference/platform/viam-micro-server/) is the lightweight version of `viam-server` that you can run on ESP32 microcontrollers.
+It supports a limited set of {{< glossary_tooltip term_id="resource" text="resources" >}} and can connect with the cloud as well as with devices running `viam-server`.
+
+## Components, services, modules
+
+A {{< glossary_tooltip term_id="component" text="component" >}} represents a physical piece of hardware in your {{< glossary_tooltip term_id="machine" text="machine" >}}, and the software that directly supports that hardware.
+
+A {{< glossary_tooltip term_id="service" text="service" >}} is a software package that adds complex capabilities such as motion planning or object detection to your machine.
+
+Viam has many built-in components and services that run within `viam-server`.
+
+A _modular resource_ is a custom component or service, not built into `viam-server` but rather provided by a _module_ that you or another user have created.
+A module runs as a process managed by `viam-server` on your machine, communicating over UNIX sockets, and `viam-server` manages its lifecycle.
+
+{{<imgproc src="/viam/machine-components.png" resize="x1100" declaredimensions=true alt="Machine structure" style="width:600px" >}}
+
+{{< expand "Click for an example" >}}
+
+Imagine you have a wheeled rover with two motors, a GPS unit, and a camera, controlled by a single-board computer (SBC) such as a Raspberry Pi.
+
+The motors, GPS, and camera each require software drivers so that the board can send signals to them and receive signals from them.
+These drivers are called _{{< glossary_tooltip term_id="component" text="components" >}}_.
+There is also a _component_ for the board itself that allows Viam software to communicate with the pins on the board.
+
+If you configure a [base component](/reference/components/base/), you can specify the size of the wheels attached to the motors, and how wide the rover base is, so `viam-server` can calculate how to coordinate the motion of the rover base.
+
+If your rover includes a piece of hardware (such as a particular sensor) that is not yet supported as a built-in in by Viam, check the registry for a contributed {{< glossary_tooltip term_id="module" text="module" >}} or write your own module to integrate it into your machine.
+
+Say you want your machine to navigate intelligently between GPS coordinates.
+Instead of writing code from scratch, you can use Viam's built-in navigation service by adding it to your configuration, specifying how the GPS and any additional movement sensors are oriented with respect to your hardware.
+Since your configuration includes information about the wheeled base of your rover as well as how that base is oriented in relation to your GPS and other sensors, `viam-server` can use the motion and navigation services to calculate how much power to send to each motor to get it to a point on the map.
+
+If you want to add some other high-level software functionality beyond the built-in services (for example, your own flavor of navigation service), you can add your own service with a module.
+
+{{< /expand >}}
+
+## Communication
+
+<img src="https://assets-global.website-files.com/62fba5686b6d47fe2a1ed2a6/63334e5e19a68d329b1c5b0e_viam-overview-illustrations-manage.svg" alt="A diagram illustrating secure machine control." class="alignleft" style="width:270px;"></img>
+
+Viam uses peer-to-peer communication, where all machines running `viam-server` or [`viam-micro-server`](/reference/platform/viam-micro-server/) (the version of `viam-server` for microcontrollers) communicate directly with each other as well as with the cloud.
+This peer-to-peer connectivity is enabled by sending [gRPC commands over WebRTC connections](/reference/architecture/machine-to-machine-comms/#low-level-inter-robotsdk-communication).
+
+On startup, `viam-server` establishes a {{< glossary_tooltip term_id="webrtc" text="WebRTC" >}} connection with Viam.
+`viam-server` pulls its configuration from the app, caches it locally, and initializes all components and services based on that configuration.
+
+If [sub-parts or remote parts](#complex-machines-with-multiple-parts) are configured, communications are established between the `viam-server` instances on each of them.
+
+If you have client code running on a separate computer, that code sends API requests to `viam-server` using gRPC over WebRTC.
+If a WebRTC connection cannot be established, the request is sent directly over gRPC.
+The Viam cloud works as the signaling server for connections where possible.
+If you are connecting to a machine over local network or in offline mode, `viam-server` functions as the signaling server instead.
+
+When a built-in service communicates with a component, for example when the vision service requests an image from a camera, `viam-server` handles that request as well.
+
+When you control your machine or view its camera streams or sensor outputs from the **CONTROL** tab, those connections happen over WebRTC.
+The web UI uses the same API endpoints as your SDK client code (in fact, it uses the Viam TypeScript SDK), with `viam-server` handling requests.
+
+{{% alert title="Protobuf APIs" color="info" %}}
+All Viam APIs are defined with the [Protocol Buffers (protobuf)](https://protobuf.dev/) framework.
+{{% /alert %}}
+
+For more details, see [Machine-to-Machine Communication](/reference/architecture/machine-to-machine-comms/).
+
+### Security
+
+TLS certificates automatically provided by Viam ensure that all communication is authenticated and encrypted.
+
+Viam uses API keys with [role-based access control (RBAC)](/organization/rbac/) to control access to machines from client code.
+
+## Data management flow
+
+{{<imgproc src="/architecture/data-flow.svg" resize="x1100" declaredimensions=true alt="Data flowing from local disk to cloud to Viam, SDKs, and MQL and SQL queries." >}}
+<br>
+
+Data is captured and synced to the Viam Cloud as follows:
+
+1. Data collected by your resources, such as sensors and cameras, is first stored locally in a specified directory (defaults to <file>~/.viam/capture</file>).
+   You control what data to capture, how often to capture it, and where to store it using the configuration.
+
+   - You can also sync data from other sources by putting it into folders you specify.
+     <br><br>
+
+1. `viam-server` syncs data to the cloud at your specified interval, and deletes the data from the local directory.
+
+1. You can view your data in the web UI or query it using Viam SDKs, MQL, or SQL.
+
+If a device has intermittent internet connectivity, data is stored locally until the machine can reconnect to the cloud.
+
+For more information, see [Data management service](/data-ai/capture-data/capture-sync/).
+
+## Basic machine example
+
+<p>
+{{<imgproc src="/architecture/simple-machine.png" class="alignright" resize="x1000" declaredimensions=true alt="viam-server running on a board connected to a sensor. Data is temporarily stored on a local folder until it is synced to Viam." style="width:400px" >}}
+</p>
+
+Imagine you have a simple device consisting of a temperature sensor connected to the GPIO pins of a single-board computer (SBC).
+You want to capture sensor data at regular intervals, and sync it to the cloud.
+Here is how this works in Viam:
+
+- You configure your machine in the web UI with a sensor {{< glossary_tooltip term_id="component" text="component" >}} and the data management {{< glossary_tooltip term_id="service" text="service" >}}.
+- `viam-server` runs on the SBC, managing all communications between hardware and the cloud using gRPC over {{< glossary_tooltip term_id="webrtc" text="WebRTC" >}}.
+  On startup, `viam-server` uses credentials stored locally to establish a connection with Viam and fetches its configuration.
+- Sensor data is cached in a local folder, then synced to the cloud at a configurable interval.
+- You can use the tools on Viam to remotely view sensor data as well as to change your machine's configuration, to view logs, and more.
+
+Now imagine you want to run code to turn on a fan when the temperature sensor reads over 100 degrees Fahrenheit:
+
+- Configure the fan motor as a motor component and wire the fan motor relay to the same board as the sensor.
+- Write your script using one of the Viam [SDKs](/reference/sdks/), for example the Viam Python SDK, using the sensor API and motor API.
+- You then run this code either locally on the SBC, or on a separate server.
+  See [Create a headless app](/operate/control/headless-app/) for more information.
+  Your code connects to the machine, authenticating with API keys, and uses the [sensor API](/reference/components/sensor/#api) to get readings and the [motor API](/reference/components/motor/#api) to turn the motor on and off.
+
+  {{< imgproc src="/build/program/sdks/robot-client.png" resize="x400" declaredimensions=true alt="A desktop computer (client in this case) sends commands to robot 1 (server) with gRPC over wifi." >}}
+
+Now, imagine you want to change to a different model of temperature sensor from a different brand:
+
+- You power down your device, disconnect the old sensor from your SBC and connect the new one.
+- You update your configuration in the web UI to indicate what model you are using, and how it's connected (imagine this one uses USB instead of GPIO pins).
+- You turn your device back on, and `viam-server` automatically fetches the config updates.
+- You do not need to change your control code, because the API is the same for all models of sensor.
+
+## Complex machines with multiple parts
+
+In Viam, a _{{< glossary_tooltip term_id="part" text="part" >}}_ is an organizational concept consisting of one instance of `viam-server` (or `viam-micro-server`) running on a SBC or other computer, and all the hardware and software that the `viam-server` instance controls.
+
+Many simple {{< glossary_tooltip term_id="machine" text="machines" >}} consist of only one part: just one computer running `viam-server` with configured components and services.
+If you have a more complex situation with multiple computers and associated hardware working together, you have two options for organization:
+
+- One complex {{< glossary_tooltip term_id="machine" text="machine" >}} consisting of multiple parts, working together.
+- Multiple individual machines (each made up of one or more parts), linked by a {{< glossary_tooltip term_id="remote-part" text="remote" >}} connection.
+
+These two options are very similar: in both cases, the parts communicate with each other securely and directly using gRPC/{{< glossary_tooltip term_id="webrtc" text="WebRTC" >}}.
+Any given part can be a remote part of multiple machines, whereas a part can only be a sub-part of one machine.
+In other words, remote connections allow sharing of resources across multiple machines, whereas main parts and sub-parts are a way to hierarchically organize one machine.
+
+Connecting parts (either as main part and sub-part, or as part and remote part) means that you can write control code that establishes a connection with the main part and controls all parts in a coordinated way.
+This streamlines authentication because you do not need to provide multiple sets of API keys as you would if you were using separate API clients.
+However, in some high-bandwidth cases it is better to establish a direct connection from an API client to a part, because connections to remotes and to sub-parts use the main part's bandwidth.
+
+{{< expand "Multi-part and remote examples" >}}
+
+- **Compute power example:** Imagine you have a robotic arm with a camera on it, connected to a SBC such as a Raspberry Pi.
+  You want to use the Viam motion service to control the arm, and you want to use the vision service on the output from the camera, but the SBC does not have the compute power to plan complex motion and also interpret camera output quickly.
+  You can set up a second {{< glossary_tooltip term_id="part" text="part" >}} on a server, as a sub-part of the same machine, and offload the heavy compute to that part.
+
+- **One weather station to many boats:** Imagine you have one weather station collecting data, and multiple boats (perhaps some in different {{< glossary_tooltip term_id="organization" text="organizations" >}}) whose behavior depends on that weather data.
+  You can set up a remote connection from each of the `viam-server` instances running on the boats to the `viam-server` instance on the weather station and get that data more directly, without having to wait for the data to sync to the cloud.
+
+- **One camera to many rovers:** Imagine you have a fleet of rovers in a factory.
+  One camera has an overhead view of the entire factory floor.
+  The camera is set up as one machine.
+  Each of the rovers is a separate machine, and they can each have the camera configured as a remote so that they can access the overhead camera stream.
+
+{{< /expand >}}
+
+See [Parts, Sub-parts and Remotes](/reference/architecture/parts/) for more details.
+
+## Next steps
+
+This page has provided an overview of the architecture of just one machine.
+For information on organizing a fleet of many machines, see [Organize your machines](/reference/account/organize/).
+
+For more details on the architecture of a single machine, see the following:

--- a/docs/reference/architecture/machine-to-machine-comms.md
+++ b/docs/reference/architecture/machine-to-machine-comms.md
@@ -4,5 +4,127 @@ linkTitle: "Machine-to-Machine Communication"
 weight: 60
 type: "docs"
 description: "Explanation of how a machine and its parts interact at the communication layer."
+aliases:
+  - /internals/robot-to-robot-comms/
+  - /internals/machine-to-machine-comms/
+  - /architecture/machine-to-machine-comms/
+  - /operate/reference/architecture/machine-to-machine-comms/
 toc_hide: true
 ---
+
+When building a smart machine application in, a user typically begins by configuring their machine which can consist of one or more {{< glossary_tooltip term_id="part" text="parts" >}}.
+Next they will test that it is wired up properly using the Control page.
+Once they've ensured everything is wired up properly, they will build their main application and the business logic for their machine using one of Viam's language SDKs.
+This SDK-based application is typically run on either the main part of the machine or a separate computer dedicated to running the business logic for the machine.
+
+Below, we describe the flow of information through a Viam-based multipart machine and then get into the specifics of what backs these connections and communications APIs.
+
+## High-level inter-robot/SDK communication
+
+To begin, let's define our machine's topology:
+
+![robot communication diagram](/internals/robot-to-robot-comms/robot-communication-diagram.png)
+
+This machine is made of two parts and a separate SDK-based application, which we'll assume is on a third machine, though it could just as easily run on the main part without any changes.
+
+- The first and main part, RDK Part 1, consists of a Raspberry Pi and a single USB connected camera called Camera.
+
+- The second and final part, RDK Part 2, consists of a Raspberry Pi connected to a robotic arm over ethernet and a gantry over GPIO.
+
+RDK Part 1 will establish a bidirectional gRPC/{{< glossary_tooltip term_id="webrtc" >}} connection to RDK Part 2.
+RDK Part 1 is considered the controlling peer (client).
+RDK Part 2 is consider the controlled peer (server).
+
+Let's suppose our SDK application uses the camera to track the largest object in the scene and instructs the arm to move to that same object.
+
+Since RDK Part 1 is the main part and has access to all other parts, the application will connect to it using the SDK.
+Once connected, it will take the following series of actions:
+
+<OL>
+<li>Get segmented point clouds from the camera and the object segmentation service.</li>
+
+<li>Find the largest object by volume.</li>
+
+<li>Take the object's center pose and tell the motion service to move the arm to that point.</li>
+
+<li>Go back to 1.</li>
+</OL>
+Let's breakdown how these steps are executed.
+
+<ol>
+<li>Get segmented point clouds from the camera and the object segmentation service:</li>
+
+![robot communication diagram](/internals/robot-to-robot-comms/getobjectpointcloud-flow.png)
+
+<OL type="a">
+<li>The SDK will send a GetObjectPointClouds request with Camera being referenced in the message to RDK Part 1's Object Segmentation Service.</li>
+
+<li>RDK Part 1 will look up the camera referenced, call the GetPointCloud method on it.</li>
+
+<li>The Camera will return the PointCloud data to RDK Part</li>
+
+<li>RDK Part 1 will use a point cloud segmentation algorithm to segment geometries in the PointCloud.</li>
+{{% alert title="Important" color="note" %}}
+The points returned are respective to the reference frame of the camera.
+This will become important in a moment.
+{{% /alert %}}
+<li>The set of segmented point clouds and their bounding geometries are sent back to the SDK-based application.</li>
+</ol>
+
+<li>Find the largest object by volume:</li>
+<ol type="a">
+<li>The application will iterate over the geometries of the segmented point clouds returned to it and find the object with the greatest volume and record its center pose.</li>
+</ol>
+
+<li>Take the object's center pose and tell the motion service to move the arm to that point:</li>
+
+![motion service move flow](/internals/robot-to-robot-comms/motion-service-move-flow.png)
+
+<ol type="a">
+<li>The SDK application will send a Move request for the arm to the motion service on RDK Part 1 with the destination set to the center point determined by the application.</li>
+
+<li>RDK Part 1's motion service will break down the Move request and perform the necessary frame transforms before sending the requests along to the relevant components.
+This is where the frame system comes into play.
+Our center pose came from the camera but we want to move the arm to that position even though the arm lives in its own frame.
+The frame system logic in the RDK automatically handles the transformation logic between these two reference frames while also handling understanding how the frame systems are connected across the two parts.</li>
+
+<li>Having computed the pose in the reference frame of the arm, the motion service takes this pose, and sends a plan on how to move the arm in addition to the gantry to achieve this new goal pose to RDK Part 2.
+The plan consists of a series of movements that combine inverse kinematics, mathematics, and constraints based motion planning to get the arm and gantry to their goal positions.</li>
+
+<li>In executing the plan, which is being coordinated on RDK Part 1, Part 1 will send messages to the Arm and Gantry on RDK Part 2.
+RDK Part 2 will be unaware of the actual plan and instead will only receive distinct messages to move the components individually.</li>
+
+<li>The arm and gantry connected to RDK Part 2 return an acknowledgement of the part Move requests to RDK Part 2.</li>
+
+<li>RDK Part 2 returns an acknowledgement of the Motion Move request to RDK Part 1.</li>
+
+<li>RDK Part 1 returns an acknowledgement of the Motion Move request to the SDK application.</li>
+</ol>
+<br>
+
+## Low-level inter-robot/SDK communication
+
+All component and service types in the RDK, and the Viam API for that matter, are represented as [Protocol Buffers (protobuf)](https://developers.google.com/protocol-buffers) services.
+protobuf is a battle tested Interface Description Language (IDL) that allows for specifying services, their methods, and the messages that comprise those methods.
+Code that uses protobuf is autogenerated and compiles messages into a binary form.
+
+[gRPC](https://grpc.io/) is responsible for the transport and communication of protobuf messages when calling protobuf methods.
+It generally works over a TCP, TLS backed HTTP2 connection operating over framing see [gRPC's HTTP2 documentation](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) for more.
+
+The RDK uses protobuf and gRPC to enable access and control to its components and services.
+That means if there are two arms in a machine configuration, there is only one Arm service that handles the Remote Procedure Calls (RPC) for all arms configured.
+
+In addition to gRPC, the RDK uses [WebRTC](https://webrtcforthecurious.com/) video and audio streams and data channels to enable peer to peer (P2P) communication between machine parts as well as SDKs and the Remote Control interface.
+
+An outline of how WebRTC is used lives on [Go.dev](https://pkg.go.dev/go.viam.com/utils@v0.0.3/rpc#hdr-Connection), but in short, an RDK is always waiting on [app.viam.com](https://app.viam.com) to inform it of a connection requesting to be made to it whereby it sends details about itself and how to connect on a per connection basis.
+Once a connection is made, [app.viam.com](https://app.viam.com) is no longer involved in any packet transport and leaves it up to the two peers to communicate with each other.
+
+### Security implications
+
+Generally you do not need to open any ports or change your network configuration, if:
+
+- machines are on the internet and can successfully talk with `app.viam.com` and WebRTC works or
+- machines are on the same local network and mDNS and WebRTC are working
+
+If WebRTC is not available, you can communicate with `viam-server` over a gRPC connection.
+The default port is 8080 but you can configure another port in the [network settings](/fleet/system-settings/#configure-bind-address-and-port).

--- a/docs/reference/architecture/parts.md
+++ b/docs/reference/architecture/parts.md
@@ -5,6 +5,155 @@ weight: 40
 type: "docs"
 description: "Connect multiple machine parts to each other as sub-parts or remotes."
 tags: ["server", "components", "services"]
+aliases:
+  - /manage/parts-and-remotes/
+  - /build/configure/parts-and-remotes/
+  - /configure/parts/
+  - /build/configure/parts/
+  - /architecture/parts/
+  - /operate/reference/architecture/parts/
 date: "2022-01-01"
 # updated: ""  # When the content was last entirely checked
 ---
+
+When {{< glossary_tooltip term_id="machine" text="smart machines" >}} communicate with each other, they can share resources and operate collaboratively.
+This document explains how to establish secure connections between machines.
+
+## Machine parts
+
+Machines are organized into _parts_, where each part represents a computer (a single-board computer, desktop, laptop, or other computer) running [`viam-server`](/reference/platform/viam-server/), the hardware {{< glossary_tooltip term_id="component" text="components" >}} attached to it, and any {{< glossary_tooltip term_id="service" text="services" >}} or other {{< glossary_tooltip term_id="resource" text="resources" >}} running on it.
+
+Every smart machine has a main part which is automatically created when you create the machine.
+Multi-part machines also have one or more _sub-parts_ representing additional computers running `viam-server`.
+
+There are two ways to link machine parts:
+
+- **Sub-part**: If you have multiple computers within the _same machine_, use one as the main part and [connect each additional part to it as a sub-part](#configure-a-sub-part).
+  Any given part can only be a sub-part of one main part.
+
+  <details>
+    <summary>Click for an example.</summary>
+   Imagine you have a system of five cameras in different places along an assembly line, each attached to its own single-board computer, and you want to run an object detector on the streams from all of them.
+   You have one main computer with greater compute power set up as the main part.
+   You set up each of the single-board computers as a sub-part.
+   This allows the main part to access all the camera streams and run object detection on all of them.<br><br>
+   You could also set this up with each single-board computer being a remote part instead of a sub-part, but it is slightly easier to configure sub-parts because you do not need to add the address of each part to your machine's config.
+   Additionally, configuring a discrete system of parts as one multi-part machine helps keep your fleet more clearly organized.
+  </details><br>
+
+- **Remote part**: To connect multiple computers that are parts of _different machines_ in the same or different organizations, [add one machine part as a remote part of the other machine or machines](#configure-a-remote-part).
+  A part can be a remote part of any number of other parts.
+
+  <details>
+    <summary>Click for an example.</summary>
+    If you have one camera connected to a computer in a warehouse that many machines should be able to share, you can configure the camera as a remote part of each machine that needs it.
+  </details>
+
+Connections between machines are established using the best network path available.
+
+When you configure a remote part or a sub-part, the main machine part can access all the components and services configured on the remote machine part as though they were entities of the main machine part.
+This is a one-way connection: the main machine part can access the resources of the remote machine part, but the remote machine cannot access the resources of the machine part remoting into it.
+
+When a part starts up, it attempts to connect to any remotes and sub-parts.
+If it cannot connect to them, the part will still successfully start up.
+
+![Example of a remote and a two part machine where the main (and only) part of machine 1 remotes into the main part of machine 2, and thus has access to all resources of machine 2.](/build/configure/parts/remotes-diagram.png)
+
+### Find part ID
+
+To copy the ID of your machine part, select the part status dropdown to the right of your machine's location and name on the top of its page and click the copy icon next to **Part ID**.
+
+For example:
+
+{{<imgproc src="/build/program/data-client/grab-part-id.png" resize="1000x" class="shadow imgzoom" style="width: 500px" declaredimensions=true alt="Part ID displayed.">}}
+
+## Configuration
+
+### Configure a sub-part
+
+You can make a multi-part machine by first configuring one part which is the "main" part, and then configuring one or more sub-parts.
+The main part will be able to access the resources of its sub-parts.
+Sub-parts will _not_ have access to the resources of the main part.
+
+Viam automatically creates the main part for you when you create a new {{< glossary_tooltip term_id="machine" text="machine" >}}.
+To add a new sub-part:
+
+1. Navigate to the **CONFIGURE** tab of your machine's page.
+2. Click the **+** (Create) icon next to the name of your main part, then click **Sub-part** from the menu:
+
+   {{<imgproc src="/build/configure/parts/sub-part-config.png" resize="x1100" declaredimensions=true alt="The create part dropdown open." style="width:500px" class="shadow" >}}
+
+3. Save the config.
+
+{{% hiddencontent %}}
+The sub-part will not be visible as a `remote` in the debug config until after you use the setup instructions to make the sub-part go live.
+{{% /hiddencontent %}}
+
+To rename or delete a sub-part, or to make it the main part, click the **...** menu:
+
+{{<imgproc src="/build/configure/parts/part-mgmt.png" resize="x1100" declaredimensions=true alt="The part actions dropdown open. Options include rename, restart part, make main part, view setup instructions, view history, and delete part." style="width:500px" class="shadow" >}}
+
+By default, all sub-parts appear in the [frame system](/reference/services/frame-system/) at the world origin.
+You can specify translations for sub-parts by configuring their frames with appropriate translation values relative to their parent frame.
+You can view the `frame` of each sub-part in the `remotes` section of the debug config.
+
+### Configure a remote part
+
+To establish a connection between a part of one machine and a part of a second machine, add one as a remote part in the other machine part's config:
+
+1. Go to the machine page of the machine part from which you want to establish a remote connection.
+   This is the machine part that will be able to access the resources of the other machine part.
+1. Navigate to the **CONFIGURE** tab, click the **+** (Create) icon next to the machine part's name in the left side menu.
+
+   {{<imgproc src="/build/configure/parts/remote-create.png" resize="x1100" declaredimensions=true alt="The create menu with options including remote part shown." style="width:500px" class="shadow" >}}
+
+1. Click **Remote part**.
+1. Select the remote part from the list of parts.
+
+   Alternatively, click **Add empty remote** and then scroll to the newly-created remote part configuration card.
+   Click on **JSON** and replace the JSON object with a remote config.
+
+   {{<imgproc src="/build/configure/parts/remote-config.png" resize="x1100" declaredimensions=true alt="The configured remote." style="width:700px" class="shadow" >}}
+
+   {{< expand "Click to see how to get a remote config object" >}}
+
+1. Go to the machine page of the smart machine part to which you wish to establish the remote connection.
+   This is the machine part whose resources will be accessible to the other machine part.
+1. Navigate to the **CONNECT** tab.
+1. Click **Configure as a remote part** in the left-hand menu.
+1. Toggle the **Include API key** switch on, then copy the entire JSON snippet including the name, address, and authentication credentials of the remote part.
+
+   {{% snippet "show-secret.md" %}}
+
+   {{< /expand >}}
+
+   Remotes have the following parameters:
+
+   <!-- prettier-ignore -->
+   | Name | Type | Required? | Description |
+   | ---- | ---- | --------- | ----------- |
+   | `name` | string | Optional | The name of the remote part. |
+   | `address` | string | Optional | The address of the remote part. |
+   | `auth` | string | Object | The authentication credentials of the remote part. For example: `{ "credential": { "type": "api-key", "payload": "abcdefghijklmnop123456789abcdefg" } }`. |
+   | `prefix` | string | Optional | If set, all resource names fetched from the remote part have the prefix. For example, a component with the name `arm-1` configured on a remote part with the configuration `"prefix": "test123"` returns the name `test123arm-1`. |
+   | `notes` | string | Optional | Descriptive text to document the purpose, configuration details, or other important information about this remote part. |
+
+1. Click **Save** in the upper right corner of the page to save your config.
+
+## Using remote parts and sub-parts with the Viam SDKs
+
+Once your sub-part or remote part is configured, you can access all the components and services configured on the sub-part or remote machine part as though they were resources of your main machine part.
+The only difference is if the remote machine part has a configured prefix.
+If there is a prefix, you must prepend it to the resource name:
+
+For example, to access a servo called `my_servo` on a sub-part or a remote without configured `prefix`, you need to call:
+
+```python
+servo = Servo.from_robot(robot=robot, name='my_servo')
+```
+
+For a remote part with a `prefix` `my_remote`, instead use:
+
+```python
+servo = Servo.from_robot(robot=robot, name='my_remotemy_servo')
+```

--- a/docs/reference/architecture/parts.md
+++ b/docs/reference/architecture/parts.md
@@ -93,7 +93,7 @@ To rename or delete a sub-part, or to make it the main part, click the **...** m
 
 {{<imgproc src="/build/configure/parts/part-mgmt.png" resize="x1100" declaredimensions=true alt="The part actions dropdown open. Options include rename, restart part, make main part, view setup instructions, view history, and delete part." style="width:500px" class="shadow" >}}
 
-By default, all sub-parts appear in the [frame system](/reference/services/frame-system/) at the world origin.
+By default, all sub-parts appear in the [frame system](/operate/reference/services/frame-system/) at the world origin.
 You can specify translations for sub-parts by configuring their frames with appropriate translation values relative to their parent frame.
 You can view the `frame` of each sub-part in the `remotes` section of the debug config.
 

--- a/docs/reference/device-setup/beaglebone-setup.md
+++ b/docs/reference/device-setup/beaglebone-setup.md
@@ -7,7 +7,92 @@ description: "Flash a BeagleBone AI-64 to prepare it for viam-server installatio
 images: ["/installation/thumbnails/beaglebone.png"]
 imageAlt: "BeagleBone A I-64"
 no_list: true
+aliases:
+  - /operate/reference/prepare/beaglebone-setup/
+  - "/installation/beaglebone-install/"
+  - "/installation/prepare/beaglebone-install/"
+  - "/installation/prepare/beaglebone-setup/"
+  - /get-started/installation/prepare/beaglebone-setup/
+  - /get-started/prepare/beaglebone-setup/
 date: "2022-01-01"
 # updated: ""  # When the content was last entirely checked
 # SMEs: Shawn and Rand
 ---
+
+The [BeagleBone AI-64](https://docs.beagleboard.org/latest/boards/beaglebone/ai-64/) from [BeagleBoard.org](https://beagleboard.org/) is an open-source single-board computer with a Debian GNU/Linux operating system based on the Texas Instruments TDA4VM processor.
+Follow this guide to set up your BeagleBone AI-64 and prepare it for `viam-server` installation.
+
+<div class="td-max-width-on-larger-screens text-center">
+{{< imgproc alt="The front of a BeagleBone AI-64 single-board computer at a 45° angle." src="/installation/beaglebone-setup/image4.png" resize="400x" declaredimensions=true >}}
+</div>
+
+## Hardware requirements
+
+You need the following hardware, tools, and software to install `viam-server` on a BeagleBone AI-64:
+
+1. A [BeagleBone AI-64](https://www.beagleboard.org/boards/beaglebone-ai-64)
+2. A 5V barrel jack (recommended) and/or USB-C power supply, to power the BeagleBone
+3. Ethernet cable and/or WiFi dongle, to establish network connection on the BeagleBone
+4. (Optional) A microSD card and a way to connect the microSD card to the computer (like a microSD slot or microSD reader)
+   - This is required if you need to set up your BeagleBone for the first time or update your BeagleBone to the latest software image.
+
+The following instructions mirror the instructions given in the [BeagleBoard Quick Start Guide](https://docs.beagleboard.org/latest/boards/beaglebone/ai-64/02-quick-start.html).
+
+If you want additional help setting up your BeagleBone, you can follow the guides there and return to the Viam docs after SSH'ing into your BeagleBone.
+
+## Power your BeagleBone
+
+Power your board by plugging a 5VDC power source into the BeagleBone's barrel jack.
+You can also power the BeagleBone with a USB-C cable, but a 5VDC power source is recommended for more reliable performance.
+
+If the board has power, the LED on the board labeled _PWR_ or _ON_ is lit steadily.
+
+## Enable a network connection
+
+You need to enable a network connection on your BeagleBone to install `viam-server` on it.
+You can do this in multiple ways:
+
+- Connect an ethernet cable to your BeagleBone's ethernet port.
+- If you are working on a macOS machine, use [internet sharing over USB](https://support.apple.com/guide/mac-help/share-internet-connection-mac-network-users-mchlp1540/mac) to share your connection.
+  After enabling the option on your machine, SSH into your BeagleBone and run `sudo dhclient usb1`.
+- If you are working on a Linux machine, read [these tips on enabling a network connection](https://elinux.org/Beagleboard:Terminal_Shells).
+- If your personal computer supports mDNS (Multicast DNS), you can check to see if your BeagleBone board has established a network connection by visiting [beaglebone.local](https://beaglebone.local).
+
+## SSH into your BeagleBone from your PC
+
+You can SSH into your BeagleBone by running the following command in your terminal:
+
+`ssh <your-username>@<your-hostname>.local`
+
+By default, the hostname, username and password on a BeagleBone are:
+
+- Hostname: `beaglebone`
+- Username: `debian`
+- Password: `temppwd`
+
+Therefore, if you are using the default settings on your BeagleBone, the command is:
+
+`ssh debian@beaglebone.local`
+
+## Update your BeagleBone
+
+After SSH'ing into your BeagleBone, verify all packages are up to date:
+
+`sudo apt update && sudo apt dist-upgrade && sudo reboot`
+
+## Next steps
+
+You have now installed an operating system on your BeagleBone.
+To use your BeagleBone, follow the [setup guide](/operate/install/setup/):
+
+{{< cards >}}
+{{% card link="/operate/install/setup/" %}}
+{{< /cards >}}
+
+## Troubleshooting
+
+If you experience any issues getting Viam working on your BeagleBone, consult the [BeagleBone documentation](https://docs.beagleboard.org/latest/boards/beaglebone/ai-64/02-quick-start.html) for help updating your BeagleBone.
+
+{{< snippet "social.md" >}}
+
+You can find additional assistance in the [Troubleshooting section](/manage/troubleshoot/troubleshoot/).

--- a/docs/reference/device-setup/board1-setup.md
+++ b/docs/reference/device-setup/board1-setup.md
@@ -10,4 +10,67 @@ no_list: true
 draft: true
 date: "2022-01-01"
 # updated: ""  # When the content was last entirely checked
+aliases:
+  - /operate/reference/prepare/board1-setup/
 ---
+
+The [<board-series-model>](http://example.com) from <manufacturer/organization> is a <brief-board-description-including-features-and-specifications>.
+It supports <operating-systems-or-distributions> and is ideal for <use-cases-or-applications>.
+Follow this guide to set up your <board-series-model> and prepare it for `viam-server` installation.
+
+{{<imgproc src="installation/thumbnails/prepare.png" alt="The <board-series-model> single-board computer." resize="350x" declaredimensions=true >}}
+
+## Hardware requirements
+
+- Development machine: laptop or computer workstation
+- An [<board-series-model>](http://example.com) board
+- ...
+
+## Install OS
+
+The <board-series-model> boots from a <storage-medium>.
+You need to install an operating system on the <storage-medium> that you will use with your <board-series-model>.
+
+<Viam-specific-OS-installation-instructions OR link-to-board-OS-installation-guide-from-company>
+
+## Power your <board-series-model>
+
+To power your <board-series-model>, connect your power adapter to the board's <port-type> port.
+The LED should light up, which indicates that the board is powered.
+
+{{% alert title="Tip" color="tip" %}}
+
+If your board's LED does not light up when powered, try re-flashing your <storage-medium> or using a different <storage-medium>.
+
+{{% /alert %}}
+
+To connect to a display, connect the <HDMI/micro-HDMI> end of your HDMI cable to the <board> and the other end to your monitor.
+Then, to connect the keyboard and mouse, plug the two devices into your computer's USB hub and connect the USB hub to your <board-series-model>'s <USB-type> port.
+
+## Establish a network connection
+
+You can plug the Ethernet cable into your <board-series-model> for a wired internet connection.
+For a wireless connection, you can <alternative-wireless-network-connection-methods>.
+
+### Update your <board-series-model>
+
+Once you're connected to your board, you can verify all packages are up to date by running the following command:
+
+`sudo apt update && sudo apt dist-upgrade && sudo reboot`
+
+## Next steps
+
+You have now installed an operating system on your BOARD.
+To use your BOARD, follow the [setup guide](/operate/install/setup/):
+
+{{< cards >}}
+{{% card link="/operate/install/setup/" %}}
+{{< /cards >}}
+
+## Troubleshooting
+
+If you experience any issues getting Viam to work on your <board-series-model>, consult the [<board-series-model> documentation](http://example.com).
+
+{{< snippet "social.md" >}}
+
+You can find additional assistance in the [Troubleshooting section](/manage/troubleshoot/troubleshoot/).

--- a/docs/reference/device-setup/jetson-agx-orin-setup.md
+++ b/docs/reference/device-setup/jetson-agx-orin-setup.md
@@ -7,7 +7,153 @@ images: ["/installation/thumbnails/jetson-agx-orin-dev-kit.png"]
 imageAlt: "Jetson A G X Orin Developer Kit"
 description: "Set up the Jetson AGX Orin Developer Kit to prepare your NVIDIA Jetson AGX Orin for viam-server installation."
 no_list: true
+aliases:
+  - /operate/reference/prepare/jetson-agx-orin-setup/
+  - /installation/prepare/jetson-agx-orin-setup/
+  - /get-started/installation/prepare/jetson-agx-orin-setup/
+  - /get-started/prepare/jetson-agx-orin-setup/
 date: "2022-01-01"
 # updated: ""  # When the content was last entirely checked
 # SMEs: Pete Garafano
 ---
+
+<div class="td-max-width-on-larger-screens text-center">
+{{<imgproc src="installation/thumbnails/jetson-agx-orin-dev-kit.png" alt="The grey and chunky front of the NVIDIA Jetson AGX Orin single-board computer development kit." resize="200x" declaredimensions=true >}}
+</div>
+
+The [Jetson AGX Orin](https://developer.nvidia.com/embedded/jetson-orin) from [NVIDIA](https://www.nvidia.com/) is a single-board computer that supports modern AI workloads and application development.
+Follow this guide to set up the [Jetson AGX Orin Developer Kit](https://developer.nvidia.com/embedded/learn/get-started-jetson-agx-orin-devkit) to prepare your NVIDIA Jetson AGX Orin for `viam-server` installation.
+
+<div style="clear:both;"><br /></div>
+
+{{< alert title="Important" color="note" >}}
+
+This guide assumes that you have a Jetson AGX Orin Developer Kit with a Jetson AGX Orin module and reference carrier board.
+If you want to use a different carrier board to incorporate your Orin into your machine, the type of carrier board you use will affect your hardware requirements.
+
+{{% /alert %}}
+
+{{% alert title="CAUTION: Use 3.3V inputs and outputs" color="caution" %}}
+
+The GPIO pins on Jetson boards are rated 3.3V signals. 5V signals from encoders and sensors can cause damage to a pin. We recommend selecting hardware that can operate 3.3V signals or lower.
+For details, see your board's specification.
+
+{{% /alert %}}
+
+## Hardware requirements
+
+You need the following hardware, tools, and software to install `viam-server` on a Jetson AGX Orin with the Jetson AGX Orin Developer Kit:
+
+**Initial setup with display attached:**
+
+1. A [Jetson AGX Orin Developer Kit](https://developer.nvidia.com/embedded/learn/get-started-jetson-agx-orin-devkit)
+2. A PC monitor (HDMI or DisplayPort)
+3. USB keyboard and mouse
+4. A DisplayPort to HDMI adapter/cable, to connect the Orin to the monitor
+5. USB Type-C power supply, to power the Orin (included with the AGX Orin Developer Kit)
+6. (Optional) Ethernet cable, to connect the Orin to the internet without Wifi access
+
+**Initial setup in headless mode:**
+
+1. A [Jetson AGX Orin Developer Kit](https://developer.nvidia.com/embedded/learn/get-started-jetson-agx-orin-devkit)
+2. An internet-connected Windows, Linux, or macOS computer
+3. A way to connect the computer to the Orin (for example, the USB Type-A to USB Type-C Cable included with the AGX Orin Developer Kit)
+
+   (Optional) If your computer doesn't have a USB Type-A port, you may need to attach a [USB-C hub](https://toomanyadapters.com/best-usb-hubs/) or similar device to your computer to connect to the Orin
+
+4. USB Type-C power supply, to power the Orin (included with the AGX Orin Developer Kit)
+5. (Optional) Ethernet cable, to connect the Orin to the internet without Wifi access
+
+## Jetson Orin setup guide
+
+Follow the instructions in [Getting Started with Jetson AGX Orin Developer Kit](https://developer.nvidia.com/embedded/learn/get-started-jetson-agx-orin-devkit) to boot up your Orin for the first time.
+
+If you have already booted up your Orin, start with "Step 2 - Install JetPack Components" to make sure you have installed the latest NVIDIA JetPack components.
+
+{{< alert title="Note" color="note" >}}
+Some vision services in the [registry](https://app.viam.com/registry) require you to install Jetpack 6 on your Jetson AGX Orin.
+If you intend to use GPIO, however, we recommend installing Jetpack 5 on your Jetson AGX Orin.
+{{< /alert >}}
+
+Look at the Troubleshooting section below for help navigating these instructions.
+Once you have reached _Next Steps_, return to the Viam docs.
+
+{{< alert title="Tip: <code>viam-server</code> installation with <code>curl</code>" color="tip" >}}
+
+If `curl` is not installed on your Orin, run `sudo apt install curl` before downloading the `viam-server` binary.
+
+If this command fails, try using `wget https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-latest-aarch64.AppImage` to download the `viam-server` binary.
+
+{{% /alert %}}
+
+## Camera setup
+
+1. Install E-Con Systems [e-CAM20_CUOAGX](https://www.e-consystems.com/nvidia-cameras/jetson-agx-orin-cameras/full-hd-ar0234-color-global-shutter-camera.asp) AR0234 driver.
+   Consult the instructions you received when purchasing your device for more information.
+2. Ensure the driver has successfully installed by running `sudo dmesg | grep ar0234`. The output should include `ar0234 Detected Ar0234 sensor`.
+3. Connect the AR0234 camera module and daughterboard to the J509 port located at the bottom of the Developer Kit.
+4. Configure the camera as a [webcam](/reference/components/camera/webcam/).
+
+## Serial communication protocol tips
+
+To change the pins that are in use for modes of serial communication, launch <file>jetson-io.py</file> with the following commands:
+
+```sh { class="command-line" data-prompt="$"}
+cd ~
+sudo /opt/nvidia/jetson-io/jetson-io.py
+```
+
+In the interactive menu that opens, select **Configure Jetson 40 Pin Header** and **Configure header pins manually** to select and deselect pins to enable use.
+For a Jetson AGX Orin, reference the following:
+
+<!-- prettier-ignore -->
+| Data Sheet ID | GPIO Header Pin | Viam Bus ID | `jetson-io.py` ID | `/dev` Path ID | Notes |
+| ------------- | --------------- | ----------- | ----------------- | ----------- | ----- |
+| I2C_GP2_DAT, I2C_GP2_CLK | 3, 5 | `7` | `i2c2` | `/dev/i2c-2` | |
+| I2C_GP5_DAT, I2C_GP5_CLK | 27, 28 | `1` | `i2c8` | `/dev/i2c-8` | |
+| SPI1_DOUT, SPI1_DIN, SPI1_SCK, SPI1_CS0, SPI1_CS1 | 19, 21, 23, 24, 26 | `0` | `spi1` | `/dev/spidev0.0`, `/dev/spidev0.1` | Must be enabled to use SPI bus, must add `spidev` to `/etc/modules` |
+
+Note that I2C buses do not need to be configured through <file>jetson-io.py</file>.
+See NVIDIA's documentation on [Configuring the Jetson Expansion Headers](https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/HR/ConfiguringTheJetsonExpansionHeaders.html) for more information.
+
+## Next steps
+
+You have now installed an operating system on your Jetson board.
+To use your Jetson board, follow the [setup guide](/operate/install/setup/):
+
+{{< cards >}}
+{{% card link="/operate/install/setup/" %}}
+{{< /cards >}}
+
+## Troubleshooting
+
+### Setup tips
+
+- NVIDIA Step 1 - Run through Ubuntu Setup (oem config)
+
+  - Headless Mode Tips:
+    - Once you reach **step e** which instructs you to connect through the host serial port, the instructions to connect are immediately under **step e**.
+      Follow those steps according to the type of computer you're using.
+    - After running `sudo screen`, note that the `Password` input prompt immediately following refers to your computer's system password.
+  - "Jetson Initial configuration" (oem-config) Command Prompt Tips:
+    - App Partition: default is fine.
+    - Nvomodel mode: default is fine.
+    - Chromium install: not necessary, you can skip.
+    - Signing into online accounts: not necessary, you can skip.
+
+- NVIDIA Step 2 - Install JetPack Components
+  - After running `sudo apt dist-upgrade`, if you are prompted with "Package distributor has shipped an updated version" hit `y` to install the updated version.
+  - Do not run `sudo apt install nvidia-jetpack` in your terminal until after `sudo reboot` has completed.
+  - If your board is powered off after `sudo reboot` has completed and refuses to turn on, disconnect and reconnect the power cable.
+  - It is normal for JetPack installation to take a very long time, up to an hour or more.
+- If you do not see an interactive menu after launching <file>jetson-io.py</file>, try resizing your window to a large size.
+
+### Install `curl`
+
+If `curl` is not installed on your Orin, run `sudo apt install curl` before downloading the `viam-server` binary.
+
+If this command fails, try using `wget https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-stable-aarch64.AppImage` to download the `viam-server` binary.
+
+You can find additional assistance in the [Troubleshooting section](/manage/troubleshoot/troubleshoot/).
+
+{{< snippet "social.md" >}}

--- a/docs/reference/device-setup/jetson-nano-setup.md
+++ b/docs/reference/device-setup/jetson-nano-setup.md
@@ -7,7 +7,119 @@ images: ["/installation/thumbnails/jetson-nano-dev-kit.png"]
 imageAlt: "Jetson Nano"
 description: "Prepare your Jetson Nano or Jetson Orin Nano for viam-server installation."
 no_list: true
+aliases:
+  - /operate/reference/prepare/jetson-nano-setup/
+  - /installation/prepare/jetson-nano-setup/
+  - /get-started/installation/prepare/jetson-nano-setup/
+  - /get-started/prepare/jetson-nano-setup/
 date: "2022-01-01"
 # updated: ""  # When the content was last entirely checked
 # SMEs: Pete Garafano
 ---
+
+The [Jetson Nano](https://developer.nvidia.com/embedded/jetson-nano) and [Jetson Orin Nano](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin) from [NVIDIA](https://www.nvidia.com/) are small computers built for embedded applications and capable of supporting modern AI workloads.
+Follow this guide to set up the [Jetson Nano Developer Kit](https://developer.nvidia.com/embedded/jetson-nano-developer-kit) or the [Jetson Orin Nano Developer Kit](https://developer.nvidia.com/embedded/jetson-agx-orin-developer-kit) to prepare your NVIDIA Jetson Nano for `viam-server` installation.
+
+<div class="td-max-width-on-larger-screens text-center">
+{{<imgproc src="installation/thumbnails/jetson-nano-dev-kit.png" resize="200x" alt="The front of the NVIDIA Jetson Nano single-board computer development kit.">}}
+{{<imgproc src="installation/thumbnails/jetson-orin-nano.jpeg" resize="200x" alt="The front of the NVIDIA Jetson Orin Nano single-board computer development kit.">}}
+</div>
+
+{{% alert title="Important" color="note" %}}
+
+This guide assumes that you have a Jetson Nano Developer Kit or a Jetson Orin Nano Developer Kit with a Jetson module and reference carrier board.
+If you want to use a different carrier board to incorporate your Nano into your machine, the type of carrier board you use will affect your hardware requirements.
+
+{{% /alert %}}
+
+{{% alert title="CAUTION: Use 3.3V inputs and outputs" color="caution" %}}
+
+The GPIO pins on Jetson boards are rated 3.3V signals. 5V signals from encoders and sensors can cause damage to a pin. We recommend selecting hardware that can operate 3.3V signals or lower. For details, see pages 1-3 of the [Jetson Nano Developer Kit 40-Pin Expansion Header GPIO Usage Considerations Applications Note](https://developer.nvidia.com/jetson-nano-developer-kit-40-pin-expansion-header-gpio-usage-considerations-applications-note).
+
+{{% /alert %}}
+
+## Hardware requirements
+
+You need the following hardware, tools, and software to install `viam-server` on a Jetson Nano or Jetson Orin Nano:
+
+**Initial setup with display attached:**
+
+1. A [Jetson Nano Developer Kit](https://developer.nvidia.com/embedded/jetson-nano-developer-kit) or [Jetson Orin Nano Developer Kit](https://developer.nvidia.com/embedded/jetson-agx-orin-developer-kit)
+2. A microSD card (32GB UHS-1 minimum recommended)
+3. A computer display (HDMI or DP) with a USB keyboard and mouse
+4. A way to connect the microSD card to the computer (like a microSD slot or microSD reader)
+5. Ethernet cable and/or Wifi dongle, to establish network connection on the Nano
+6. 5V-2A (Nano) or 9-19V (Orin Nano) DC power supply with barrel jack connector
+
+**Initial setup in headless mode:**
+
+1. A [Jetson Nano Developer Kit](https://developer.nvidia.com/embedded/jetson-nano-developer-kit) or [Jetson Orin Nano Developer Kit](https://developer.nvidia.com/embedded/jetson-agx-orin-developer-kit)
+2. A microSD card (32GB UHS-1 minimum recommended)
+3. An internet-connected computer
+4. A way to connect the computer to the Nano (like a USB 2.0 A-Male to Micro B Cable)
+5. A way to connect the microSD card to the computer (like a microSD slot or microSD reader)
+6. Ethernet cable and/or Wifi dongle, to establish network connection on the Nano
+7. 5V-2A (Nano) or 9-19V (Orin Nano) DC power supply with barrel jack connector
+
+## Nano setup guide
+
+Follow the instructions in [Getting Started with Jetson Nano Developer Kit](https://developer.nvidia.com/embedded/learn/get-started-jetson-nano-devkit) or [Getting Started with Jetson Orin Nano Developer Kit](https://developer.nvidia.com/embedded/learn/get-started-jetson-orin-nano-devkit).
+Once you have reached _Next Steps_, return to the Viam docs.
+
+{{< alert title="Note" color="note" >}}
+Some vision services in the [registry](https://app.viam.com/registry) require you to install Jetpack 6 on your Jetson AGX Orin.
+If you intend to use GPIO, however, we recommend installing Jetpack 5 on your Jetson AGX Orin.
+{{< /alert >}}
+
+## Serial communication protocol tips
+
+To change the pins that are in use for modes of serial communication, launch <file>jetson-io.py</file> with the following commands:
+
+```sh { class="command-line" data-prompt="$"}
+cd ~
+sudo /opt/nvidia/jetson-io/jetson-io.py
+```
+
+In the interactive menu that opens, select **Configure Jetson 40 Pin Header** and **Configure header pins manually** to select and deselect pins to enable use.
+For a Jetson Orin Nano, reference the following:
+
+<!-- prettier-ignore -->
+| GPIO Header Pin | Viam Bus ID | `jetson-io.py` ID |
+| --------------- | ----------- | ----------------- |
+| 3, 5 | `7` | `i2c2` |
+| 27, 28 | `1` | `i2c8` |
+| 19, 21, 23, 24, 26 | `0` | `spi1` |
+| 13, 16, 18, 22, 37 | `2` | `spi3` |
+| 15 | | `pwm1` |
+| 33 | | `pwm5` |
+
+Note that I2C buses do not need to be configured through <file>jetson-io.py</file>.
+See NVIDIA's documentation on [Configuring the Jetson Expansion Headers](https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/HR/ConfiguringTheJetsonExpansionHeaders.html) for more information.
+
+## Next steps
+
+You have now installed an operating system on your Jetson board.
+To use your Jetson board, follow the [setup guide](/operate/install/setup/):
+
+{{< cards >}}
+{{% card link="/operate/install/setup/" %}}
+{{< /cards >}}
+
+## Troubleshooting
+
+### Install `curl`
+
+If `curl` is not installed on your Orin, run `sudo apt install curl` before downloading the `viam-server` binary.
+
+If this command fails, try using `wget https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-stable-aarch64.AppImage` to download the `viam-server` binary.
+
+### Barrel jack power supply polarity
+
+Make sure the polarity on your barrel jack power supply is matched when powering your machine.
+See the last step of your appropriate [initial setup guide](#hardware-requirements) for instructions on choosing the correct power supply for your Nano board.
+
+If you do not see an interactive menu after launching <file>jetson-io.py</file>, try resizing your window to a large size.
+
+You can find additional assistance in the [Troubleshooting section](/manage/troubleshoot/troubleshoot/).
+
+{{< snippet "social.md" >}}

--- a/docs/reference/device-setup/odroid-c4-setup.md
+++ b/docs/reference/device-setup/odroid-c4-setup.md
@@ -7,7 +7,74 @@ description: "Image a Odroid-C4 to prepare it for viam-server installation."
 images: ["/installation/thumbnails/odroid-c4.png"]
 imageAlt: "Odroid-C4"
 no_list: true
+aliases:
+  - /operate/reference/prepare/odroid-c4-setup/
+  - /get-started/installation/prepare/odroid-c4-setup/
+  - /get-started/prepare/odroid-c4-setup/
+  - /installation/prepare/odroid-c4-setup/
 date: "2022-01-01"
 # updated: ""  # When the content was last entirely checked
 # SME: Olivia Miller
 ---
+
+The [Odroid-C4](https://wiki.odroid.com/odroid-c4/odroid-c4#odroid-c4) is a single-board computer that features an Amlogic S905x3 CPU and runs a variety of Linux or Android distributions.
+
+{{<imgproc src="installation/thumbnails/odroid-c4.png" alt="The Odroid-C4 single-board computer." resize="350x" declaredimensions=true >}}
+
+Follow this guide to set up your Odroid-C4.
+
+## Hardware requirements
+
+- An [Odroid-C4 board](https://www.hardkernel.com/shop/odroid-c4/)
+- A 12V/2A power supply
+- An ethernet cable and/or USB Wi-Fi dongle, for network connectivity
+- A computer, for development
+- A microSD card, if you plan to boot from SD instead of eMMC
+- (Optional) An HDMI cable, for display
+
+## Power your Odroid C4
+
+Before you power the board, you need to install an operating system.
+Visit [Odroid's OS Installation Guide](https://wiki.odroid.com/getting_started/os_installation_guide#os_installation_guide) to choose the right OS for your needs and follow the instructions to flash the OS to your microSD card or eMMC.
+
+To power your Odroid-C4, connect your power adapter to the Odroid-C4's power jack.
+The red LED should light up, which indicates that the board is powered.
+
+To connect to a display, connect one end of your HDMI cable to the Odroid and the other end to your monitor.
+
+## Establish a network connection
+
+Plug the Ethernet cable into your Odroid-C4for a wired internet connection.
+For a wireless connection, you can connect a USB Wi-Fi dongle and configure Wi-Fi settings through your operating system.
+
+## Access and update your Odroid-C4
+
+To access your Odroid remotely, use an SSH client like [TeraTerm](https://teratermproject.github.io/index-en.html).
+You'll also need the IP address of your Odroid-C4 board to connect remotely.
+Alternatively, connect a keyboard and mouse to interact with the board directly using a connected monitor.
+
+Once you're connected, open a terminal and run the following commands
+
+```sh {class="command-line" data-prompt="$"}
+sudo apt update && sudo apt upgrade
+```
+
+## Install `viam-server`
+
+{{< readfile "/static/include/install/install-linux.md" >}}
+
+## Try an example
+
+{{< readfile "/static/include/install/try-example.md" >}}
+
+## Next steps
+
+{{< cards >}}
+{{% card link="/operate/modules/configure-modules/" %}}
+{{% card link="/operate/hello-world/tutorial-desk-safari/" %}}
+{{% card link="/dev/tools/tutorials/" %}}
+{{< /cards >}}
+
+## Troubleshooting
+
+Visit the [Odroid Forum](https://forum.odroid.com/index.php) for troubleshooting tips and tricks specific to the Odroid-C4.

--- a/docs/reference/device-setup/orange-pi-3-lts.md
+++ b/docs/reference/device-setup/orange-pi-3-lts.md
@@ -7,7 +7,94 @@ description: "Image an Orange Pi 3 LTS to prepare it for viam-server installatio
 images: ["/installation/thumbnails/orange-pi-3-LTS.png"]
 imageAlt: "Orange Pi 3 LTS"
 no_list: true
+aliases:
+  - /operate/reference/prepare/orange-pi-3-lts/
+  - /get-started/installation/prepare/orange-pi-3-lts/
+  - /get-started/prepare/orange-pi-3-lts/
+  - /installation/prepare/orange-pi-3-lts/
 date: "2022-01-01"
 # updated: ""  # When the content was last entirely checked
 # SME: Olivia Miller
 ---
+
+The [Orange Pi 3 LTS](http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-Zero-2.html) is a highly compact, open-source single-board computer equipped with dual-band WiFi and Bluetooth 5.0.
+It can run Ubuntu, Android10, or Debian distributions.
+
+{{<imgproc src="installation/thumbnails/orange-pi-3-LTS.png" alt="The Orange Pi 3 LTS single-board computer." resize="350x" declaredimensions=true >}}
+
+Follow this guide to set up your Orange Pi 3 LTS to run `viam-server`.
+
+## Hardware requirements
+
+- Development machine: laptop or computer workstation
+- An [Orange Pi 3 LTS](http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/orange-pi-3-LTS.html)
+- A 5V 3A power supply with a USB-C connector
+- A micro-SD card (TF card): Minimum of 8GB, 16GB recommended
+- [SD card reader](https://www.amazon.com/Reader-Beikell-Connector-Memory-Adapter/dp/B0BGNZGDTC/) (recommended with USB-C connector)
+- A monitor: for display
+- [HDMI cable](https://www.amazon.com/Highwings-Braided-Cord-Supports-ARC-Compatible-Ethernet/dp/B07TDH11BJ/): to connect Orange Pi to monitor display
+- USB keyboard and mouse
+- [USB-C to USB-A cables](https://www.amazon.com/Anker-2-Pack-Premium-Samsung-Galaxy/dp/B07DD5YHMH/): to connect keyboard and mouse to USB hub or Orange Pi ports (recommended, hardware dependent)
+- [USB hub](https://www.amazon.com/BYEASY-Extended-Portable-Splitter-MacBook/dp/B07TVH9NHP/) with USB-A connector (recommended)
+
+## Power your Orange Pi 3 LTS
+
+Before you power the board, you need to install an operating system.
+
+1. First, download an [Orange Pi 3 LTS Ubuntu image](https://drive.google.com/drive/folders/1KzyzyByev-fpZat7yvgYz1omOqFFqt1k) to your development machine.
+   We recommend `ubuntu_jammy_desktop`.
+1. Unzip the image.
+1. Insert the micro-SD card into the SD card reader and connect the reader to your development machine.
+1. Follow the [Orange Pi guide to prepare your microSD card](https://sbc-community.org/docs/general_guides/prepare_sd_card/) to flash the OS to your micro-SD card using [balenaEtcher](https://etcher.balena.io/).
+
+   {{< alert title="Tip: How to think about building a machine" color="tip" >}}
+   While flashing your microSD card, we recommend reading [How to think about building a machine](/operate/hello-world/building/).
+   {{< /alert >}}
+
+1. Insert the micro-SD into the Orange Pi.
+
+To power your Orange Pi 3 LTS, connect your power adapter to the LTS's USB-C port.
+The LED should light up, which indicates that the board is powered.
+
+{{% alert title="Tip" color="tip" %}}
+If your board's LED does not light up when powered, try re-flashing your micro-SD card with the `ubuntu_jammy_desktop` image or using a different micro-SD card.
+The Orange Pi will only power on with a compatible operating system installed.
+{{% /alert %}}
+
+To connect to a display, connect the HDMI cable to the Orange Pi's HDMI port and the other end to your monitor.
+Then, connect your keyboard and mouse to the two USB-A ports on your Orange Pi.
+Alternatively, you can connect your peripherals to a USB hub and connect the USB hub to your Orange Pi's USB-A port.
+
+{{% alert title="Tip" color="tip" %}}
+For board schematics, consult the [Orange Pi 3 LTS documentation](http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/orange-pi-3-LTS.html).
+{{% /alert %}}
+
+Once the Orange Pi successfully boots, you should be greeted with the Orange Pi desktop display.
+If you are prompted for a login password, note that the default password for Orange Pi devices is "orangepi".
+
+## Establish a network connection
+
+The Orange Pi 3 LTS comes equipped with a wireless network antenna.
+To connect to WiFi through the desktop, click on the WiFi icon in the top right of the monitor display, select your preferred network or hotspot, and enter the password.
+
+{{% alert title="Tip" color="tip" %}}
+You can also connect to WiFi while connected to the Orange Pi on the terminal with several different methods, including the `nmcli` tool.
+For more information, consult the [official user manual](https://drive.google.com/file/d/1jka7avWnzNeTIQFkk78LoJdygWaGH2iu/view) (page 80).
+{{% /alert %}}
+
+## Next steps
+
+You have now installed an operating system on your Orange Pi.
+To use your Orange Pi, follow the [setup guide](/operate/install/setup/):
+
+{{< cards >}}
+{{% card link="/operate/install/setup/" %}}
+{{< /cards >}}
+
+If you want to use the GPIO pins on the board, add a [`orangepi` board as a component](https://github.com/viam-modules/orange-pi/) after installing `viam-server`.
+
+## Troubleshooting
+
+If you are prompted for a password in the terminal, the default password for Orange Pis is "orangepi".
+
+Visit the [Orange Pi Forum](http://www.orangepi.org/orangepibbsen/) for troubleshooting tips and tricks specific to the Orange Pi.

--- a/docs/reference/device-setup/orange-pi-zero2.md
+++ b/docs/reference/device-setup/orange-pi-zero2.md
@@ -7,7 +7,87 @@ description: "Image an Orange Pi Zero2 to prepare it for viam-server installatio
 images: ["/installation/thumbnails/orange-pi-zero2.png"]
 imageAlt: "Orange Pi Zero2"
 no_list: true
+aliases:
+  - /operate/reference/prepare/orange-pi-zero2/
+  - /get-started/installation/prepare/orange-pi-zero2/
+  - /get-started/prepare/orange-pi-zero2/
+  - /installation/prepare/orange-pi-zero2/
 date: "2022-01-01"
 # updated: ""  # When the content was last entirely checked
 # SME: Olivia Miller
 ---
+
+The [Orange Pi Zero2](http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-Zero-2.html) is a highly compact, open-source single-board computer equipped with dual-band WiFi and Bluetooth 5.0.
+It can run Ubuntu, Android10, or Debian distributions.
+
+{{<imgproc src="installation/thumbnails/orange-pi-zero2.png" alt="The Orange Pi Zero2 single-board computer." resize="350x" declaredimensions=true >}}
+
+Follow this guide to set up your Orange Pi Zero2 to run `viam-server`.
+
+## Hardware requirements
+
+- Development machine: laptop or computer workstation
+- An [Orange Pi Zero2](http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/service-and-support/Orange-Pi-Zero-2.html)
+- A 5V 3A power supply with a USB-C connector
+- A microSD card: Minimum of 8GB, 16GB recommended
+- [SD card reader](https://www.amazon.com/Reader-Beikell-Connector-Memory-Adapter/dp/B0BGNZGDTC/) (recommended with USB-C connector)
+- A monitor: for display
+- [Micro-HDMI to HDMI cable](https://www.amazon.com/Amazon-Basics-Flexible-Durable-18Gpbs/dp/B07KSDB25X/): to connect Orange Pi to monitor display
+- USB keyboard and mouse
+- [USB-C to USB-A cables](https://www.amazon.com/Anker-2-Pack-Premium-Samsung-Galaxy/dp/B07DD5YHMH/): to connect keyboard and mouse to USB hub
+- [USB hub](https://www.amazon.com/BYEASY-Extended-Portable-Splitter-MacBook/dp/B07TVH9NHP/) with USB-A connector (recommended)
+
+## Power your Orange Pi Zero2
+
+Before you power the board, you need to install an operating system.
+
+1. First, download an [Orange Pi Ubuntu image](https://drive.google.com/drive/folders/1ohxfoxWJ0sv8yEHbrXL1Bu2RkBhuCMup) to your development machine.
+   We recommend `ubuntu_jammy_desktop`.
+1. Unzip the image.
+1. Insert the micro-SD card into the SD card reader and connect the reader to your development machine.
+1. Follow [this guide](https://sbc-community.org/docs/general_guides/prepare_sd_card/) to flash the OS to your micro-SD card using [balenaEtcher](https://etcher.balena.io/).
+   {{< alert title="Tip: How to think about building a machine" color="tip" >}}
+   While flashing your microSD card, we recommend reading [How to think about building a machine](/operate/hello-world/building/).
+   {{< /alert >}}
+1. Insert the micro-SD into the Orange Pi.
+
+To power your Orange Pi Zero2, connect your power adapter to the Zero2's USB-C port.
+The LED should light up, which indicates that the board is powered.
+
+{{% alert title="Tip" color="tip" %}}
+If your board's LED does not light up when powered, try re-flashing your micro-SD card with the `ubuntu_jammy_desktop` image or using a different micro-SD card.
+The Orange Pi will only power on with a compatible operating system installed.
+{{% /alert %}}
+
+To connect to a display, connect the micro-HDMI end of your HDMI cable to the Orange Pi and the other end to your monitor.
+Then, to connect the keyboard and mouse, plug the two devices into your USB hub and connect the USB hub to your Orange Pi's USB-A port.
+
+After it boots, you should be greeted with the Orange Pi desktop display.
+If it prompts you for a password, note that the default password for Orange Pi devices is "orangepi".
+
+## Establish a network connection
+
+The Orange Pi Zero2 comes equipped with a wireless network antenna.
+To connect to WiFi, click on the WiFi icon in the top right of the monitor display, select your preferred network or hotspot, and enter the password.
+
+{{% alert title="Tip" color="tip" %}}
+You can also connect to WiFi while connected to the Orange Pi on the terminal with several different methods, including the `nmcli` tool.
+For more information, consult the [official user manual](https://drive.google.com/file/d/1jka7avWnzNeTIQFkk78LoJdygWaGH2iu/view) (page 80).
+{{% /alert %}}
+
+## Next steps
+
+You have now installed an operating system on your Orange Pi.
+To use your Orange Pi, follow the [setup guide](/operate/install/setup/):
+
+{{< cards >}}
+{{% card link="/operate/install/setup/" %}}
+{{< /cards >}}
+
+If you want to use the GPIO pins on the board, add a [`orangepi` board as a component](https://github.com/viam-modules/orange-pi/) after installing `viam-server`.
+
+## Troubleshooting
+
+If you are prompted for a password in the terminal, the default password for Orange Pis is "orangepi".
+
+Visit the [Orange Pi Forum](http://www.orangepi.org/orangepibbsen/) for troubleshooting tips and tricks specific to the Orange Pi.

--- a/docs/reference/device-setup/pumpkin.md
+++ b/docs/reference/device-setup/pumpkin.md
@@ -7,6 +7,259 @@ images: ["/installation/thumbnails/pumpkin.png"]
 imageAlt: "Pumpkin board"
 description: "Configure the pin mappings to use a pumpkin board."
 no_list: true
+aliases:
+  - /operate/reference/prepare/pumpkin/
+  - /installation/prepare/pumpkin/
+  - /get-started/installation/prepare/pumpkin/
+  - /get-started/prepare/pumpkin/
 date: "2022-01-01"
 # updated: ""  # When the content was last entirely checked
 ---
+
+To use a [Mediatek Genio 500 Pumpkin single-board computer](https://ologicinc.com/portfolio/mediateki500/) with Viam:
+
+1. [Install `viam-server`](/operate/install/setup/) on your machine.
+1. [Create a board definitions file](#create-a-board-definitions-file), specifying the mapping between your board's GPIO pins and connected hardware.
+1. [Configure a `customlinux` board](#configure-a-customlinux-board) on your machine, specifying the path to the definitions file in the board configuration.
+
+## Create a board definitions file
+
+The board definitions file describes the location of each GPIO pin on the board so that `viam-server` can access the pins correctly.
+
+On your Pumpkin board, create a JSON file in the <file>/home/root</file> directory named <file>board.json</file>, and provide the mappings between your GPIO pins and connected hardware.
+Use the template and example below to populate the JSON file with a single key, `"pins"`, whose value is a list of objects that each represent a pin on the board.
+
+```json
+{
+  "pins": [
+    {
+      "name": "3",
+      "device_name": "gpiochip0",
+      "line_number": 81,
+      "pwm_id": -1
+    },
+    {
+      "name": "5",
+      "device_name": "gpiochip0",
+      "line_number": 84,
+      "pwm_id": -1
+    },
+    {
+      "name": "7",
+      "device_name": "gpiochip0",
+      "line_number": 150,
+      "pwm_id": -1
+    },
+    {
+      "name": "11",
+      "device_name": "gpiochip0",
+      "line_number": 173,
+      "pwm_id": -1
+    },
+    {
+      "name": "13",
+      "device_name": "gpiochip0",
+      "line_number": 152,
+      "pwm_id": -1
+    },
+    {
+      "name": "15",
+      "device_name": "gpiochip0",
+      "line_number": 94,
+      "pwm_id": -1
+    },
+    {
+      "name": "19",
+      "device_name": "gpiochip0",
+      "line_number": 163,
+      "pwm_id": -1
+    },
+    {
+      "name": "21",
+      "device_name": "gpiochip0",
+      "line_number": 161,
+      "pwm_id": -1
+    },
+    {
+      "name": "23",
+      "device_name": "gpiochip0",
+      "line_number": 164,
+      "pwm_id": -1
+    },
+    {
+      "name": "27",
+      "device_name": "gpiochip0",
+      "line_number": 82,
+      "pwm_id": -1
+    },
+    {
+      "name": "29",
+      "device_name": "gpiochip0",
+      "line_number": 98,
+      "pwm_id": -1
+    },
+    {
+      "name": "31",
+      "device_name": "gpiochip0",
+      "line_number": 12,
+      "pwm_id": -1
+    },
+    {
+      "name": "33",
+      "device_name": "gpiochip0",
+      "line_number": 101,
+      "pwm_id": -1
+    },
+    {
+      "name": "35",
+      "device_name": "gpiochip0",
+      "line_number": 171,
+      "pwm_id": -1
+    },
+    {
+      "name": "37",
+      "device_name": "gpiochip0",
+      "line_number": 169,
+      "pwm_id": -1
+    },
+    {
+      "name": "8",
+      "device_name": "gpiochip0",
+      "line_number": 115,
+      "pwm_id": -1
+    },
+    {
+      "name": "10",
+      "device_name": "gpiochip0",
+      "line_number": 121,
+      "pwm_id": -1
+    },
+    {
+      "name": "12",
+      "device_name": "gpiochip0",
+      "line_number": 170,
+      "pwm_id": -1
+    },
+    {
+      "name": "16",
+      "device_name": "gpiochip0",
+      "line_number": 165,
+      "pwm_id": -1
+    },
+    {
+      "name": "18",
+      "device_name": "gpiochip0",
+      "line_number": 1,
+      "pwm_id": -1
+    },
+    {
+      "name": "22",
+      "device_name": "gpiochip0",
+      "line_number": 2,
+      "pwm_id": -1
+    },
+    {
+      "name": "24",
+      "device_name": "gpiochip0",
+      "line_number": 162,
+      "pwm_id": -1
+    },
+    {
+      "name": "26",
+      "device_name": "gpiochip0",
+      "line_number": 0,
+      "pwm_id": -1
+    },
+    {
+      "name": "28",
+      "device_name": "gpiochip0",
+      "line_number": 83,
+      "pwm_id": -1
+    },
+    {
+      "name": "32",
+      "device_name": "gpiochip0",
+      "line_number": 97,
+      "pwm_id": -1
+    },
+    {
+      "name": "36",
+      "device_name": "gpiochip0",
+      "line_number": 151,
+      "pwm_id": -1
+    },
+    {
+      "name": "38",
+      "device_name": "gpiochip0",
+      "line_number": 174,
+      "pwm_id": -1
+    },
+    {
+      "name": "40",
+      "device_name": "gpiochip0",
+      "line_number": 172,
+      "pwm_id": -1
+    }
+  ]
+}
+```
+
+## Configure a `customlinux` board
+
+Configure your board as a [`customlinux`](https://app.viam.com/module/viam/customlinux) board to use your board definitions file:
+
+{{< tabs name="Configure a customlinux board" >}}
+{{% tab name="Config Builder" %}}
+
+Navigate to the **CONFIGURE** tab of your machine's page.
+Click the **+** icon next to your machine part in the left-hand menu and select **Component or service**.
+Select the `board` type, then select the `customlinux` model.
+Enter a name or use the suggested name for your `customlinux` board and click **Create**.
+
+[Example configuration for a pumpkin board using customlinux](https://github.com/viam-modules/customlinux/blob/main/README.md#example-configuration-for-a-pumpkin-board)
+
+Copy and paste the following json object into your board's attributes field.
+
+```json {class="line-numbers linkable-line-numbers"}
+{
+  "board_defs_file_path": "/home/root/board.json"
+}
+```
+
+{{% /tab %}}
+{{% tab name="JSON Template" %}}
+
+```json {class="line-numbers linkable-line-numbers"}
+{
+  "components": [
+    {
+      "name": "myCustomBoard",
+      "model": "customlinux",
+      "api": "rdk:component:board",
+      "attributes": {
+        "board_defs_file_path": "/home/root/board.json"
+      },
+      "depends_on": []
+    }
+  ]
+}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Try an example
+
+{{< readfile "/static/include/install/try-example.md" >}}
+
+## Next steps
+
+{{< cards >}}
+{{% card link="/operate/modules/configure-modules/" %}}
+{{% card link="/operate/hello-world/tutorial-desk-safari/" %}}
+{{% card link="/dev/tools/tutorials/" %}}
+{{< /cards >}}
+
+## Need assistance?
+
+{{< snippet "social.md" >}}

--- a/docs/reference/device-setup/rpi-setup.md
+++ b/docs/reference/device-setup/rpi-setup.md
@@ -7,7 +7,188 @@ description: "Image a Raspberry Pi to prepare it for viam-server installation."
 images: ["/installation/thumbnails/raspberry-pi-4-b-2gb.png"]
 imageAlt: "Raspberry Pi"
 no_list: true
+aliases:
+  - /operate/reference/prepare/rpi-setup/
+  - /getting-started/rpi-setup/
+  - /installation/rpi-setup/
+  - /installation/prepare/rpi-setup/
+  - /get-started/installation/prepare/rpi-setup/
+  - /get-started/prepare/rpi-setup/
+  - /operate/reference/prepare/rpi-enable-protocols/
+  - /operate/reference/prepare/wifi-credentials/
 # SME: James
 date: "2022-01-01"
 # updated: ""  # When the content was last entirely checked
 ---
+
+{{<youtube embed_url="https://www.youtube-nocookie.com/embed/drl2p2of-qA">}}
+
+We recommend using Viam on a 64-bit Linux distribution.
+Support for older Raspberry Pis running on 32-bit ARM v7 is in beta.
+
+If you already have a Linux distribution installed on your {{< glossary_tooltip term_id="pi" text="Pi" >}}, you can skip ahead to [install `viam-server`](/operate/install/setup/).
+
+{{% expand "Click to check whether the Linux installation on your Raspberry Pi is 64-bit or 32-bit" %}}
+
+To check whether the Linux installation on your Raspberry Pi is 64-bit or 32-bit, `ssh` into your Pi and then run `lscpu`.
+
+Example output:
+
+{{< imgproc alt="Screenshot of a terminal running the 'lscpu' command. The output lists of this command on a Raspberry Pi. A red box highlights the command and the top of the output which reads 'Architecture: aarch64.'" src="/installation/rpi-setup/lscpu-output.png" resize="800x" declaredimensions=true class="shadow" >}}
+
+If the value of "Architecture: _'xxxxxx'_" ends in "64", you can skip ahead to [install `viam-server`](/operate/install/setup/).
+
+{{% /expand%}}
+
+## Hardware requirements
+
+- A [Raspberry Pi single-board computer](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/)
+- A microSD card
+- An internet-connected computer
+- A way to connect the microSD card to the computer (microSD slot or microSD reader)
+
+## Install Raspberry Pi OS
+
+The Raspberry Pi boots from a microSD card.
+You need to install Raspberry Pi OS (formerly called Raspbian) on the microSD card you will use with your Pi:
+
+1. Connect the microSD card to your computer.
+
+1. Download the [Raspberry Pi Imager](https://www.raspberrypi.com/software/) and launch it.
+
+   {{< imgproc alt="Raspberry Pi Imager launcher window showing a 'Choose OS' and 'Choose Storage' buttons." src="/installation/rpi-setup/imager-launch-screen.png" resize="800x" declaredimensions=true class="shadow" >}}
+
+1. Click **CHOOSE DEVICE**.
+   Select your model of Pi.
+
+   {{< imgproc alt="Raspberry Pi Imager window showing available pi models." src="/installation/rpi-setup/select-pi-models.png" resize="800x" declaredimensions=true class="shadow" >}}
+
+1. Click **CHOOSE OS**.
+   Select **Raspberry Pi OS (other)**.
+
+   {{< imgproc alt="Raspberry Pi Imager window showing Raspberry Pi OS (Other) is selected." src="/installation/rpi-setup/select-other-custom-os.png" resize="800x" declaredimensions=true class="shadow" >}}
+
+   Select **Raspberry Pi OS Full (64-bit)** or **Raspberry Pi OS Full (32-bit)** from the menu.
+
+   {{< imgproc alt="Raspberry Pi Imager window showing Raspberry Pi OS (Legacy, 64-bit) Full is selected." src="/installation/rpi-setup/select-other-rpi.png" resize="800x" declaredimensions=true class="shadow"  >}}
+
+   You should be brought back to the initial launch screen.
+
+1. Click **CHOOSE STORAGE**.
+   From the list of devices, select the microSD card you intend to use in your Raspberry Pi.
+
+   If no devices are listed, make sure your microSD card is connected to your computer correctly.
+
+   {{< imgproc alt="The storage screen is shown with a generic SD card available as an option." src="/installation/rpi-setup/imager-select-storage.png" resize="800x" declaredimensions=true class="shadow"  >}}
+
+1. Configure your Raspberry Pi for remote access.
+   Click **Next**.
+   When prompted to apply OS customization settings, select **EDIT SETTINGS**.
+
+   {{< imgproc alt="Raspberry Pi Imager window showing gear-shaped settings icon is selected." src="/installation/rpi-setup/advanced-options.png" resize="800x" declaredimensions=true class="shadow"  >}}
+
+   {{% alert title="Important" color="note" %}}
+
+   If you are using a non-Raspberry Pi OS, altering the OS customization settings will cause the initial boot to fail.
+
+   {{% /alert %}}
+
+   Check **Set hostname** and enter the name you would like to access the Pi by in that field:
+
+   {{< imgproc alt="Raspberry Pi Imager window showing the advanced options menu with set hostname checked and set to my-machine.local." src="/installation/rpi-setup/imager-set-hostname.png" resize="600x" declaredimensions=true class="shadow"  >}}
+
+   There are two ways you can secure your Raspberry Pi: with an SSH key or with password authentication.
+
+   - For a learning project or a fun hobby project, we recommend using password authentication because it is easiest to set up for first-time users.
+   - For production use, we recommend using SSH keys for more secure authentication; only someone with the private SSH key will be able to authenticate to your system.
+
+   {{< tabs >}}
+
+{{% tab name="Password" %}}
+
+1. Select the checkbox next to **Set username and password** and set a username (for example, your first name) and a unique password that you will use to log into the Pi:
+
+   {{< imgproc alt="Raspberry Pi Imager window showing the 'Set username and password' option is selected. The user has entered username 'Robota' and some hidden password." src="/installation/rpi-setup/imager-set-passwordauthentication.png" resize="550x" declaredimensions=true class="shadow"  >}}
+
+2. Select the **SERVICES** tab.
+3. Check **Enable SSH**.
+
+{{% alert title="IMPORTANT" color="note" %}}
+
+Be sure that you remember the `hostname`, `username`, and `password` you set, as you will need them when you SSH into your Pi.
+
+Do not use the default username and password on a Raspberry Pi, as this poses a [security risk](https://www.zdnet.com/article/linux-malware-enslaves-raspberry-pi-to-mine-cryptocurrency/).
+
+{{% /alert  %}}
+
+{{% /tab %}}
+{{% tab name="SSH" %}}
+
+To set up SSH authentication:
+
+1. Select the checkbox for **Set username and password** and set a username (for example, your first name) that you will use to log into the Pi.
+   If you skip this step, the default username will be `pi` (not recommended for security reasons).
+   You do not need to specify a password.
+
+   {{< imgproc alt="Raspberry Pi Imager with username specified as 'Robota' and the password field left blank." src="/installation/rpi-setup/imager-set-username.png" resize="500x" declaredimensions=true class="shadow"  >}}
+
+1. Select the **SERVICES** tab.
+1. Check **Enable SSH**.
+1. Select **Allow public-key authentication only**.
+
+   If you select **Allow public-key authentication only**, and the section **Set authorized\_ keys for ''** is pre-populated, that means you have a public SSH key that is ready to use.
+   In that case, you can leave the pre-populated key as-is.
+   If this section is empty, you can either generate a new SSH key using [these instructions](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent), or you can use password authentication instead.
+
+   {{< imgproc alt="Raspberry Pi Imager window showing 'Set Hostname' and 'Enable SSH' both selected." src="/installation/rpi-setup/imager-set-ssh.png" resize="500x" declaredimensions=true class="shadow"  >}}
+
+{{% alert title="IMPORTANT" color="note" %}}
+
+Be sure that you remember the `hostname` and `username` you set, as you will need this when you SSH into your Pi.
+
+{{% /alert  %}}
+
+{{% /tab %}}
+{{< /tabs >}}
+
+    Lastly, connect your Pi to Wi-Fi so that you can run `viam-server` wirelessly.
+    Check **Configure wireless LAN** and enter your wireless network credentials.
+    SSID (short for Service Set Identifier) is your Wi-Fi network name, and password is the network password.
+    Change the section `Wireless LAN country` to where your router is currently being operated:
+
+    {{< imgproc alt="Raspberry Pi Imager window showing the 'Configure wireless LAN' option selected with SSID and password information for a wireless network." src="/installation/rpi-setup/imager-set-wifi.png" resize="550x" declaredimensions=true class="shadow"  >}}
+
+    Click **SAVE**.
+
+1.  Double check your OS and Storage settings and then click `YES`:
+
+    {{< imgproc alt="Edit image customization options window" src="/installation/rpi-setup/apply-settings-yes.png" resize="800x" declaredimensions=true class="shadow"  >}}
+
+    You will be prompted to confirm erasing your microSD card: select `YES`.
+
+    {{< imgproc alt="Edit image customization options window" src="/installation/rpi-setup/imager-write-confirm.png" resize="800x" declaredimensions=true class="shadow"  >}}
+
+    You may also be prompted by your operating system to enter an administrator password:
+
+    {{< imgproc alt="macOS admin password confirmation screen." src="/installation/rpi-setup/imager-permission.png" resize="300x" declaredimensions=true class="shadow"  >}}
+
+    After granting permissions to the Imager, it will begin writing and then verifying the Linux installation to the MicroSD card.
+
+    Remove the microSD card from your computer when the installation is complete.
+
+    {{< alert title="Tip: How to think about building a machine" color="tip" >}}
+
+While the Imager is flashing your microSD card, we recommend reading [How to think about building a machine](/operate/hello-world/building/).
+
+    {{< /alert >}}
+
+2.  Place the SD card into your Raspberry Pi and boot the Pi by plugging it in to an outlet.
+    A red LED will turn on to indicate that the Pi is connected to power.
+
+## Next steps
+
+Continue setting up `viam-server` on your Raspberry Pi in [the Viam app](https://app.viam.com/):
+
+{{< cards >}}
+{{% card link="/operate/install/setup/" %}}
+{{< /cards >}}

--- a/docs/reference/device-setup/sk-tda4vm.md
+++ b/docs/reference/device-setup/sk-tda4vm.md
@@ -7,6 +7,116 @@ images: ["/installation/thumbnails/tda4vm.png"]
 imageAlt: "S K - T D A 4 V M"
 description: "Image a Texas Instruments TDA4VM starter kit board to prepare it for viam-server installation."
 no_list: true
+aliases:
+  - /operate/reference/prepare/sk-tda4vm/
+  - /installation/prepare/sk-tda4vm/
+  - /get-started/installation/prepare/sk-tda4vm/
+  - /get-started/prepare/sk-tda4vm/
 date: "2022-01-01"
 # updated: ""  # When the content was last entirely checked
 ---
+
+## Hardware requirements
+
+- A [Texas Instruments TDA4VM single-board computer](https://www.ti.com/tool/SK-TDA4VM)
+- A USB-C power cable to power the TDA4VM board
+- A microSD card
+- A desktop or laptop computer for flashing the microSD card
+- A way to connect the microSD card to the computer (a microSD slot or microSD reader)
+- An Ethernet cable
+- An HDMI cable
+
+## Required downloads
+
+Download the following files to your computer:
+
+- Download the <a href="https://www.ti.com/tool/download/PROCESSOR-SDK-LINUX-SK-TDA4VM" target="_blank">PROCESSOR-SDK-LINUX-SK-TDA4VM — Linux SDK for edge AI applications on TDA4VM Jacinto™ processors</a> image.
+
+- Next, download and install the <a href="https://etcher.balena.io/#download-etcher" target="_blank">Balena Etcher</a> for your desktop/laptop OS.
+  You will use the Balena Etcher to flash the microSD card.
+
+## Flash the image
+
+{{% alert title="Important" color="note" %}}
+You must extract the image from the zip file before flashing the microSD card.
+{{% /alert %}}
+
+{{< imgproc alt="The Balena Etcher interface." src="/installation/sk-tda4vm/etcher.png" resize="600x" declaredimensions=true >}}
+
+<br>
+<br>
+
+1. Insert the microSD card into a reader connected to your computer.
+
+2. Launch Balena Etcher.
+
+3. Click **Flash from File** to open the file selector.
+
+4. Navigate to and select the image you downloaded.
+
+5. Click **Select Target** to choose the storage device corresponding to your microSD card from the selector window.
+
+6. Click on the desired device, then click **Select** to continue.
+
+7. Click **Flash!**.
+   If you receive a warning concerning the size of the microSD card, ensure that you have inserted the proper microSD and also selected the proper device, then click, **Yes, I'm sure** to flash the board.
+   The flashing and verification process may take 10-20 minutes, depending on your system.
+
+   {{< alert title="Tip: How to think about building a machine" color="tip" >}}
+   While the Etcher is flashing your microSD card, we recommend reading [How to think about building a machine](/operate/hello-world/building/).
+   {{< /alert >}}
+
+8. On completion of the flashing and validation process, remove the microSD card from your computer and insert it into the TDA4VM.
+
+{{< imgproc alt="Successful image flash completion screen." src="/installation/sk-tda4vm/completed.png" resize="600x" declaredimensions=true class="shadow"  >}}
+
+## Install Viam dependencies on the TDA4VM
+
+1. Connect the board to Ethernet.
+
+2. Connect the board to a monitor with the HDMI cable.
+
+3. Connect the board to power using the USB-C power cable.
+
+4. Use the credentials and IP address displayed in the upper right-hand corner of the monitor to SSH into the board.
+
+From the SSH session on the TDA4VM board:
+
+1. Clone the TDA4VM repo:
+
+   ```sh {class="command-line" data-prompt="$"}
+   git clone https://github.com/viam-labs/tda4vm-setup.git
+   ```
+
+2. Navigate to the setup directory:
+
+   ```sh {class="command-line" data-prompt="$"}
+   cd tda4vm-setup/
+   ```
+
+3. Make the server setup script executable:
+
+   ```sh {class="command-line" data-prompt="$"}
+   chmod +x tda4vm-viam-setup.sh
+   ```
+
+4. Launch the setup script to install `viam-server` dependencies:
+
+   ```sh {class="command-line" data-prompt="$"}
+   ./tda4vm-viam-setup.sh
+   ```
+
+   Once this process completes, the board will reboot.
+
+## Next steps
+
+You have now installed an operating system on your board.
+To use your board, follow the [setup guide](/operate/install/setup/):
+
+{{< cards >}}
+{{% card link="/operate/install/setup/" %}}
+{{< /cards >}}
+
+## Need assistance?
+
+{{< snippet "social.md" >}}

--- a/docs/reference/glossary/api-namespace-triplet.md
+++ b/docs/reference/glossary/api-namespace-triplet.md
@@ -3,4 +3,23 @@ title: API Namespace Triplet
 id: api-namespace-triplet
 full_link:
 short_description: namespace:type:subtype, for example `rdk:component:sensor`
+aliases:
+  - /dev/reference/glossary/api-namespace-triplet/
 ---
+
+Every Viam {{< glossary_tooltip term_id="resource" text="resource" >}} implements an [application programming interface (API)](https://en.wikipedia.org/wiki/API) that describes how you can interact with that resource.
+
+These APIs are organized by colon-delimited-triplet identifiers, in the form of `namespace:type:subtype`.
+
+The `namespace` for built-in Viam resources is `rdk`, while the `type` is `component` or `service`.
+`subtype` refers to a specific component or service, like a `camera` or `vision`.
+
+One API can have various {{< glossary_tooltip term_id="model" text="models" >}}, custom or built-in, but they all must conform to the same API definition.
+This requirement ensures that when a resource of that model is deployed, you can [interface with it](/reference/sdks/) using the same [client API methods](/reference/apis/) you would when programming resources of the same API with a different model.
+
+Each resource implements one and only one API.
+
+For example:
+
+- The API of the built-in component [camera](/reference/components/camera/) is `rdk:component:camera`, which exposes methods such as `GetImages()`.
+- The API of the built-in service [vision](/reference/services/vision/) is `rdk:service:vision`, which exposes methods such as `GetDetectionsFromCamera()`.

--- a/docs/reference/glossary/api.md
+++ b/docs/reference/glossary/api.md
@@ -5,4 +5,18 @@ full_link:
 short_description: Application programming interface, a set of defined rules that enable different applications to communicate with each other.
 aka:
 type: "page"
+aliases:
+  - /dev/reference/glossary/api/
 ---
+
+API stands for application programming interface.
+An API defines the methods and data structures that allow different software components or systems to communicate with each other.
+
+In the Viam platform, APIs are used extensively to:
+
+- Control hardware components (motors, cameras, sensors, etc.)
+- Access services (vision, motion, navigation, etc.)
+- Manage machines and organizations
+- Process and analyze data
+
+These APIs are accessible through various {{< glossary_tooltip term_id="sdk" text="SDKs" >}} in languages like Python, Go, and TypeScript.

--- a/docs/reference/glossary/attribute.md
+++ b/docs/reference/glossary/attribute.md
@@ -5,4 +5,8 @@ full_link:
 short_description: A configuration parameter of a resource.
 aka:
 type: "page"
+aliases:
+  - /dev/reference/glossary/attribute/
 ---
+
+A configuration parameter of a resource.

--- a/docs/reference/glossary/base.md
+++ b/docs/reference/glossary/base.md
@@ -3,4 +3,11 @@ title: Base
 id: base
 full_link: /components/base/
 short_description: A physical, mobile platform that the other parts of a mobile robot attach to.
+aliases:
+  - /dev/reference/glossary/base/
 ---
+
+A physical, mobile platform that the other parts of a mobile robot attach to.
+For example, a wheeled rover, boat, or flying drone.
+
+For more information see [Base Component](/reference/components/base/).

--- a/docs/reference/glossary/blob-storage.md
+++ b/docs/reference/glossary/blob-storage.md
@@ -5,4 +5,8 @@ full_link:
 short_description: A cheap but slow storage medium.
 aka:
 type: "page"
+aliases:
+  - /dev/reference/glossary/blob-storage/
 ---
+
+A cheap but slow storage medium.

--- a/docs/reference/glossary/board.md
+++ b/docs/reference/glossary/board.md
@@ -3,4 +3,12 @@ title: Board
 id: board
 full_link: /components/board/
 short_description: A board is the signal wire hub of a machine that provides access to GPIO pins.
+aliases:
+  - /dev/reference/glossary/board/
 ---
+
+A board is the signal wire hub of a machine that provides access to GPIO pins.
+
+Examples of boards include Jetson, Raspberry Pi, or Numato.
+
+For more information see [Board Component](/reference/components/board/).

--- a/docs/reference/glossary/captive-web-portal.md
+++ b/docs/reference/glossary/captive-web-portal.md
@@ -2,4 +2,10 @@
 title: Captive web portal
 id: captive-web-portal
 short_description: A web page which is automatically displayed to users when connecting to a network.
+aliases:
+  - /dev/reference/glossary/captive-web-portal/
 ---
+
+A captive portal is a web page that is automatically displayed to users often as a landing or log-in page when connecting to a network.
+
+For more information see [captive portal](https://en.wikipedia.org/wiki/Captive_portal).

--- a/docs/reference/glossary/client-application.md
+++ b/docs/reference/glossary/client-application.md
@@ -3,4 +3,11 @@ title: Client Application
 id: client-application
 full_link:
 short_description: Client applications run business logic to operate your machine.
+aliases:
+  - /dev/reference/glossary/client-application/
 ---
+
+Client applications run business logic to operate your machine.
+
+You can run a client application on the same {{< glossary_tooltip term_id="part" text="part" >}} that runs `viam-server`, or on a separate device.
+Client applications typically use an {{< glossary_tooltip term_id="sdk" text="SDK" >}} to talk to their machine.

--- a/docs/reference/glossary/component.md
+++ b/docs/reference/glossary/component.md
@@ -2,4 +2,12 @@
 title: Component
 id: component
 short_description: A resource that often represents a physical piece of hardware which a computer controls; for example, a servo, a camera, or an arm.
+aliases:
+  - /dev/reference/glossary/component/
 ---
+
+A resource that often represents a physical piece of hardware in a machine which a computer controls; for example, a servo, a camera, or an arm.
+
+Each component is typed by a proto API, such as the [component proto definitions](https://github.com/viamrobotics/api/tree/main/proto/viam/component).
+
+For more information, see [Components](/operate/modules/configure-modules/).

--- a/docs/reference/glossary/flashed.md
+++ b/docs/reference/glossary/flashed.md
@@ -7,4 +7,24 @@ aka:
   - flashed
   - flashing
 type: "page"
+aliases:
+  - /dev/reference/glossary/flashed/
 ---
+
+Flashed or flashing refers to the process of writing an operating system, firmware, or other software directly to a device's non-volatile storage medium, such as an SD card, eMMC storage, or flash memory.
+
+In the context of robotics and the Viam platform, flashing is commonly performed when:
+
+- Setting up a new {{< glossary_tooltip term_id="pi" text="Raspberry Pi" >}} with an operating system
+- Installing the Viam Micro-RDK on supported microcontrollers
+
+The flashing process typically involves:
+
+1. Downloading an image file (OS or firmware)
+2. Using specialized software to write the image to the target device
+3. Verifying the write was successful
+4. Booting or resetting the device to load the new software
+
+For example, when setting up a Raspberry Pi for use with Viam, you would "flash" Raspberry Pi OS to an SD card using the [Raspberry Pi Imager](/reference/prepare/rpi-setup/#install-raspberry-pi-os) or similar software.
+
+Flashing is different from regular software installation because it involves writing directly to storage at a low level, often replacing everything on the target storage medium.

--- a/docs/reference/glossary/fragment.md
+++ b/docs/reference/glossary/fragment.md
@@ -1,6 +1,12 @@
 ---
 title: Fragment
 id: fragment
-full_link: /fleet/reuse-configuration/
+full_link: /manage/fleet/reuse-configuration/
 short_description: A reusable configuration block that you can share across multiple machines.
+aliases:
+  - /dev/reference/glossary/fragment/
 ---
+
+A reusable configuration block that you can share across multiple machines.
+
+For more information, see [Fragments](/manage/fleet/reuse-configuration/).

--- a/docs/reference/glossary/frame-system.md
+++ b/docs/reference/glossary/frame-system.md
@@ -1,6 +1,10 @@
 ---
 title: Frame System
 id: frame-system
-full_link: /motion-planning/frame-system/
+full_link: /operate/reference/services/frame-system/
 short_description: The frame system holds reference frame information for the relative position of components in space.
+aliases:
+  - /dev/reference/glossary/frame-system/
 ---
+
+The frame system holds reference frame information for the relative position of components in space.

--- a/docs/reference/glossary/frame.md
+++ b/docs/reference/glossary/frame.md
@@ -3,4 +3,11 @@ title: Frame
 id: frame
 full_link:
 short_description: A frame represents a coordinate system that describes the position and orientation of an object.
+aliases:
+  - /dev/reference/glossary/frame/
 ---
+
+A frame represents a coordinate system that describes the position and orientation of an object.
+See also {{< glossary_tooltip term_id="frame-system" text="frame system" >}}.
+
+The location of a frame is described in relation to its parent frame using rigid transformations rather than in absolute terms.

--- a/docs/reference/glossary/gantry.md
+++ b/docs/reference/glossary/gantry.md
@@ -3,4 +3,8 @@ title: Gantry
 id: attribute
 full_link: /components/gantry/
 short_description: A mechanical system that only uses linear motion to carry out a task.
+aliases:
+  - /dev/reference/glossary/gantry/
 ---
+
+A mechanical system that only uses linear motion to carry out a task; for example, the scaffolding of a 3D printer, which moves the print head around on motorized linear rails.

--- a/docs/reference/glossary/grpc.md
+++ b/docs/reference/glossary/grpc.md
@@ -3,4 +3,12 @@ title: gRPC
 id: grpc
 full_link:
 short_description: An open source, cross-platform, high performance Remote Procedure Call (RPC) framework initially developed at Google in 2015.
+aliases:
+  - /dev/reference/glossary/grpc/
 ---
+
+An open source, cross-platform, high performance Remote Procedure Call (RPC) framework initially developed at Google in 2015.
+With gRPC, a client application can communicate directly with a server application on a different machine.
+This framework can run in any environment and efficiently connect distributed applications and services.
+
+For more information see [grpc.io](https://grpc.io/).

--- a/docs/reference/glossary/index.md
+++ b/docs/reference/glossary/index.md
@@ -9,4 +9,7 @@ card:
   name: reference
   weight: 10
   title: Glossary
+aliases:
+  - /dev/reference/glossary/
+  - "/appendix/glossary/"
 ---

--- a/docs/reference/glossary/job.md
+++ b/docs/reference/glossary/job.md
@@ -1,6 +1,15 @@
 ---
 title: Jobs
 id: job
-full_link: /fleet/scheduled-jobs/
+full_link: /manage/software/scheduled-jobs/
 short_description: Automated tasks that run on machines at specified intervals to perform routine operations.
+aliases:
+  - /dev/reference/glossary/job/
 ---
+
+Jobs are automated tasks that run on machines at specified intervals to perform routine operations such as a task based on sensor readings, maintenance operations, and system checks.
+
+The job scheduler is built into `viam-server` and executes configured jobs according to their specified schedules.
+Each job targets a specific resource on your machine and calls a designated method at the scheduled intervals.
+
+For more information, see [Schedule automated jobs](/manage/software/scheduled-jobs/).

--- a/docs/reference/glossary/location.md
+++ b/docs/reference/glossary/location.md
@@ -1,6 +1,12 @@
 ---
 title: Location
 id: location
-full_link: /reference/account/organize/
+full_link: /manage/reference/organize/
 short_description: A location is a virtual grouping of machines that allows you to organize machines and manage access to your fleet.
+aliases:
+  - /dev/reference/glossary/location/
 ---
+
+A location is a virtual grouping of machines that allows you to organize machines and manage access to your fleet.
+
+For more information, see [Manage Locations and Sub-Locations](/manage/reference/organize/).

--- a/docs/reference/glossary/machine-config.md
+++ b/docs/reference/glossary/machine-config.md
@@ -3,4 +3,10 @@ title: Machine Config
 id: machine-config
 full_link: /configure/
 short_description: The complete configuration of a single machine part.
+aliases:
+  - /dev/reference/glossary/machine-config/
 ---
+
+The complete configuration of a single machine {{< glossary_tooltip term_id="part" text="part" >}}, including components, services, and scheduled jobs.
+
+For more information, see [Configuration](/operate/modules/configure-modules/).

--- a/docs/reference/glossary/machine-fqdn.md
+++ b/docs/reference/glossary/machine-fqdn.md
@@ -5,4 +5,9 @@ full_link:
 short_description: The fully qualified domain name (FQDN) of a machine in the Viam platform.
 aka:
 type: "page"
+aliases:
+  - /dev/reference/glossary/machine-fqdn/
 ---
+
+The fully qualified domain name (FQDN) of a {{< glossary_tooltip term_id="machine" text="machine" >}} in the Viam platform, typically in the format `<machine-name>.<location-id>.viam.cloud`.
+Used to uniquely identify and access a machine through Viam cloud infrastructure.

--- a/docs/reference/glossary/machine-id.md
+++ b/docs/reference/glossary/machine-id.md
@@ -5,4 +5,12 @@ full_link:
 short_description: A unique identifier assigned to each machine in the Viam platform.
 aka:
 type: "page"
+aliases:
+  - /dev/reference/glossary/machine-id/
 ---
+
+A **Machine ID** is a unique identifier assigned to each {{< glossary_tooltip term_id="machine" text="machine" >}} in the Viam platform.
+This ID is used to identify and reference a specific machine within the Viam ecosystem.
+
+Machine IDs are automatically generated when a new machine is created on Viam.
+You can get it using the web UI and the [Fleet management API](/reference/apis/fleet/).

--- a/docs/reference/glossary/machine.md
+++ b/docs/reference/glossary/machine.md
@@ -3,4 +3,8 @@ title: Machine
 id: machine
 full_link: /fleet/machines/
 short_description: An organizational concept, consisting of a computer and the components and services it controls, or sometimes multiple computers working closely together.
+aliases:
+  - /dev/reference/glossary/machine/
 ---
+
+A smart machine is an organizational concept, consisting of either one _{{< glossary_tooltip term_id="part" text="part" >}}_, or multiple _parts_ working closely together to complete tasks.

--- a/docs/reference/glossary/ml.md
+++ b/docs/reference/glossary/ml.md
@@ -5,4 +5,10 @@ full_link:
 short_description: Machine learning, a field of artificial intelligence focused on building systems that learn from data.
 aka:
 type: "page"
+aliases:
+  - /dev/reference/glossary/ml/
 ---
+
+ML stands for machine learning, a field of artificial intelligence that focuses on building systems that can learn from and make decisions based on data.
+
+Viam provides tools for [training ML models](/data-ai/train/train/), [deploying them to machines](/data-ai/ai/deploy/), [running inference](/data-ai/ai/run-inference/), and [interpret visual data from cameras](/data-ai/ai/alert/) to enable intelligent behavior in robotic systems.

--- a/docs/reference/glossary/model-namespace-triplet.md
+++ b/docs/reference/glossary/model-namespace-triplet.md
@@ -2,4 +2,11 @@
 title: Model Namespace Triplet
 id: model-namespace-triplet
 short_description: namespace:module-name:name or rdk:builtin:name
+aliases:
+  - /dev/reference/glossary/model-namespace-triplet/
 ---
+
+{{< glossary_tooltip term_id="model" text="Models" >}} are uniquely namespaced as colon-delimited-triplets.
+Modular resource model names have the form `namespace:module-name:model-name`, for example `esmeraldaLabs:sensors:moisture`.
+Built-in model names have the form `rdk:builtin:name`, for example `rdk:builtin:gpio`.
+See [Write your module](/operate/modules/write-a-driver-module/#2-implement-the-resource-api) for more information.

--- a/docs/reference/glossary/model.md
+++ b/docs/reference/glossary/model.md
@@ -3,4 +3,19 @@ title: Model
 id: model
 full_link:
 short_description: A particular implementation of a resource. For example, UR5e is a model of the arm component API.
+aliases:
+  - /dev/reference/glossary/model/
 ---
+
+A particular implementation of a {{< glossary_tooltip term_id="resource" text="resource" >}} [API](/reference/apis/).
+
+Models allow you to control hardware or software of a similar category, such as motors, with a consistent set of methods as an interface, even if the underlying implementation differs.
+
+For example, some _models_ of DC motors communicate using [GPIO](/reference/components/board/), while other DC motors use serial protocols like the SPI bus.
+Regardless, you can power any motor model that implements the `rdk:component:motor` API with the `SetPower()` method.
+
+Models are either included with [`viam-server`](/reference/viam-server/) or provided through {{< glossary_tooltip term_id="module" text="modules" >}}.
+All models are uniquely namespaced as colon-delimited-triplets.
+Built-in model names have the form `rdk:builtin:name`.
+Modular resource model names have the form `namespace:module-name:model-name`.
+See [Write your module](/operate/modules/write-a-driver-module/#2-implement-the-resource-api) for more information.

--- a/docs/reference/glossary/modular-resource.md
+++ b/docs/reference/glossary/modular-resource.md
@@ -2,4 +2,12 @@
 title: Modular Resource
 id: modular-resource
 short_description: A modular resource is a model of a component or service provided by a module.
+aliases:
+  - /dev/reference/glossary/modular-resource/
 ---
+
+A modular resource is a {{< glossary_tooltip term_id="model" text="model" >}} of a {{< glossary_tooltip term_id="component" text="component" >}} or {{< glossary_tooltip term_id="service" text="service" >}} provided by a {{< glossary_tooltip term_id="module" text="module" >}}.
+A modular resource runs in a module process.
+This differs from built-in resources, which run as part of `viam-server`.
+
+For more information see the [Create a module](/operate/modules/write-a-driver-module/#2-implement-the-resource-api).

--- a/docs/reference/glossary/module.md
+++ b/docs/reference/glossary/module.md
@@ -3,4 +3,11 @@ title: Module
 id: module
 full_link:
 short_description: Modules are the code packages that provide functionality like drivers, integrations, and control logic to your machines.
+aliases:
+  - /dev/reference/glossary/module/
 ---
+
+A _module_ is a code package which provides one or more {{< glossary_tooltip term_id="modular-resource" text="modular resources" >}}, which add {{< glossary_tooltip term_id="resource" text="resource" >}} {{< glossary_tooltip term_id="type" text="types" >}} or {{< glossary_tooltip term_id="model" text="models" >}}, integrations, or control logic for your machines.
+Modules run alongside `viam-server` as separate process, communicating with `viam-server` over UNIX sockets.
+
+You can [create your own module](/operate/modules/write-a-driver-module/) or [add existing modules from the registry](/operate/modules/configure-modules/).

--- a/docs/reference/glossary/mql.md
+++ b/docs/reference/glossary/mql.md
@@ -3,4 +3,10 @@ title: MQL
 id: mql
 full_link:
 short_description: MQL is the MongoDB query language, similar to SQL but specific to the MongoDB document model.
+aliases:
+  - /dev/reference/glossary/mql/
 ---
+
+MQL is the [MongoDB query language](https://www.mongodb.com/docs/manual/tutorial/query-documents/), similar to {{< glossary_tooltip term_id="sql" text="SQL" >}} but specific to the MongoDB document model.
+
+You can use MQL to query data that you have synced to Viam using the [data management service](/data-ai/capture-data/capture-sync/).

--- a/docs/reference/glossary/organization.md
+++ b/docs/reference/glossary/organization.md
@@ -1,6 +1,14 @@
 ---
 title: Organization
 id: organization
-full_link: /reference/account/organize/
+full_link: /manage/reference/organize/
 short_description: An organization is a group of one or more locations that helps you organize your fleet and manage who has access to your fleet.
+aliases:
+  - /dev/reference/glossary/organization/
 ---
+
+An organization or org is the highest level grouping in the Viam platform, which generally represents a company, or other institution.
+Every {{< glossary_tooltip term_id="location" text="location" >}} is grouped into an organization.
+You can also have organizations for departments or other entities, or for personal use.
+
+For more information, see [Organize your machines](/manage/reference/organize/).

--- a/docs/reference/glossary/origin-frame.md
+++ b/docs/reference/glossary/origin-frame.md
@@ -3,4 +3,16 @@ title: Origin frame
 id: origin-frame
 full_link:
 short_description: The origin frame is the frame at the base of an arm or other component that has a complex kinematics chain.
+aliases:
+  - /dev/reference/glossary/origin-frame/
 ---
+
+The origin frame is the frame at the base of an arm, gantry, or other component.
+This is typically the point at the center of where the component is mounted to a table or stand.
+
+Every component that has a kinematics chain has an origin frame and an end effector frame, for example `my_arm_origin` and `my_arm`.
+
+If you parent a gripper to the arm's `my_arm` frame, the frame system will know the gripper is at the end of the arm.
+If you mistakenly parent the gripper to the arm's `my_arm_origin` frame, the frame system will think the gripper is at the base of the arm, and the gripper will not move when you move the arm.
+
+For more information, see [How the frame system works](/reference/services/frame-system/#how-the-frame-system-works).

--- a/docs/reference/glossary/package.md
+++ b/docs/reference/glossary/package.md
@@ -3,4 +3,10 @@ title: Package
 id: package
 full_link:
 short_description: An archive, module, ML model, SLAM Map, or other bundle of binary code.
+aliases:
+  - /dev/reference/glossary/package/
 ---
+
+A _package_ is an archive, module, ML model, SLAM map, or other bundle of binary code.
+
+Packages are used to deploy software to machines.

--- a/docs/reference/glossary/part.md
+++ b/docs/reference/glossary/part.md
@@ -1,6 +1,12 @@
 ---
 title: Part
 id: part
-full_link: /reference/architecture/parts/
+full_link: /operate/reference/architecture/parts/
 short_description: A single-board computer, desktop, laptop, or other computer running viam-server, the hardware components attached to it, and any services or other resources running on it.
+aliases:
+  - /dev/reference/glossary/part/
 ---
+
+Smart machines are organized into _parts_, where each part represents a computer (a single-board computer, desktop, laptop, or other computer) running `viam-server`, the hardware {{< glossary_tooltip term_id="component" text="components" >}} attached to it, and any {{< glossary_tooltip term_id="service" text="services" >}} or other resources running on it.
+
+For more information, see [Machine Architecture: Parts](/reference/architecture/parts/).

--- a/docs/reference/glossary/pi.md
+++ b/docs/reference/glossary/pi.md
@@ -5,4 +5,13 @@ full_link:
 short_description: Short for Raspberry Pi, a series of small single-board computers developed by the Raspberry Pi Foundation.
 aka:
 type: "page"
+aliases:
+  - /dev/reference/glossary/pi/
 ---
+
+Pi is short for Raspberry Pi, a series of small, affordable single-board computers developed by the Raspberry Pi Foundation.
+These credit card-sized computers are widely used in robotics, IoT projects, education, and DIY electronics.
+
+Viam supports many different devices including Raspberry Pis as host computers for running `viam-server`.
+
+To set up a Raspberry Pi, see [the Raspberry Pi setup instructions](/reference/prepare/rpi-setup/).

--- a/docs/reference/glossary/pin-number.md
+++ b/docs/reference/glossary/pin-number.md
@@ -3,4 +3,14 @@ title: Pin Number
 id: pin-number
 full_link:
 short_description: A pin number is the index of the pin on the board. Not the same as a pin's GPIO number.
+aliases:
+  - /dev/reference/glossary/pin-number/
 ---
+
+A pin number is the physical index of a pin on a {{< glossary_tooltip term_id="board" text="board" >}}.
+
+This number is distinct from the GPIO number assigned to general purpose input/output (GPIO) pins.
+For example, pin number "11" on a NVIDIA Jetson Nano is GPIO "50", and pin number "11" on a Raspberry Pi 4 is GPIO "17".
+When Viam documentation refers to pin number, it will always mean the pin's physical index and not GPIO number.
+
+Pin numbers are found on a board's pinout diagram and datasheet.

--- a/docs/reference/glossary/protobuf.md
+++ b/docs/reference/glossary/protobuf.md
@@ -3,4 +3,10 @@ title: Protocol Buffers (Protobuf)
 id: protobuf
 full_link:
 short_description: A free and open-source, language-neutral, cross-platform data format for serializing structured data.
+aliases:
+  - /dev/reference/glossary/protobuf/
 ---
+
+A free and open-source, language-neutral, cross-platform data format for serializing structured data.
+
+Protocol Buffers are useful in developing programs that communicate with each other over a network or for storing data.

--- a/docs/reference/glossary/rdk.md
+++ b/docs/reference/glossary/rdk.md
@@ -1,6 +1,10 @@
 ---
 title: RDK (Robot Development Kit)
 id: rdk
-full_link: /reference/platform/viam-server/
+full_link: /operate/reference/viam-server/
 short_description: The official Viam-developed codebase that provides all functionality of an SDK and more.
+aliases:
+  - /dev/reference/glossary/rdk/
 ---
+
+Viam’s Robot Development Kit (RDK) is the [open-source](https://github.com/viamrobotics/rdk), on-machine portion of the Viam platform, that provides [`viam-server`](/reference/viam-server/) and the Go SDK.

--- a/docs/reference/glossary/remote-part.md
+++ b/docs/reference/glossary/remote-part.md
@@ -4,4 +4,10 @@ id: remote-part
 full_link: /architecture/parts/
 short_description: A machine part which is controlled by another machine part.
 aka:
+aliases:
+  - /dev/reference/glossary/remote-part/
 ---
+
+A machine part which is controlled by another machine part.
+
+For more information, see [Machine Architecture: Parts](/reference/architecture/parts/).

--- a/docs/reference/glossary/resource.md
+++ b/docs/reference/glossary/resource.md
@@ -3,4 +3,19 @@ title: Resource
 id: resource
 full_link:
 short_description: Resources are individual, addressable elements of a machine such as components or services.
+aliases:
+  - /dev/reference/glossary/resource/
 ---
+
+Resources are individual, addressable elements of a machine.
+
+{{< glossary_tooltip term_id="part" text="Parts" >}} can operate multiple types of resources:
+
+- physical {{< glossary_tooltip term_id="component" text="components" >}}
+- software {{< glossary_tooltip term_id="service" text="services" >}}
+- {{< glossary_tooltip term_id="modular-resource" text="modular resources" >}} provided by {{< glossary_tooltip term_id="module" text="modules" >}}
+
+Each part has local resources and can also have resources from another {{< glossary_tooltip term_id="remote-part" text="remote">}} machine part.
+The capabilities of each resource are exposed through the part’s API.
+
+Each resource on your machine implements either one of the [existing Viam APIs](/reference/apis/), or a [custom interface](/reference/advanced-modules/#new-apis).

--- a/docs/reference/glossary/sdk.md
+++ b/docs/reference/glossary/sdk.md
@@ -1,6 +1,14 @@
 ---
 title: SDK (Software Development Kit)
 id: sdk
-full_link: /reference/apis/
+full_link: /dev/reference/apis/
 short_description: Viam provides software development kits (SDKs) to help you write client applications and create support for custom component types.
+aliases:
+  - /dev/reference/glossary/sdk/
 ---
+
+Viam provides software development kits (SDKs) to help you write client applications and create support for custom {{< glossary_tooltip term_id="component" text="component" >}} types.
+
+The SDKs wrap the `viam-server` {{< glossary_tooltip term_id="grpc" text="gRPC" >}} {{< glossary_tooltip term_id="viam-robot-api" text="Viam Robot API" >}} and streamline connection, authentication, and encryption.
+
+For more information, see [Interact with Resources with Viam's Client SDKs](/reference/apis/).

--- a/docs/reference/glossary/service.md
+++ b/docs/reference/glossary/service.md
@@ -2,4 +2,12 @@
 title: Service
 id: service
 short_description: Built-in software packages for complex capabilities such as SLAM, Computer Vision, Motion Planning, and Data Collection.
+aliases:
+  - /dev/reference/glossary/service/
 ---
+
+Services are built-in software packages for complex capabilities such as simultaneous localization and mapping (SLAM), computer vision, motion planning, and data collection.
+
+Each service is typed by a proto API, such as the [service proto definitions](https://github.com/viamrobotics/api/tree/main/proto/viam/service).
+
+For more information, see [Service APIs](/reference/apis/#service-apis).

--- a/docs/reference/glossary/setup.md
+++ b/docs/reference/glossary/setup.md
@@ -3,4 +3,9 @@ title: View setup instructions
 id: setup
 full_link:
 short_description: To view setup instructions for a machine part, navigate to the CONFIGURE tab, find the part's card, click the "..." menu in the upper right corner of the card, and select "View setup instructions".
+aliases:
+  - /dev/reference/glossary/setup/
 ---
+
+Before configuring a machine {{< glossary_tooltip term_id="part" text="part" >}}, you must follow the correct setup instructions for your machine's architecture.
+You can view the setup instructions by clicking on the part status dropdown next to your machine's name in the top left corner of the page and clicking **View setup instructions**.

--- a/docs/reference/glossary/slam.md
+++ b/docs/reference/glossary/slam.md
@@ -1,6 +1,12 @@
 ---
 title: SLAM
 id: slam
-full_link: /reference/services/slam/
+full_link: /operate/reference/services/slam/
 short_description: Simultaneous Localization And Mapping (SLAM) algorithms use data from a machine's sensors to generate a map of the environment and determine the machine's position within it.
+aliases:
+  - /dev/reference/glossary/slam/
 ---
+
+SLAM (Simultaneous Localization and Mapping) algorithms use data from a machine's sensors, like LiDARs, cameras, and movement sensors, to generate a map of the environment and determine the machine's position within it.
+
+For more information, see [SLAM](/reference/services/slam/).

--- a/docs/reference/glossary/smart-machine.md
+++ b/docs/reference/glossary/smart-machine.md
@@ -3,4 +3,9 @@ title: Smart Machine
 id: smart-machine
 full_link:
 short_description: A machine or device that lives in the real world and has some ability to perceive the world (with a sensor, for example) and perform actions like operating a motor.
+aliases:
+  - /dev/reference/glossary/smart-machine/
 ---
+
+A machine or device that lives in the real world and has some ability to perceive the world (with a sensor, for example) and perform actions like operating a motor.
+The machine might also interact with other systems, with the cloud, or with users.

--- a/docs/reference/glossary/sql.md
+++ b/docs/reference/glossary/sql.md
@@ -3,4 +3,10 @@ title: SQL
 id: sql
 full_link:
 short_description: SQL (structured query language) is the widely-used, industry-standard query language popular with relational databases.
+aliases:
+  - /dev/reference/glossary/sql/
 ---
+
+[SQL (structured query language)](https://en.wikipedia.org/wiki/SQL) is the widely-used, industry-standard query language popular with [relational databases](https://en.wikipedia.org/wiki/Relational_database).
+
+You can use SQL to query data that you have synced to Viam using the [data management service](/data-ai/capture-data/capture-sync/).

--- a/docs/reference/glossary/subtype.md
+++ b/docs/reference/glossary/subtype.md
@@ -3,4 +3,16 @@ title: Subtype
 id: subtype
 full_link:
 short_description: A group of component or service models that share the same API. For example, arm is a subtype of component.
+aliases:
+  - /dev/reference/glossary/subtype/
 ---
+
+A category within a {{< glossary_tooltip term_id="type" text="type" >}} of {{< glossary_tooltip term_id="resource" text="resource" >}}.
+Resource models belonging to a subtype share the same API.
+{{< glossary_tooltip term_id="model" text="Models" >}} implement that subtype's API protocol with different drivers.
+
+For example, an arm is a subtype of the {{< glossary_tooltip term_id="component" text="component" >}} resource type, while the `ur5e` is a {{< glossary_tooltip term_id="model" text="model" >}} of the arm subtype's API.
+
+The [Vision Service](/reference/services/vision/) is a subtype of the {{< glossary_tooltip term_id="service" text="service" >}} resource type.
+
+The `subtype` string is the third part of the {{< glossary_tooltip term_id="api-namespace-triplet" text="API namespace triplet" >}}.

--- a/docs/reference/glossary/trigger.md
+++ b/docs/reference/glossary/trigger.md
@@ -1,6 +1,18 @@
 ---
 title: Trigger
 id: trigger
-full_link: /reference/configuration/triggers/
+full_link: /data-ai/reference/triggers-configuration/
 short_description: A mechanism that sends alerts by email or webhook when specific events occur in your machine or data.
+aliases:
+  - /dev/reference/glossary/trigger/
 ---
+
+A trigger is a mechanism that sends alerts by email or webhook when specific events occur in your machine or data.
+
+Triggers can alert you when the following events occur:
+
+- Machine telemetry data syncs from your local device to the Viam cloud
+- Data syncs from a machine
+- A service detects a specified object or classifies a specified label
+
+For more information, see [Trigger configuration](/data-ai/reference/triggers-configuration/).

--- a/docs/reference/glossary/type.md
+++ b/docs/reference/glossary/type.md
@@ -3,4 +3,8 @@ title: Type
 id: type
 full_link:
 short_description: Component and service are the built-in types of resource API the RDK provides.
+aliases:
+  - /dev/reference/glossary/type/
 ---
+
+In the {{< glossary_tooltip term_id="rdk" text="RDK" >}} architecture's {{< glossary_tooltip term_id="api-namespace-triplet" text="namespace triplet" >}} for resource APIs, _type_ refers to the distinction between {{< glossary_tooltip term_id="component" text="component" >}} or {{< glossary_tooltip term_id="service" text="service" >}}.

--- a/docs/reference/glossary/viam-agent.md
+++ b/docs/reference/glossary/viam-agent.md
@@ -3,4 +3,11 @@ title: Viam Agent
 id: viam-agent
 full_link:
 short_description: The Viam provisioning application for deploying viam-server.
+aliases:
+  - /dev/reference/glossary/viam-agent/
 ---
+
+The Viam Agent is a provisioning application for deploying and managing `viam-server` across a fleet of machines.
+You can use the Viam Agent to provision a machine as it first comes online with a pre-defined configuration, including WiFi networks or additional build or provision steps.
+
+See [Provision Machines](/manage/fleet/provision/setup/) for more information.

--- a/docs/reference/glossary/viam-micro-server.md
+++ b/docs/reference/glossary/viam-micro-server.md
@@ -1,6 +1,14 @@
 ---
 title: viam-micro-server
 id: viam-micro-server
-full_link: /reference/platform/viam-micro-server/
+full_link: /operate/reference/viam-micro-server/
 short_description: The lightweight version of viam-server that can run on ESP32 devices.
+aliases:
+  - /dev/reference/glossary/viam-micro-server/
 ---
+
+The lightweight version of `viam-server`, built for microcontrollers.
+`viam-micro-server` is a set of open-source utilities which run on your microcontroller and provides Viam functionality to your machine.
+`viam-micro-server` is built from the Micro-RDK.
+
+For more information see [Architecture](/reference/viam-micro-server/).

--- a/docs/reference/glossary/viam-robot-api.md
+++ b/docs/reference/glossary/viam-robot-api.md
@@ -3,4 +3,15 @@ title: Viam Robot API
 id: viam-robot-api
 full_link:
 short_description: The specification for communication with resources.
+aliases:
+  - /dev/reference/glossary/viam-robot-api/
 ---
+
+The specification for communication with resources.
+
+- The SDKs implement the Viam Robot API server-side.
+- The SDKs use the Viam Robot API to act as clients.
+
+Currently, the Viam Robot API is defined in a collection of Protocol Buffer files.
+
+All SDKs written by Viam use {{< glossary_tooltip term_id="grpc" text="gRPC" >}} but the Viam Robot API itself does not mandate gRPC as the transport mechanism.

--- a/docs/reference/glossary/viam-server.md
+++ b/docs/reference/glossary/viam-server.md
@@ -1,6 +1,13 @@
 ---
 title: viam-server
 id: viam-server
-full_link: /reference/platform/viam-server/
+full_link: /operate/reference/viam-server/
 short_description: The executable binary which runs on and provides functionality to machines.
+aliases:
+  - /dev/reference/glossary/viam-server/
 ---
+
+The open-source executable binary that runs on your machine's computer (such as a single-board computer or a server) and provides most Viam functionality.
+`viam-server` is built from the RDK.
+
+For more information see [Architecture](/reference/viam-server/).

--- a/docs/reference/glossary/vision-service.md
+++ b/docs/reference/glossary/vision-service.md
@@ -1,8 +1,15 @@
 ---
 title: Vision service
 id: vision-service
-full_link: /reference/services/vision/
+full_link: /operate/reference/services/vision/
 short_description: A service that enables machines to interpret visual data from cameras using computer vision and machine learning.
 aka:
 type: "page"
+aliases:
+  - /dev/reference/glossary/vision-service/
 ---
+
+The vision service is a {{< glossary_tooltip term_id="service" text="service" >}} in the Viam platform that enables machines to interpret visual data captured by camera using computer vision and {{< glossary_tooltip term_id="ml" text="machine learning" >}} techniques.
+Vision services can use various models, including pre-trained models or custom models trained on your own data using the Viam platform.
+
+For more information, see the [Vision service documentation](/reference/services/vision/) or [Alert on inferences](/data-ai/ai/alert/).

--- a/docs/reference/glossary/web-sockets.md
+++ b/docs/reference/glossary/web-sockets.md
@@ -3,4 +3,8 @@ title: Websockets
 id: web-sockets
 full_link:
 short_description: A computer communications protocol that provides full-duplex communication channels over a single Transmission Control Protocol (TCP) connection.
+aliases:
+  - /dev/reference/glossary/web-sockets/
 ---
+
+A computer communications protocol that provides full-duplex communication channels over a single Transmission Control Protocol (TCP) connection.

--- a/docs/reference/glossary/webrtc.md
+++ b/docs/reference/glossary/webrtc.md
@@ -3,4 +3,10 @@ title: WebRTC
 id: webrtc
 full_link:
 short_description: An open source project which provides applications with real-time communication (RTC) using application programming interfaces (API) allowing powerful voice and video integration.
+aliases:
+  - /dev/reference/glossary/webrtc/
 ---
+
+An open source project which provides applications with real-time communication (RTC) using application programming interfaces (API) allowing powerful voice and video integration.
+
+For more information see [webrtc.org](https://webrtc.org/).

--- a/docs/reference/glossary/world-frame.md
+++ b/docs/reference/glossary/world-frame.md
@@ -1,7 +1,16 @@
 ---
 title: World frame
 id: world-frame
-full_link: /motion-planning/frame-system/
+full_link: /operate/mobility/move-arm/frame-how-to/
 short_description: The fixed, user-defined global coordinate system that is the reference point for all other coordinate frames in a robotic system.
 aka: world frame, world
+aliases:
+  - /dev/reference/glossary/world-frame/
 ---
+
+The world reference [frame](/reference/services/frame-system/) is the fixed, global coordinate system that serves as the reference point for all other coordinate frames in a robotic system.
+It provides a consistent basis for describing the position and orientation of robots, components, and objects in the physical space.
+All other coordinate frames (such as machine frames and component frames) are defined relative to this world frame, either directly or through a chain of transformations.
+
+The user chooses the world frame, and defines it implicitly.
+For example, if you have a robot arm mounted on a table and you define the arm's origin frame as having no translation or orientation relative to the world frame, then the arm's origin frame is the origin of the world frame.

--- a/docs/reference/platform/viam-agent/_index.md
+++ b/docs/reference/platform/viam-agent/_index.md
@@ -5,6 +5,392 @@ weight: 20
 type: docs
 description: "The viam-agent is a self-updating service manager that maintains the lifecycle for Viam's system services, among them viam-server and provisioning."
 date: "2025-02-14"
+aliases:
+  - /configure/agent/
 # updated: ""  # When the content was last entirely checked
 # SMEs: James, Ale
 ---
+
+The [`viam-agent`](https://github.com/viamrobotics/agent) is a self-updating service manager that maintains the lifecycle for itself and `viam-server`.
+
+Among other things, `viam-agent`:
+
+- Installs, runs, and monitors `viam-server` or a custom build of `viam-server`.
+- Provides tooling for device provisioning and network management.
+- Provides automatic updates for `viam-server` and the agent itself.
+- Allows control of deployed software versions.
+- Provides various operating system settings.
+
+{{< alert title="Support notice" color="note" >}}
+Currently, `viam-agent` is only supported on Linux for amd64 (x86_64) and arm64 (aarch64) CPUs, MacOS for arm64 (M/silicon) CPUs, and Windows (native).
+{{< /alert >}}
+
+To provision machines using `viam-agent`, see [Provision Machines](/fleet/provision-devices/setup/).
+
+## Installation
+
+{{< table >}}
+{{% tablestep start=1 %}}
+Add a new machine.
+{{% /tablestep %}}
+{{% tablestep %}}
+Navigate to the machine's **CONFIGURE** tab.
+{{% /tablestep %}}
+{{% tablestep %}}
+Click **View setup instructions** on the alert to **Set up your machine part**:
+
+{{<imgproc src="/installation/setup.png" resize="400x" declaredimensions=true alt="Machine setup alert in a newly created machine" class="shadow imgzoom">}}
+{{% /tablestep %}}
+{{% tablestep %}}
+Follow the instructions to install `viam server` with `viam-agent`.
+Your machine must have `curl` available in order to install `viam-agent`.
+
+{{< tabs >}}
+{{% tab name="Linux/MacOS" %}}
+
+You can use `viam-agent` either with
+
+{{< tabs >}}
+{{% tab name="environment variables" %}}
+
+The command will be of the following form:
+
+```sh {class="command-line" data-prompt="$" data-output=""}
+sudo /bin/sh -c "VIAM_API_KEY_ID=<KEYID> VIAM_API_KEY=<KEY> VIAM_PART_ID=<PARTID>; $(curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent/install.sh)"
+```
+
+{{% /tab %}}
+{{% tab name="a machine credentials file" %}}
+
+```sh {class="command-line" data-prompt="$"}
+sudo /bin/sh -c "$(curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent/install.sh)"
+```
+
+The machine credentials file must be at <file>/etc/viam.json</file>.
+You can get the machine cloud credentials by clicking the copy icon next to **Machine cloud credentials** in the part status dropdown to the right of your machine's name on the top of the page.
+
+{{<imgproc src="configure/machine-part-info.png" resize="500x" declaredimensions=true alt="Machine part info dropdown" class="shadow">}}
+
+{{% /tab %}}
+{{< /tabs >}}
+
+On Linux, `viam-agent` will install itself as a systemd service named `viam-agent`. On MacOS, `viam-agent` will install itself as a launchd daemon named `system/com.viam.agent`.
+
+For information on managing the service, see [Manage `viam-agent`](/reference/platform/viam-agent/manage-viam-agent/).
+
+{{% /tab %}}
+{{% tab name="Windows" %}}
+
+On Windows, the [`viam-agent` installer](https://storage.googleapis.com/packages.viam.com/apps/viam-agent/viam-agent-windows-installer.exe) installs `viam-agent` as a service.
+Your machine credentials file must be at <file>\etc\viam.json</file>.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+{{% /tablestep %}}
+{{< /table >}}
+
+## Configuration
+
+{{< tabs >}}
+{{% tab name="Config Builder" %}}
+
+1. Navigate to your machine's page.
+1. Navigate to the **CONFIGURE** tab.
+1. Click on **machine settings**.
+1. Edit and fill in the attributes as applicable.
+
+{{% /tab %}}
+{{% tab name="JSON Example" %}}
+
+```json {class="line-numbers linkable-line-numbers"}
+{
+  "agent": {
+    "version_control": {
+      "agent": "stable",
+      "viam-server": "0.52.1"
+    },
+    "advanced_settings": {
+      "debug": false,
+      "wait_for_update_check": false,
+      "viam_server_start_timeout_minutes": 10,
+      "disable_viam_server": false,
+      "disable_network_configuration": false,
+      "disable_system_configuration": false,
+      "viam_server_env": {
+        "CUSTOM_VAR": "value"
+      }
+    },
+    "network_configuration": {
+      "manufacturer": "viam",
+      "model": "custom",
+      "fragment_id": "",
+      "hotspot_interface": "wlan0",
+      "hotspot_prefix": "viam-setup",
+      "hotspot_password": "viamsetup",
+      "disable_captive_portal_redirect": false,
+      "disable_bt_provisioning": false,
+      "disable_wifi_provisioning": false,
+      "bluetooth_trust_all": false,
+      "offline_before_starting_hotspot_minutes": 2,
+      "user_idle_minutes": 5,
+      "retry_connection_timeout_minutes": 10,
+      "turn_on_hotspot_if_wifi_has_no_internet": true,
+      "wifi_power_save": null
+    },
+    "additional_networks": {
+      "network1": {
+        "type": "wifi",
+        "interface": "",
+        "ssid": "fallbackNetOne",
+        "psk": "myFirstPassword",
+        "priority": 30,
+        "ipv4_address": "",
+        "ipv4_gateway": "",
+        "ipv4_dns": [],
+        "ipv4_route_metric": 0
+      },
+      "network2": {
+        "type": "wifi",
+        "interface": "",
+        "ssid": "fallbackNetTwo",
+        "psk": "mySecondPassword",
+        "priority": 10,
+        "ipv4_address": "",
+        "ipv4_gateway": "",
+        "ipv4_dns": [],
+        "ipv4_route_metric": 0
+      }
+    },
+    "system_configuration": {
+      "logging_journald_system_max_use_megabytes": 128,
+      "logging_journald_runtime_max_use_megabytes": 96,
+      "os_auto_upgrade_type": "all",
+      "forward_system_logs": "all,-gdm,-tailscaled"
+    }
+  }
+}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+<a id="version_control-version-management-for-viam-agent-and-viam-server"></a>
+
+## `version_control`: Version management for `viam-agent` and `viam-server` {#version-control}
+
+By default, when a new version of `viam-server` becomes available, it will automatically download.
+When `viam-agent` next restarts, it installs and starts using the new version of `viam-server`.
+To ensure that updates only occur when your machines are ready, configure a [maintenance window](/reference/platform/viam-server/#maintenance-window). With a configured maintenance window, `viam-agent` will restart and upgrade `viam-server` only when maintenance is allowed and when `viam-server` is not currently processing config changes.
+
+{{< alert title="Tip: Check versions of viam-agent and viam-server" color="tip" >}}
+
+You can find the installed versions of viam-agent and viam-server on your machine's page. Click on the part status dropdown to the right of your machine's name on the top of the page.
+
+{{< /alert >}}
+
+<!-- prettier-ignore -->
+| Name       | Type | Required? | Description |
+| ---------- | ---- | --------- | ----------- |
+| `agent` | string | **Required** | The version of Viam agent specified as either:<ul><li>a version number`"5.6.77"` or `"0.65.1-dev.7"` (indicating the seventh commit to "main" after the previous non-dev release, `0.65.0`)</li><li>a tag such as`"stable"` or `"dev"`.</li><li>a URL such as `"http://example.com/viam-agent-test-aarch64"`, `"file:///home/myuser/viam-agent-test-aarch64"`, or `"file:///C:/Users/viam/Downloads/viam-agent-v0.31.0-windows-x86_64.exe"`</li></ul> Viam agent is semantically versioned and is tested before release. Releases happen infrequently. When set to `"stable"`, `viam-agent` will automatically upgrade when a new version is released. Default: `"stable"`. |
+| `viam-server` | string | **Required** | The version of `viam-server` specified as `"5.6.77"`, `"stable"`, `"dev"` or by providing a URL such as `"http://example.com/viam-server-test-aarch64"`, `"file:///home/myuser/viam-server-test-aarch64"`, or `"file:///C:/Users/viam/Downloads/viam-server-v0.72.0-windows-x86_64.exe"`. `viam-server` is semantically versioned and is tested before release. When set to `"stable"`, `viam-server` will automatically upgrade when a new stable version is released. Default: `"stable"`. |
+
+For more information on managing `viam-agent` see [Manage `viam-agent`](/reference/platform/viam-agent/manage-viam-agent/).
+
+### Update or downgrade `viam-server` with `viam-agent`
+
+{{< alert title="Tip" color="tip" >}}
+The current version of `viam-server` is displayed in the machine's part status dropdown to the right of your machine’s name on its page.
+{{< /alert >}}
+
+{{% hiddencontent %}}
+`viam-server` is made from the RDK. Therefore the version of RDK and `viam-server` installed on a machine is always the same.
+
+To check the version of `viam-server` (or the RDK) check the machine part status dropdown.
+To update the version of `viam-server` (or the RDK) update the machine settings.
+{{% /hiddencontent %}}
+
+1. Navigate to your machine's **CONFIGURE** tab.
+2. Click on **machine settings** on the left side of the page.
+3. Change the specified `viam-server` version.
+4. Save your configuration.
+
+<a id="advanced_settings"></a>
+
+## `advanced_settings` {#advanced-settings}
+
+<!-- prettier-ignore -->
+| Name       | Type | Required? | Description |
+| ---------- | ---- | --------- | ----------- |
+| `debug` | boolean | Optional | Sets the log level to debug for any logging from the Viam agent binary. Default: `false`. |
+| `disable_network_configuration` | boolean | Optional | Disables the network and hotspot configuration, as well as the configuration of additional networks. Default: `false`. |
+| `disable_system_configuration` | boolean | Optional | Disables the system configuration. Default: `false`. |
+| `disable_viam_server` | boolean | Optional | Disable `viam-server` remotely. This option is often used by developers working on Viam agent or when manually running `viam-server`. Default: `false`. |
+| `viam_server_env` | object | Optional | A map of environment variable names to values that `viam-agent` passes to `viam-server` and its child processes (including modules). Both keys and values must be strings. See [Environment Variables for viam-server](#environment-variables-for-viam-server). Default: `{}` (empty). |
+| `viam_server_start_timeout_minutes` | integer | Optional | Specify a time after which, if `viam-server` hasn't successfully started, Viam agent will kill it and restart. Default: `10`. |
+| `wait_for_update_check` | boolean | Optional | If set to `true`, `viam-agent` will wait for a network connection and check for updates before starting `viam-server`. See [Reduce startup time](#reduce-startup-time). Default: `false`. |
+
+### Environment Variables for viam-server
+
+You can configure environment variables for `viam-server` using the `viam_server_env` setting in `advanced_settings`.
+Environment variables set through `viam_server_env` are passed to `viam-server` and all child processes it launches, including modules.
+`viam-server` also inherits existing environment variables from `viam-agent`, such as `HOME`, `PWD`, `TERM`, `PATH`.
+
+{{< alert title="Important" color="note" >}}
+When you change environment variables in `viam_server_env`, `viam-agent` will automatically restart `viam-server` to apply these and any other changes made before saving.
+This restart will occur immediately if `viam-server` is in a maintenance window and not currently processing configuration changes.
+{{< /alert >}}
+
+Changes to `viam_server_env` are the only changes that automatically trigger a `viam-server` restart. Changing other configuration options requires a manual restart unless you've also changed `viam_server_env`.
+
+#### Example configurations
+
+```json
+{
+  "agent": {
+    "advanced_settings": {
+      "viam_server_env": {
+        "PION_LOG_TRACE": "all", # Debug logging for WebRTC
+        "HTTPS_PROXY": "socks5://proxy.example.com:1080", # SOCKS proxy
+        "HTTP_PROXY": "socks5://proxy.example.com:1080",
+        "CUSTOM_VAR": "value"
+      }
+    }
+  }
+}
+```
+
+To remove an environment variable, remove it from the `viam_server_env` object and save your configuration.
+
+### Reduce startup time
+
+You can set `wait_for_update_check` to `false` to bypass `viam-agent` waiting for a network connection to be established and checking for updates during initial startup.
+This will result in `viam-server` executing as quickly as possible.
+
+This is useful if you have a device that often starts when offline or on a slow connection, and if having the latest version immediately after start isn't required.
+
+{{< alert title="Note" color="note" >}}
+Periodic update checks will continue to run afterwards.
+This setting only affects the initial startup sequencing.
+{{< /alert >}}
+
+You can also start `viam-agent` in fast start mode by setting `VIAM_AGENT_FAST_START=1` in your environment.
+
+## `network_configuration`
+
+<!-- prettier-ignore -->
+| Name       | Type | Required? | Description |
+| ---------- | ---- | --------- | ----------- |
+| `device_reboot_after_offline_minutes` | integer | Optional | If set, `viam-agent` will reboot the device after it has been offline for the specified duration. Default: `0` (disabled). |
+| `disable_bt_provisioning` | boolean | Optional | When set to true, disables Bluetooth provisioning. The machine will not advertise Bluetooth services for provisioning. Both WiFi hotspot and Bluetooth provisioning can be enabled simultaneously. Default: `false`. |
+| `disable_captive_portal_redirect` | boolean | Optional | By default, ALL DNS lookups using the provisioning hotspot will redirect to the device. This causes most phones/mobile devices to automatically redirect the user to the {{< glossary_tooltip term_id="captive-web-portal" text="captive portal" >}} as a "sign in" screen. When disabled, only domains ending in .setup (ex: viam.setup) will be redirected. This generally avoids displaying the portal to users and is mainly used in conjunction with a mobile provisioning application workflow. Default: `false`. |
+| `disable_wifi_provisioning` | boolean | Optional | When set to true, disables WiFi hotspot provisioning. The machine will not create a WiFi hotspot for provisioning. Both WiFi hotspot and Bluetooth provisioning can be enabled simultaneously. Default: `false`. |
+| `bluetooth_trust_all` | boolean | Optional | Set to true to accept all Bluetooth pairing requests (which is only needed for Bluetooth tethering) without requiring an unlock command from a mobile app. Default: `false`. |
+| `fragment_id` | string | Optional | The `fragment_id` of the fragment to configure machines with. Required when using Bluetooth or the Viam mobile app for provisioning. The Viam mobile app uses the fragment to configure the machine. |
+| `hotspot_interface` | string | Optional | The interface to use for hotspot/provisioning/wifi management. Example: `"wlan0"`. Default: first discovered 802.11 device. |
+| `hotspot_password` | string | Optional | Depending on the provisioning method, this is either the Wifi password or bluetooth connection password for the provisioning hotspot. **Important:** When provisioning devices with the Viam mobile app, the password must currently be `"viamsetup"`. Be aware that if you do not set a custom password this may be a security risk. Default: `"viamsetup"`. |
+| `hotspot_prefix` | string | Optional | `viam-agent` will prepend this to the hostname of the device and use the resulting string for the provisioning hotspot SSID or the Bluetooth device name(`<hotspot_prefix>-<hostname>`).  Default: `"viam-setup"`. |
+| `manufacturer` | string | Optional | Purely informative. May be displayed on captive portal or provisioning app. Default: `"viam"`. |
+| `model` | string | Optional | Purely informative. May be displayed on captive portal or provisioning app. Default: `"custom"`. |
+| `offline_before_starting_hotspot_minutes` | integer | Optional | Amount of time the device will spend offline, in minutes, before the machine begins broadcasting a wireless hotspot. Default: `2`. |
+| `retry_connection_timeout_minutes` | integer | Optional | Provisioning mode will exit after this time (in minutes), to allow other unmanaged (for example wired) or manually configured connections to be tried. Provisioning mode will restart if the connection/online status doesn't change. Default: `10`. |
+| `turn_on_hotspot_if_wifi_has_no_internet` | boolean | Optional | When enabled, Wi-Fi connections without Internet access are considered offline. After `offline_before_starting_hotspot_minutes` minutes offline, your device will begin broadcasting a hotspot. This setting must be enabled for your device to attempt connecting to `additional_networks`. Default: `false`. |
+| `user_idle_minutes` | integer | Optional | Amount of time before considering a user (using the captive web portal or provisioning app) idle, and resuming normal behavior. Used to avoid interrupting provisioning mode (for example for network tests/retries) when a user might be busy entering details. Default: `5` (5 minutes). |
+| `wifi_power_save` | boolean | Optional | If set, will explicitly enable or disable power save for all WiFi connections managed by NetworkManager. If not set, the system default applies. Default: `null`. |
+
+For more detailed instructions on what these settings do, see [Provisioning](/fleet/provision-devices/setup/).
+
+## `additional_networks`
+
+For an already-online device, you can configure new WiFi or wired networks in the machine's [`viam-agent` configuration](/reference/platform/viam-agent/#configuration).
+It's primarily useful for a machine that moves between different networks, so the machine can automatically connect when moved between locations.
+
+<!-- prettier-ignore -->
+| Name       | Type | Required? | Description | Available with the Micro-RDK |
+| ---------- | ---- | --------- | ----------- | ---------------------------- |
+| `interface` | string | Optional | Name of interface, for example: `"wlan0"`, `"eth0"`, `"enp14s0"`. Default: `""`. | |
+| `ipv4_address` | string | Optional | IPv4 address in CIDR format, for example: `"192.168.0.1/24"`. Default: `"auto"`. | |
+| `ipv4_dns` | string | Optional | Array of IPv4 DNS such as `["192.168.0.254", "8.8.8.8"]`. Default: `[]`. | |
+| `ipv4_gateway` | string | Optional | IPv4 gateway. Default: `""`. | |
+| `ipv4_route_metric` | integer | Optional | IPv4 route metric. Lower values are preferred. Default: `0` which defaults to `100` for wired networks and `600` for wireless network. | |
+| `priority` | integer | Optional | Priority to choose the network with. Values between -999 and 999 with higher values taking precedence. Default: `0`. | <p class="center-text"><i class="fas fa-check" title="yes"></i></p> |
+| `psk` | string | Optional | The network password/pre-shared key. Default: `""`. | <p class="center-text"><i class="fas fa-check" title="yes"></i></p> |
+| `ssid` | string | Optional | The WiFi network's SSID. Only needed for WiFi networks. Default: `""`. | <p class="center-text"><i class="fas fa-check" title="yes"></i></p> |
+| `type` | string | Optional | The type of the network. Required if a network is provided. Options: `"wifi"`, `"wired"`. | |
+
+To add additional networks add them using the JSON editor for your device's config.
+
+{{< alert title="Important" color="note" >}}
+Note that if you are adding networks to a machine's configuration, the machine will need to be connected to the internet to retrieve the configuration information containing the network credentials before it can use them.
+{{< /alert >}}
+
+During provisioning, `viam-agent` will try to connect to each specified network in order of `priority` from highest to lowest.
+If the highest-priority network is not available (or, if `turn_on_hotspot_if_wifi_has_no_internet` is enabled, the machine can connect but internet is not available), `viam-agent` will then attempt to connect to the next-highest network, and so on until all configured networks have been tried.
+
+## `system-configuration`
+
+<!-- prettier-ignore -->
+| Name       | Type | Required? | Description |
+| ---------- | ---- | --------- | ----------- |
+| `forward_system_logs` | string | Optional | Enable forwarding of system logs (journald) to the cloud. A comma-separated list of SYSLOG_IDENTIFIERs to include, optionally prefixed with "-" to exclude. "all" is a special keyword to log everything. Examples: `"kernel,tailscaled,NetworkManager"` or `"all,-gdm,-tailscaled"`. Default: `""` (disabled). |
+| `logging_journald_runtime_max_use_megabytes` | integer | Optional |Set the temporary space limit for logs. `-1` to disable. Default: `512` (512 MB). |
+| `logging_journald_system_max_use_megabytes` | integer | Optional | Sets the maximum disk space `journald` will use for persistent log storage. `-1` to disable. Default: `512` (512 MB). |
+| `os_auto_upgrade_type` | string | Optional | Manage OS package updates using Viam by setting this field. Installs the `unattended-upgrades` package, and replace `20auto-upgrades` and `50unattended-upgrades` in <FILE>/etc/apt/apt.conf.d/</FILE>, with an automatically generated Origins-Pattern list that is generated based on that of `50unattended-upgrades`. Custom repos installed on the system at the time the setting is enabled will be included. Options: `"all"` (automatic upgrades are performed for all packages), `"security"` (automatic upgrades for only packages containing `"security"` in their codename (for example `bookworm-security`)), `"disable"` (disable automatic upgrades), `""` (do not change system settings). Default: `""`. |
+
+For more detailed instructions, see [Configure machine settings](/fleet/system-settings/).
+
+## Agent logs
+
+These log messages include `viam-server` stops and starts, the status of `viam-agent`, and any errors or warnings encountered during operation.
+
+{{< tabs >}}
+{{% tab name="App UI" %}}
+
+`viam-agent` writes log messages to Viam.
+
+`viam-agent` only sends messages when your machine is online and connected to the internet.
+If your machine is offline, log messages are queued and are sent to Viam once your machine reconnects to the internet.
+
+Navigate to the **LOGS** tab of your machine's page.
+
+Select from the **Levels** dropdown menu to filter the logs by severity level:
+
+{{<imgproc src="/build/program/sdks/log-level-info.png" resize="600x" declaredimensions=true alt="Filtering by log level of info in the logs tab." class="shadow imgzoom">}}
+
+{{% /tab %}}
+{{% tab name="Command line on Linux" %}}
+
+```sh {class="command-line" data-prompt="$"}
+sudo journalctl --unit=viam-agent
+```
+
+{{% /tab %}}
+{{% tab name="Command line on MacOS" %}}
+
+```sh {class="command-line" data-prompt="$"}
+less /var/log/viam-agent.log
+```
+
+{{% /tab %}}
+{{% tab name="Event Viewer on Windows" %}}
+
+Open the Windows Event Viewer (`eventvwr` from the command line).
+
+You will find the `viam-agent` logs under **Windows Logs > Application** on the **Details** tab
+
+{{<imgproc src="/manage/windows-logs.png" resize="1000x" class="imgzoom" style="width:600px" declaredimensions=true alt="Windows Event Viewer showing logs">}}
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Core options
+
+<!-- prettier-ignore -->
+| Option | Description |
+| ------ | ----------- |
+| `-c`, `--config` | Path to machine credentials file. Default: `/etc/viam.json`. |
+| `--defaults` | Path to manufacturer defaults file. Default: `/etc/viam-defaults.json` |
+| `-d`, `--debug` | Enable debug logging (on agent only). Can also be set with environment variable `VIAM_AGENT_DEBUG`. |
+| `-w`, `--wait` | Update versions before starting. Can also be set with environment variable `VIAM_AGENT_WAIT_FOR_UPDATE`. |
+| `-h`, `--help` | Show help message. |
+| `--install` | Install systemd/launchd service. |

--- a/docs/reference/platform/viam-agent/_index.md
+++ b/docs/reference/platform/viam-agent/_index.md
@@ -25,7 +25,7 @@ Among other things, `viam-agent`:
 Currently, `viam-agent` is only supported on Linux for amd64 (x86_64) and arm64 (aarch64) CPUs, MacOS for arm64 (M/silicon) CPUs, and Windows (native).
 {{< /alert >}}
 
-To provision machines using `viam-agent`, see [Provision Machines](/fleet/provision-devices/setup/).
+To provision machines using `viam-agent`, see [Provision Machines](/fleet/provision-devices/).
 
 ## Installation
 
@@ -298,7 +298,7 @@ You can also start `viam-agent` in fast start mode by setting `VIAM_AGENT_FAST_S
 | `user_idle_minutes` | integer | Optional | Amount of time before considering a user (using the captive web portal or provisioning app) idle, and resuming normal behavior. Used to avoid interrupting provisioning mode (for example for network tests/retries) when a user might be busy entering details. Default: `5` (5 minutes). |
 | `wifi_power_save` | boolean | Optional | If set, will explicitly enable or disable power save for all WiFi connections managed by NetworkManager. If not set, the system default applies. Default: `null`. |
 
-For more detailed instructions on what these settings do, see [Provisioning](/fleet/provision-devices/setup/).
+For more detailed instructions on what these settings do, see [Provisioning](/fleet/provision-devices/).
 
 ## `additional_networks`
 

--- a/docs/reference/platform/viam-agent/manage-viam-agent.md
+++ b/docs/reference/platform/viam-agent/manage-viam-agent.md
@@ -7,7 +7,237 @@ type: docs
 draft: false
 images: ["/installation/thumbnails/manage.png"]
 imageAlt: "Manage viam-agent"
-description: "Control and manage the viam-agent systemd service."
+description: "Control and manage the viam-agent system service."
 date: "2024-08-16"
+aliases:
+  - /manage/reference/viam-agent/manage-viam-agent/
+  - /installation/manage-viam-agent/
 # updated: ""  # When the content was last entirely checked
 ---
+
+[`viam-agent`](/reference/platform/viam-agent/) is installed as a `systemd` service named
+`viam-agent` on Linux, and as a `launchd` daemon named `system/com.viam.agent` on MacOS.
+
+{{< tabs >}}
+{{% tab name="Linux" %}}
+
+- To restart `viam-agent`:
+
+  {{< alert title="Alert" color="note" >}}
+  When you restart `viam-agent`, the agent will restart `viam-server` as well.
+  {{< /alert >}}
+
+  {{< tabs >}}
+  {{% tab name="Web UI" %}}
+
+  1. Navigate to your machine in [Viam](https://app.viam.com).
+  1. Click on the machine status indicator next to the machine name.
+  1. Click on the restart arrow symbol.
+     This will restart `viam-server` and `viam-agent`.
+
+  {{% /tab %}}
+  {{% tab name="Shell" %}}
+
+  ```sh {class="command-line" data-prompt="$"}
+  sudo systemctl restart viam-agent
+  ```
+
+  {{% /tab %}}
+  {{< /tabs >}}
+
+- To start `viam-agent`:
+
+  ```sh {class="command-line" data-prompt="$"}
+  sudo systemctl start viam-agent
+  ```
+
+- To stop `viam-agent`:
+
+  {{< alert title="Alert" color="note" >}}
+  When you stop `viam-agent`, the agent will stop `viam-server` as well.
+  {{< /alert >}}
+
+  ```sh {class="command-line" data-prompt="$"}
+  sudo systemctl stop viam-agent
+  ```
+
+- To completely uninstall `viam-agent` and `viam-server`, run the following command:
+
+  ```sh {class="command-line" data-prompt="$"}
+  sudo /bin/sh -c "$(curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent/uninstall.sh)"
+  ```
+
+  This command uninstalls `viam-agent`, `viam-server`, the machine cloud credentials file (<file>/etc/viam.json</file>), and the provisioning configuration file (<file>/etc/viam-provisioning.json</file>).
+
+{{< alert title="Caution" color="caution" >}}
+If you remove the machine cloud credentials file you will not be able to connect to your machine.
+You can only restore this file if you have access to the machine configuration.
+{{< /alert >}}
+
+{{% /tab %}}
+{{% tab name="MacOS" %}}
+
+- To restart `viam-agent`:
+
+  {{< alert title="Alert" color="note" >}}
+  When you restart `viam-agent`, the agent will restart `viam-server` as well.
+  {{< /alert >}}
+
+  {{< tabs >}}
+  {{% tab name="Web UI" %}}
+
+  1. Navigate to your machine in [Viam](https://app.viam.com).
+  1. Click on the machine status indicator next to the machine name.
+  1. Click on the restart arrow symbol.
+     This will restart `viam-server` and `viam-agent`.
+
+  {{% /tab %}}
+  {{% tab name="Shell" %}}
+
+  ```sh {class="command-line" data-prompt="$"}
+  sudo launchctl kickstart -k system/com.viam.agent
+  ```
+
+  {{% /tab %}}
+  {{< /tabs >}}
+
+- To start `viam-agent`:
+
+  ```sh {class="command-line" data-prompt="$"}
+  sudo launchctl kickstart system/com.viam.agent
+  ```
+
+  If the service fails to start, make sure it is bootstrapped. The following command will
+  print an error message if the service is NOT bootstrapped.
+
+  ```sh {class="command-line" data-prompt="$"}
+  sudo launchctl print system/com.viam.agent
+  ```
+
+  The following command will bootstrap the service.
+
+  ```sh {class="command-line" data-prompt="$"}
+  sudo launchctl bootstrap system /Library/LaunchDaemons/com.viam.agent.plist
+  ```
+
+  If the service STILL fails to start, ensure that it is enabled. The following command
+  will enable the service.
+
+  ```sh {class="command-line" data-prompt="$"}
+  sudo launchctl enable system/com.viam.agent
+  ```
+
+- To stop `viam-agent`:
+
+  {{< alert title="Alert" color="note" >}}
+  When you stop `viam-agent`, the agent will stop `viam-server` as well.
+  {{< /alert >}}
+
+  `sudo launchctl kill` and `sudo launchctl stop` will NOT fully stop `viam-agent`, as
+  launchd will automatically resurrect it. You can use the following to "boot out" the
+  service and fully stop it.
+
+  ```sh {class="command-line" data-prompt="$"}
+  sudo launchctl bootout system/com.viam.agent
+  ```
+
+  If you would like to start `viam-agent` again after this command, you will need to
+  bootstrap it again.
+
+  ```sh {class="command-line" data-prompt="$"}
+  sudo launchctl bootstrap system /Library/LaunchDaemons/com.viam.agent.plist
+  ```
+
+- To completely uninstall `viam-agent` and `viam-server`, run the following command:
+
+  ```sh {class="command-line" data-prompt="$"}
+  sudo /bin/sh -c "$(curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent/uninstall.sh)"
+  ```
+
+  This command uninstalls `viam-agent`, `viam-server`, and the machine cloud credentials file (<file>/etc/viam.json</file>).
+
+{{< alert title="Caution" color="caution" >}}
+If you remove the machine cloud credentials file you will not be able to connect to your machine.
+You can only restore this file if you have access to the machine configuration.
+{{< /alert >}}
+
+{{% /tab %}}
+{{% tab name="Windows native" %}}
+
+On Windows, you can manage `viam-agent` using the Services GUI or the command line.
+You can also use the Viam web UI to restart `viam-agent`.
+
+{{< tabs >}}
+{{% tab name="Services GUI" %}}
+
+1. Open the **Services** management console from your computer's start menu.
+
+1. Find `viam-agent` in the list of services.
+
+   {{<imgproc src="/manage/viam-agent-windows-services-manager.png" resize="x1100" declaredimensions=true alt="Windows Services manager with viam-agent highlighted." style="max-width:600px" class="shadow imgzoom" >}}
+
+1. Use the **Restart Service**, **Stop Service**, and **Start Service** buttons to manage `viam-agent`.
+
+1. To change the startup type of `viam-agent`, right-click on `viam-agent` and select **Properties**.
+   Select your desired startup type from the **Startup type** dropdown menu.
+
+   {{<imgproc src="/manage/startup-type-windows.png" resize="x1000" declaredimensions=true alt="Windows Services manager with viam-agent properties open." style="max-width:350px" class="shadow imgzoom" >}}
+
+{{% /tab %}}
+{{% tab name="Command line" %}}
+
+1. Open a PowerShell prompt, selecting **Run as administrator**.
+
+1. Use the following commands to manage `viam-agent`:
+
+   - To start `viam-agent`:
+
+     ```sh {class="command-line" data-prompt="$"}
+     Start-Service viam-agent
+     ```
+
+   - To stop `viam-agent`:
+
+     ```sh {class="command-line" data-prompt="$"}
+     Stop-Service viam-agent
+     ```
+
+   - To restart `viam-agent`:
+
+     ```sh {class="command-line" data-prompt="$"}
+     Restart-Service viam-agent
+     ```
+
+   - To change the startup type of `viam-agent`, use one of the following commands:
+
+     ```sh {class="command-line" data-prompt="$"}
+     Set-Service -Name "viam-agent" -StartupType Manual
+     Set-Service -Name "viam-agent" -StartupType Automatic
+     ```
+
+{{% /tab %}}
+{{% tab name="Web UI" %}}
+
+1. Navigate to your machine in [Viam](https://app.viam.com).
+1. Click on the machine status indicator next to the machine name.
+1. Click on the restart arrow symbol.
+   This will restart `viam-server` and `viam-agent`.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+To uninstall `viam-agent`, run the following command in an administrator prompt:
+
+```sh {class="command-line" data-prompt="$"}
+sc stop viam-agent
+sc delete viam-agent
+Remove-Item \opt\viam -Recurse
+Remove-Item C:\Windows\system32\config\systemprofile\.viam -Recurse
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Troubleshooting
+
+You can find assistance in the [Troubleshooting section](/manage/troubleshoot/troubleshoot/).

--- a/docs/reference/platform/viam-micro-server.md
+++ b/docs/reference/platform/viam-micro-server.md
@@ -1,12 +1,404 @@
 ---
-title: "The Micro-RDK and viam-micro-server"
-linkTitle: "viam-micro-server"
-weight: 40
-type: docs
-images: ["/installation/thumbnails/esp32-espressif.png"]
-imageAlt: "E S P 32 - espressif"
-description: "Set up the Espressif ESP32 for development with `viam-micro-server`."
-date: "2024-09-03"
-# updated: ""  # When the content was last entirely checked
-# SMEs: Nicolas M., Gautham V., Andrew M.
+linkTitle: "Set up an ESP32"
+title: "Set up an ESP32"
+weight: 25
+layout: "docs"
+type: "docs"
+images: ["/installation/thumbnails/install.png"]
+imageAlt: "Install Viam"
+no_list: false
+description: "Install the lightweight version of the software that drives hardware and connects your device to the cloud."
+aliases:
+  - /operate/install/setup-micro/
+  - /installation/microcontrollers/
+  - /installation/prepare/microcontrollers/
+  - /installation/prepare/microcontrollers/
+  - /build/micro-rdk/
+  - /get-started/installation/microcontrollers/
+  - /installation/viam-micro-server-setup/
+  - /operate/reference/viam-micro-server/viam-micro-server-troubleshooting/
+  - /operate/get-started/setup-micro/
 ---
+
+Viam maintains a [lightweight version of `viam-server`](/reference/platform/viam-micro-server/) for microcontrollers.
+
+## Supported microcontrollers
+
+To work with Viam's Micro-RDK, ESP32 microcontrollers must have at least:
+
+- 2 cores
+- 384kB SRAM
+- 2MB PSRAM
+- 8MB flash
+
+The following microcontrollers have been tested with Viam:
+
+- [ESP32-WROVER Series](https://www.espressif.com/en/products/modules/esp32)
+
+{{% hiddencontent %}}
+The Micro-RDK and `viam-micro-server` do not support 32-bit Linux.
+{{% /hiddencontent %}}
+
+## About ESP32 microcontroller setup
+
+Microcontrollers do not run operating systems and are instead flashed with dedicated firmware.
+Because of this, the microcontroller setup process is different than for SBCs, laptops, and desktops.
+
+To use an ESP32 controller with custom hardware, you build a firmware version from the Micro-RDK and modules to support your hardware.
+
+To quickly try out Viam for microcontrollers, you can use the pre-built binary `viam-micro-server` which supports the following components:
+
+- [`gpio`](/reference/components/servo/gpio-micro-rdk/): A servo controlled by GPIO pins.
+- [`two_wheeled_base`](/reference/components/base/two_wheeled_base/): A robotic base with differential steering.
+- [`free_heap_sensor`](https://github.com/viamrobotics/micro-rdk/tree/main/examples/modular-drivers/src): Reports the amount of free heap memory on the microcontroller.
+- [`wifi_rssi_sensor`](https://github.com/viamrobotics/micro-rdk/tree/main/examples/modular-drivers/src): Reports the signal strength of the ESP32's WiFi connection.
+
+## Quickstart with pre-built firmware
+
+{{% hiddencontent %}}
+Viam provides installers to flash an ESP32 from macOS or Linux running on the x86_64 or ARM64 (AArch64) processor architectures.
+{{% /hiddencontent %}}
+
+To get started quickly with the pre-built `viam-micro-server` binary, follow these steps:
+
+1. Create a Viam account on [app.viam.com](https://app.viam.com).
+   You can configure and manage devices and data collection in the web UI.
+
+1. Add a new _{{< glossary_tooltip term_id="machine" text="machine" >}}_ using the button in the top right corner of the **LOCATIONS** tab in the app.
+   A machine represents your device.
+
+1. On your machine's page, click **View setup instructions** and follow the steps for your operating system.
+   The app provides commands to install `viam-micro-server` and connect it to the cloud with your machine's unique credentials.
+
+1. A secure connection is automatically established between your machine and Viam.
+   When you update your machine's configuration, `viam-micro-server` automatically gets the updates.
+
+   You are ready to [configure](#configure-and-test-your-machine) any of the components listed above on your machine.
+
+## Build and flash custom firmware
+
+If you are using your ESP32 with resources that are not supported by the pre-built binary, you can build your own firmware with the Micro-RDK and your choice of {{< glossary_tooltip term_id="module" text="modules" >}}.
+
+### Set up your development environment
+
+The [Micro-RDK](https://github.com/viamrobotics/micro-rdk) (from which `viam-micro-server` is built) is written in Rust.
+To be able to develop for the Micro-RDK on macOS and Linux systems, you must install the following software on your development machine:
+
+1. Install dependencies:
+
+   {{< tabs >}}
+   {{% tab name="Linux" %}}
+
+   ```sh { class="command-line" data-prompt="$"}
+   sudo apt-get install bison ccache cmake curl dfu-util flex git gperf libffi-dev libssl-dev libudev-dev libusb-1.0-0 ninja-build python3 python3-pip python3-venv wget
+   ```
+
+   {{% /tab %}}
+   {{% tab name="macOS" %}}
+
+   If you haven't already, [install Homebrew](https://brew.sh/).
+
+   Then, install dependencies:
+
+   ```sh { class="command-line" data-prompt="$"}
+   brew install cmake dfu-util ninja
+   ```
+
+   {{% /tab %}}
+   {{< /tabs >}}
+
+1. If you do not yet have a Rust environment installed, install it with `rustup`.
+
+   ```sh { class="command-line" data-prompt="$"}
+   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+   ```
+
+   Once completed, start a new shell instance, or run `. "$HOME/.cargo/env"` in the current one.
+
+   See the [Rust Installation guide](https://www.rust-lang.org/tools/install) for more information and other installation methods.
+
+1. Install `espup` and ESP development utilities with `cargo`:
+
+   ```sh { class="command-line" data-prompt="$"}
+   cargo install cargo-espflash cargo-generate espflash espup ldproxy
+   ```
+
+1. Use `espup` to download and install the ESP Rust toolchain:
+
+   ```sh { class="command-line" data-prompt="$"}
+   espup install -s -f /dev/null -v 1.85.0
+   ```
+
+{{% hiddencontent %}}
+Prior versions of the above `espup` instructions created a file called `export-rs.sh` which needed to be sourced before proceeding.
+That requirement [no longer applies](https://github.com/esp-rs/esp-idf-hal/issues/319#issuecomment-1785168921) for Micro-RDK development.
+The above command redirects `espup`'s production of the setup script to `/dev/null` to avoid cluttering the home directory.
+If you would like to instead retain the setup script, replace `/dev/null` in the above command with the location where you would like the script to be written, or remove the `-f /dev/null` entirely and the file will be written to `$HOME/export-esp.sh` by default.
+{{% /hiddencontent %}}
+
+### Build your firmware
+
+Create firmware that integrates an existing module with the Micro-RDK:
+
+1. Create a new machine and obtain its credentials:
+
+   Add a new machine on [Viam](https://app.viam.com).
+   Click on the name of the machine to go to the machine's page, then select the **CONFIGURE** tab.
+
+   Then select the part status dropdown to the right of your machine's name on the top of the page and copy the **Machine cloud credentials**:
+
+   {{<imgproc src="/get-started/micro-credentials.png" resize="450x" declaredimensions=true alt="Machine part info menu accessed by Live status indicator, with machine cloud credentials button highlighted." class="shadow" >}}
+
+   The Micro-RDK needs these credentials, which contain your machine part secret key and cloud app address, to connect to Viam.
+
+1. Generate a new project skeleton from [this template](https://github.com/viamrobotics/micro-rdk/tree/main/templates/project):
+
+   ```sh { class="command-line" data-prompt="$"}
+   cargo generate --git https://github.com/viamrobotics/micro-rdk.git
+   ```
+
+   Follow the prompts:
+
+   - Which sub-template should be expanded?: `templates/project`.
+   - Project name: Your choice.
+   - MCU: `esp32`.
+   - Include camera module?: If you will use an `esp32-camera` or a `fake` camera as a component of your machine, select `true`.
+   - Machine cloud credentials: Paste in the machine cloud credentials you obtained in step 1.
+   - Enter Wi-Fi name: The name of the Wi-Fi network for the ESP32 to connect to on boot. Note that you must provide a 2.4 GHz network.
+   - Enter the Wi-Fi password: The password for the 2.GHz WiFi network.
+
+   Hit **Enter** to generate the project.
+   The CLI automatically initializes a git repository in the generated directory for version control.
+
+1. Navigate into the generated project:
+
+   ```sh { class="command-line" data-prompt="$"}
+   cd <path-to/your-project-directory>
+   ```
+
+1. Add any desired modules to the project by including them in the `dependencies` section of the `Cargo.toml` for the generated project:
+
+   {{< tabs >}}
+   {{% tab name="Local path dependency" %}}
+
+   While developing a module, you'll typically use a local path dependency to reference your module directory, for example:
+
+   ```toml {class="line-numbers linkable-line-numbers" data-line="3"}
+   [dependencies]
+   ...
+   my-module = { path = "../my-module" }
+   ```
+
+   {{% /tab %}}
+   {{% tab name="Git repository dependency" %}}
+
+   For modules hosted in a Git repository, specify the repository URL and optionally a specific commit (`rev`), branch (`branch`), or tag (`tag`), for example:
+
+   ```toml {class="line-numbers linkable-line-numbers" data-line="3"}
+   [dependencies]
+   ...
+   my-module = { git = "https://github.com/username/my-module.git", tag = "v1.0.0" }
+   ```
+
+   To use any of the [example modules](https://github.com/viamrobotics/micro-rdk/blob/main/examples/modular-drivers/README.md#example-modules) provided by Viam, use this line, specifying the Micro-RDK version that matches your development environment:
+
+   ```toml {class="line-numbers linkable-line-numbers" data-line="3"}
+   [dependencies]
+   ...
+   micro-rdk-modular-driver-example = { git = "https://github.com/viamrobotics/micro-rdk.git", rev = "v0.5.0", package = "micro-rdk-modular-driver-example", features = ["esp32"] }
+   ```
+
+   {{% /tab %}}
+   {{< /tabs >}}
+
+1. Compile the project:
+
+   ```sh { class="command-line" data-prompt="$"}
+   make build-esp32-bin
+   ```
+
+   The first build can take a few minutes, as ESP-IDF must be cloned and built, and all dependent Rust crates must be fetched and built.
+   Subsequent builds will be faster.
+
+### Flash your ESP32
+
+Upload the generated firmware to your ESP32:
+
+1. Use a data cable to connect your ESP32 board to a USB port on your development machine.
+
+1. Run the following command to flash the firmware to your ESP32:
+
+   ```sh { class="command-line" data-prompt="$"}
+   make flash-esp32-bin
+   ```
+
+   When prompted, select the serial port that your ESP32 is connected to through a data cable.
+
+   If the flash is successful, you will retain a serial connection to the board until you press `Ctrl-C`.
+   While the serial connection is live, you can also restart the currently flashed image with `Ctrl-R`.
+
+1. Navigate to your new machine's page.
+   If successful, the status indicator should turn green and show the **Live** status.
+
+### Configure and test your machine
+
+You can now configure the models you included in your firmware and test them:
+
+1. Navigate to your machine's page.
+
+1. From the **CONFIGURE** tab, click **JSON** mode.
+   Micro-RDK components and services must be configured in JSON.
+
+1. Add your components and services to the machine configuration.
+   If you are using one of the example modules, find configuration details in the [example modules README](https://github.com/viamrobotics/micro-rdk/blob/main/examples/modular-drivers/README.md#example-modules).
+   For example, if you want to use a free heap sensor, your configuration could look like this:
+
+   ```json
+   {
+     "components": [
+       {
+         "name": "my-free-heap-sensor",
+         "api": "rdk:component:sensor",
+         "model": "free-heap",
+         "attributes": {}
+       }
+     ]
+   }
+   ```
+
+1. Click **Builder** mode and find the configuration card of the component you want to test.
+
+1. Click to open the **Test** section of the card and use the interface to test the component.
+
+1. If you make changes to your module code, rerun the build and flash steps to update the firmware and test the new version on your ESP32.
+
+## Configure over-the-air updates
+
+You can update the firmware on your microcontroller without a physical connection.
+
+{{% hiddencontent %}}
+Over-the-air updates are available for `viam-server` and the Micro-RDK. For information about `viam-server` see [Deploy software packages to machines](/manage/software/deploy-software/).
+The following information covers the Micro-RDK.
+{{% /hiddencontent %}}
+
+The first time you flash your microcontroller, you must build a full firmware image, and use a data cable to flash it to your microcontroller.
+After the initial flash, you can update the firmware remotely by using the over-the-air (OTA) service to pull [cloud-hosted, OTA-ready firmware](#build-and-host-ota-firmware) from a URL.
+
+The firmware hosting endpoint must use HTTP/2.
+
+To configure OTA updates:
+
+1. On your machine's page, go to the **CONFIGURE** tab and select **JSON** mode.
+
+1. Paste in the template below, then configure the URL from which to fetch new firmware, and a version name of your choice.
+   The value of the `version` field is not directly used by the OTA service, so you can use any string.
+
+   {{< tabs >}}
+   {{% tab name="JSON Template" %}}
+
+```json {class="line-numbers linkable-line-numbers" data-line="3-11"}
+{
+  "services": [
+    {
+      "name": "OTA",
+      "api": "rdk:service:generic",
+      "model": "rdk:builtin:ota_service",
+      "attributes": {
+        "url": "<URL where firmware is stored in cloud storage>",
+        "version": "<version name>"
+      }
+    }
+  ]
+}
+```
+
+{{% /tab %}}
+{{% tab name="JSON Example" %}}
+
+```json {class="line-numbers linkable-line-numbers"}
+{
+  "services": [
+    {
+      "name": "OTA",
+      "api": "rdk:service:generic",
+      "model": "rdk:builtin:ota_service",
+      "attributes": {
+        "url": "https://github.com/Jessamy/modulefirmware/releases/download/v0.1.2/modulefirmware-ota.bin",
+        "version": "myVersion1"
+      }
+    }
+  ]
+}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+Your device checks for configuration updates periodically.
+If the device receives a configuration with a modified `version` field, the device downloads the new firmware to an inactive partition and restarts.
+When the device boots it loads the new firmware.
+
+To trigger a remote update of the firmware on your microcontroller after the initial configuration, edit the `version` field and save the config.
+
+{{% alert title="Note" color="note" %}}
+There is no way to roll back to previous firmware after a bad upgrade without reflashing the device with a physical connection, so test your firmware thoroughly before deploying it to a fleet.
+{{% /alert %}}
+
+### Update multiple microcontrollers at the same time
+
+To update the firmware version for a group of microcontrollers at the same time, you can [create a fragment](/manage/software/deploy-software/) with the OTA service configuration and apply it to multiple machines.
+Then, whenever you update the `version` field in the fragment, the version will be updated for each machine that has that fragment in its config, triggering a firmware update the next time the devices fetch their configs.
+
+### Build and host OTA firmware
+
+To use the OTA service, you must host your firmware in the cloud so that it can be accessed at a URL.
+
+GitHub workflows simplify the process of building and hosting your firmware by eliminating the need to build locally and then upload the firmware image to a cloud storage bucket.
+
+{{< tabs >}}
+{{% tab name="Use GitHub workflows (recommended)" %}}
+
+To build firmware on GitHub, follow these steps:
+
+1. [Create a firmware project](#build-and-flash-custom-firmware).
+   _Do not include Wi-Fi credentials or machine cloud credentials in the project_, since you will be publishing the project to a public GitHub repository.
+   The OTA service does not modify the partition containing the machine cloud credentials and WiFi credentials, so OTA updates do not require the credentials.
+
+1. Create a public GitHub repository for your firmware project, and upload the contents of the firmware project directory to the repository.
+   The `templates/project` template you used to create your project contains a GitHub workflow file that is used to build your firmware.
+
+1. In the firmware GitHub repository, navigate to **Settings** &rarr; **Actions** &rarr; **General** and enable **Read and write permissions**.
+
+1. Go to the firmware GitHub repository's **Releases** page and create a new release.
+   Create a tag starting with `v` followed by a version number, for example `v1.0.0`.
+   Click **Publish release** to trigger a build of the firmware.
+
+To deploy the firmware:
+
+1. Wait for the build to complete.
+
+1. In your firmware GitHub repository, navigate to the **Releases** page and find the assets for the release you just created.
+   The assets include the full and OTA firmware images.
+   Copy the URL of the OTA firmware image.
+
+1. Navigate to your machine's **CONFIGURE** tab and [configure the OTA service](#configure-over-the-air-updates) with the URL of the firmware image you just copied.
+
+{{% /tab %}}
+{{% tab name="Build locally and host manually" %}}
+
+If you want to use OTA updates, but don't want to use GitHub Actions, follow these steps:
+
+1. Build the OTA firmware locally with the following command:
+
+   ```sh { class="command-line" data-prompt="$"}
+   make build-esp32-ota
+   ```
+
+   Note that this is different from the `make build-esp32-bin` command, which builds a full firmware image that you must use the first time you flash your microcontroller.
+
+1. Upload the OTA firmware image to a cloud storage bucket.
+
+1. Configure the URL of the cloud storage bucket in your microcontroller's OTA service configuration.
+
+{{% /tab %}}
+{{< /tabs >}}

--- a/docs/reference/platform/viam-server/_index.md
+++ b/docs/reference/platform/viam-server/_index.md
@@ -5,6 +5,468 @@ weight: 31
 type: "docs"
 description: "viam-server is the open-source, on-machine portion of the Viam platform."
 tags: ["server", "rdk"]
+aliases:
+  - "/product-overviews/rdk"
+  - "/build/program/rdk"
+  - /internals/rdk/
+  - /architecture/rdk/
+  - /architecture/viam-server/
+  - /internals/local-configuration-file/
+  - /operate/reference/viam-server/local-configuration-file/
 date: "2022-01-01"
 # updated: ""  # When the content was last entirely checked
 ---
+
+The `viam-server` executable runs on a computer and manages hardware, software, and data for a machine.
+`viam-server` is built from the open-source [Robot Development Kit (RDK)](https://github.com/viamrobotics/rdk).
+If you are working with microcontrollers, [`viam-micro-server`](/reference/platform/viam-micro-server/) is a lightweight version of `viam-server` which can run on resource-limited embedded systems that cannot run the fully-featured `viam-server`.
+
+To use Viam with a machine, you create a configuration specifying which hardware and software the machine consists of.
+`viam-server` then manages and runs the drivers for the configured {{< glossary_tooltip term_id="resource" text="resources" >}}.
+
+Overall, `viam-server` manages:
+
+- [Communication](#communication)
+- [Start-up](#start-up)
+- [Reconfiguration](#reconfiguration)
+- [Maintenance windows](#maintenance-window)
+- [Shutdown](#shutdown)
+- [Logging](#logging)
+
+## Communication
+
+`viam-server` handles all {{< glossary_tooltip term_id="grpc" text="gRPC" >}} and {{< glossary_tooltip term_id="webrtc" >}} communication for connecting machines to the cloud or for connecting to other parts of your machine.
+
+All communication happens securely over HTTPS using secret tokens that are in the machine's config.
+
+## Lifecycle
+
+### Start-up
+
+The machine setup steps copy your machine's credentials to your machine.
+When you turn on your machine, `viam-server` starts up and uses the provided credentials to fetch its configuration from Viam.
+
+`viam-server` ensures that any configured {{< glossary_tooltip term_id="module" text="modules" >}}, {{< glossary_tooltip term_id="resource" text="built-in resources" >}} and {{< glossary_tooltip term_id="modular-resource" text="modular resources" >}} are loaded on startup.
+`viam-server` handles [dependency](/operate/modules/advanced/dependencies/) management between resources.
+
+After start-up, `viam-server` manages:
+
+- the connections to hardware,
+- the running services, and
+- the {{< glossary_tooltip term_id="module" text="modules" >}} that provide the {{< glossary_tooltip term_id="modular-resource" text="modular resources" >}}.
+
+### Reconfiguration
+
+Once the machine has a configuration, it caches it locally (in a file at <FILE>~/.viam/cached_cloud_config\_\<PART-ID\>.json</FILE>) and can use the config for up to 60 days.
+Since the configuration is cached locally, your machine does not need to stay connected to Viam after it has obtained its configuration file.
+
+If it is online, the machine automatically checks for new configurations every 15 seconds.
+When you or your collaborators change the configuration of a machine, `viam-server` automatically synchronizes the configuration to your machine and updates the running resources.
+
+Reconfiguration of individual resources happens concurrently if there are no configured dependencies for any resources.
+If there are configured dependencies, resources are reconfigured in groups.
+
+You can see configuration changes made by yourself or by your collaborators by selecting **History** on the right side of your machine part's card on the **CONFIGURE** tab.
+You can also revert to an earlier configuration from the History tab.
+
+{{% hiddencontent %}}
+If you want to force a reconfiguration of a resource, you can click the **Disable** button in the resource menu, save, and then re-enable the resource.
+
+Alternatively, if you are having issues with a module, try the **Restart module** button in the module menu.
+{{% /hiddencontent %}}
+
+### Maintenance window
+
+There are a few updates that may make your machine temporarily unavailable:
+
+- [`viam-agent` updating itself](/reference/platform/viam-agent/#version-control)
+- [`viam-agent` updating `viam-server`](/reference/platform/viam-agent/#update-or-downgrade-viam-server-with-viam-agent)
+- configuration updates
+
+To avoid performing these updates until your machine is ready for maintenance, you can define a maintenance window.
+A maintenance window consists of one or multiple conditions that determine if maintenance is currently allowed.
+To configure a maintenance window, you need to create a sensor that returns true when your maintenance conditions are met and false otherwise.
+
+{{< tabs >}}
+{{% tab name="Builder UI" %}}
+
+To configure a maintenance window, click the **+** icon next to your {{< glossary_tooltip term_id="part" text="machine part" >}} in the left-hand menu of the **CONFIGURE** tab and select **Maintenance window**.
+
+In the new panel, specify the name of the sensor and the key for the value to be used to determine when maintenance is allowed.
+
+{{% /tab %}}
+{{% tab name="JSON" %}}
+
+To configure a maintenance window, add the following configuration to your machine's JSON configuration:
+
+```json
+// components: [ ... ],
+// services: [ ... ],
+maintenance : {
+   "sensor_name" : string,
+   "maintenance_allowed_key" : string
+}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+<!-- prettier-ignore -->
+| Attribute | Type | Required? | Description |
+| --------- | ---- | --------- | ----------- |
+| `sensor_name` | string | **Required** | The full name of the sensor that provides the information if it is safe to update a machine's configuration. For example `rdk:component:sensor/sensor1`. |
+| `maintenance_allowed_key` | string | **Required** | The key of the key value pair for the reading returned by the sensor. |
+
+### Shutdown
+
+During machine shutdown, `viam-server` handles modular resource instances similarly to built-in resource instances - it signals them for shutdown in topological (dependency) order.
+
+## Logging
+
+Log messages appear under the [**LOGS** tab](/manage/troubleshoot/troubleshoot/#check-logs) for a machine.
+
+The default log level for `viam-server` and any running resources is `"Info"`.
+Logs are stored for 30 days before they are deleted.
+
+If you need more logs for an individual resource, click **Enable debug logs** in the **...** menu on the resource.
+
+To set other log levels for individual resources, add the `log_configuration` option to the resource's JSON configuration:
+
+```json
+"log_configuration": {
+    "level": "Debug"
+},
+"attributes": { ... }
+```
+
+For modular resources, you must instead set the `log_level` attribute on the module itself:
+
+```json {class="line-numbers linkable-line-numbers" data-line="3"}
+"module_id": "viam:raspberry-pi",
+"version": "1.9.0",
+"log_level":  "debug"
+```
+
+Alternatively, you can configure logs for all machine resources, inside your machine config.
+To specify the log level for a specific resource, add the `log` field to your machine config:
+
+For example:
+
+```json
+"components": [ ... ]
+"log": [
+    {
+    "pattern": "rdk.components.arm",
+    "level": "debug",
+    }, {
+    "pattern": "rdk.services.*",
+    "level": "debug",
+    }, {
+    "pattern": "<module-name>",
+    "level": "debug",
+    }
+]
+```
+
+<!-- prettier-ignore -->
+| Attribute | Description |
+| --------- | ----------- |
+| `pattern` | A regular expression (regex) pattern matching one or more resources. |
+| `level` | The log level: `"debug"`, `"info"`, `"warn"`, or `"error"`. |
+
+Patterns are processed from top to bottom.
+If multiple patterns apply, the last pattern to be processed will apply.
+If log configurations are applied at a resource level using the `log_configuration` field, these take precedence over log levels applied in the `log` field of the machine configuration.
+
+{{% expand "Click to view full configuration example" %}}
+
+```json {class="line-numbers linkable-line-numbers" data-line="10-18"}
+{
+  "components": [
+    {
+      "name": "camera1",
+      "api": "rdk:component:camera",
+      "model": "fake"
+    }
+  ],
+  "services": [],
+  "log": [
+    {
+      "pattern": "rdk.resource_manager",
+      "level": "info"
+    },
+    {
+      "pattern": "rdk.resource_manager.*",
+      "level": "debug"
+    }
+  ]
+}
+```
+
+{{% /expand%}}
+
+### Disable log deduplication
+
+By default, `viam-server` deduplicates log messages that are deemed noisy.
+A log is deemed noisy if it has been output 3 times in the past 10 seconds.
+
+To disable log deduplication, set `disable_log_deduplication` in your machine's configuration:
+
+```json
+"disable_log_deduplication": true
+```
+
+{{% expand "Click to view full configuration example" %}}
+
+```json {class="line-numbers linkable-line-numbers" data-line="10"}
+{
+  "components": [
+    {
+      "name": "camera1",
+      "api": "rdk:component:camera",
+      "model": "fake"
+    }
+  ],
+  "services": [],
+  "disable_log_deduplication": true
+}
+```
+
+{{% /expand%}}
+
+### Delete machine logs
+
+You cannot delete machine logs.
+If your machine has generated a large amount of logs and you are concerned about the cost, you can:
+
+1. Copy the machine's configuration to a new machine.
+2. Delete the old machine.
+
+If you delete a machine you will not be charged for the remainder of the 30 days until logs from that machine are deleted.
+
+### Debugging
+
+You can enable debug level logs in two ways:
+
+- Start `viam-server` with the `-debug` option.
+- Add `"debug": true` to the machine's configuration:
+
+  ```json
+  {
+    "debug": true,
+    "components": [{ ... }]
+  }
+  ```
+
+Enabling debug level logs will take precedence over all logging configuration set using the `log` field on a machine or the `log_configuration` field on a resource.
+
+## Core options
+
+<!-- prettier-ignore -->
+| Option | Description |
+| ------ | ----------- |
+| `-allow-insecure-creds` | Allow connections to send credentials over plaintext. |
+| `-config <filename>` | The machine configuration file containing machine cloud credentials or a full configuration. |
+| `-cpuprofile string` | Write CPU profile to file. |
+| `-debug` | Enable debug level logs. |
+| `-disable-mdns` | Disable server discovery through multicast DNS. |
+| `-dump-resources <filepath>` | Dump all resource registrations as JSON to the provided file path. |
+| `-ftdc` | Enable fulltime data capture for diagnostics. Default: `true`. |
+| `-log-file <filename>` | Write logs to a file with log rotation. |
+| `-network-check` | Only runs normal network checks. |
+| `-no-tls` | Starts an insecure HTTP server without TLS certificates even if one exists. |
+| `-output-telemetry` | Print out telemetry data (metrics and spans). |
+| `-reveal-sensitive-config-diffs` | Show config diffs. |
+| `-shareddir <directory-name>` | The location of the static web assets. |
+| `-untrusted-env` | Disable processes and shell from running in an untrusted environment. |
+| `-version` | Print version. |
+| `-webprofile` | Include profiler in HTTP server. |
+| `-webrtc` | Force WebRTC connections instead of direct connections. Default: `true`. |
+
+## Install `viam-server` without the web UI
+
+{{% alert title="Tip" color="tip" %}}
+The recommended way to install `viam-server` and connect your machine to Viam is covered in the [Set up a computer or SBC guide](/operate/install/setup/).
+{{% /alert %}}
+
+If you need to install `viam-server` without the web UI, you can run the following commands.
+
+{{< tabs >}}
+{{% tab name="Linux (Aarch64)" %}}
+{{< tabs >}}
+{{% tab name="Install manually" %}}
+
+```bash {class="line-numbers linkable-line-numbers"}
+curl https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-stable-aarch64.AppImage -o viam-server
+```
+
+Next, to make the `viam-server` executable and install as a system service, run the following command:
+
+```bash {class="line-numbers linkable-line-numbers"}
+chmod 755 viam-server && sudo ./viam-server --aix-install
+```
+
+The `viam-server` binary is installed at <FILE>/usr/local/bin/viam-server</FILE>.
+
+{{% /tab %}}
+{{% tab name="Install using viam-agent" %}}
+
+```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+sudo /bin/sh -c "$(curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent/install.sh)"
+```
+
+The `viam-agent` and `viam-server` binaries are installed at <FILE>/opt/viam/bin/viam-server</FILE>.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+{{% /tab %}}
+{{% tab name="Linux (x86_64)" %}}
+
+{{< tabs >}}
+{{% tab name="Install manually" %}}
+
+```bash {class="line-numbers linkable-line-numbers"}
+curl https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-stable-x86_64.AppImage -o viam-server
+```
+
+Next, to make the `viam-server` executable and install as a system service, run the following command:
+
+```bash {class="line-numbers linkable-line-numbers"}
+chmod 755 viam-server && sudo ./viam-server --aix-install
+```
+
+The `viam-server` binary is installed at <FILE>/usr/local/bin/viam-server</FILE>.
+
+{{% /tab %}}
+{{% tab name="Install using viam-agent" %}}
+
+```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
+sudo /bin/sh -c "$(curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent/install.sh)"
+```
+
+The `viam-agent` and `viam-server` binaries are installed at <FILE>/opt/viam/bin/viam-server</FILE>.
+
+{{% /tab %}}
+{{< /tabs >}}
+{{% /tab %}}
+{{% tab name="macOS" %}}
+
+```bash {class="line-numbers linkable-line-numbers"}
+brew tap viamrobotics/brews && brew install viam-server
+```
+
+The `viam-server` binary is installed at <FILE>/opt/homebrew/bin/viam-server</FILE>.
+
+The brew installation of `viam-server` CANNOT be run as a system service in the
+background. If you would like to run `viam-server` in the background, install
+[`viam-agent`](/reference/platform/viam-agent/) instead.
+
+{{% /tab %}}
+{{% tab name="Windows Subsystem for Linux (WSL)" %}}
+
+```bash {class="line-numbers linkable-line-numbers"}
+curl https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-stable-x86_64 -o viam-server && chmod 755 viam-server
+```
+
+{{% /tab %}}
+{{% tab name="Windows native" %}}
+
+Manual installation is not available for native Windows; you must download the [Viam Agent installer](https://storage.googleapis.com/packages.viam.com/apps/viam-agent/viam-agent-windows-installer.exe).
+
+The `viam-agent` and `viam-server` binaries are installed at <FILE>C:\opt\viam\cache</FILE>.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### Install a specific version of `viam-server`
+
+In some cases, you may need to install an older version of `viam-server`.
+
+{{< tabs name="Install specific version of viam-server" >}}
+{{% tab name="Linux" %}}
+
+For Linux systems, the recommended approach to install an older version is to build from source:
+
+```sh {class="command-line" data-prompt="$"}
+# Clone the RDK repository
+git clone https://github.com/viamrobotics/rdk.git
+
+# Change to the RDK directory
+cd rdk
+
+# Check out a specific version tag (replace v0.46.0 with your desired version)
+git checkout v0.46.0
+
+# Build the server
+make server
+
+# The binary will be available in the bin directory for your architecture
+cd bin/Linux-amd64  # or Linux-arm64 for ARM-based systems
+```
+
+You can then run the server directly:
+
+```sh {class="command-line" data-prompt="$"}
+sudo ./viam-server -config /path/to/your/config.json
+```
+
+{{% /tab %}}
+{{% tab name="macOS" %}}
+
+There are two approaches to installing an older version of `viam-server` on macOS:
+
+### Option 1: Build from source
+
+The most reliable way to install a specific version of `viam-server` is to clone the RDK repository at a specific tag and build it yourself:
+
+```sh {class="command-line" data-prompt="$"}
+# Clone the RDK repository
+git clone https://github.com/viamrobotics/rdk.git
+
+# Change to the RDK directory
+cd rdk
+
+# Check out a specific version tag (replace v0.46.0 with your desired version)
+git checkout v0.46.0
+
+# Build the server
+make server
+
+# The binary will be available in the bin directory for your architecture
+cd bin/Darwin-arm64  # Use the folder matching your architecture
+```
+
+You can then run the server directly:
+
+```sh {class="command-line" data-prompt="$"}
+./viam-server -config /path/to/your/config.json
+```
+
+### Option 2: Use an older version of the Homebrew tap
+
+If you've already installed `viam-server` with Homebrew, you can try checking out an older version of the Viam Homebrew tap:
+
+```sh {class="command-line" data-prompt="$"}
+# Navigate to the Homebrew tap directory
+cd /opt/homebrew/Library/Taps/viamrobotics/homebrew-brews/
+
+# Check out an older version of the tap
+git checkout <older-commit-hash>
+
+# Reinstall viam-server
+brew reinstall viam-server
+```
+
+Note that this method may not work for versions that are too old, as Homebrew doesn't officially support installing older versions of dependencies. If the version you need is significantly older, building from source (Option 1) is recommended.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Next steps
+
+{{< cards >}}
+{{% card link="/reference/apis/" %}}
+{{% card link="/operate/modules/configure-modules/" %}}
+{{% card link="/operate/install/setup/" %}}
+{{< /cards >}}

--- a/docs/reference/platform/viam-server/debug-endpoints.md
+++ b/docs/reference/platform/viam-server/debug-endpoints.md
@@ -5,4 +5,92 @@ weight: 130
 type: "docs"
 description: "Advanced debugging endpoints available in viam-server for troubleshooting and development."
 date: "2025-05-19"
+aliases:
+  - /operate/reference/viam-server/debug-endpoints/
 ---
+
+The RDK (Robot Development Kit) that powers `viam-server` includes several debug endpoints that expose server internals.
+These endpoints can be helpful during development or when troubleshooting complex issues:
+
+- [`pprof`](#pprof)
+- [`graph`](#graph)
+
+## `pprof`
+
+Setting `enable_web_profile` to `true` in your machine configuration allows you to visualize runtime profiling data by opening a locally hosted webpage that displays profiling data.
+The pprof tool provides the following information about machine performance:
+
+- CPU usage
+- Memory allocation
+- Goroutine blocking
+- Execution tracing
+
+For more detailed information on using pprof, refer to the [Go pprof documentation](https://pkg.go.dev/net/http/pprof).
+
+### Configuration
+
+To enable the pprof endpoints, set `enable_web_profile` to `true` in your machine configuration:
+
+1. Navigate to the **CONFIGURE** tab of your machine
+1. Click on the **...** menu next to your machine part in the left-hand menu
+1. Select **Edit JSON**
+1. Add the `enable_web_profile` field at the root level of your configuration:
+
+```json
+{
+  "components": [...],
+  "services": [...],
+  "enable_web_profile": true
+}
+```
+
+{{< alert title="Caution" color="caution" >}}
+The debug endpoints expose internal details about your machine's configuration and runtime behavior.
+Only enable these endpoints in development environments.
+{{< /alert >}}
+
+### Available Endpoints
+
+Once enabled, you can access the pprof interface by navigating to `https://localhost:8080/debug/pprof/` in your browser.
+
+The following pprof routes are available:
+
+- `/debug/pprof/cmdline`: Command line arguments used to start the process
+- `/debug/pprof/profile`: CPU profile data (30-second sample by default)
+- `/debug/pprof/symbol`: Symbol lookup for program counters
+- `/debug/pprof/trace`: Execution trace data
+
+## `graph`
+
+The `/debug/graph` endpoint shows a graphical representation of the machine resources managed by the RDK.
+
+To access this endpoint, visit `https://localhost:8080/debug/graph` on the machine.
+
+### Layout Options
+
+To view different [layouts](https://graphviz.org/docs/layouts/), use the `layout` query parameter:
+
+The following example URL specifies the `circo` layout:
+
+```txt
+https://localhost:8080/debug/graph?layout=circo
+```
+
+Available layout options include:
+
+- `dot` (default): Hierarchical layout
+- `neato`: Spring model layout
+- `fdp`: Force-directed layout
+- `sfdp`: Multiscale version of fdp for large graphs
+- `circo`: Circular layout
+- `twopi`: Radial layout
+- `osage`: Array-based layout
+- `text`: raw [DOT](https://graphviz.org/doc/info/lang.html) text of the graph, for use with external tools
+
+## Next Steps
+
+{{< cards >}}
+{{% card link="/manage/troubleshoot/troubleshoot/" %}}
+{{% card link="/reference/platform/viam-server/manage-viam-server/" %}}
+{{% card link="/dev/tools/common-errors/" %}}
+{{< /cards >}}

--- a/docs/reference/platform/viam-server/manage-viam-server.md
+++ b/docs/reference/platform/viam-server/manage-viam-server.md
@@ -10,4 +10,374 @@ imageAlt: "Manage viam-server"
 description: "If you have manually installed viam-server, you can chose to run it as a system service or on the command line."
 date: "2024-08-16"
 # updated: ""  # When the content was last entirely checked
+aliases:
+  - /operate/reference/viam-server/manage-viam-server/
+  - /installation/update/
+  - /installation/manage-viam-server/
+  - /get-started/installation/manage-viam-server/
 ---
+
+If you have manually [installed `viam-server`](/operate/install/setup/), you can chose to run it as a system service or directly on the command line.
+Running as a system service enables you to configure `viam-server` to start automatically when your system boots, and is the [default installation option](/operate/install/setup/#installation-methods-viam-agent-versus-manual) on Linux.
+Running on the command line is suitable for local development.
+
+{{< alert title="Note" color="note" >}}
+If you have installed `viam-agent`, see [Manage `viam-agent`](/reference/platform/viam-agent/manage-viam-agent/) instead.
+{{< /alert >}}
+
+## Run `viam-server`
+
+Select the tab for your platform:
+
+{{< tabs name="Managing viam-server">}}
+{{% tab name="Linux"%}}
+
+### Run as a system service
+
+After [installation](/operate/install/setup/), the `viam-server` [AppImage](https://appimage.org/) binary will be located at <file>/usr/local/bin/viam-server</file>, and a `systemd` service file will be placed at <file>/etc/systemd/system/viam-server.service</file>.
+By default, `viam-server` is configured to start when the machine boots.
+
+Running `viam-server` as a system service is the recommended method for Linux.
+
+You can use the following commands to manage `viam-server` when installed as a system service.
+These commands require that you store your machine cloud credentials file at <file>/etc/viam.json</file>.
+
+#### Start
+
+```sh {class="command-line" data-prompt="$"}
+sudo systemctl start viam-server
+```
+
+#### Stop
+
+```sh {class="command-line" data-prompt="$"}
+sudo systemctl stop viam-server
+```
+
+#### Restart
+
+```sh {class="command-line" data-prompt="$"}
+sudo systemctl restart viam-server
+```
+
+#### Enable (start automatically with system boot, default)
+
+```sh {class="command-line" data-prompt="$"}
+sudo systemctl enable viam-server
+```
+
+#### Disable (do not start automatically with system boot)
+
+```sh {class="command-line" data-prompt="$"}
+sudo systemctl disable viam-server
+```
+
+<br>
+
+### Run from the command line
+
+When running `viam-server` on the command line, you can use the following commands to manage the process.
+If `viam-server` is already running as a system service, be sure to stop the service first before using these commands.
+
+#### Start
+
+Run the following on the command line to start `viam-server`, providing the path to your configuration file:
+
+```sh {class="command-line" data-prompt="$"}
+sudo viam-server -config /path/to/my/config.json
+```
+
+If you followed the [Installation Guide](/operate/install/setup/), your machine's cloud credentials file is available at <file>/etc/viam.json</file>.
+You can provide this path in the above command, or move the configuration file to a desired location and change the path in this command accordingly.
+
+Note that on a Raspberry Pi, `viam-server` must always run as `root` (using `sudo`) in order to access the DMA subsystem for GPIO.
+When running `viam-server` from your home directory on a Linux computer, you do not need to use `sudo`.
+
+#### Stop
+
+Press **Ctrl + C** on your keyboard within the terminal session where you are running `viam-server` to stop it.
+
+{{% /tab %}}
+
+{{% tab name="macOS"%}}
+
+### Run from the command line
+
+After [installation](/operate/install/setup/), `viam-server` can be run directly on the command line.
+
+Running `viam-server` on the command line is the recommended method for macOS.
+
+You can use the following commands to manage `viam-server` on the command line:
+
+#### Start
+
+Run the following on the command line to start `viam-server`, providing the path to your own configuration file:
+
+```sh {class="command-line" data-prompt="$"}
+viam-server -config /path/to/my/config.json
+```
+
+If you followed the [Installation Guide](/operate/install/setup/), your machine's configuration file is available in your <file>~/Downloads/</file> directory, named similarly to <file>viam-machinename-main.json</file>.
+You can provide this path in the above command, or move the configuration file to a desired location and change the path in this command accordingly.
+
+#### Stop
+
+Type **Ctrl + C** on your keyboard within the terminal session where you are running `viam-server` to stop it.
+
+<br>
+
+### Run as a system service
+
+The brew installation of `viam-server` CANNOT be run as a system service in the
+background. If you would like to run `viam-server` in the background, install
+[`viam-agent`](/reference/platform/viam-agent/) instead.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Update `viam-server`
+
+The steps to update `viam-server` differ depending on your installation method.
+To determine your installation method, check if the `viam-agent` process is running.
+Run the following command:
+
+```sh {class="command-line" data-prompt="$" data-output="2"}
+ps aux | grep viam-agent
+root      566431  0.5  0.2 1247148 20336 ?       Ssl  11:24   0:00 /opt/viam/bin/viam-agent --config /etc/viam.json
+```
+
+If the output includes a process named `viam-agent`, you used `viam-agent` to install `viam-server`.
+Follow the steps to use `viam-agent` to update `viam-server`.
+
+If the output does not include a process named `viam-agent`, you did not use `viam-agent`.
+Follow the manual steps to update the standalone version.
+
+{{< tabs >}}
+{{% tab name="Installed with viam-agent" %}}
+
+By default, `viam-agent` automatically upgrades to the latest stable version of `viam-server`.
+You can change this behavior in the [`version_control` settings of your machine](/reference/platform/viam-agent/#version-control).
+For example, the following `version_control` configuration will always update to the latest stable release of `viam-agent` and the latest development release of `viam-server`:
+
+```json {class="line-numbers linkable-line-numbers" data-line=""}
+{
+  "agent": {
+    "version_control": {
+      "agent": "stable",
+      "viam-server": "dev"
+    }
+  },
+  "components": [ ... ]
+}
+```
+
+{{% /tab %}}
+{{% tab name="Manual" %}}
+
+To update to the newest RDK version, you need to update your `viam-server`.
+Select the tab for your platform:
+
+{{< tabs name="Updating viam-server" >}}
+{{% tab name=Linux %}}
+
+`viam-server` is distributed for Linux as an [AppImage](https://appimage.org/), and includes a built-in self-update feature.
+When you [run `viam-server`](#run-viam-server) as a service on Linux, it will check for updates automatically on launch, and update itself if a newer version is detected.
+
+The automatic update behavior of `viam-server` should meet the needs of most deployments, but if you need to manually force an update, you can do so with the `--aix-update` flag:
+
+```sh {class="command-line" data-prompt="$"}
+sudo viam-server --aix-update
+```
+
+{{% /tab %}}
+{{% tab name=macOS %}}
+
+`viam-server` is distributed for macOS through the Homebrew package manager, which includes a built-in update feature.
+
+To upgrade to the latest version of `viam-server` using Homebrew:
+
+```sh {class="command-line" data-prompt="$"}
+brew upgrade viam-server
+```
+
+Homebrew does not support automatic updates, so you will need to manually perform this step each time you wish to check for updates.
+We recommend running `brew upgrade viam-server` on a regular basis.
+{{% /tab %}}
+
+{{< /tabs >}}
+{{% /tab %}}
+{{< /tabs >}}
+
+### Disable automatic updates
+
+{{< tabs >}}
+{{% tab name="Installed with viam-agent" %}}
+
+To disable automatic updates, configure the [`version_control` settings of your machine](/reference/platform/viam-agent/#version-control) to a specific version number.
+For example, the following `version_control` configuration pins `viam-server` to version `0.52.1`, preventing `viam-server` from updating to a more recent version:
+
+```json {class="line-numbers linkable-line-numbers" data-line=""}
+{
+  "agent": {
+    "version_control": {
+      "agent": "stable",
+      "viam-server": "0.52.1"
+    }
+  },
+  "components": [ ... ]
+}
+```
+
+If you are changing to a different version of `viam-server` and `viam-agent`, `viam-agent` restarts itself automatically.
+This also restarts `viam-server`.
+{{% /tab %}}
+{{% tab name="Manual" %}}
+
+`viam-server` automatically checks for updates.
+On Linux, you can disable automatic `viam-server` updates.
+To disable the updates, open <file>/etc/systemd/system/viam-server.service</file> and comment out the line that starts with `ExecStartPre`.
+Add a `#` character at the beginning of the line so that it matches the following:
+
+```sh
+# ExecStartPre=-/usr/local/bin/viam-server --aix-update
+```
+
+Then, reload the service file with the following command:
+
+```sh {class="command-line" data-prompt="$"}
+sudo systemctl daemon-reload
+```
+
+To resume automatic update checking, delete the leading `#` character in <file>/etc/systemd/system/viam-server.service</file>, then run `sudo systemctl daemon-reload` again.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## View `viam-server` logs
+
+`viam-server` writes log messages as it starts up and runs, providing useful information when managing or troubleshooting the process.
+Use the following commands to view these log messages locally on your system.
+
+{{< alert title="Tip" color="tip" >}}
+If your system is able to connect to Viam, you can also view logs in the **LOGS** tab.
+{{< /alert >}}
+
+Select the tab below for your platform:
+
+{{< tabs name="View logs">}}
+{{% tab name="Linux"%}}
+
+### As a system service
+
+If you are running `viam-server` as a system service, run the following command to view log messages:
+
+```sh {class="command-line" data-prompt="$"}
+sudo journalctl --unit=viam-server
+```
+
+Use the arrow keys to page vertically or horizontally through the log messages.
+
+You can also "tail" the logs, viewing new messages as they come in with:
+
+```sh {class="command-line" data-prompt="$"}
+sudo journalctl -f --unit=viam-server
+```
+
+Use the q key to stop following the logs.
+
+You can also view log messages specific to `viam-server` in the `syslog` with the following command:
+
+```sh {class="command-line" data-prompt="$"}
+grep viam-server /var/log/syslog
+```
+
+### From the command line
+
+If you are running `viam-server` on the command line, log messages are written to standard out (`stdout`) in the same terminal session you started `viam-server` in.
+
+You can also view log messages specific to `viam-server` in the `syslog` with the following command:
+
+```sh {class="command-line" data-prompt="$"}
+grep viam-server /var/log/syslog
+```
+
+{{% /tab %}}
+
+{{% tab name="macOS" %}}
+
+When running `viam-server` on macOS, log messages are written to standard out (`stdout`) in the same terminal session you started `viam-server` in.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Uninstall `viam-server`
+
+{{< tabs name="Uninstall viam-server">}}
+{{% tab name="Linux"%}}
+
+Remove the system installed service with the following three commands:
+
+```sh {class="command-line" data-prompt="$"}
+sudo systemctl disable --now viam-server
+sudo rm /etc/systemd/system/viam-server.service
+sudo systemctl daemon-reload
+```
+
+To remove the machine cloud credentials file, run:
+
+```sh {class="command-line" data-prompt="$"}
+sudo rm /etc/viam.json
+```
+
+{{< alert title="Caution" color="caution" >}}
+If you remove the machine cloud credentials file you will not be able to connect to your machine.
+You can only restore this file if you have access to the machine configuration.
+{{< /alert >}}
+
+To remove various Viam caches and logs for the root (service) user, run:
+
+```sh {class="command-line" data-prompt="$"}
+sudo rm -r /root/.viam/
+```
+
+If you ever run `viam-server` directly, to remove various Viam caches and logs for your own user run:
+
+```sh {class="command-line" data-prompt="$"}
+rm -r ~/.viam/
+```
+
+To remove the `viam-server` binary itself, run:
+
+```sh {class="command-line" data-prompt="$"}
+sudo rm /usr/local/bin/viam-server
+```
+
+{{% /tab %}}
+{{% tab name="macOS" %}}
+
+Uninstall `viam-server` with the following command:
+
+```sh {class="command-line" data-prompt="$"}
+brew uninstall viam-server
+```
+
+To remove various Viam caches and logs, run:
+
+```sh {class="command-line" data-prompt="$"}
+rm -r ~/.viam/
+```
+
+To remove the machine cloud credentials file, run:
+
+```sh {class="command-line" data-prompt="$"}
+rm ~/Downloads/viam-<your-part-name>.json
+```
+
+For example, `rm ~/Downloads/viam-mymachine1-main.json`.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Troubleshooting
+
+You can find additional assistance in the [Troubleshooting section](/manage/troubleshoot/troubleshoot/).

--- a/docs/reference/sdks/_index.md
+++ b/docs/reference/sdks/_index.md
@@ -4,4 +4,36 @@ linkTitle: "SDKs"
 weight: 10
 type: "docs"
 description: "Write code to control your machine with Viam's Python, Go, TypeScript, Flutter, and C++ SDKs."
+aliases:
+  - /sdks/
 ---
+
+## Backend SDKs
+
+The backend SDKs allow you to build business logic to control [components](/reference/apis/#component-apis) and [services](/reference/apis/#service-apis), as well as manage your [fleet](/reference/apis/fleet/) and [data](/reference/apis/data-client/), and [billing information](/reference/apis/billing-client/), or [provision](/fleet/provision-devices/) machines.
+With the backend SDKs you can also create custom {{< glossary_tooltip term_id="modular-resource" text="modular resources" >}}.
+
+{{< sectionlist-custom class="horizontal" >}}
+{{% sectionlist-custom-item link="/reference/sdks/python/" %}}
+{{% sectionlist-custom-item link="/reference/sdks/go/" %}}
+{{% sectionlist-custom-item link="/reference/sdks/cpp/" %}}
+{{< /sectionlist-custom >}}
+<br>
+
+## Frontend SDKs
+
+The frontend TypeScript SDK allows you to control your machine's [components](/reference/apis/#component-apis), as well as manage your [data](/reference/apis/data-client/) or [provision](/fleet/provision-devices/) machines.
+
+{{< sectionlist-custom class="horizontal" >}}
+{{% sectionlist-custom-item link="/reference/sdks/typescript/" %}}
+{{< /sectionlist-custom >}}
+<br>
+
+## Mobile SDK
+
+The mobile SDK allows you to build iOS and Android apps to control your machine's [components](/reference/apis/#component-apis), as well as manage your [fleet](/reference/apis/fleet/) and [data](/reference/apis/data-client/), or [provision](/fleet/provision-devices/) machines.
+
+{{< sectionlist-custom class="horizontal">}}
+{{% sectionlist-custom-item link="/reference/sdks/flutter/" %}}
+{{< /sectionlist-custom >}}
+<br>

--- a/docs/reference/sdks/connectivity.md
+++ b/docs/reference/sdks/connectivity.md
@@ -6,6 +6,88 @@ type: "docs"
 description: "When you connect to a machine, the machine automatically chooses the best connection over local LAN, WAN or the internet."
 tags:
   ["client", "sdk", "viam-server", "networking", "apis", "robot api", "session"]
+aliases:
+  - /dev/reference/sdks/connectivity/
+  - /program/connectivity/
+  - /sdks/connectivity/
 date: "2022-01-01"
 # updated: ""  # When the content was last entirely checked
 ---
+
+When connecting to a machine using the connection code from the [**CONNECT** tab](/reference/sdks/), a [client session](/reference/apis/sessions/) automatically uses the most efficient route to connect to your machine either through local LAN or WAN or the internet.
+
+## Connect over local network or offline
+
+To connect directly to your local machine, you can use the connection code from the **CONNECT** tab if you are using the Python SDK, Go SDK, Flutter SDK, or C++ SDK.
+
+For the TypeScript SDK, you must disable TLS verification for your `viam-server` and change the sinaling address for the connection code:
+
+{{< tabs >}}
+{{% tab name="Command-line" %}}
+
+Restart `viam-server` with the `-no-tls` flag.
+
+{{% /tab %}}
+{{% tab name="Configuration" %}}
+
+1. Add `"no_tls": true` to the `"network"` section of your machine's JSON configuration:
+
+   ```json {class="line-numbers linkable-line-numbers" data-line="5"}
+   "network": {
+   "no_tls": true
+   }
+   ```
+
+1. Restart your machine.
+   You can restart your machine by clicking on the machine status indicator in Viam and clicking **Restart**.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+Update the signaling address in your connection code:
+
+```ts {class="line-numbers linkable-line-numbers" data-line="1,12"}
+const host = "mymachine-main.0a1bcdefgi.viam.cloud";
+
+const machine = await VIAM.createRobotClient({
+  host,
+  credentials: {
+    type: "api-key",
+    /* Replace "<API-KEY>" (including brackets) with your machine's API key */ payload:
+      "<API-KEY>",
+    authEntity: "<API-KEY-ID>",
+    /* Replace "<API-KEY-ID>" (including brackets) with your machine's API key ID */
+  },
+  signalingAddress: `http://${host}.local:8080`,
+});
+```
+
+## Connectivity Issues
+
+When a machine loses its connection to the internet but is still connected to a LAN or WAN:
+
+- Client sessions connected through the same LAN or WAN will function normally.
+- Client sessions connected through the internet will timeout and end.
+  If the client is on the same LAN or WAN but the route it chose to connect is through the internet, the client will automatically disconnect and then reconnect over LAN.
+- Cloud sync for the [data management service](/data-ai/capture-data/capture-sync/) will pause until the internet connection is re-established since the machine will be unable to connect to Viam.
+
+When a machine loses its connection to LAN or WAN, all client sessions will timeout and end by default.
+
+### Client session timeout and end
+
+When your client cannot connect to your machine's `viam-server` instance, `viam-server` will end any current client [_sessions_](/reference/apis/sessions/) on this machine and all client operations will [time out automatically](/reference/apis/sessions/) and halt: any active commands will be cancelled, stopping any moving parts, and no new commands will be able to reach the machine until the connection is restored.
+
+To disable the default behavior and manage resource timeout and reconfiguration over a networking session yourself, you can [disable the default behavior](/reference/apis/sessions/#disable-default-session-management) of session management, then use [Viam's SDKs](/reference/sdks/) in your code to make calls to [the session management API](https://pkg.go.dev/go.viam.com/rdk/session#hdr-API).
+
+{{% alert title="Note" color="note" %}}
+
+There are a couple of exceptions to the general timeout behavior:
+
+- If a [`MoveOnMap`](/reference/apis/services/motion/#moveonmap) or [`MoveOnGlobe`](/reference/apis/services/motion/#moveonglobe) command has completed a motion plan and returned an execution ID before the connection is lost, the resource that receives the motion plan will complete the motion without a connection.
+- If a navigation service and motion service are running on the same machine, the navigation service will continue sending requests to the motion service even after losing internet connectivity.
+
+{{% /alert %}}
+
+### Configure a connection timeout
+
+When connecting to a machine using the [robot API](/reference/apis/robot/) from a supported [Viam SDK](/reference/apis/), you can configure an [optional timeout](/reference/apis/sessions/#change-the-session-timeout) to account for intermittent or delayed network connectivity.

--- a/docs/reference/sdks/cpp.md
+++ b/docs/reference/sdks/cpp.md
@@ -7,5 +7,7 @@ layout: "empty"
 icon: true
 images: ["/logos/cpp.svg"]
 canonical: "https://cpp.viam.dev/"
-description: "C++."
+aliases:
+  - /dev/reference/sdks/cpp/
+  - /sdks/cpp/
 ---

--- a/docs/reference/sdks/docommand.md
+++ b/docs/reference/sdks/docommand.md
@@ -7,4 +7,173 @@ description: "Implement DoCommand in your module or use it from Viam's SDKs."
 tags: ["sdk", "extend"]
 date: "2025-04-29"
 # updated: ""  # When the content was last entirely checked
+aliases:
+  - /dev/reference/sdks/docommand/
 ---
+
+The `DoCommand` method is a flexible wrapper that you can use to send commands that have no corresponding built-in API method.
+`DoCommand` is part of every [component](/reference/apis/#component-apis) and [service API](/reference/apis/#service-apis), though most models do not implement it.
+
+In the majority of cases, you should use a more specific method for your component or service.
+As the developer of a resource, you can implement `DoCommand` in your module if you need to add custom commands to your resource.
+
+As the user of a resource, you can only call `DoCommand` if it is implemented in the model you are using.
+Refer to the model's documentation to see whether `DoCommand` is implemented and how to use it.
+
+## Implement DoCommand in your component or service
+
+`DoCommand` takes a map of key-value pairs as input.
+The contents of the map are entirely up to the developer of the resource.
+
+`DoCommand` also returns a map of key-value pairs, but many implementations return an empty map, or a map that confirms that the command was received.
+
+There are many ways to implement `DoCommand` in your module, with the following example being just one.
+See [More examples](#more-examples) for more.
+
+### Example implementation
+
+Imagine you have a robotic vacuum cleaner that has a docking sequence and can clean specific areas such as the kitchen and the living room.
+
+You could [write a module](/operate/modules/write-a-driver-module/) that implements the [base API](/reference/apis/components/base/).
+The base API includes methods like `MoveStraight` to drive the vacuum cleaner around, and like all resource APIs, it includes a `DoCommand` method.
+In addition to the standard base methods, you could implement `DoCommand` to trigger the docking and cleaning sequences:
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+```python {class="line-numbers linkable-line-numbers"}
+async def do_command(
+    self,
+    command: Mapping[str, ValueTypes],
+    *,
+    timeout: Optional[float] = None,
+    **kwargs
+) -> Mapping[str, ValueTypes]:
+    for name, value in command.items():
+        if name == "action":
+            action = value
+            if action == "dock":
+                await self.run_docking_sequence()
+                return {"status": "docked"}
+            elif isinstance(action, dict) and "clean_area" in action:
+                area = action["clean_area"]
+                if area in ["kitchen", "living_room"]:
+                    await self.clean_area(area)
+                    return {"status": f"cleaned {area}"}
+                else:
+                    raise ValueError(f"Unknown area: {area}")
+            else:
+                raise ValueError(f"Unknown action: {action}")
+        else:
+            raise ValueError(f"Unknown command: {command}")
+
+# TODO: Implement run_docking_sequence()
+# TODO: Implement clean_area()
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+```go {class="line-numbers linkable-line-numbers"}
+func (s *Vacuum) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+  action, ok := cmd["action"]
+  if !ok {
+    return nil, fmt.Errorf("missing 'action' key in command")
+  }
+
+  switch action := action.(type) {
+  case string:
+    if action == "dock" {
+      if err := s.runDockingSequence(ctx); err != nil {
+        return nil, err
+      }
+      return map[string]interface{}{"status": "docked"}, nil
+    }
+  case map[string]interface{}:
+    if cleanArea, ok := action["clean_area"].(string); ok {
+      if cleanArea == "kitchen" || cleanArea == "living_room" {
+        if err := s.cleanArea(ctx, cleanArea); err != nil {
+          return nil, err
+        }
+        return map[string]interface{}{"status": fmt.Sprintf("cleaned %s", cleanArea)}, nil
+      }
+      return nil, fmt.Errorf("unknown area: %s", cleanArea)
+    }
+  }
+
+  return nil, fmt.Errorf("unknown action: %v", action)
+}
+
+// TODO: Implement runDockingSequence()
+// TODO: Implement cleanArea()
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Use DoCommand in SDK code
+
+Continuing with the vacuum cleaner example, you could use `DoCommand` in your control code as follows:
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+```python {class="line-numbers linkable-line-numbers"}
+# Dock the vacuum cleaner
+await vacuum.do_command({"action": "dock"})
+
+# Clean the kitchen
+await vacuum.do_command({"action": {"clean_area": "kitchen"}})
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+```go {class="line-numbers linkable-line-numbers"}
+// Dock the vacuum cleaner
+_, err := vacuum.DoCommand(context.Background(), map[string]interface{}{
+    "action": "dock"})
+if err != nil {
+  logger.Error(fmt.Errorf("failed to dock vacuum: %w", err))
+}
+
+// Clean the kitchen
+_, err = vacuum.DoCommand(context.Background(), map[string]interface{}{
+    "action": map[string]interface{}{"clean_area": "kitchen"},
+})
+if err != nil {
+  logger.Error(fmt.Errorf("failed to clean area: %w", err))
+}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Use DoCommand in the web UI
+
+You can use `DoCommand` in the web UI:
+
+1. Navigate to your machine's **CONTROL** tab.
+1. Find your resource and expand the **DO COMMAND** section.
+1. Enter a key and value in the text box using JSON syntax, for example
+
+   ```json {class="line-numbers linkable-line-numbers"}
+   {
+     "action": { "clean_area": "kitchen" }
+   }
+   ```
+
+   {{<imgproc src="/components/generic/vacuum-control.png" resize="x1100" declaredimensions=true alt="DoCommand section of the vacuum generic resource's control panel, with clean_area set to kitchen." style="max-width:600px" class="shadow imgzoom" >}}
+
+1. Click **Execute**.
+
+## More examples
+
+For an example that implements `DoCommand` in a generic API Python module, see [Add control logic to your module](/operate/modules/write-a-logic-module/#5-implement-docommand).
+
+For additional examples, look at the GitHub repositories of [registry](https://app.viam.com/registry), especially modules that use the generic API.
+Essentially all generic models implement `DoCommand` (since it is the only method of the generic API), and various other models implement it as well.
+
+{{% hiddencontent %}}
+`DoCommand` is styled as `do_command` in Python.
+{{% /hiddencontent %}}

--- a/docs/reference/sdks/flutter.md
+++ b/docs/reference/sdks/flutter.md
@@ -7,5 +7,7 @@ layout: "empty"
 icon: true
 images: ["/logos/flutter.svg"]
 canonical: "https://flutter.viam.dev/"
-description: "Flutter."
+aliases:
+  - /dev/reference/sdks/flutter/
+  - /sdks/flutter/
 ---

--- a/docs/reference/sdks/go.md
+++ b/docs/reference/sdks/go.md
@@ -7,5 +7,7 @@ layout: "empty"
 icon: true
 images: ["/logos/golang.svg"]
 canonical: "https://pkg.go.dev/go.viam.com/rdk"
-description: "Go."
+aliases:
+  - /dev/reference/sdks/go/
+  - /sdks/go/
 ---

--- a/docs/reference/sdks/python/_index.md
+++ b/docs/reference/sdks/python/_index.md
@@ -7,5 +7,7 @@ layout: "empty"
 icon: true
 images: ["/logos/python.svg"]
 canonical: "https://python.viam.dev/"
-description: "Python."
+aliases:
+  - /dev/reference/sdks/python/
+  - /sdks/python/
 ---

--- a/docs/reference/sdks/python/python-venv.md
+++ b/docs/reference/sdks/python/python-venv.md
@@ -7,6 +7,99 @@ description: "Prepare your Python Virtual Environment to program machines with t
 images: ["/services/icons/sdk.svg"]
 tags:
   ["client", "sdk", "application", "sdk", "fleet", "program", "python", "venv"]
+aliases:
+  - /dev/reference/sdks/python/python-venv/
+  - /program/python-venv/
+  - /sdks/python/python-venv/
 date: "2022-01-01"
 # updated: ""  # When the content was last entirely checked
 ---
+
+To manage Python packages for your code, it is recommended that you use a virtual environment, or `venv`.
+By using a `venv`, you can install Python packages like Viam's client SDK within a virtual environment, avoiding conflicts with other projects or your system.
+
+Follow this guide to set up a fresh virtual environment on your working computer and install the Python SDK as a requirement for your Viam client application.
+
+## Install virtualenv
+
+1. Install [`pip`](https://pip.pypa.io/en/stable/installation/#).
+   To check if you have `pip` installed, run the following command:
+
+   ```sh {class="command-line" data-prompt="$"}
+   pip3 --version
+   ```
+
+   The expected output is the pip version number.
+
+2. [Install `virtualenv` using `pip`](https://virtualenv.pypa.io/en/latest/installation.html#via-pip):
+
+   ```sh {class="command-line" data-prompt="$"}
+   python3 -m pip install --user virtualenv
+   ```
+
+## Set up your project
+
+First, create a directory for your project.
+For example, name your directory `viam-python`:
+
+```sh {class="command-line" data-prompt="$"}
+mkdir viam-python
+cd viam-python
+```
+
+## Create and activate a virtual environment
+
+In the project directory, create and activate a virtual environment for Python to run in.
+
+```sh {class="command-line" data-prompt="$"}
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+Now, `.venv` prepends the commands in your terminal window to indicate the Python packages being used are from this particular environment.
+You can exit this environment by running `deactivate`.
+
+## Install Viam
+
+Inside the activated `.venv` Python environment, you can now install the Viam Python SDK:
+
+```sh {class="command-line" data-prompt="$"}
+pip3 install viam-sdk
+```
+
+This installs the Viam Python SDK and all required general dependencies.
+
+If you intend to use the [ML (machine learning) model service](/data-ai/ai/deploy/), install the Python SDK using the `mlmodel` extra:
+
+```sh {class="command-line" data-prompt="$"}
+pip3 install 'viam-sdk[mlmodel]'
+```
+
+This installs the Viam Python SDK and all required dependencies, including for the ML model service.
+
+You can also run this command on an existing Python SDK install to add support for the ML model service.
+
+If you need to install your own requirements, also install them in this virtual environment.
+To make your required packages easier to install in the future, you can also [create a](https://openclassrooms.com/en/courses/6900846-set-up-a-python-environment/6990546-manage-virtual-environments-using-requirements-files) <file>requirements.txt</file> file with a list of all the packages you need and then install the requirements for your client application by running `pip3 install -r requirements.txt`.
+
+## Set up your IDE
+
+If you would like to be able to use the environment you created with your IDE, point your IDE to use the Python interpreter of your new environment, rather than the default interpreter, likely the global Python interpreter.
+
+The following steps are for VS Code.
+If you're not using VS Code, please read your IDE's documentation on selecting Python interpreters.
+
+1. Open the `viam-python` directory in VS Code
+1. Open the Command Palette (using `⇧⌘P` or through the menus View -> Command Palette)
+1. Select the command `Python: Select Interpreter`.
+   There, you should see all the interpreters available to you.
+   You're looking for the on you just made: `.venv`.
+   It will look something like: `Python 3.XX.X ('.venv': venv) ./.venv/bin/python`.
+   If you don't see it, click the `Refresh` icon on the top right of the Command Palette.
+   Select the `.venv` interpreter.
+
+Your IDE will now recognize all packages installed in this environment.
+
+## Start building
+
+You are now ready to [start using Viam's Python SDK](/reference/sdks/)!

--- a/docs/reference/sdks/typescript.md
+++ b/docs/reference/sdks/typescript.md
@@ -7,5 +7,7 @@ layout: "empty"
 icon: true
 images: ["/logos/typescript.svg"]
 canonical: "https://ts.viam.dev/"
-description: "TypeScript."
+aliases:
+  - /dev/reference/sdks/typescript/
+  - /sdks/typescript/
 ---

--- a/docs/reference/sdks/use-extra-params.md
+++ b/docs/reference/sdks/use-extra-params.md
@@ -6,6 +6,164 @@ type: "docs"
 description: "Using the extra parameter on resource API methods with Viam's SDKs."
 images: ["/services/icons/sdk.svg"]
 tags: ["sdk", "extra", "extend"]
+aliases:
+  - /dev/reference/sdks/use-extra-params/
+  - /program/sdks/use-extra-params
+  - /program/use-extra-params/
+  - /sdks/use-extra-params/
 date: "2022-01-01"
 # updated: ""  # When the content was last entirely checked
 ---
+
+How to [use](#use) and [define](#define) the `extra` parameters that many {{< glossary_tooltip term_id="resource" text="resource" >}} [API methods](/reference/apis/) offer in the Go and Python SDKs.
+
+## Use
+
+You can use `extra` parameters with modular {{< glossary_tooltip term_id="resource" text="resource" >}} implementations that are _models_ of built-in resource types.
+
+For example, a new model of [sensor](/reference/components/sensor/), or a new model of {{< glossary_tooltip term_id="slam" text="SLAM" >}} service.
+
+The `extra` parameters in that built-in resource type's [API](/reference/apis/) allow users to pass information to a resource's driver that isn't specified as a parameter for all models of the resource type.
+This is necessary to keep the API of resource types consistent across, for example, all models of [motor](/reference/components/motor/) or all models of [camera](/reference/components/camera/).
+
+Send extra information in an API call in `extra` parameters as follows:
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+[`Optional[Dict[str, Any]]`](https://docs.python.org/3/library/typing.html#typing.Optional) indicates you are required to pass in an object of either type `Dict[str, Any]` or `None` as a parameter when calling this method.
+
+An object of type `Dict[str, Any]` is a [dictionary](https://docs.python.org/3/tutorial/datastructures.html#dictionaries) with keys of type [`str`](https://docs.python.org/3/library/stdtypes.html#str) and values of [`any type`](https://docs.python.org/3/library/typing.html#typing.Any),
+
+For example:
+
+```python {class="line-numbers linkable-line-numbers"}
+async def main():
+    # ... Connect to the machine.
+
+    # Get your sensor resource from the machine.
+    your_sensor = YourSensor.from_robot(robot, "your-sensor")
+
+    # Define a dictionary containing extra information.
+    your_info = {"type": "temperature", "description": "more info", "id": 123}
+
+    # Send this information in an call to the sensor resource's API.
+    await your_sensor.get_readings(extra=your_info)
+```
+
+{{% alert title="Tip" color="tip" %}}
+
+If passing an object of type `None`, you do not have to specify `None` in the method call.
+
+{{% /alert %}}
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+`extra (map[string]interface{})` indicates you are required to pass in an object of either type `map[string]interface{}` or `nil` as a parameter when calling this method.
+
+An object of type `map[string]interface{}` is an [map](https://go.dev/blog/maps) with keys of type [`string`](https://go.dev/blog/strings) and values of [any type that you have cast to an interface](https://jordanorelli.com/post/32665860244/how-to-use-interfaces-in-go).
+
+For example:
+
+```go {class="line-numbers linkable-line-numbers"}
+func main() {
+    ... // Connect to the machine
+
+    // Get your sensor resource from the machine.
+    yourSensor, err := sensor.FromProvider(robot, "your-sensor")
+
+    // Define a map containing extra information.
+    your_info := map[string]interface{}{"type": "temperature", "description": "more info", "id": 123}
+
+    // Send this information in an call to the sensor resource's API.
+    err := yourSensor.Readings(context.Background(), your_info)
+}
+```
+
+{{% alert title="Important" color="note" %}}
+
+If passing an object of type `nil`, you must specify `nil` in the method call or the method will fail.
+
+{{% /alert %}}
+{{% /tab %}}
+{{% /tabs %}}
+
+## Define
+
+If `extra` information must be passed to a resource, it is handled within a new, _modular_ resource model's [custom API](/operate/modules/write-a-driver-module/) wrapper.
+
+{{%expand "Click for instructions on defining a custom model to use extra params" %}}
+
+To do this, define a custom implementation of the resource's API as a new _model_, and modify the resource's API methods to handle the `extra` information you send.
+Follow the steps in the [Modular Resources documentation](/operate/modules/write-a-driver-module/) to do so.
+
+For an example of how to check the values of keys in an `extra` parameter of a built-in resource [API method](/reference/apis/), reference this modification to the built-in [sensor](/reference/components/sensor/) resource type's [Readings](/reference/apis/components/sensor/#getreadings) method in the code of a new sensor model:
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+```python {class="line-numbers linkable-line-numbers"}
+# Readings depends on extra parameters.
+@abc.abstractmethod
+async def get_readings(self,
+                       *,
+                       extra: Optional[Dict[str, Any]] = None,
+                       timeout: Optional[float] = None,
+                       **kwargs):
+
+    # Define an empty dictionary for readings.
+    readings = {}
+
+    # If extra["type"] is temperature or humidity, get the temperature or
+    # humidity from helper functions and return these values as the readings
+    # the sensor has provided.
+    if extra["type"] == "temperature":
+        readings["type"] = get_temp()
+    elif extra["type"] == "humidity":
+        readings["type"] = get_humidity()
+    # If the type is not one of these two cases, raise an exception.
+    else:
+        raise Exception(f"Invalid sensor reading request: type {type}")
+
+    return readings
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+```go {class="line-numbers linkable-line-numbers"}
+// Readings depends on extra parameters.
+func (s *mySensor) Readings(ctx context.Context, extra map[string]interface{}) (map[string]interface{}, error) {
+
+    // Define an empty map for readings.
+    readings := map[string]interface{}{}
+
+    // If extra["type"] is temperature or humidity, get the temperature or humidity from helper methods and return these values as the readings the sensor has provided.
+    if readingType, ok := extra["type"]; ok {
+        rType, ok := readingType.(string)
+        if !ok {
+            return nil, errors.New("invalid sensor reading request")
+        }
+        switch rType {
+        case "temperature":
+            readings[rType] = getTemp()
+        case "humidity":
+            readings[rType] = getHumidity()
+        // If the type is not one of these two cases, return an error.
+        default:
+            return nil, errors.Errorf("Invalid sensor reading request: type %s", rType)
+        }
+    }
+
+    // Return the readings and `nil`/no error.
+    return readings, nil
+}
+```
+
+{{% /tab %}}
+{{% /tabs %}}
+
+See [Create a module](/operate/modules/write-a-driver-module/) for more information and instructions on modifying built-in API specifications.
+
+{{% /expand%}}


### PR DESCRIPTION
## Summary

Populates reference section stubs with content from hidden sections. Four commits covering four subsections.

## Changes

### API reference (33 files)
- Add missing overview cards: audio-in, audio-out, world-state-store, sessions
- Fix weight ordering across all 33 API pages (eliminate ties)

### Architecture (3 pages, 475 lines)
- Viam architecture overview: viam-server, components/services/modules, communication flow, data management, machine examples
- Parts, sub-parts, remotes: configuration and SDK usage
- Machine-to-machine communication: gRPC/WebRTC flow

### SDKs (10 pages, 549 lines)
- SDK overview, per-language pages (Go, Python, TypeScript, Flutter, C++)
- Python virtual environment setup
- Connectivity and session management
- DoCommand usage, extra parameter handling

### Platform (6 pages, 1,939 lines)
- viam-server: configuration, logging, process management, network settings
- Manage viam-server: run, restart, update, view logs
- Debug endpoints: pprof and graph
- viam-agent: configuration, subsystems, provisioning, network management
- Manage viam-agent: install, update, manage
- viam-micro-server: ESP32 setup and configuration

## All changes include
- Alias redirects from old paths (operate/, manage/, dev/)
- Internal links updated to new reference/ paths
- Linters pass (prettier, markdownlint, vale)
- Build passes

## Test plan

- [ ] All new pages render in deploy preview
- [ ] Old paths redirect correctly
- [ ] No broken links (htmltest)
- [ ] Nav sidebar shows correct ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)