### PR TITLE
Update CLI docs: viam module update-models --binary is now optional

### DIFF
--- a/docs/cli/build-and-deploy-modules.md
+++ b/docs/cli/build-and-deploy-modules.md
@@ -84,7 +84,7 @@ viam module restart --part-id=<part-id>
 ## Update model definitions
 
 After adding or changing models in your module, update the model definitions in `meta.json`.
-This command runs the module binary in a sandbox, queries it for the API-model pairs it advertises, and updates the manifest.
+This command runs the module's executable (binary or script) in a sandbox, queries it for the API-model pairs it advertises, and updates the manifest.
 It also auto-detects markdown documentation files named `namespace_module_model.md`.
 
 If you omit `--binary`, the CLI uses the entrypoint declared in `meta.json`:

--- a/docs/cli/build-and-deploy-modules.md
+++ b/docs/cli/build-and-deploy-modules.md
@@ -93,7 +93,7 @@ If you omit `--binary`, the CLI uses the entrypoint declared in `meta.json`:
 viam module update-models
 ```
 
-To point at a specific binary or packaged tarball, pass `--binary`:
+To point at a specific executable, pass `--binary`:
 
 ```sh {class="command-line" data-prompt="$"}
 viam module update-models --binary=./bin/module

--- a/docs/cli/build-and-deploy-modules.md
+++ b/docs/cli/build-and-deploy-modules.md
@@ -87,6 +87,14 @@ After adding or changing models in your module, update the model definitions in 
 This command runs the module binary in a sandbox, queries it for the API-model pairs it advertises, and updates the manifest.
 It also auto-detects markdown documentation files named `namespace_module_model.md`.
 
+If you omit `--binary`, the CLI uses the entrypoint declared in `meta.json`:
+
+```sh {class="command-line" data-prompt="$"}
+viam module update-models
+```
+
+To point at a specific binary or packaged tarball, pass `--binary`:
+
 ```sh {class="command-line" data-prompt="$"}
 viam module update-models --binary=./bin/module
 ```

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -870,7 +870,7 @@ viam module local-app-testing --app-url http://localhost:3000
 <!-- prettier-ignore -->
 | Argument | Description | Applicable commands | Required? |
 | -------- | ----------- | ------------------- | --------- |
-| `--binary` | The module executable to run. Accepts a binary, a packaged `.tar.gz` archive, or a script. Must work on the OS or processor of the device. If omitted, the CLI uses the entrypoint defined in <file>meta.json</file>. | `update-models` | Optional |
+| `--binary` | The module executable to run (binary or script). Must work on the OS or processor of the device. If omitted, the CLI uses the entrypoint defined in <file>meta.json</file>. | `update-models` | Optional |
 | `--count` | Number of cloud builds to list, defaults to displaying all builds | `build list` | Optional |
 | `--cloud-config` | The location of the <FILE>viam.json</FILE> file which contains the machine ID to lookup the part-id. Alternative to `--part-id`. Default: `/etc/viam.json` | `reload`, `reload-local`, `restart` | Optional |
 | `--destination` | Output directory for downloaded package (default: `.`) | `download` | Optional |

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -870,7 +870,7 @@ viam module local-app-testing --app-url http://localhost:3000
 <!-- prettier-ignore -->
 | Argument | Description | Applicable commands | Required? |
 | -------- | ----------- | ------------------- | --------- |
-| `--binary` | The binary for the module to run. The binary has to work on the OS or processor of the device. If omitted, the CLI uses the entrypoint defined in <file>meta.json</file>. | `update-models` | Optional |
+| `--binary` | The module executable to run. Accepts a binary, a packaged `.tar.gz` archive, or a script. Must work on the OS or processor of the device. If omitted, the CLI uses the entrypoint defined in <file>meta.json</file>. | `update-models` | Optional |
 | `--count` | Number of cloud builds to list, defaults to displaying all builds | `build list` | Optional |
 | `--cloud-config` | The location of the <FILE>viam.json</FILE> file which contains the machine ID to lookup the part-id. Alternative to `--part-id`. Default: `/etc/viam.json` | `reload`, `reload-local`, `restart` | Optional |
 | `--destination` | Output directory for downloaded package (default: `.`) | `download` | Optional |

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -737,7 +737,7 @@ If you update and release your module as part of a continuous integration (CI) w
 viam module generate
 viam module create --name=<module-name> [--org-id=<org-id> | --public-namespace=<namespace>]
 viam module update [--module=<path to meta.json>]
-viam module update-models --binary=<binary> [...named args]
+viam module update-models [--binary=<binary>] [...named args]
 viam module build start --version=<version> [...named args]
 viam module build local --module=<path to meta.json> [arguments...]
 viam module build list [command options] [arguments...]
@@ -870,7 +870,7 @@ viam module local-app-testing --app-url http://localhost:3000
 <!-- prettier-ignore -->
 | Argument | Description | Applicable commands | Required? |
 | -------- | ----------- | ------------------- | --------- |
-| `--binary` | The binary for the module to run. The binary has to work on the OS or processor of the device. | `update-models` | **Required** |
+| `--binary` | The binary for the module to run. The binary has to work on the OS or processor of the device. If omitted, the CLI uses the entrypoint defined in <file>meta.json</file>. | `update-models` | Optional |
 | `--count` | Number of cloud builds to list, defaults to displaying all builds | `build list` | Optional |
 | `--cloud-config` | The location of the <FILE>viam.json</FILE> file which contains the machine ID to lookup the part-id. Alternative to `--part-id`. Default: `/etc/viam.json` | `reload`, `reload-local`, `restart` | Optional |
 | `--destination` | Output directory for downloaded package (default: `.`) | `download` | Optional |


### PR DESCRIPTION
## Source change

- viamrobotics/rdk#5890 (`02453f7`): The `--binary` flag on `viam module update-models` is now optional. When omitted, the CLI falls back to the `entrypoint` declared in `meta.json`.

## Docs changes

- `docs/cli/reference.md`: changed the synopsis line from `--binary=<binary>` to `[--binary=<binary>]`; updated the flag table entry from **Required** to Optional and noted the meta.json fallback.
- `docs/cli/build-and-deploy-modules.md`: showed the no-flag invocation as the recommended usage and kept the explicit-`--binary` form as an alternative.

## How I found these

- Grep for `update-models` across the docs repo (5 hits in 2 files were docs prose; the other hits were in metajson and tutorials referencing `viam module update`, not `update-models`).
- Verified the new behavior in `rdk/cli/module_registry.go` `UpdateModelsAction` and `rdk/cli/app.go` `update-models` flag definition (no `Required: true`).

---
Generated by daily docs change agent