### PR TITLE
Fix new-docs-site deploy: add three alias redirects

### DIFF
--- a/docs/motion-planning/_index.md
+++ b/docs/motion-planning/_index.md
@@ -13,6 +13,7 @@ notoc: true
 aliases:
   - /operate/mobility/
   - /operate/mobility/motion-concepts/
+  - /motion-planning/motion-how-to/
 ---
 
 Your robot arm needs to move from one position to another without colliding with

--- a/docs/motion-planning/frame-system/_index.md
+++ b/docs/motion-planning/frame-system/_index.md
@@ -15,6 +15,7 @@ aliases:
   - /services/frame-system/frame-config/
   - /mobility/frame-system/frame-config/
   - /reference/services/frame-system/frame-config/
+  - /motion-planning/frame-system-how-to/
 ---
 
 A robot with an arm, a camera, and a gripper has three components, and each one

--- a/docs/motion-planning/obstacles/_index.md
+++ b/docs/motion-planning/obstacles/_index.md
@@ -15,6 +15,7 @@ aliases:
   - /services/frame-system/nested-frame-config/
   - /mobility/frame-system/nested-frame-config/
   - /reference/services/frame-system/nested-frame-config/
+  - /operate/reference/services/frame-system/nested-frame-config/
 ---
 
 A robot arm that knows nothing about its surroundings plans the shortest path


### PR DESCRIPTION
## Summary

PR #4938 merged cleanly through CI but failed at the Netlify branch-deploy stage. The `no-more-404` plugin caught three paths that existed in production but are now missing after the motion-planning reorg:

- `/motion-planning/motion-how-to/` — subsection dissolved; how-tos moved to topical subsections
- `/motion-planning/frame-system-how-to/` — merged into `/motion-planning/frame-system/`
- `/operate/reference/services/frame-system/nested-frame-config/` — content merged into `/motion-planning/obstacles/`; I had the `/reference/services/` and `/mobility/` variants but missed the `/operate/reference/` prefix

This PR adds each missing URL as an alias on the appropriate destination page. No content changes.

## Test plan

- [ ] Netlify deploy preview builds cleanly (the no-more-404 plugin runs here too)
- [ ] Spot-check the three redirects:
  - `/motion-planning/motion-how-to/` → `/motion-planning/`
  - `/motion-planning/frame-system-how-to/` → `/motion-planning/frame-system/`
  - `/operate/reference/services/frame-system/nested-frame-config/` → `/motion-planning/obstacles/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)