### PR TITLE
Note that DeleteTabularData also deletes from the hot data store

### DIFF
--- a/docs/cli/manage-data.md
+++ b/docs/cli/manage-data.md
@@ -170,6 +170,8 @@ Pass `0` to delete all tabular data for your organization.
 viam data delete tabular --org-id=<org-id> --delete-older-than-days=90
 ```
 
+If the organization has a [hot data store](/data/hot-data-store/), matching data is deleted from that store as well.
+
 {{< alert title="Caution" color="caution" >}}
 Passing `--delete-older-than-days=0` deletes **all** tabular data in the organization. This command has no component or location filter.
 {{< /alert >}}

--- a/docs/data/overview.md
+++ b/docs/data/overview.md
@@ -67,6 +67,8 @@ Delete tabular data older than a number of days:
 viam data delete tabular --org-id=<org-id> --delete-older-than-days=30
 ```
 
+If the organization has a [hot data store](/data/hot-data-store/), matching data is deleted from that store as well.
+
 {{< alert title="Caution" color="caution" >}}
 `--delete-older-than-days=0` deletes **all** tabular data in the organization. The CLI tabular delete has no component or location filter: it applies to the entire org.
 {{< /alert >}}
@@ -86,7 +88,7 @@ The binary delete command requires `--org-ids`, `--start`, and `--end`. You can 
 
 The [data client API](/dev/reference/apis/data-client/) supports these delete operations; see the API reference for your SDK's method names and signatures:
 
-- Delete tabular data older than a specified number of days.
+- Delete tabular data older than a specified number of days. Also deletes matching data from the [hot data store](/data/hot-data-store/) when one is configured.
 - Delete binary data matching a filter, such as organization, location, or time range.
 - Delete specific binary items by ID.
 

--- a/static/include/app/apis/generated/data.md
+++ b/static/include/app/apis/generated/data.md
@@ -986,6 +986,7 @@ For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_s
 ### DeleteTabularData
 
 Delete tabular data older than a specified number of days.
+If the organization has a [hot data store](/data/hot-data-store/), matching data is deleted from that store as well.
 
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/static/include/app/apis/overrides/protos/data.DeleteTabularData.md
+++ b/static/include/app/apis/overrides/protos/data.DeleteTabularData.md
@@ -1,1 +1,2 @@
 Delete tabular data older than a specified number of days.
+If the organization has a [hot data store](/data/hot-data-store/), matching data is deleted from that store as well.


### PR DESCRIPTION
## Source changes

- viamrobotics/app#11352 (commit `3a50fdbae`): `DeleteTabularData` now also deletes matching data from the organization's recent data collection (the hot data store) when one exists. The handler inserts a filter-scoped `DataDeletionRequest` with `target=recent_data` whenever the org has a recent data collection.

## Docs changes

- `static/include/app/apis/overrides/protos/data.DeleteTabularData.md`: Added a second sentence to the canonical API description noting the hot data store deletion.
- `static/include/app/apis/generated/data.md`: Mirrored the override in the generated `### DeleteTabularData` section so readers of the reference see the behavior today (before the next codegen run).
- `docs/cli/manage-data.md`: Added the note under `### Delete tabular data`, since `viam data delete tabular` calls this API and is also affected.
- `docs/data/overview.md`: Added the note to the CLI delete block and to the SDK delete bullet under **Delete data**.

## How I found these

- Detected the behavior change by reading the diff of `domains/datamanagement/delete_tabular_data.go` in viamrobotics/app#11352 and confirming via the PR description that "the job still handles deleting recent data for sensor-2".
- Xref lookup: `app-api-xref.md` → `DeleteTabularData` entry.
- Grep matches: `DeleteTabularData|delete tabular data` across the docs repo surfaced the 5 prose locations and the override / generated include.

---
Generated by daily docs change agent