### PR TITLE
Update data capture and frame instructions for feature-button UI

### DIFF
--- a/docs/data/capture-sync/capture-and-sync-data.md
+++ b/docs/data/capture-sync/capture-and-sync-data.md
@@ -22,10 +22,10 @@ Confirm it shows as **Live** in the upper left.
 ## 2. Enable data capture on a component
 
 1. Find your component (for example, `my-camera`) in the machine configuration.
-2. Click **+** on the **Data Capture** card.
+2. Click the **Data Capture** button.
 3. If you see a "Data management service missing" banner, click
    **Create data management service**, click **Save**, navigate back to
-   your component, and click **+** on the **Data Capture** card again.
+   your component, and click the **Data Capture** button again.
 4. Select the method to capture:
    - For a camera, select **GetImages**. This captures a frame from the camera
      each time it fires.

--- a/docs/data/capture-sync/remote-parts-capture.md
+++ b/docs/data/capture-sync/remote-parts-capture.md
@@ -35,10 +35,10 @@ Each sub-part is an independent `viam-server` instance with its own configuratio
 
 1. In the Viam app, navigate to the sub-part's section of your machine's **CONFIGURE** tab.
 2. Find the component on the sub-part that you want to capture from.
-3. Click **+** on the component's **Data Capture** card.
+3. Click the **Data Capture** button on the component.
 4. If you see a "Data management service missing" banner, click
    **Create data management service**, click **Save**, navigate back to
-   the component, and click **+** on the **Data Capture** card again.
+   the component, and click the **Data Capture** button again.
 5. Select the capture method and frequency as you would for a local component.
 6. Click **Save**.
 
@@ -65,7 +65,7 @@ For more details on remote part configuration, including authentication and manu
 Once the remote part is added, its components appear on the main machine's **CONFIGURE** tab under the remote's section. Configure data capture through the main machine's config, not through the remote machine's config:
 
 1. Find the remote component in the main machine's **CONFIGURE** tab.
-2. Click **+** on the component's **Data Capture** card.
+2. Click the **Data Capture** button on the component.
 3. Select the capture method (for example, **GetImages** for a camera, **Readings** for a sensor).
 4. Set the capture frequency.
 5. Click **Save**.

--- a/docs/data/data-management-tutorial.md
+++ b/docs/data/data-management-tutorial.md
@@ -43,10 +43,10 @@ Expand the **test** section on the sensor's component card. You should see `{"a"
 Now we will tell Viam to record every reading from this sensor.
 
 1. Find the `test-sensor` component in the **CONFIGURE** tab.
-2. Click **+** on the **Data Capture** card.
+2. Click the **Data Capture** button.
 3. If you see a "Data management service missing" banner, click
    **Create data management service**, click **Save**, navigate back to
-   `test-sensor`, and click **+** on the **Data Capture** card again.
+   `test-sensor`, and click the **Data Capture** button again.
 4. Select the **Readings** method.
 5. Set the capture frequency to **0.2** (one reading every 5 seconds).
 6. Click **Save**.

--- a/docs/data/hot-data-store.md
+++ b/docs/data/hot-data-store.md
@@ -26,12 +26,12 @@ choose which components send data to it and how many hours of data to retain.
 1. Go to [app.viam.com](https://app.viam.com) and navigate to your machine's
    **CONFIGURE** tab.
 2. Find the component you want to enable hot storage for (for example, your sensor).
-3. Click the **Data Capture** card to expand it.
+3. Click the **Data Capture** button on the component.
 4. If you see a "Data management service missing" banner, click
    **Create data management service**, then click **Save**. Navigate back
-   to your component.
-5. Add a capture method: select a **Method**, set the **Frequency**, and
-   toggle it **On**. Click **Save**.
+   to your component and click the **Data Capture** button again.
+5. Select a **Method**, set the **Frequency**, and toggle it **On**.
+   Click **Save**.
 6. On the capture method, click the chevron to expand **Advanced** options.
 7. Enable **Sync to Hot Data Store**.
 8. Set the **Time frame** to the number of hours of data to retain (for example, 24

--- a/docs/monitor/alert.md
+++ b/docs/monitor/alert.md
@@ -74,10 +74,10 @@ Click **Save**, then click **Test** at the bottom of the sensor configuration ca
 
 ### Configure data capture
 
-1. On your sensor's configuration card, click **+** on the **Data Capture** card.
+1. On your sensor's configuration card, click the **Data Capture** button.
 1. If you see a "Data management service missing" banner, click
    **Create data management service**, click **Save**, navigate back to
-   your sensor, and click **+** on the **Data Capture** card again.
+   your sensor, and click the **Data Capture** button again.
 1. Select `Readings` from the **Method** dropdown and set the **Frequency** to `0.05` Hz (once every 20 seconds).
 1. Click **Save**.
 

--- a/docs/motion-planning/frame-system-how-to/arm-fixed-camera.md
+++ b/docs/motion-planning/frame-system-how-to/arm-fixed-camera.md
@@ -36,7 +36,7 @@ Mark the origin physically so you can take consistent measurements to both the a
 ### 2. Add a frame to the arm
 
 In the [Viam app](https://app.viam.com), navigate to your machine and click the **CONFIGURE** tab.
-Find your arm component and click **+ Add frame**.
+Find your arm component and click the **Frame** button.
 
 Measure the distance from your world frame origin to the arm base along each axis.
 For an arm base 300 mm to the right and 250 mm forward from a table corner:
@@ -56,7 +56,7 @@ Click **Save**.
 
 ### 3. Add a frame to the gripper
 
-Find your gripper component and click **+ Add frame**.
+Find your gripper component and click the **Frame** button.
 Set the parent to the arm:
 
 ```json
@@ -76,7 +76,7 @@ Click **Save**.
 
 ### 4. Add a frame to the fixed camera
 
-Find your camera component and click **+ Add frame**.
+Find your camera component and click the **Frame** button.
 The camera's parent is `"world"`, not the arm.
 
 Measure the camera's position relative to your world frame origin.

--- a/docs/motion-planning/frame-system-how-to/arm-gripper-camera.md
+++ b/docs/motion-planning/frame-system-how-to/arm-gripper-camera.md
@@ -39,7 +39,7 @@ Mark your chosen origin physically so you can take consistent measurements.
 ### 2. Add a frame to the arm
 
 In the [Viam app](https://app.viam.com), navigate to your machine and click the **CONFIGURE** tab.
-Find your arm component and click **+ Add frame**.
+Find your arm component and click the **Frame** button.
 
 If the arm base is your world frame origin:
 
@@ -92,7 +92,7 @@ For example, if the arm's +x points opposite to your intended +x, rotate 180 deg
 
 ### 4. Add a frame to the gripper
 
-Find your gripper component in the **CONFIGURE** tab and click **+ Add frame**.
+Find your gripper component in the **CONFIGURE** tab and click the **Frame** button.
 
 If the gripper attaches directly to the arm's end effector with no adapter plate, use a zero offset:
 
@@ -125,7 +125,7 @@ Click **Save**.
 
 ### 5. Add a frame to the wrist camera
 
-Find your camera component in the **CONFIGURE** tab and click **+ Add frame**.
+Find your camera component in the **CONFIGURE** tab and click the **Frame** button.
 
 The camera's parent is the arm, not the world frame.
 Measure the offset from the arm's end effector to the camera's optical center.

--- a/docs/motion-planning/frame-system-how-to/mobile-base-arm.md
+++ b/docs/motion-planning/frame-system-how-to/mobile-base-arm.md
@@ -39,7 +39,7 @@ All component positions are defined relative to this center point.
 ### 2. Add a frame to the base
 
 In the [Viam app](https://app.viam.com), navigate to your machine and click the **CONFIGURE** tab.
-Find your base component and click **+ Add frame**.
+Find your base component and click the **Frame** button.
 
 ```json
 {
@@ -56,7 +56,7 @@ Click **Save**.
 
 ### 3. Add a frame to the arm
 
-Find your arm component and click **+ Add frame**.
+Find your arm component and click the **Frame** button.
 The arm's parent is the base, not the world frame.
 
 Measure the offset from the center of the base to the arm's mounting point.

--- a/docs/motion-planning/frame-system-how-to/mobile-base-sensors.md
+++ b/docs/motion-planning/frame-system-how-to/mobile-base-sensors.md
@@ -37,7 +37,7 @@ Instead, all sensor positions are defined relative to the center of the base.
 ### 2. Add a frame to the base
 
 In the [Viam app](https://app.viam.com), navigate to your machine and click the **CONFIGURE** tab.
-Find your base component and click **+ Add frame**.
+Find your base component and click the **Frame** button.
 
 Since the world frame origin is at the base center, the translation is zero:
 
@@ -56,7 +56,7 @@ Click **Save**.
 
 ### 3. Add a frame to the LIDAR
 
-Find your LIDAR component and click **+ Add frame**.
+Find your LIDAR component and click the **Frame** button.
 Measure the offset from the center of the base to the LIDAR's sensor origin.
 
 For a LIDAR mounted on top of the base, centered horizontally and 150 mm above the base center:
@@ -90,7 +90,7 @@ Click **Save**.
 
 ### 4. Add frames to the cameras
 
-Find each camera component and click **+ Add frame**.
+Find each camera component and click the **Frame** button.
 Measure the offset from the base center to each camera's mounting position.
 
 **Front-facing camera:**

--- a/docs/operate/mobility/move-arm/configure-additional.md
+++ b/docs/operate/mobility/move-arm/configure-additional.md
@@ -27,7 +27,7 @@ Configure the gripper's frame to describe its position and orientation relative 
 
 1. In the **CONFIGURE** tab, find the gripper's configuration card.
 
-1. Click **+ Add frame**.
+1. Click the **Frame** button.
 
 1. Select the arm's frame as the parent frame.
 
@@ -80,7 +80,7 @@ If you have a camera that can see the environment, configure the camera's frame 
 
 1. In the **CONFIGURE** tab, find the camera's configuration card.
 
-1. Click **+ Add frame**.
+1. Click the **Frame** button.
 
 1. Edit the frame depending on where the camera is mounted:
 
@@ -114,7 +114,7 @@ If you have a passive object attached to the arm such as a camera mount, you wil
 
 1. Enter a name and click **Create**.
 
-1. Click **+ Add frame**.
+1. Click the **Frame** button.
 
 1. Set the parent frame to the name of the arm or gripper, depending on where the object is attached.
 

--- a/docs/operate/mobility/move-arm/frame-how-to.md
+++ b/docs/operate/mobility/move-arm/frame-how-to.md
@@ -28,7 +28,7 @@ You define it implicitly by configuring the frame of a component relative to wor
 ### Add a frame to your arm
 
 1. Mount the arm in a fixed location.
-1. On your arm's configuration card, click **+ Add frame**.
+1. On your arm's configuration card, click the **Frame** button.
 1. The card will populate with the following default values:
 
    ```json {class="line-numbers linkable-line-numbers"}

--- a/docs/operate/reference/services/frame-system/_index.md
+++ b/docs/operate/reference/services/frame-system/_index.md
@@ -45,7 +45,7 @@ You can configure a reference frame within the frame system for each of your mac
 
 1. Find the configuration card for the component you want to add a frame to.
 
-1. Click **+ Add frame**.
+1. Click the **Frame** button.
 
 1. Leave the default values, or edit the frame configuration.
    The frame configuration is a JSON object with the following parameters:

--- a/docs/operate/reference/services/navigation/_index.md
+++ b/docs/operate/reference/services/navigation/_index.md
@@ -180,7 +180,7 @@ To make sure your rover base's autonomous GPS navigation with the navigation ser
 Add [reference frames](/operate/reference/services/frame-system/#configuration) to your rover [base](/operate/reference/components/base/) and [movement sensor](/operate/reference/components/movement-sensor/) configurations:
 
 - Navigate to the **CONFIGURE** tab of your machine's page.
-- Find your base configuration card and click **+ Add frame**.
+- Find your base configuration card and click the **Frame** button.
 - Since you haven't adjusted any parameters yet, the default reference frame will be shown for your base:
 
   {{<imgproc src="/services/navigation/select-base-frame.png" resize="700x" style="width: 300px" alt="Frame card for a base with the default reference frame settings">}}
@@ -194,7 +194,7 @@ Add [reference frames](/operate/reference/services/frame-system/#configuration) 
 
   {{<imgproc src="/services/navigation/configure-base-geometry.png" resize="700x" style="width: 300px" alt="The frame card for the base.">}}
 
-- Add a frame to your movement sensor configuration by clicking **+ Add frame**.
+- Add a frame to your movement sensor configuration by clicking the **Frame** button.
 - Set the `parent` within the frame card to the name of your base.
 - Give the movement sensor a `translation` that reflects where it is mounted on your base, measuring the coordinates with respect to the origin of the base.
   In other words, designate the base origin as `(0,0,0)` and measure the distance between that and the origin of the sensor to obtain the coordinates.

--- a/docs/try/part-2.md
+++ b/docs/try/part-2.md
@@ -41,7 +41,7 @@ The default configuration options for the data service are correct for our appli
 **Enable data capture on the vision service:**
 
 1. Click `vision-service` in your machine configuration
-2. Click **+** on the **Data Capture** card
+2. Click the **Data Capture** button
 3. Select the method to capture: `CaptureAllFromCamera`
 4. Set **Frequency (hz)** to `0.5` (every 2 seconds)
 5. Set **Camera name** to `inspection-cam`

--- a/docs/try/part-4.md
+++ b/docs/try/part-4.md
@@ -277,7 +277,7 @@ This tells viam-server to wait for `inspector-service` to initialize before the 
 **Enable data capture on the inspector:**
 
 1. In the **CONFIGURE** tab, click on `inspector-service` to open its configuration panel
-2. Click **+** on the **Data Capture** card
+2. Click the **Data Capture** button
 3. Select the method: `DoCommand`
 4. Set **Frequency (hz)** to `0.5` (captures every 2 seconds)
 5. In the **Additional parameters** section, add the DoCommand input:

--- a/docs/tutorials/services/navigate-with-rover-base.md
+++ b/docs/tutorials/services/navigate-with-rover-base.md
@@ -343,7 +343,7 @@ In the **JSON** mode in your machine's **CONFIGURE** tab, add the following JSON
 
     - Make sure your `merged` movement sensor is configured to gather `"position"` readings from the `gps` movement sensor.
     - [Configure the frame system](/operate/reference/services/frame-system/) for this movement sensor so that the navigation service knows where it is in relation to the base.
-      - On the **CONFIGURE** tab, add a frame to your movement sensor configuration by clicking **+ Add Frame**.
+      - On the **CONFIGURE** tab, add a frame to your movement sensor configuration by clicking the **Frame** button.
         If your movement sensor is mounted on top of the rover like ours is, leave the default frame values.
       - Set the `base` as the `parent` frame.
 

--- a/docs/vision/alert-on-detections.md
+++ b/docs/vision/alert-on-detections.md
@@ -110,7 +110,7 @@ Add the data management service to capture and sync filtered images:
 Enable data capture on the filtered camera:
 
 1. Locate the `objectfilter-cam` panel.
-2. Click **+** on the **Data Capture** card.
+2. Click the **Data Capture** button.
 3. Select **GetImages** as the type.
 4. Set the capture frequency to `0.2` images per second (one image every 5 seconds). Adjust as needed for your use case.
 


### PR DESCRIPTION
## Source change

- viamrobotics/app#11599 (commit `72cfc81e6`): Data Capture and Frame are no longer always-visible sections on component and service configuration cards. They are now opt-in `FeatureButton` elements titled **Data Capture** and **Frame** (each with an icon on the left, a short description, and a trailing "+" icon). Clicking the button adds the corresponding section. When the section is present, the card shows a regular `CardSection` with a **Remove** button in its header. The old inline "Add frame" button inside a persistent Frame section is gone, and the "+" affordance that sat inside the persistent Data Capture section is no longer available outside the button.

## Docs changes

Data capture instructions (replace "click **+** on the **Data Capture** card" with "click the **Data Capture** button"):

- `docs/data/capture-sync/capture-and-sync-data.md`
- `docs/data/capture-sync/remote-parts-capture.md`
- `docs/data/data-management-tutorial.md`
- `docs/data/hot-data-store.md` (also adjust step 5 since the button now opens the section with a method draft already present)
- `docs/monitor/alert.md`
- `docs/try/part-2.md`
- `docs/try/part-4.md`
- `docs/vision/alert-on-detections.md`

Frame instructions (replace "click **+ Add frame**" with "click the **Frame** button"):

- `docs/motion-planning/frame-system-how-to/arm-fixed-camera.md`
- `docs/motion-planning/frame-system-how-to/arm-gripper-camera.md`
- `docs/motion-planning/frame-system-how-to/mobile-base-arm.md`
- `docs/motion-planning/frame-system-how-to/mobile-base-sensors.md`
- `docs/operate/mobility/move-arm/configure-additional.md`
- `docs/operate/mobility/move-arm/frame-how-to.md`
- `docs/operate/reference/services/frame-system/_index.md`
- `docs/operate/reference/services/navigation/_index.md`
- `docs/tutorials/services/navigate-with-rover-base.md`

Intentionally not touched:

- `docs/dev/reference/changelog.md` — the 2025-05-15 changelog entry describes the prior UI (when "+ Add frame" was introduced to replace the "Frame tab"). Historical changelog wording is preserved.

## How I found these

- Started from the app PR's code diff (`72cfc81e6`). The new component and service cards use `FeatureButton` with `title="Data Capture"` / `title="Frame"`; the old cards always rendered a `DataCaptureSection` or `FrameSection` with internal add/remove controls.
- Grep across the docs repo for every variant of the prior wording (`+ Add frame`, `+ Add Frame`, `+ on the Data Capture card`, `Data Capture card`). Processed every match; each one was a how-to or tutorial that instructs users to click the now-renamed control.
- Verified no remaining instances after the edits.
- Pre-existing MD060 table warnings in `frame-system/_index.md` and `navigation/_index.md` are not introduced by this PR; left in place so this PR stays focused.

---
Generated by daily docs change agent