### PR TITLE
Motion planning review feedback: quick fixes

### DIFF
--- a/docs/motion-planning/3d-scene/_index.md
+++ b/docs/motion-planning/3d-scene/_index.md
@@ -8,8 +8,8 @@ no_list: true
 description: "Visualize your machine's frame system, geometries, and point clouds in an interactive 3D view."
 ---
 
-The **3D scene** tab renders your machine's frame system as an interactive 3D visualization on your machine's page in the [Viam app](https://app.viam.com).
-Frame configuration is otherwise invisible: a JSON translation of `{x: 50, y: 0, z: 110}` tells you nothing about whether the gripper actually sits where the arm needs it. The 3D scene makes that spatial relationship visible so you can catch misconfigurations before a motion plan fails.
+The **3D SCENE** tab renders your machine's frame system as an interactive 3D visualization on your machine's page in the [Viam app](https://app.viam.com).
+Frame configuration is otherwise invisible: a JSON translation of `{x: 50, y: 0, z: 110}` tells you nothing about whether the gripper actually sits where the arm needs it. The **3D SCENE** tab makes that spatial relationship visible so you can catch misconfigurations before a motion plan fails.
 
 The tab reads your machine's configuration and, when the machine is online, connects for live data. Each component's frame appears as a set of coordinate axes positioned by its translation and orientation relative to its parent frame. Attached geometries render as translucent shapes, and point clouds from depth cameras render as colored point sets.
 
@@ -52,19 +52,19 @@ Entities that can be removed (for example, dropped PCD files) also show a **Remo
 
 ## Navigation controls
 
-| Action                   | Mouse             | Keyboard             |
-| ------------------------ | ----------------- | -------------------- |
-| Orbit (rotate view)      | Left-click drag   | Arrow keys           |
-| Pan                      | Right-click drag  |                      |
-| Zoom                     | Scroll wheel      | `R` (in) / `F` (out) |
-| Strafe camera            |                   | `W`/`A`/`S`/`D`      |
-| Select entity            | Left-click        |                      |
-| Deselect                 | Click empty space |                      |
-| Exit object view         |                   | `Escape`             |
-| Toggle camera mode       |                   | `C`                  |
-| Toggle entity visibility |                   | `H`                  |
+| Action                   | Mouse             | Keyboard              |
+| ------------------------ | ----------------- | --------------------- |
+| Orbit (rotate view)      | Left-click drag   | Arrow keys            |
+| Pan                      | Right-click drag  |                       |
+| Zoom                     | Scroll wheel      | `R` (in) / `F` (out)  |
+| Strafe camera            |                   | `W`/`A`/`S`/`D`       |
+| Select entity            | Left-click        |                       |
+| Deselect                 | Click empty space |                       |
+| Exit object view         |                   | `Escape`              |
+| Toggle camera mode       |                   | `C`                   |
+| Toggle entity visibility |                   | `H` (selected entity) |
 
-Holding `⌘` (or `Ctrl`) disables keyboard navigation, which is useful when you are editing a value in the Details panel.
+Holding `⌘` (or `Ctrl`) disables keyboard navigation, which is useful when you are editing a value in the Details panel. `H` only affects the currently selected or focused entity, so click an entity (or its row in the World panel) before pressing it.
 
 ## Settings
 

--- a/docs/motion-planning/3d-scene/_index.md
+++ b/docs/motion-planning/3d-scene/_index.md
@@ -22,7 +22,7 @@ The tab has four areas, each doing a distinct job: the **viewport** renders the 
 **World panel** (floating, upper-left): A hierarchical list of every entity in the scene, titled **World**.
 The panel is always visible (it has no close button) but is draggable and resizable.
 The root node `World` mirrors your machine's world frame.
-Each row shows an expand caret, the entity name, and an eye toggle (click the eye, or select the row and press `H`, to hide or show that entity).
+Each row shows an expand caret, the entity name, and an eye toggle. Click the eye or select the row and press `H` to hide or show the entity.
 Click a row to select the entity; its details appear in the Details panel.
 
 **Details panel** (floating, upper-right): Shows the selected entity's spatial properties.
@@ -82,7 +82,7 @@ This is useful for loading saved SLAM maps or point cloud captures for compariso
 
 ## Link related entities (HoverLink)
 
-When you select a point cloud or arrows entity (typically dropped PCD or PLY files), the Details panel shows an **Add Relationship** button. Use this to link two indexable entities so that hovering an item in one entity highlights the corresponding item in the other.
+HoverLink links two indexable entities so that hovering an item in one highlights the matching item in the other. When you select a point cloud or arrows entity (typically dropped PCD or PLY files), the Details panel shows an **Add Relationship** button to set this up.
 
 To add a HoverLink:
 

--- a/docs/motion-planning/3d-scene/_index.md
+++ b/docs/motion-planning/3d-scene/_index.md
@@ -84,6 +84,23 @@ Settings are grouped by what they affect: connection, scene decoration, point cl
 You can drag and drop `.pcd`, `.ply`, or `.json` (scene snapshot) files directly onto the 3D viewport to load external data into the scene.
 This is useful for loading saved SLAM maps or point cloud captures for comparison with your live frame system.
 
+## Link related entities (HoverLink)
+
+When you select a point cloud or arrows entity (typically dropped PCD or PLY files), the Details panel shows an **Add Relationship** button. Use this to link two indexable entities so that hovering an item in one entity highlights the corresponding item in the other.
+
+To add a HoverLink:
+
+1. Select a point cloud or arrows entity in the World panel.
+2. In the Details panel, click **Add Relationship**.
+3. Pick **HoverLink** as the relationship type.
+4. Pick a second entity from the **Entity** dropdown.
+5. Set an **Index mapping** formula. The default `index` maps point N in the source to point N in the target. Other expressions over `index` map between non-aligned datasets.
+6. Click **Add**.
+
+After the link is added, hovering a point in the source entity highlights the matching point in the target entity (and updates the hover tooltip with both points' positions). Existing links appear under **Relationships** in the Details panel and have per-link remove buttons.
+
+This is useful for comparing point clouds that should align (a registered scan against a transformed version, ground-truth points against predicted points) without flipping back and forth between separate views.
+
 ## How-to guides
 
 {{< cards >}}

--- a/docs/motion-planning/3d-scene/_index.md
+++ b/docs/motion-planning/3d-scene/_index.md
@@ -15,13 +15,9 @@ The tab reads your machine's configuration and, when the machine is online, conn
 
 ## The interface
 
-The tab has four main areas: a 3D viewport in the center, a World panel on the upper-left, a Details panel on the upper-right, and a Dashboard toolbar on top. The viewport is where you look; the other three are where you navigate, inspect, and change views.
+The tab has four areas, each doing a distinct job: the **viewport** renders the scene; the **World panel** and **Details panel** select and inspect entities; the **Dashboard toolbar** changes how the viewport renders.
 
-**3D viewport** (center): The main rendering area.
-You can orbit, pan, and zoom to view your frame system from any angle.
-Components appear as labeled coordinate axes, with attached geometries rendered as translucent shapes.
-Point clouds from cameras render as colored point sets.
-An XY grid provides spatial reference.
+**3D viewport** (center): the interactive rendering area. Orbit, pan, and zoom to see your frame system from any angle. Components appear as labeled coordinate axes; attached geometries render as translucent shapes; point clouds render as colored point sets. An XY grid provides spatial reference.
 
 **World panel** (floating, upper-left): A hierarchical list of every entity in the scene, titled **World**.
 The panel is always visible (it has no close button) but is draggable and resizable.

--- a/docs/motion-planning/3d-scene/_index.md
+++ b/docs/motion-planning/3d-scene/_index.md
@@ -60,7 +60,7 @@ Entities that can be removed (for example, dropped PCD files) also show a **Remo
 | Strafe camera            |                   | `W`/`A`/`S`/`D`      |
 | Select entity            | Left-click        |                      |
 | Deselect                 | Click empty space |                      |
-| Exit focus mode          |                   | `Escape`             |
+| Exit object view         |                   | `Escape`             |
 | Toggle camera mode       |                   | `C`                  |
 | Toggle entity visibility |                   | `H`                  |
 

--- a/docs/motion-planning/3d-scene/_index.md
+++ b/docs/motion-planning/3d-scene/_index.md
@@ -59,7 +59,8 @@ Entities that can be removed (for example, dropped PCD files) also show a **Remo
 | Zoom                     | Scroll wheel      | `R` (in) / `F` (out) |
 | Strafe camera            |                   | `W`/`A`/`S`/`D`      |
 | Select entity            | Left-click        |                      |
-| Deselect                 | Click empty space | `Escape`             |
+| Deselect                 | Click empty space |                      |
+| Exit focus mode          |                   | `Escape`             |
 | Toggle camera mode       |                   | `C`                  |
 | Toggle entity visibility |                   | `H`                  |
 

--- a/docs/motion-planning/3d-scene/calibrate-frame-offsets.md
+++ b/docs/motion-planning/3d-scene/calibrate-frame-offsets.md
@@ -7,7 +7,7 @@ type: "docs"
 description: "Verify and adjust the spatial relationship between components using the 3D scene and measurement tool."
 ---
 
-When you configure a camera on an arm, or a sensor on a base, the frame system needs the exact translation and orientation between the two components. A 15 mm error in a camera offset places a detected object 15 mm off; the arm then reaches for the wrong spot, or the point cloud sits behind the table instead of on it. The 3D scene tab lets you verify offsets visually and measure distances directly, so you can catch these errors before they produce bad motion.
+When you configure a camera on an arm, or a sensor on a base, the frame system needs the exact translation and orientation between the two components. A 15 mm error in a camera offset places a detected object 15 mm off; the arm then reaches for the wrong spot, or the point cloud sits behind the table instead of on it. The **3D SCENE** tab lets you verify offsets visually and measure distances directly, so you can catch these errors before they produce bad motion.
 
 ## Prerequisites
 
@@ -16,7 +16,7 @@ When you configure a camera on an arm, or a sensor on a base, the frame system n
 
 ## Verify frame offsets
 
-### 1. Open the 3D scene tab
+### 1. Open the 3D SCENE tab
 
 Navigate to your machine in the [Viam app](https://app.viam.com) and click the **3D SCENE** tab.
 
@@ -66,7 +66,7 @@ Frame calibration is often iterative:
 
 1. Measure physically.
 2. Enter the values in the frame configuration.
-3. Check the result in the 3D scene.
+3. Check the result in the **3D SCENE** tab.
 4. Adjust and repeat until the scene matches reality.
 
 For high-precision applications, use the camera calibration procedure to compute intrinsic parameters before adjusting frame offsets.

--- a/docs/motion-planning/3d-scene/debug-motion-plan.md
+++ b/docs/motion-planning/3d-scene/debug-motion-plan.md
@@ -8,13 +8,13 @@ description: "Use the 3D scene to inspect the frame system and obstacle geometry
 ---
 
 When a motion plan fails with a collision error or produces a path that
-does not look right, the 3D scene tab lets you inspect the static view
+does not look right, the **3D SCENE** tab lets you inspect the static view
 of the world the planner sees at the moment you look: configured frame
 positions, collision geometries, and the arm's current pose. Most
 motion planning failures come down to one of a few problems that are
 immediately visible in 3D.
 
-The 3D scene tab does not replay motion plans and has no timeline,
+The **3D SCENE** tab does not replay motion plans and has no timeline,
 scrubber, or plan-playback control. It is an inspector of the
 configured frame system and live component poses. If you need to watch
 a plan execute over time, poll `GetPlan` from code (see
@@ -28,7 +28,7 @@ step the arm to intermediate joint positions manually and reinspect.
 
 ## Diagnose the problem
 
-### 1. Open the 3D scene tab
+### 1. Open the 3D SCENE tab
 
 Navigate to your machine in the [Viam app](https://app.viam.com) and
 click the **3D SCENE** tab. The scene loads your current frame system
@@ -105,7 +105,7 @@ the frame pair with
 
 ## Common causes of motion plan failures
 
-| Symptom                       | Likely cause                                  | What to check in 3D scene                                                  |
+| Symptom                       | Likely cause                                  | What to check in 3D SCENE                                                  |
 | ----------------------------- | --------------------------------------------- | -------------------------------------------------------------------------- |
 | "no valid path found"         | Target unreachable or blocked by obstacles    | Is the target inside an obstacle? Is it within the arm's reach?            |
 | Collision error               | Obstacle geometry intersects the planned path | Are obstacles positioned correctly? Are they the right size?               |

--- a/docs/motion-planning/3d-scene/edit-frames.md
+++ b/docs/motion-planning/3d-scene/edit-frames.md
@@ -65,12 +65,14 @@ Edits are held locally until you save. The CONFIGURE tab shows an unsaved-change
 
 To delete a frame, remove it from the component's configuration on the CONFIGURE tab (there is no **Delete frame** button in the embedded **3D SCENE** tab).
 
-## When to use visual editing
+## When to edit JSON instead
 
-Visual frame editing is most useful when:
+Visual editing covers most cases, but a few are faster in JSON:
 
-- You are setting up a new frame system and want to see the result as you go, rather than configuring JSON and then checking the **3D SCENE** tab.
-- You need to make small adjustments to frame positions and want immediate visual feedback.
-- You are adding geometry to components and want to see whether the shapes cover the physical objects correctly.
-
-For bulk configuration changes, complex orientation values, or frames that reference components on different machine parts, editing the JSON configuration directly may be more efficient.
+- **Bulk changes** (renaming many frames, regenerating a layout) — JSON
+  edits are easier in a text editor.
+- **Frames that reference components on a different machine part** —
+  the visual editor's parent dropdown only shows local frames.
+- **Complex orientations** (rotations expressed in `axis_angles` or
+  `quaternion` rather than `ov_degrees`) — the visual editor surfaces
+  only the orientation vector form.

--- a/docs/motion-planning/3d-scene/edit-frames.md
+++ b/docs/motion-planning/3d-scene/edit-frames.md
@@ -7,7 +7,7 @@ type: "docs"
 description: "Add, edit, and attach geometry to frames directly in the 3D scene instead of editing JSON configuration."
 ---
 
-The 3D scene tab can serve as a configuration editor: you can add, move, re-parent, and reshape frames without writing JSON.
+The **3D SCENE** tab can serve as a configuration editor: you can add, move, re-parent, and reshape frames without writing JSON.
 
 Visual editing is most useful while you are still figuring out where things go. Typing coordinates into JSON and reloading the 3D view to check them is slow; editing in the viewport and seeing the result immediately is faster. The trade-off is that the visual editor writes the same JSON fields through a smaller surface area, so it is less suited to bulk changes or cross-machine-part frames. Changes flow back to the machine configuration, and the app surfaces an unsaved-changes banner on the CONFIGURE tab where you save them with **Save** or `⌘/Ctrl+S`.
 
@@ -17,7 +17,7 @@ Visual editing is most useful while you are still figuring out where things go. 
 
 ## Add a frame to a component
 
-1. Open the 3D scene tab.
+1. Open the **3D SCENE** tab.
 2. Click the **Add frames** button (axis-arrow icon) in the top-center toolbar. A floating panel opens listing components that do not yet have a frame.
 3. Select a component from the dropdown.
 4. Click **Add frame** (singular) inside the panel.
@@ -63,13 +63,13 @@ To remove a geometry, click **None**.
 
 Edits are held locally until you save. The CONFIGURE tab shows an unsaved-changes banner with a **Save** button; click it (or press `⌘/Ctrl+S` on the CONFIGURE tab) to commit them. If you navigate away first, the edits are lost.
 
-To delete a frame, remove it from the component's configuration on the CONFIGURE tab (there is no **Delete frame** button in the embedded 3D scene tab).
+To delete a frame, remove it from the component's configuration on the CONFIGURE tab (there is no **Delete frame** button in the embedded **3D SCENE** tab).
 
 ## When to use visual editing
 
 Visual frame editing is most useful when:
 
-- You are setting up a new frame system and want to see the result as you go, rather than configuring JSON and then checking the 3D scene.
+- You are setting up a new frame system and want to see the result as you go, rather than configuring JSON and then checking the **3D SCENE** tab.
 - You need to make small adjustments to frame positions and want immediate visual feedback.
 - You are adding geometry to components and want to see whether the shapes cover the physical objects correctly.
 

--- a/docs/motion-planning/3d-scene/set-up-obstacle-avoidance.md
+++ b/docs/motion-planning/3d-scene/set-up-obstacle-avoidance.md
@@ -46,23 +46,15 @@ Check that:
 
 ## Add or adjust obstacles
 
-Obstacles are defined in the motion service configuration or passed as a `WorldState` parameter to `Move` requests.
-For static obstacles (tables, walls, posts), define them in the configuration so they persist across motion plans.
+Static obstacles are defined in the component frame configuration. See
+[Define obstacles](/motion-planning/obstacles/) for the geometry types,
+JSON schema, and worked examples. The
+[geometry types table](/motion-planning/obstacles/#geometry-types) on
+that page gives recommendations for which type to use for which physical
+object.
 
-See [Define obstacles](/motion-planning/obstacles/) for the full configuration reference, including JSON examples for each geometry type.
-
-After changing obstacle configuration, return to the **3D SCENE** tab to verify the changes.
-The scene reflects the current saved configuration.
-
-## Choose the right geometry type
-
-| Physical object  | Recommended geometry | Notes                                                                                 |
-| ---------------- | -------------------- | ------------------------------------------------------------------------------------- |
-| Table or shelf   | Box                  | Match the surface dimensions. Include thickness if the arm could approach from below. |
-| Post or column   | Capsule              | Set the radius to match the column width, length to match the height.                 |
-| Round obstacle   | Sphere               | Use the bounding radius. Simple and fast for collision checking.                      |
-| Wall or barrier  | Box                  | Use a thin box with large x and z dimensions.                                         |
-| Irregular object | Box (oversized)      | Use the bounding box of the object. Oversizing is safer than undersizing.             |
+After changing obstacle configuration, return to the **3D SCENE** tab to
+verify the changes. The scene reflects the current saved configuration.
 
 ## Verify coverage
 
@@ -75,6 +67,15 @@ After defining obstacles, run through this checklist in the **3D SCENE** tab:
 
 ## Dynamic obstacles
 
-Static obstacles in configuration cover fixed workspace objects. For objects that move, pass geometry at runtime through the `WorldState` parameter of the `Move` request. Runtime geometry uses the same shape types as static geometry and appears in the **3D SCENE** tab the same way.
+Static obstacles in configuration cover fixed workspace objects. For objects
+that move, pass geometry at runtime through the `WorldState` parameter of the
+`Move` request. See
+[Static vs dynamic obstacles](/motion-planning/obstacles/#static-vs-dynamic-obstacles)
+for the distinction and
+[Define obstacles programmatically with WorldState](/motion-planning/obstacles/#3-define-obstacles-programmatically-with-worldstate)
+for code examples.
 
-Pair a vision service with a camera to detect moving objects and feed the detections into `Move` as runtime obstacles. See the [motion service API reference](/motion-planning/reference/) for obstacle detectors.
+Dynamic obstacles passed to a single `Move` call are not drawn in the **3D
+SCENE** tab. To verify a dynamic obstacle's position visually, log its pose
+from your code or temporarily add a static geometry with the same dimensions
+to a component frame.

--- a/docs/motion-planning/3d-scene/set-up-obstacle-avoidance.md
+++ b/docs/motion-planning/3d-scene/set-up-obstacle-avoidance.md
@@ -7,7 +7,7 @@ type: "docs"
 description: "Visualize and adjust obstacle geometry so the motion planner routes around physical objects."
 ---
 
-The motion planner avoids obstacles only if it knows about them, and it knows about them only as geometries you define: boxes, spheres, or capsules positioned in the frame system. That definition is invisible in JSON. A box specified as `{x: 800, y: 1200, z: 20}` at some parent-relative translation either covers the table or it doesn't, and you can't tell which from the numbers. The 3D scene tab lets you see what the planner sees, so you can check coverage before running a plan.
+The motion planner avoids obstacles only if it knows about them, and it knows about them only as geometries you define: boxes, spheres, or capsules positioned in the frame system. That definition is invisible in JSON. A box specified as `{x: 800, y: 1200, z: 20}` at some parent-relative translation either covers the table or it doesn't, and you can't tell which from the numbers. The **3D SCENE** tab lets you see what the planner sees, so you can check coverage before running a plan.
 
 ## Prerequisites
 
@@ -17,7 +17,7 @@ The motion planner avoids obstacles only if it knows about them, and it knows ab
 
 ## Visualize existing obstacles
 
-### 1. Open the 3D scene tab
+### 1. Open the 3D SCENE tab
 
 Navigate to your machine in the [Viam app](https://app.viam.com) and click the **3D SCENE** tab.
 
@@ -51,7 +51,7 @@ For static obstacles (tables, walls, posts), define them in the configuration so
 
 See [Define obstacles](/motion-planning/obstacles/) for the full configuration reference, including JSON examples for each geometry type.
 
-After changing obstacle configuration, return to the 3D scene tab to verify the changes.
+After changing obstacle configuration, return to the **3D SCENE** tab to verify the changes.
 The scene reflects the current saved configuration.
 
 ## Choose the right geometry type
@@ -66,7 +66,7 @@ The scene reflects the current saved configuration.
 
 ## Verify coverage
 
-After defining obstacles, run through this checklist in the 3D scene:
+After defining obstacles, run through this checklist in the **3D SCENE** tab:
 
 1. **Orbit to each workspace boundary.** If the arm can reach past the geometry into the physical object, the geometry is too small.
 2. **Check the floor and ceiling.** If the arm can reach the floor, add a floor plane. Do the same for ceiling-mounted setups.
@@ -75,6 +75,6 @@ After defining obstacles, run through this checklist in the 3D scene:
 
 ## Dynamic obstacles
 
-Static obstacles in configuration cover fixed workspace objects. For objects that move, pass geometry at runtime through the `WorldState` parameter of the `Move` request. Runtime geometry uses the same shape types as static geometry and appears in the 3D scene the same way.
+Static obstacles in configuration cover fixed workspace objects. For objects that move, pass geometry at runtime through the `WorldState` parameter of the `Move` request. Runtime geometry uses the same shape types as static geometry and appears in the **3D SCENE** tab the same way.
 
 Pair a vision service with a camera to detect moving objects and feed the detections into `Move` as runtime obstacles. See the [motion service API reference](/motion-planning/reference/) for obstacle detectors.

--- a/docs/motion-planning/3d-scene/set-up-obstacle-avoidance.md
+++ b/docs/motion-planning/3d-scene/set-up-obstacle-avoidance.md
@@ -26,7 +26,7 @@ Navigate to your machine in the [Viam app](https://app.viam.com) and click the *
 Obstacle geometries appear as translucent shapes in the viewport and as child rows under their parent frame in the **World** panel.
 Each geometry is positioned according to its frame configuration: its location is defined by a translation and orientation relative to a parent frame.
 
-There is no separate "obstacles" list; toggle an obstacle's visibility with the eye icon on its row in the World panel, or select the row and press `H`.
+Obstacles do not get their own list. To toggle an obstacle's visibility, click the eye icon on its row in the World panel, or select the row and press `H`.
 
 Click an obstacle in the scene or in the World panel to see its details:
 

--- a/docs/motion-planning/3d-scene/verify-point-cloud-alignment.md
+++ b/docs/motion-planning/3d-scene/verify-point-cloud-alignment.md
@@ -9,7 +9,7 @@ aliases:
   - /motion-planning/3d-scene/inspect-point-clouds/
 ---
 
-Depth cameras produce point clouds: sets of 3D points that represent the surfaces the camera sees. The 3D scene tab renders those points in your frame system, so you can check two things at once: the camera is producing usable data, and the data lines up with the rest of the workspace.
+Depth cameras produce point clouds: sets of 3D points that represent the surfaces the camera sees. The **3D SCENE** tab renders those points in your frame system, so you can check two things at once: the camera is producing usable data, and the data lines up with the rest of the workspace.
 
 Misalignment usually means one of two things: the camera's frame offset is wrong, or the camera itself has a problem. Finding that out now, before a motion plan runs or an ML detector ships, costs minutes; finding it out later costs a day of debugging a downstream pipeline.
 
@@ -21,7 +21,7 @@ Misalignment usually means one of two things: the camera's frame offset is wrong
 
 ## Steps
 
-### 1. Open the 3D scene tab
+### 1. Open the 3D SCENE tab
 
 Navigate to your machine in the [Viam app](https://app.viam.com) and click the **3D SCENE** tab.
 Your machine must be online for live point cloud data.

--- a/docs/motion-planning/3d-scene/verify-point-cloud-alignment.md
+++ b/docs/motion-planning/3d-scene/verify-point-cloud-alignment.md
@@ -59,3 +59,47 @@ If the point cloud is in the right place but the data looks wrong, look for comm
 
 Data quality problems are camera issues, not frame system issues.
 Adjust the camera's configuration, mounting angle, or lighting conditions to address them.
+
+## From point clouds to obstacles
+
+A raw point cloud is just a set of 3D points; the motion planner does
+not consume it directly. To turn point cloud data into something the
+planner can avoid, run it through a vision service whose model produces
+3D objects (one with a 3D segmenter, like the [`obstacles_pointcloud`
+module](https://app.viam.com/module/viam/obstacles-pointcloud) or any
+custom segmenter that implements `GetObjectPointClouds`). The vision
+service returns each detected object with a bounding geometry the
+planner can use as an obstacle.
+
+Two ways to feed those obstacles into motion planning:
+
+- **Per-call (`Move`):** call `GetObjectPointClouds` from your code,
+  convert each returned object's bounding geometry into a
+  `Geometry`, and pass the result as `WorldState.obstacles` on the
+  `Move` request. See
+  [Define obstacles programmatically with WorldState](/motion-planning/obstacles/#3-define-obstacles-programmatically-with-worldstate)
+  for the construction pattern. The planner uses these only for that
+  call.
+
+- **During execution (`MoveOnMap` / `MoveOnGlobe`):** configure
+  `obstacle_detectors` on the `MotionConfiguration` for the call.
+  The motion service polls each `(vision_service, camera)` pair at the
+  configured rate and feeds new detections to the planner without you
+  re-issuing `Move`. See
+  [ObstacleDetector](/motion-planning/reference/motion-configuration/#obstacledetector)
+  and
+  [Replanning behavior](/motion-planning/replanning-behavior/) for the
+  poll cadence and how detections trigger replans.
+
+If you just need to align a point cloud with the rest of the scene
+visually (no obstacle pipeline yet), the steps above are enough; you
+do not need a vision service to use the **3D SCENE** tab.
+
+## What's next
+
+- [Pick an object](/motion-planning/pick-and-place/pick-an-object/):
+  uses `GetObjectPointClouds` to localize the target the arm should
+  grasp.
+- [Define obstacles](/motion-planning/obstacles/): the geometry types
+  the motion planner accepts as obstacles, regardless of whether
+  they come from vision or from configuration.

--- a/docs/motion-planning/3d-scene/verify-point-cloud-alignment.md
+++ b/docs/motion-planning/3d-scene/verify-point-cloud-alignment.md
@@ -60,46 +60,22 @@ If the point cloud is in the right place but the data looks wrong, look for comm
 Data quality problems are camera issues, not frame system issues.
 Adjust the camera's configuration, mounting angle, or lighting conditions to address them.
 
-## From point clouds to obstacles
-
-A raw point cloud is just a set of 3D points; the motion planner does
-not consume it directly. To turn point cloud data into something the
-planner can avoid, run it through a vision service whose model produces
-3D objects (one with a 3D segmenter, like the [`obstacles_pointcloud`
-module](https://app.viam.com/module/viam/obstacles-pointcloud) or any
-custom segmenter that implements `GetObjectPointClouds`). The vision
-service returns each detected object with a bounding geometry the
-planner can use as an obstacle.
-
-Two ways to feed those obstacles into motion planning:
-
-- **Per-call (`Move`):** call `GetObjectPointClouds` from your code,
-  convert each returned object's bounding geometry into a
-  `Geometry`, and pass the result as `WorldState.obstacles` on the
-  `Move` request. See
-  [Define obstacles programmatically with WorldState](/motion-planning/obstacles/#3-define-obstacles-programmatically-with-worldstate)
-  for the construction pattern. The planner uses these only for that
-  call.
-
-- **During execution (`MoveOnMap` / `MoveOnGlobe`):** configure
-  `obstacle_detectors` on the `MotionConfiguration` for the call.
-  The motion service polls each `(vision_service, camera)` pair at the
-  configured rate and feeds new detections to the planner without you
-  re-issuing `Move`. See
-  [ObstacleDetector](/motion-planning/reference/motion-configuration/#obstacledetector)
-  and
-  [Replanning behavior](/motion-planning/replanning-behavior/) for the
-  poll cadence and how detections trigger replans.
-
-If you just need to align a point cloud with the rest of the scene
-visually (no obstacle pipeline yet), the steps above are enough; you
-do not need a vision service to use the **3D SCENE** tab.
-
 ## What's next
+
+The motion planner does not consume raw point clouds directly: a vision
+service with a 3D segmenter (such as the
+[`obstacles_pointcloud` module](https://app.viam.com/module/viam/obstacles-pointcloud))
+turns point clouds into bounded 3D objects, and you feed those to the
+planner.
 
 - [Pick an object](/motion-planning/pick-and-place/pick-an-object/):
   uses `GetObjectPointClouds` to localize the target the arm should
-  grasp.
+  grasp on a single `Move` call.
 - [Define obstacles](/motion-planning/obstacles/): the geometry types
-  the motion planner accepts as obstacles, regardless of whether
-  they come from vision or from configuration.
+  the motion planner accepts, including the
+  [`WorldState.obstacles`](/motion-planning/obstacles/#3-define-obstacles-programmatically-with-worldstate)
+  pattern for per-call dynamic obstacles.
+- [ObstacleDetector](/motion-planning/reference/motion-configuration/#obstacledetector):
+  configures the motion service to poll a vision service during
+  `MoveOnMap` and `MoveOnGlobe`, so detections trigger replans without
+  re-issuing `Move`.

--- a/docs/motion-planning/_index.md
+++ b/docs/motion-planning/_index.md
@@ -44,7 +44,7 @@ fake components so you can run it on any machine:
 Motion planning in Viam connects several pieces:
 
 1. **Frame system**: a coordinate tree that tracks where every component is in
-   space. The frame system lets you specify target positions in any frame and
+   space. The frame system lets you specify target poses in any frame and
    translates between them automatically.
 
 2. **Kinematic model**: a description of the arm's joints and links that tells

--- a/docs/motion-planning/_index.md
+++ b/docs/motion-planning/_index.md
@@ -16,18 +16,17 @@ aliases:
   - /motion-planning/motion-how-to/
 ---
 
-Your robot arm needs to move from one position to another without colliding with
-the table, the walls, or itself. Computing a collision-free path through 3D
-space means reasoning about the arm's kinematic model, the workspace geometry,
-and any constraints on how the arm should move.
+Your robot arm needs to move from one pose to another without colliding with
+the table, the walls, or itself. To move safely, the planner must reason about
+the arm's kinematic model, the workspace geometry, and the motion constraints
+you impose.
 
-Viam's motion service handles this for you. You describe the spatial layout of
-your workspace (the frame system) and any obstacles, then tell the arm where to
-go. The planner finds a safe path and executes it.
+Viam's motion service plans a collision-free path and executes it, using a
+frame system you describe and obstacles you declare. You tell it where to go;
+it handles the search.
 
-This section covers motion planning for arms, gantries, and other kinematic
-chains. For GPS-based autonomous navigation with mobile bases, see
-[Navigation](/navigation/).
+This section covers motion planning for arms and gantries. For GPS-based
+autonomous navigation with mobile bases, see [Navigation](/navigation/).
 
 ## Start here
 
@@ -41,26 +40,15 @@ fake components so you can run it on any machine:
 
 ## How it works
 
-Motion planning in Viam connects several pieces:
+Each `Move` request to the motion service runs the same pipeline: it reads
+the [frame system](/motion-planning/frame-system/) to know where every
+component sits, reads the arm's [kinematic model](/motion-planning/reference/kinematics/)
+to know what joint configurations are reachable, applies any
+[obstacles](/motion-planning/obstacles/) and
+[constraints](/motion-planning/move-an-arm/constraints/) you declare, and
+returns a collision-free path from the current pose to your target.
 
-1. **Frame system**: a coordinate tree that tracks where every component is in
-   space. The frame system lets you specify target poses in any frame and
-   translates between them automatically.
-
-2. **Kinematic model**: a description of the arm's joints and links that tells
-   the planner what configurations are physically possible.
-
-3. **Obstacles**: geometry (boxes, spheres, capsules) that define regions the
-   arm must avoid.
-
-4. **Constraints**: rules about how the arm should move between poses, such as
-   keeping the end effector on a straight line or maintaining its orientation.
-
-5. **Motion service**: takes the frame system, kinematic model, obstacles, and
-   constraints and computes a collision-free path from the current pose to the
-   target.
-
-## Topic subsections
+## Core topics
 
 {{< cards >}}
 {{% card link="/motion-planning/frame-system/" noimage="true" %}}

--- a/docs/motion-planning/debug-motion-with-cli.md
+++ b/docs/motion-planning/debug-motion-with-cli.md
@@ -18,7 +18,7 @@ frame's current world-frame pose, and `set-pose` drives a component to a pose
 so you can isolate reachability.
 
 This guide walks through the most common debugging flows. For the
-visual equivalent on machines where the **3D scene** tab is available,
+visual equivalent on machines where the **3D SCENE** tab is available,
 see [Debug a motion plan](/motion-planning/3d-scene/debug-motion-plan/).
 For the dry command reference, see
 [Motion CLI commands](/motion-planning/reference/cli-commands/).

--- a/docs/motion-planning/debug-motion-with-cli.md
+++ b/docs/motion-planning/debug-motion-with-cli.md
@@ -63,7 +63,7 @@ Common issues you will catch at this step:
 viam machines part motion print-status --part "my-machine-main"
 ```
 
-The output is every frame part and its computed world-frame pose:
+`print-status` prints one line per frame part with its computed world-frame pose:
 
 ```text
          my-arm : X:    0.00 Y:    0.00 Z:    0.00 OX:   0.00 OY:   0.00 OZ:   1.00 Theta:   0.00
@@ -111,10 +111,10 @@ Note the X, Y, Z values.
 
 ### 2. Move a small distance first
 
-The small step is a dividing test. If it fails, the planner cannot reach any
-pose near the current position, which usually means a configuration error
-rather than a target-reachability issue. If it succeeds, the current position
-is not the problem and you can work outward from there.
+This small step isolates the problem. If it fails, the planner cannot reach
+any pose near the current position, which usually means a configuration
+error rather than a target-reachability issue. If it succeeds, the current
+position is not the problem and you can work outward from there.
 
 ```sh
 viam machines part motion set-pose \

--- a/docs/motion-planning/frame-system/_index.md
+++ b/docs/motion-planning/frame-system/_index.md
@@ -186,6 +186,15 @@ Common uses:
 - **Convert detections**: transform a point detected in a camera frame to world coordinates so an arm can reach it.
 - **Compare across frames**: when two components report positions in different frames, transform both to a common frame before comparing.
 
+## Verify visually with the 3D scene
+
+The [3D SCENE tab](/motion-planning/3d-scene/) renders your frame hierarchy in
+3D: every configured component appears at its computed world pose, with
+geometry and axes drawn. Open it after a configuration change to confirm the
+arm is mounted on the table, the camera is above the arm, and any obstacles
+sit where you expect. Most frame configuration mistakes (wrong parent, wrong
+axis, missing rotation) show up immediately in this view.
+
 ## Verify with the CLI
 
 You can inspect your frame system from the command line without writing code:

--- a/docs/motion-planning/frame-system/_index.md
+++ b/docs/motion-planning/frame-system/_index.md
@@ -186,7 +186,7 @@ Common uses:
 - **Convert detections**: transform a point detected in a camera frame to world coordinates so an arm can reach it.
 - **Compare across frames**: when two components report positions in different frames, transform both to a common frame before comparing.
 
-## Verify visually with the 3D scene
+## Verify visually with the 3D SCENE tab
 
 The [3D SCENE tab](/motion-planning/3d-scene/) renders your frame hierarchy in
 3D: every configured component appears at its computed world pose, with

--- a/docs/motion-planning/frame-system/_index.md
+++ b/docs/motion-planning/frame-system/_index.md
@@ -138,7 +138,57 @@ Geometry is centered on the frame's origin by default. You can add a
 it relative to the frame.
 
 For detailed information about obstacle geometry, see
-[Define Obstacles](/motion-planning/obstacles/).
+[Define obstacles](/motion-planning/obstacles/).
+
+## Edit a frame in the Viam app
+
+To configure a frame, open the **CONFIGURE** tab in the Viam app, click
+the component's card in the sidebar, and click **Frame**. The Frame
+section is a JSON editor with no form, parent dropdown, or
+geometry-type picker. Edit the JSON directly to set parent, translation,
+orientation, and any geometry. Save with the **Save** button (or
+`⌘`/`Ctrl`+`S`).
+
+A typical frame configuration looks like this:
+
+```json
+{
+  "parent": "world",
+  "translation": { "x": 0, "y": 0, "z": 0 },
+  "orientation": {
+    "type": "ov_degrees",
+    "value": { "x": 0, "y": 0, "z": 1, "th": 0 }
+  }
+}
+```
+
+After saving, the [3D SCENE tab](/motion-planning/3d-scene/) renders the
+frame at its computed world pose so you can verify visually. For
+hardware-specific walkthroughs (table-mounted arm with gripper and
+camera, mobile manipulator, mobile base with sensors), see the cards at
+the bottom of this page.
+
+### Verify with TransformPose
+
+To verify a frame programmatically, transform a known point in the
+component's frame to the world frame and compare against a physical
+measurement.
+
+For example, transform the gripper's origin into the world frame; the
+result should match where the gripper physically sits when the arm is
+at its current joint configuration:
+
+```python
+gripper_origin = PoseInFrame(
+    reference_frame="my-gripper",
+    pose=Pose(x=0, y=0, z=0, o_x=0, o_y=0, o_z=1, theta=0),
+)
+gripper_in_world = await machine.transform_pose(gripper_origin, "world")
+print(f"Gripper in world: x={gripper_in_world.pose.x:.1f}, y={gripper_in_world.pose.y:.1f}, z={gripper_in_world.pose.z:.1f}")
+```
+
+If the printed coordinates do not match the physical measurement, check
+the translation and orientation values in the frame configuration.
 
 ## TransformPose
 

--- a/docs/motion-planning/frame-system/arm-fixed-camera.md
+++ b/docs/motion-planning/frame-system/arm-fixed-camera.md
@@ -27,7 +27,7 @@ world
 └── table-surface
 ```
 
-The key difference from a wrist-mounted camera setup is that the camera is a child of the world frame, not the arm.
+Unlike a wrist-mounted camera, this camera is a child of the world frame, not the arm.
 The camera frame stays fixed in space when the arm moves.
 
 ## Steps
@@ -85,7 +85,7 @@ In the sidebar, click your camera component to open its card. On the card, click
 The camera's parent is `"world"`, not the arm.
 
 Measure the camera's position relative to your world frame origin.
-You need to measure in all three axes: left/right (x), forward/backward (y), and height (z).
+Measure along all three axes: x (right), y (forward), z (up).
 
 **Overhead camera example:**
 For a camera mounted 200 mm to the right, 300 mm forward, and 800 mm above the world frame origin:
@@ -101,12 +101,12 @@ For a camera mounted 200 mm to the right, 300 mm forward, and 800 mm above the w
 }
 ```
 
-An overhead camera's lens points at the floor. In the default camera frame,
-+z points out of the lens, so without rotation the camera's +z would point up
-and the floor would be in -z. Rotating 180 degrees around the x axis flips z
-to point down (the direction the lens is actually aimed), and flips y to
-compensate. The result: +z now matches "away from the camera" in the physical
-sense, and the camera's 2D coordinates map intuitively to world positions.
+An overhead camera's lens points at the floor. In the default camera
+frame, +z points out of the lens, so an unrotated overhead camera has
+its +z pointing up rather than down at the workspace. The 180-degree
+rotation around x flips the camera's +z to point downward, matching the
+lens's actual aim, so 2D image coordinates map intuitively to world
+positions.
 
 **Tripod-mounted camera at an angle:**
 For a camera on a tripod 500 mm to the left, 600 mm forward, and 700 mm above the origin, tilted 45 degrees downward:

--- a/docs/motion-planning/frame-system/arm-fixed-camera.md
+++ b/docs/motion-planning/frame-system/arm-fixed-camera.md
@@ -41,10 +41,7 @@ Mark the origin physically so you can take consistent measurements to both the a
 
 ### 2. Add a frame to the arm
 
-In the [Viam app](https://app.viam.com), navigate to your machine and click the **CONFIGURE** tab.
-In the sidebar, click your arm component to open its card. On the card, click **Frame**.
-
-The Frame section opens a JSON editor (there is no form, no parent dropdown, or geometry-type picker). Edit the JSON directly.
+In the **CONFIGURE** tab, click the arm component's card and then click **Frame**. (For details on the Frame editor, see [Edit a frame in the Viam app](/motion-planning/frame-system/#edit-a-frame-in-the-viam-app).)
 
 Measure the distance from your world frame origin to the arm base along each axis.
 For an arm base 300 mm to the right and 250 mm forward from a table corner:

--- a/docs/motion-planning/frame-system/arm-gripper-camera.md
+++ b/docs/motion-planning/frame-system/arm-gripper-camera.md
@@ -44,10 +44,7 @@ time you add or adjust a frame.
 
 ### 2. Add a frame to the arm
 
-In the [Viam app](https://app.viam.com), navigate to your machine and click the **CONFIGURE** tab.
-In the sidebar, click your arm component to open its card. On the card, click **Frame**.
-
-The Frame section opens a JSON editor (there is no form, no parent dropdown, or geometry-type picker). Edit the JSON directly.
+In the **CONFIGURE** tab, click the arm component's card and then click **Frame**. (For details on the Frame editor, see [Edit a frame in the Viam app](/motion-planning/frame-system/#edit-a-frame-in-the-viam-app).)
 
 If the arm base is your world frame origin:
 

--- a/docs/motion-planning/frame-system/arm-gripper-camera.md
+++ b/docs/motion-planning/frame-system/arm-gripper-camera.md
@@ -33,14 +33,14 @@ The gripper and camera are both children of the arm, so they move with the arm a
 
 ### 1. Choose your world frame origin
 
-Every frame on the machine will be defined relative to the world frame, so the
-origin is the point you measure from. Two good choices for a table-mounted
-arm: the arm's base, or a corner of the table. Using the arm base as the
-origin means the arm's translation is `(0, 0, 0)` and every other measurement
-starts from the arm. Using a table corner gives you a physical landmark (you
-can literally see the corner) at the cost of measuring arm-base-to-corner
-first. Either way, mark the origin physically; you will refer to it every
-time you add or adjust a frame.
+Pick either the arm's base or a corner of the table as your world frame
+origin, then mark that point physically. The trade-off: using the arm
+base means the arm's translation is `(0, 0, 0)` and every measurement
+starts from the arm. Using a table corner gives you a visible landmark
+but requires measuring arm-base-to-corner first.
+
+Every frame on the machine is defined relative to this point, so you
+will refer to it every time you add or adjust a frame.
 
 ### 2. Add a frame to the arm
 
@@ -100,10 +100,10 @@ In the sidebar, click your gripper component to open its card. On the card, clic
 
 #### Pick where the gripper frame origin sits
 
-Choose a point on the gripper as the frame origin. It is up to you, but a
-point near the center of the gripper jaws is usually the most convenient
-choice: when you later call the motion service to move the gripper to a
-target pose, the point you pick here is what gets moved to that pose.
+A point near the center of the gripper jaws is usually the most
+convenient frame origin. When you later call the motion service to move
+the gripper to a target pose, whatever point you pick here is what gets
+moved to that pose.
 
 #### Configure the frame
 
@@ -150,13 +150,13 @@ jaw linkages. If the gripper has one, the motion planner already knows
 the gripper's volume and you do not need to add collision geometry to
 the gripper frame.
 
-Call `GetKinematics` on the gripper (or check the module source) to see
-whether kinematics are provided. If they are, verify that the gripper
-renders as expected in the **3D SCENE** tab. If it does, you are done.
+Call `GetKinematics` on the gripper (or check the module source). If
+the call returns kinematics data, verify the gripper renders as expected
+in the **3D SCENE** tab and you are done.
 
-If the gripper does not have a kinematics file and you want the planner
-to avoid collisions with the gripper body, add a `geometry` field to the
-gripper's frame describing its physical volume. See
+If the gripper has no kinematics file, add a `geometry` field to the
+gripper's frame describing its physical volume so the planner can avoid
+collisions with the gripper body. See
 [Define obstacles](/motion-planning/obstacles/#passive-objects-attached-to-a-component)
 for the pattern.
 

--- a/docs/motion-planning/frame-system/arm-gripper-camera.md
+++ b/docs/motion-planning/frame-system/arm-gripper-camera.md
@@ -12,10 +12,9 @@ aliases:
 A table-mounted arm, a gripper bolted to the end effector, and a camera
 clamped near the wrist is the most common manipulation setup. The camera moves
 with the arm, so its view is always centered on wherever the arm is reaching.
-For the motion service and vision pipelines to know that, that the camera is
-on the arm, not separate from it, you have to tell the frame system three
-relationships: arm-to-world, gripper-to-arm, and camera-to-arm. This guide
-walks through all three.
+The motion service and vision pipelines do not know that on their own; you
+have to declare three frame relationships: arm-to-world, gripper-to-arm, and
+camera-to-arm. This guide walks through all three.
 
 ## Frame hierarchy
 

--- a/docs/motion-planning/frame-system/camera-calibration.md
+++ b/docs/motion-planning/frame-system/camera-calibration.md
@@ -62,8 +62,10 @@ differs.
 
 ### 1. Print a calibration target
 
-Print a standard chessboard calibration pattern (at least 8x6 inner corners).
-Mount it on a flat, rigid surface. Measure the square size with a ruler.
+Print a standard chessboard calibration pattern (at least 8x6 inner corners). The [Viam-labs calibration repository](https://github.com/viam-labs/camera-calibration) provides a
+ready-to-print [A4 8x6 25 mm checkerboard](https://github.com/viam-labs/camera-calibration/blob/main/Checkerboard-A4-25mm-8x6.pdf).
+Mount the print on a flat, rigid surface (foam board or a clipboard works well).
+Measure the square size with a ruler to confirm your printer did not scale the pattern.
 
 ### 2. Capture calibration images
 
@@ -227,6 +229,12 @@ fmt.Printf("  z=%.1f mm\n", pt.Z)
 
 If the computed position is within 10-20 mm of the measured position at a
 working distance of 500-1000 mm, your calibration is good.
+
+For a visual sanity check, open the [3D SCENE tab](/motion-planning/3d-scene/).
+The camera frame should sit in the correct position and orientation relative
+to the arm, and any visible obstacles should appear in plausible locations.
+See [Calibrate frame offsets](/motion-planning/3d-scene/calibrate-frame-offsets/)
+for the full workflow.
 
 ## Troubleshooting
 

--- a/docs/motion-planning/frame-system/camera-calibration.md
+++ b/docs/motion-planning/frame-system/camera-calibration.md
@@ -11,16 +11,18 @@ aliases:
   - /motion-planning/camera-calibration/
 ---
 
-A camera captures 2D images, but your robot operates in 3D space. Converting
-a pixel coordinate to a real-world position, for example to tell the arm
-where an object is, requires the camera's intrinsic parameters. These
-parameters describe how the camera projects 3D space onto its 2D sensor. They
-include the focal length, the principal point (the optical center), and the
-lens distortion characteristics.
+Configuring a camera's frame tells the motion service where the camera
+sits in the workspace; calibrating the camera's intrinsic parameters
+tells it how to convert what the camera sees into positions. Motion
+planning needs both: the frame to know the camera's pose, and the
+intrinsics to know what a detected pixel means in 3D.
 
-Without accurate intrinsics, every 2D-to-3D conversion will be wrong. Detected
-objects will appear shifted, depth estimates will be inaccurate, and the arm will
-miss its targets.
+A camera captures 2D images, but your robot operates in 3D space. The
+intrinsic parameters describe how the camera projects 3D space onto its
+2D sensor: focal length, principal point (the optical center), and lens
+distortion characteristics. Without accurate intrinsics, every 2D-to-3D
+conversion is wrong: detected objects appear shifted, depth estimates
+drift, and the arm misses its targets.
 
 ## Concepts
 

--- a/docs/motion-planning/frame-system/camera-calibration.md
+++ b/docs/motion-planning/frame-system/camera-calibration.md
@@ -265,9 +265,9 @@ for the full workflow.
 
 ## What's next
 
-- [Define Your Frame System](/motion-planning/frame-system/): configure
+- [Define your frame system](/motion-planning/frame-system/): configure
   component frames for spatial reasoning.
-- [Define Obstacles](/motion-planning/obstacles/): add collision geometry using
+- [Define obstacles](/motion-planning/obstacles/): add collision geometry using
   calibrated camera data.
-- [Move an Arm to a Target Pose](/motion-planning/move-an-arm/move-to-pose/):
+- [Move an arm to a target pose](/motion-planning/move-an-arm/move-to-pose/):
   use calibrated positions to plan arm movements.

--- a/docs/motion-planning/frame-system/mobile-base-arm.md
+++ b/docs/motion-planning/frame-system/mobile-base-arm.md
@@ -9,14 +9,14 @@ aliases:
   - /motion-planning/frame-system-how-to/mobile-base-arm/
 ---
 
-A mobile manipulator, a base with an arm on top, has two distinct kinds of
-motion: the base moves through the environment, and the arm moves within
-reach of the base. The frame system represents this correctly by parenting
-the arm to the base rather than to the world. Every arm-attached component
-(the gripper, a wrist camera) then inherits the base's motion, while
-navigation sensors mounted directly on the base form a parallel subtree.
-This guide builds the full hierarchy: world to base to (arm to (gripper,
-wrist camera), navigation sensors).
+A mobile manipulator is a base with an arm on top. It has two distinct
+kinds of motion: the base moves through the environment, and the arm
+moves within reach of the base. The frame system represents this by
+parenting the arm to the base rather than to the world. Every
+arm-attached component (the gripper, a wrist camera) then inherits the
+base's motion, while navigation sensors mounted directly on the base
+form a parallel subtree. This guide builds the full hierarchy: world to
+base to (arm to (gripper, wrist camera), navigation sensors).
 
 ## Frame hierarchy
 
@@ -40,8 +40,11 @@ about the floor consistent while the arm reaches for something.
 
 ### 1. Choose your world frame
 
-For a mobile base, the world frame origin is typically the center of the base.
-All component positions are defined relative to this center point.
+For a mobile base, the world frame origin is the base center at machine
+start. Unlike a table-mounted arm where you pick a fixed physical
+landmark, the frame system tracks the base's motion from this initial
+origin, so you do not mark anything physically. All component positions
+are defined relative to this point.
 
 ### 2. Add a frame to the base
 
@@ -167,8 +170,8 @@ Click **Save** after adding each frame.
 
 1. Open the **3D SCENE** tab.
 2. Confirm the tree structure: arm, gripper, and wrist camera under the base; navigation sensors as direct children of the base.
-3. Jog the arm from the **CONTROL** tab. The arm subtree should move; the base and navigation sensors should not. This is the single clearest test that the hierarchy is correct.
-4. Drive the base a short distance. Every frame should shift together.
+3. **Jog the arm from the CONTROL tab — the single clearest test that your hierarchy is correct.** Only the arm subtree should move; the base and navigation sensors should stay put.
+4. **Drive the base a short distance.** Every frame should shift together.
 5. Measure a known physical offset (base center to lidar, for example) and compare to the translation values in your config.
 
 ### 7. Verify with TransformPose

--- a/docs/motion-planning/frame-system/mobile-base-arm.md
+++ b/docs/motion-planning/frame-system/mobile-base-arm.md
@@ -45,10 +45,7 @@ All component positions are defined relative to this center point.
 
 ### 2. Add a frame to the base
 
-In the [Viam app](https://app.viam.com), navigate to your machine and click the **CONFIGURE** tab.
-In the sidebar, click your base component to open its card. On the card, click **Frame**.
-
-The Frame section opens a JSON editor (no form, parent dropdown, or geometry-type picker). Edit the JSON directly for each component below.
+In the **CONFIGURE** tab, click the base component's card and then click **Frame**. (For details on the Frame editor, see [Edit a frame in the Viam app](/motion-planning/frame-system/#edit-a-frame-in-the-viam-app).) Edit the JSON for each component below as you go.
 
 ```json
 {

--- a/docs/motion-planning/frame-system/mobile-base-sensors.md
+++ b/docs/motion-planning/frame-system/mobile-base-sensors.md
@@ -9,14 +9,14 @@ aliases:
   - /motion-planning/frame-system-how-to/mobile-base-sensors/
 ---
 
-A mobile base only knows where it is to the extent its sensors report. Lidar
-sweeps tell the base what is around it; front and rear cameras feed detection
-and SLAM. Every one of those sensor readings is in the sensor's own reference
-frame: a lidar point at `(2.0 m, 0, 0)` is two meters in front of the lidar,
-not in front of the base. The frame system is what converts sensor frames to
-the base frame and on to the world frame, so the navigation stack sees
-consistent positions. Configuring it correctly is a one-time setup; this
-guide walks through it.
+A mobile base's sense of its own position comes from its sensors,
+nothing else. Lidar sweeps tell the base what is around it; front and
+rear cameras feed detection and SLAM. Every sensor reading is in the
+sensor's own reference frame: a lidar point at `(2.0 m, 0, 0)` is two
+meters in front of the lidar, not in front of the base. The frame
+system converts sensor frames to the base frame and on to the world
+frame, so the navigation stack sees consistent positions. Configuring
+it is a one-time setup; this guide walks through it.
 
 ## Frame hierarchy
 
@@ -35,13 +35,11 @@ All sensors are children of the base, so the entire sensor subtree moves with th
 
 ### 1. Choose your world frame origin
 
-For a mobile base, the world frame origin is the center of the base itself at
-machine start. Because the base moves through the environment, the world
-frame origin is not a fixed physical location; it is wherever the base was
-when it came online. Sensor positions are all measured relative to the base
-center, not relative to a point in the room, so you do not need to mark
-anything physically. The frame system tracks the base's motion from that
-initial origin.
+For a mobile base, the world frame origin is the base center at machine
+start: not a fixed point in the room, but wherever the base was when it
+came online. Sensor positions are measured relative to the base center,
+so you do not need to mark anything physically. The frame system tracks
+the base's motion from that initial origin.
 
 ### 2. Add a frame to the base
 
@@ -116,7 +114,7 @@ For a camera mounted at the front of the base, 200 mm forward and 120 mm above t
 ```
 
 The default orientation has the camera looking along the +y axis (forward).
-If your camera's optical axis does not align with the base's forward direction, adjust the orientation accordingly.
+If your camera is mounted rotated, set `value.th` to the rotation angle in degrees.
 
 **Rear-facing camera:**
 

--- a/docs/motion-planning/frame-system/mobile-base-sensors.md
+++ b/docs/motion-planning/frame-system/mobile-base-sensors.md
@@ -45,10 +45,7 @@ initial origin.
 
 ### 2. Add a frame to the base
 
-In the [Viam app](https://app.viam.com), navigate to your machine and click the **CONFIGURE** tab.
-In the sidebar, click your base component to open its card. On the card, click **Frame**.
-
-The Frame section opens a JSON editor (no form, parent dropdown, or geometry-type picker). Edit the JSON directly for each component below.
+In the **CONFIGURE** tab, click the base component's card and then click **Frame**. (For details on the Frame editor, see [Edit a frame in the Viam app](/motion-planning/frame-system/#edit-a-frame-in-the-viam-app).) Edit the JSON for each component below as you go.
 
 Since the world frame origin is at the base center, the translation is zero:
 

--- a/docs/motion-planning/how-planning-works.md
+++ b/docs/motion-planning/how-planning-works.md
@@ -25,7 +25,7 @@ Rapidly-Exploring Random Tree. This is the only planning algorithm in
 the built-in service. Modules may implement alternative planners, but
 cBiRRT handles the general arm-planning case.
 
-cBiRRT comes from Berenson et al., 2009. The name unpacks to three ideas:
+cBiRRT comes from [Berenson et al., 2009](https://www.ri.cmu.edu/pub_files/2009/5/berenson_dmitry_2009_2.pdf). The name unpacks to three ideas:
 the "constrained" part enforces orientation and linear constraints, the
 "bidirectional" part searches from the start and the goal at the same time,
 and the "RRT" part samples random configurations to explore joint space.

--- a/docs/motion-planning/how-planning-works.md
+++ b/docs/motion-planning/how-planning-works.md
@@ -18,12 +18,16 @@ six joints, so every configuration is a point in six-dimensional joint
 space. The planner has to find a continuous path through this space
 that satisfies all the constraints.
 
+When planning fails (and it will, because the search is probabilistic),
+the error messages mean little unless you understand what the planner
+was trying to do. This page gives you that model.
+
 ## The algorithm: cBiRRT
 
-Viam's built-in motion service uses **cBiRRT**: Constrained Bidirectional
-Rapidly-Exploring Random Tree. This is the only planning algorithm in
-the built-in service. Modules may implement alternative planners, but
-cBiRRT handles the general arm-planning case.
+Viam's built-in motion service uses **cBiRRT** (Constrained Bidirectional
+Rapidly-Exploring Random Tree), which handles the general arm-planning
+case. It is the only algorithm the built-in service runs; modules may
+implement alternative planners.
 
 cBiRRT comes from [Berenson et al., 2009](https://www.ri.cmu.edu/publications/manipulation-planning-on-constraint-manifolds/). The name unpacks to three ideas:
 the "constrained" part enforces orientation and linear constraints, the

--- a/docs/motion-planning/how-planning-works.md
+++ b/docs/motion-planning/how-planning-works.md
@@ -25,7 +25,7 @@ Rapidly-Exploring Random Tree. This is the only planning algorithm in
 the built-in service. Modules may implement alternative planners, but
 cBiRRT handles the general arm-planning case.
 
-cBiRRT comes from [Berenson et al., 2009](https://www.ri.cmu.edu/pub_files/2009/5/berenson_dmitry_2009_2.pdf). The name unpacks to three ideas:
+cBiRRT comes from [Berenson et al., 2009](https://www.ri.cmu.edu/publications/manipulation-planning-on-constraint-manifolds/). The name unpacks to three ideas:
 the "constrained" part enforces orientation and linear constraints, the
 "bidirectional" part searches from the start and the goal at the same time,
 and the "RRT" part samples random configurations to explore joint space.
@@ -46,8 +46,8 @@ At each iteration, the planner:
    orientation or line constraint.
 
 When the two trees meet, the planner smooths the resulting path (three
-sequential passes of 10, 3, and 1 iterations) to remove unnecessary
-detours.
+sequential passes with triplet step sizes of 10, 3, and 1) to remove
+unnecessary detours.
 
 ## Why this works well for arms
 
@@ -107,10 +107,12 @@ planning timeout (300 seconds by default). Common causes:
    simpler target close to the current position to isolate whether the
    planner works at all.
 5. **Multiple IK solutions exist but the one the planner picks is bad.**
-   cBiRRT plans shortest-path in joint space, so for some Cartesian targets
-   it routes through a wrist flip or an elbow reconfiguration that is
-   physically feasible but undesirable. Seed the planner by calling
-   `MoveToJointPositions` first, or break the motion into smaller steps.
+   cBiRRT returns the first feasible path it finds rather than the
+   shortest one, so for some Cartesian targets it routes through a wrist
+   flip or an elbow reconfiguration that is physically feasible but
+   undesirable. Move the arm to a configuration that biases the planner
+   toward the IK branch you want by calling `MoveToJointPositions`
+   first, or break the motion into smaller steps.
 
 If the failure is non-deterministic (the same plan worked last time but
 fails now), retry a few times before changing the request. The

--- a/docs/motion-planning/monitor-a-running-plan.md
+++ b/docs/motion-planning/monitor-a-running-plan.md
@@ -157,23 +157,31 @@ button, an external sensor, a higher-level task abort) should call
 {{% tab name="Python" %}}
 
 ```python
-async def watch_for_abort(motion_service, component_name, stop_event):
-    while not stop_event.is_set():
+# `safety_condition_triggered()` is your application-specific check
+# (a button, a sensor reading, an external abort signal).
+async def watch_for_abort(motion_service, component_name):
+    while True:
         if await safety_condition_triggered():
             await motion_service.stop_plan(component_name=component_name)
             return
         await asyncio.sleep(0.1)
 
-# Run the poll loop and the watchdog concurrently.
-stop_event = asyncio.Event()
-try:
-    await asyncio.gather(
-        poll_until_terminal(motion_service, "my-base", execution_id),
-        watch_for_abort(motion_service, "my-base", stop_event),
-    )
-finally:
-    stop_event.set()
+# Run the poll loop and the watchdog concurrently. The first task to
+# finish wins; cancel the other so it does not run forever.
+poll_task = asyncio.create_task(
+    poll_until_terminal(motion_service, "my-base", execution_id)
+)
+watch_task = asyncio.create_task(
+    watch_for_abort(motion_service, "my-base")
+)
+done, pending = await asyncio.wait(
+    {poll_task, watch_task}, return_when=asyncio.FIRST_COMPLETED,
+)
+for task in pending:
+    task.cancel()
 ```
+
+Wrap the polling logic in `poll_until_terminal(motion_service, component_name, execution_id)` (the `while True` body from the polling pattern above).
 
 {{% /tab %}}
 {{% tab name="Go" %}}
@@ -207,8 +215,9 @@ go func() {
 
 After `StopPlan` returns, the plan's terminal state transitions to
 `STOPPED`. The polling loop then exits on the next `GetPlan` cycle.
-`StopPlan` is idempotent: calling it on a plan that has already reached
-a terminal state is safe.
+Behavior when calling `StopPlan` on a plan that has already reached a
+terminal state depends on the implementation; check the docs for the
+specific motion-service module you are using.
 
 ## Replanning and ExecutionID
 

--- a/docs/motion-planning/monitor-a-running-plan.md
+++ b/docs/motion-planning/monitor-a-running-plan.md
@@ -146,6 +146,70 @@ err = motionService.StopPlan(ctx, motion.StopPlanReq{ComponentName: "my-base"})
 {{% /tab %}}
 {{< /tabs >}}
 
+### Safety-stop pattern
+
+A non-blocking motion runs independently of your polling loop. Treat `StopPlan`
+as the cut-off switch: any condition your application reads (a safety
+button, an external sensor, a higher-level task abort) should call
+`StopPlan` directly without waiting for the polling loop to notice.
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+```python
+async def watch_for_abort(motion_service, component_name, stop_event):
+    while not stop_event.is_set():
+        if await safety_condition_triggered():
+            await motion_service.stop_plan(component_name=component_name)
+            return
+        await asyncio.sleep(0.1)
+
+# Run the poll loop and the watchdog concurrently.
+stop_event = asyncio.Event()
+try:
+    await asyncio.gather(
+        poll_until_terminal(motion_service, "my-base", execution_id),
+        watch_for_abort(motion_service, "my-base", stop_event),
+    )
+finally:
+    stop_event.set()
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+```go
+// Run the poll loop and the watchdog in separate goroutines.
+watchCtx, cancelWatch := context.WithCancel(ctx)
+defer cancelWatch()
+
+go func() {
+    ticker := time.NewTicker(100 * time.Millisecond)
+    defer ticker.Stop()
+    for {
+        select {
+        case <-watchCtx.Done():
+            return
+        case <-ticker.C:
+            if safetyConditionTriggered() {
+                _ = motionService.StopPlan(ctx, motion.StopPlanReq{
+                    ComponentName: "my-base",
+                })
+                return
+            }
+        }
+    }
+}()
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+After `StopPlan` returns, the plan's terminal state transitions to
+`STOPPED`. The polling loop then exits on the next `GetPlan` cycle.
+`StopPlan` is idempotent: calling it on a plan that has already reached
+a terminal state is safe.
+
 ## Replanning and ExecutionID
 
 If the motion service replans during execution (for example, after the

--- a/docs/motion-planning/monitor-a-running-plan.md
+++ b/docs/motion-planning/monitor-a-running-plan.md
@@ -14,17 +14,17 @@ aliases:
 `MoveOnMap` and `MoveOnGlobe` return immediately with an `ExecutionID` and run
 the actual motion in the background. Your code has to poll that execution to
 learn when it completes, fails, or stops. This page gives the polling pattern
-in Go and Python. For the built-in `Move`, which blocks until the motion
-finishes, the pattern collapses to a try/except: covered at the end.
+in Go and Python.
 
-## Before you start
+Neither RPC is implemented by the built-in motion service: the built-in
+returns "not supported" for both. You need the
+[navigation service](/navigation/), which calls `MoveOnGlobe` internally,
+or a motion-service module that provides them. If you are using the
+built-in `Move` instead (which blocks until completion), skip to the
+last section.
 
-- **`MoveOnMap` and `MoveOnGlobe` are not implemented by the built-in motion
-  service.** You need the navigation service (which calls them internally) or
-  a motion-service module that provides them. The built-in motion service
-  returns "not supported" for both.
-- For background on the methods and states, see
-  [Plan monitoring](/motion-planning/reference/plan-monitoring/).
+For background on the methods and states, see
+[Plan monitoring](/motion-planning/reference/plan-monitoring/).
 
 ## The polling pattern
 
@@ -151,7 +151,9 @@ err = motionService.StopPlan(ctx, motion.StopPlanReq{ComponentName: "my-base"})
 A non-blocking motion runs independently of your polling loop. Treat `StopPlan`
 as the cut-off switch: any condition your application reads (a safety
 button, an external sensor, a higher-level task abort) should call
-`StopPlan` directly without waiting for the polling loop to notice.
+`StopPlan` directly without waiting for the polling loop to notice. Run
+the safety check and the polling loop concurrently so either can call
+`StopPlan` without waiting on the other.
 
 {{< tabs >}}
 {{% tab name="Python" %}}
@@ -214,10 +216,9 @@ go func() {
 {{< /tabs >}}
 
 After `StopPlan` returns, the plan's terminal state transitions to
-`STOPPED`. The polling loop then exits on the next `GetPlan` cycle.
-Behavior when calling `StopPlan` on a plan that has already reached a
-terminal state depends on the implementation; check the docs for the
-specific motion-service module you are using.
+`STOPPED`. The polling loop then exits on the next `GetPlan` cycle. If
+you call `StopPlan` after a plan has already reached a terminal state,
+behavior depends on the module; check the motion-service module's docs.
 
 ## Replanning and ExecutionID
 

--- a/docs/motion-planning/move-an-arm/_index.md
+++ b/docs/motion-planning/move-an-arm/_index.md
@@ -7,28 +7,26 @@ type: "docs"
 description: "Command an arm to a target pose, along a constrained path, or directly in joint space."
 ---
 
-Viam exposes three ways to command an arm, each suited to a different
-situation:
+Viam exposes three ways to command an arm. Three questions sort them:
 
-- **[Move to a Cartesian pose](/motion-planning/move-an-arm/move-to-pose/)**
-  uses the motion service. The planner finds a collision-free path from
-  the arm's current pose to the target. This is the right default when
-  you know where the end effector needs to go and you want the planner
-  to figure out how to get there.
+1. **What do you know about the destination?** A Cartesian target (a pose
+   in space) calls for the motion service. A specific joint configuration
+   calls for direct joint commands.
+2. **Does the shape of the motion matter, or only the endpoint?** If you
+   need a straight line, a fixed orientation, or any other rule about
+   the path itself, you need constraints.
+3. **Do you want obstacle avoidance and IK picked for you, or fine
+   manual control?** The motion service handles both; direct joint
+   commands skip both.
 
-- **[Move with constraints](/motion-planning/move-an-arm/move-with-constraints/)**
-  is the same Cartesian-target path plus rules about how the arm moves
-  (stay on a straight line, keep the end effector level). Use this
-  when the shape of the motion matters, not just the destination.
+| Pattern                                                                          | Input                    | Obstacle avoidance | Path-shape control | When to pick                                                                                                                                     |
+| -------------------------------------------------------------------------------- | ------------------------ | ------------------ | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [Move to a pose](/motion-planning/move-an-arm/move-to-pose/)                     | Cartesian target         | Yes                | No                 | You know where the end effector needs to go and want the planner to figure out how.                                                              |
+| [Move with constraints](/motion-planning/move-an-arm/move-with-constraints/)     | Cartesian target + rules | Yes                | Yes                | The shape of the motion matters (straight-line tool path, level end effector).                                                                   |
+| [Move by joint positions](/motion-planning/move-an-arm/move-by-joint-positions/) | Joint angles             | No                 | Direct             | You know the joint angles, need predictable motion between known configurations, or want to avoid the planner picking an unexpected IK solution. |
 
-- **[Move by setting joint positions](/motion-planning/move-an-arm/move-by-joint-positions/)**
-  bypasses the planner and drives each joint directly to a commanded
-  angle. Use this when you know the joint angles you want, you need
-  predictable motion between two known configurations, or you want to
-  avoid the planner picking an unexpected IK solution.
-
-See [Constraints](/motion-planning/move-an-arm/constraints/) for the
-full reference on the four constraint types.
+For the four constraint types the planner enforces, see
+[Configure motion constraints](/motion-planning/move-an-arm/constraints/).
 
 ## How-tos
 

--- a/docs/motion-planning/move-an-arm/constraints.md
+++ b/docs/motion-planning/move-an-arm/constraints.md
@@ -52,9 +52,9 @@ Forces the end effector to maintain a consistent orientation throughout the
 motion. Use this when the end effector must stay level or keep a fixed
 orientation (for example, carrying a liquid).
 
-| Parameter                    | Type             | Description                                                                  |
-| ---------------------------- | ---------------- | ---------------------------------------------------------------------------- |
-| `orientation_tolerance_degs` | float (optional) | Maximum orientation deviation, in degrees. Only checked when greater than 0. |
+| Parameter                    | Type             | Description                                                                                                                                               |
+| ---------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `orientation_tolerance_degs` | float (required) | Maximum orientation deviation, in degrees, for orientations that fall outside the start-to-goal box. A value of 0 rejects any deviation outside that box. |
 
 The planner checks each orientation vector component (`OX`, `OY`, `OZ`,
 `Theta`) against the start and goal independently. If every component of

--- a/docs/motion-planning/move-an-arm/constraints.md
+++ b/docs/motion-planning/move-an-arm/constraints.md
@@ -91,7 +91,10 @@ This is useful when:
 
 Frame names support hierarchical matching: specifying `"my-arm"` matches all
 sub-geometries of the arm (such as `my-arm:upper_arm_link`,
-`my-arm:forearm_link`).
+`my-arm:forearm_link`). For hierarchical matching details, self-collision
+patterns, and worked examples (arm detecting itself through a vision
+service, gripper holding an object), see
+[Allow frame collisions](/motion-planning/obstacles/allow-frame-collisions/).
 
 ## Using constraints in code
 

--- a/docs/motion-planning/move-an-arm/constraints.md
+++ b/docs/motion-planning/move-an-arm/constraints.md
@@ -237,9 +237,9 @@ to find than unconstrained ones.
 
 ## What's next
 
-- [Move an Arm with Constraints](/motion-planning/move-an-arm/move-with-constraints/):
+- [Move an arm with constraints](/motion-planning/move-an-arm/move-with-constraints/):
   practical examples of constrained motion.
 - [How motion planning works](/motion-planning/how-planning-works/):
   how the planner searches for constrained paths.
-- [Define Obstacles](/motion-planning/obstacles/): define the geometry the
+- [Define obstacles](/motion-planning/obstacles/): define the geometry the
   planner uses for collision checking.

--- a/docs/motion-planning/move-an-arm/constraints.md
+++ b/docs/motion-planning/move-an-arm/constraints.md
@@ -56,9 +56,15 @@ orientation (for example, carrying a liquid).
 | ---------------------------- | ---------------- | ---------------------------------------------------------------------------- |
 | `orientation_tolerance_degs` | float (optional) | Maximum orientation deviation, in degrees. Only checked when greater than 0. |
 
-The planner checks that the current orientation stays within the specified
-tolerance of whichever is closer: the start orientation or the goal orientation.
-This allows smooth transitions when start and goal have different orientations.
+The planner checks each orientation vector component (`OX`, `OY`, `OZ`,
+`Theta`) against the start and goal independently. If every component of
+the current orientation falls between the corresponding components of the
+start and goal, the constraint is satisfied with zero error. Otherwise the
+planner measures the angular distance to whichever is closer, start or
+goal, and rejects the path if that distance exceeds
+`orientation_tolerance_degs`. This per-component check allows smooth
+transitions when start and goal have different orientations, and the
+tolerance provides a cushion on either side.
 
 ### PseudolinearConstraint
 

--- a/docs/motion-planning/move-an-arm/constraints.md
+++ b/docs/motion-planning/move-an-arm/constraints.md
@@ -58,13 +58,14 @@ orientation (for example, carrying a liquid).
 
 The planner checks each orientation vector component (`OX`, `OY`, `OZ`,
 `Theta`) against the start and goal independently. If every component of
-the current orientation falls between the corresponding components of the
-start and goal, the constraint is satisfied with zero error. Otherwise the
-planner measures the angular distance to whichever is closer, start or
-goal, and rejects the path if that distance exceeds
-`orientation_tolerance_degs`. This per-component check allows smooth
-transitions when start and goal have different orientations, and the
-tolerance provides a cushion on either side.
+the current orientation falls between the corresponding start and goal
+values, the constraint is satisfied with zero error.
+
+Otherwise, the planner measures the angular distance to whichever
+endpoint is closer (start or goal) and rejects the path if that distance
+exceeds `orientation_tolerance_degs`. The per-component box check allows
+smooth transitions when start and goal have different orientations; the
+tolerance gives a cushion on either side.
 
 ### PseudolinearConstraint
 
@@ -102,130 +103,21 @@ patterns, and worked examples (arm detecting itself through a vision
 service, gripper holding an object), see
 [Allow frame collisions](/motion-planning/obstacles/allow-frame-collisions/).
 
-## Using constraints in code
+## Pass constraints to Move
 
-{{< tabs >}}
-{{% tab name="Python" %}}
-
-```python
-from viam.services.motion import MotionClient
-from viam.proto.service.motion import Constraints, LinearConstraint, OrientationConstraint
-from viam.proto.common import PoseInFrame, Pose
-
-motion_service = MotionClient.from_robot(machine, "builtin")
-
-# Keep the end effector on a straight line with a level orientation
-constraints = Constraints(
-    linear_constraint=[
-        LinearConstraint(
-            line_tolerance_mm=5.0,
-        )
-    ],
-    orientation_constraint=[
-        OrientationConstraint(
-            orientation_tolerance_degs=5.0,
-        )
-    ]
-)
-
-destination = PoseInFrame(
-    reference_frame="world",
-    pose=Pose(x=300, y=200, z=400, o_x=0, o_y=0, o_z=-1, theta=0)
-)
-
-await motion_service.move(
-    component_name="my-arm",
-    destination=destination,
-    constraints=constraints
-)
-```
-
-{{% /tab %}}
-{{% tab name="Go" %}}
-
-```go
-import (
-    "go.viam.com/rdk/motionplan"
-    "go.viam.com/rdk/services/motion"
-)
-
-motionService, err := motion.FromProvider(machine, "builtin")
-if err != nil {
-    logger.Fatal(err)
-}
-
-constraints := &motionplan.Constraints{
-    LinearConstraint: []motionplan.LinearConstraint{
-        {LineToleranceMm: 5.0},
-    },
-    OrientationConstraint: []motionplan.OrientationConstraint{
-        {OrientationToleranceDegs: 5.0},
-    },
-}
-
-// Pass constraints in the Move request
-_, err = motionService.Move(ctx, motion.MoveReq{
-    ComponentName: "my-arm",
-    Destination:   destination,
-    Constraints:   constraints,
-})
-```
-
-{{% /tab %}}
-{{< /tabs >}}
-
-### Allowing specific collisions
-
-Use `CollisionSpecification` to let the planner accept contact between
-specific frame pairs, for example when a gripper must touch the object it is
-picking up.
-
-{{< tabs >}}
-{{% tab name="Python" %}}
-
-```python
-from viam.proto.service.motion import (
-    Constraints, CollisionSpecification
-)
-
-# Allow the gripper to contact the target object
-collision_spec = CollisionSpecification(
-    allows=[
-        CollisionSpecification.AllowedFrameCollisions(
-            frame1="my-gripper",
-            frame2="target-object"
-        )
-    ]
-)
-
-constraints = Constraints(
-    collision_specification=[collision_spec]
-)
-```
-
-{{% /tab %}}
-{{% tab name="Go" %}}
-
-```go
-constraints := &motionplan.Constraints{
-    CollisionSpecification: []motionplan.CollisionSpecification{
-        {
-            Allows: []motionplan.CollisionSpecificationAllowedFrameCollisions{
-                {Frame1: "my-gripper", Frame2: "target-object"},
-            },
-        },
-    },
-}
-```
-
-{{% /tab %}}
-{{< /tabs >}}
+Build a `Constraints` object containing one or more constraint entries
+and pass it on the `Move` request's `Constraints` field. For worked
+examples (straight-line tool path, level end effector, combined
+constraints), see
+[Move with constraints](/motion-planning/move-an-arm/move-with-constraints/).
+For `CollisionSpecification` (allow specific frame pairs to collide), see
+[Allow frame collisions](/motion-planning/obstacles/allow-frame-collisions/).
 
 ## Performance considerations
 
-Constraints make planning harder. The planner checks each candidate path
-segment against every constraint you set, and constrained solutions are harder
-to find than unconstrained ones.
+Every constraint adds a check to every candidate path segment, and
+tight tolerances shrink the set of valid paths. Both raise planning time
+and the failure rate.
 
 - **Tight tolerances** (small `line_tolerance_mm` or `orientation_tolerance_degs`)
   increase planning time and may cause the planner to fail if no path exists

--- a/docs/motion-planning/move-an-arm/move-to-pose.md
+++ b/docs/motion-planning/move-an-arm/move-to-pose.md
@@ -278,9 +278,9 @@ viam machines part motion set-pose --part "my-machine-main" --component "my-arm"
 
 ## What's next
 
-- [Move with Constraints](/motion-planning/move-an-arm/move-with-constraints/):
+- [Move with constraints](/motion-planning/move-an-arm/move-with-constraints/):
   keep the end effector on a straight line or at a fixed orientation.
-- [Avoid Obstacles](/motion-planning/obstacles/avoid-obstacles/):
+- [Avoid obstacles](/motion-planning/obstacles/avoid-obstacles/):
   detailed obstacle configuration for complex workspaces.
-- [Pick an Object](/motion-planning/pick-and-place/pick-an-object/):
+- [Pick an object](/motion-planning/pick-and-place/pick-an-object/):
   combine motion planning with vision and gripper control.

--- a/docs/motion-planning/move-an-arm/move-with-constraints.md
+++ b/docs/motion-planning/move-an-arm/move-with-constraints.md
@@ -19,11 +19,11 @@ through intermediate poses and tilts the end effector along the way.
 ## Prerequisites
 
 - A running machine with an arm and [frame system](/motion-planning/frame-system/) configured
-- Familiarity with [Move Arm to Pose](/motion-planning/move-an-arm/move-to-pose/)
+- Familiarity with [Move arm to pose](/motion-planning/move-an-arm/move-to-pose/)
 
 ## Steps
 
-### 1. Move in a straight line
+### 1. Welding: straight-line tool path
 
 Use a `LinearConstraint` to keep the end effector within a tolerance of the
 direct line between start and goal.
@@ -78,7 +78,7 @@ _, err = motionService.Move(ctx, motion.MoveReq{
 {{% /tab %}}
 {{< /tabs >}}
 
-### 2. Maintain end effector orientation
+### 2. Carrying a liquid: level end effector
 
 Use an `OrientationConstraint` to keep the end effector level (or at any
 fixed orientation) throughout the motion.
@@ -195,20 +195,24 @@ constraints := &motionplan.Constraints{
 
 ## Tips
 
-- **Start with loose tolerances, tighten only if the task requires it.** 10-20
-  mm and 10-15 degrees is a reasonable starting point. Tight tolerances raise
-  both planning time and failure rate.
 - **Constraints and obstacles compete.** If an obstacle blocks the
-  straight-line path, the planner has to pick one constraint to violate and
-  typically fails. Either widen the constraint or move the obstacle.
-- **Orientation is checked against the nearer endpoint.** The planner compares
-  the current orientation to the start and goal, then uses whichever is closer
-  as the reference. This lets the constraint track intent as the motion
-  progresses rather than locking to one endpoint.
+  straight-line path, no path satisfies both the constraint and the
+  collision check, so the planner returns no-path. Widen the constraint
+  or move the obstacle.
+- **Orientation is checked against the nearer endpoint.** The planner
+  compares the current orientation to the start and goal, then uses
+  whichever is closer as the reference. This lets the constraint track
+  intent as the motion progresses rather than locking to one endpoint.
+
+For tolerance selection guidance and more on planning cost, see the
+[Performance considerations](/motion-planning/move-an-arm/constraints/#performance-considerations)
+section in the constraints reference.
 
 ## What's next
 
 - [Configure motion constraints](/motion-planning/move-an-arm/constraints/):
   full reference for all four constraint types.
+- [Allow frame collisions](/motion-planning/obstacles/allow-frame-collisions/):
+  the fourth constraint type, for letting specific frame pairs touch.
 - [Plan collision-free paths](/motion-planning/obstacles/avoid-obstacles/):
   combine constraints with obstacle avoidance.

--- a/docs/motion-planning/move-an-arm/move-with-constraints.md
+++ b/docs/motion-planning/move-an-arm/move-with-constraints.md
@@ -208,7 +208,7 @@ constraints := &motionplan.Constraints{
 
 ## What's next
 
-- [Configure Motion Constraints](/motion-planning/move-an-arm/constraints/):
+- [Configure motion constraints](/motion-planning/move-an-arm/constraints/):
   full reference for all four constraint types.
-- [Plan Collision-Free Paths](/motion-planning/obstacles/avoid-obstacles/):
+- [Plan collision-free paths](/motion-planning/obstacles/avoid-obstacles/):
   combine constraints with obstacle avoidance.

--- a/docs/motion-planning/move-gantry.md
+++ b/docs/motion-planning/move-gantry.md
@@ -19,7 +19,12 @@ guide covers both.
 
 ## Direct axis control
 
-Use the gantry component API for simple, direct movements.
+Use the gantry component API for direct moves to specific positions.
+Direct axis control bypasses the motion service: there is no obstacle
+checking, no IK, no path planning. Use it when you know the path is
+clear and you want the move to happen now. Read current state first
+(`get_position`, `get_lengths`) so you know where each axis sits and
+how much travel is available.
 
 {{< tabs >}}
 {{% tab name="Python" %}}
@@ -84,11 +89,13 @@ if err != nil {
 
 ## Motion-service planning
 
-The motion service treats a gantry the same way it treats an arm: you pass a
-target pose and a `WorldState`, and it returns a collision-free path. Use it
-when the gantry has obstacles to avoid, when you want to compose a gantry move
-with other components, or when you want the same planning API across every
-machine in your fleet.
+The motion service treats a gantry the same way it treats an arm: you pass
+a target pose and the planner returns a collision-free path that respects
+the obstacles in the frame system and any `WorldState` you supply. Planning
+takes longer than a direct move (a planning call before execution), but it
+is the only safe choice when obstacles share the workspace, when you need
+to coordinate the gantry with other components, or when you want the same
+planning API across every machine in your fleet.
 
 {{< tabs >}}
 {{% tab name="Python" %}}
@@ -131,6 +138,8 @@ _, err = motionService.Move(ctx, motion.MoveReq{
 
 ## What's next
 
+- [Define your frame system](/motion-planning/frame-system/): required
+  when planning gantry moves through the motion service.
 - [Move arm to pose](/motion-planning/move-an-arm/move-to-pose/):
   similar workflow for robot arms.
 - [Define obstacles](/motion-planning/obstacles/):

--- a/docs/motion-planning/move-gantry.md
+++ b/docs/motion-planning/move-gantry.md
@@ -131,7 +131,7 @@ _, err = motionService.Move(ctx, motion.MoveReq{
 
 ## What's next
 
-- [Move Arm to Pose](/motion-planning/move-an-arm/move-to-pose/):
+- [Move arm to pose](/motion-planning/move-an-arm/move-to-pose/):
   similar workflow for robot arms.
-- [Define Obstacles](/motion-planning/obstacles/):
+- [Define obstacles](/motion-planning/obstacles/):
   add obstacle geometry for collision avoidance.

--- a/docs/motion-planning/obstacles/_index.md
+++ b/docs/motion-planning/obstacles/_index.md
@@ -31,6 +31,13 @@ dangerous motion.
 
 ## Concepts
 
+Five ideas make up Viam's obstacle model: the geometry types you have
+available, the sizing rule (Viam does not add clearance for you), the
+split between static and dynamic obstacles, the `WorldState` container
+that carries dynamic ones, and the passive-object pattern for things
+that move with a component but have no API. The same primitives also
+serve as keep-out zones; the planner treats them identically.
+
 ### Geometry types
 
 Viam supports five geometry types for defining obstacles. The three primitives
@@ -46,17 +53,23 @@ are the most commonly used:
 
 For irregular objects, use a Box that fully encloses the object (over-approximation is safer than under-approximation, even though it shrinks the planner's solution space).
 
-Each geometry has a center point (pose) that defines where it sits in space. The
-pose is relative to a reference frame, typically the world frame. Geometry
-configs also support `translation` and `orientation` offsets to shift the shape
-relative to the frame origin.
+Each geometry has a center point (pose) relative to a reference frame, typically the world frame. Geometry configs also support `translation` and `orientation` offsets to shift the shape relative to the frame origin. Capsule length must be at least twice the radius; a capsule whose length equals exactly twice the radius becomes a sphere.
 
-You do not need to model every surface detail of an obstacle. Approximate shapes
-that fully enclose the real object are safer and work better with the motion
-planner.
+### Sizing obstacles safely
 
-Capsule length must be at least twice the radius. A capsule whose length
-equals exactly twice the radius becomes a sphere.
+The motion planner does not add clearance around obstacle geometries by
+default. The built-in collision buffer is effectively zero (1e-8 mm,
+present only to prevent numerical edge cases). To keep the robot clear
+of physical obstacles, size your obstacle geometries to fully enclose
+the real object plus any desired safety margin: 20 to 50 mm is a
+reasonable starting point for most arms. Approximate shapes that fully
+enclose the real object are safer and work better with the planner than
+ones that try to model every surface detail.
+
+You can override the buffer on a per-call basis by passing
+`collision_buffer_mm` in the `extra` map on a Move request. This adds
+the specified clearance in millimeters to every collision check for
+that call.
 
 ### Static vs dynamic obstacles
 
@@ -103,31 +116,11 @@ causes the call to fail with `frame with name "<name>" already in frame
 system`. Use transforms to introduce new frames (a detected object, a
 picked-up workpiece), not to rewrite the pose of an existing component.
 
-### Keep-out zones
+{{< expand "Coming from ROS" >}}
 
-A keep-out zone is a region of space where the robot should never enter. Define
-it the same way as any other obstacle, as a box, sphere, or capsule positioned
-in the workspace. The motion planner treats it identically to a physical
-obstacle.
-
-### Collision buffer
-
-The motion planner does not add clearance around obstacle geometries by
-default. The built-in collision buffer is effectively zero (1e-8 mm, present
-only to prevent numerical edge cases). To keep the robot clear of physical
-obstacles, size your obstacle geometries to fully enclose the real object plus
-any desired safety margin. 20 to 50 mm is a reasonable starting point for most
-arms.
-
-You can override the buffer on a per-call basis by passing
-`collision_buffer_mm` in the `extra` map on a Move request. This adds the
-specified clearance in millimeters to every collision check for that call.
-
-### How Viam's world model differs from ROS
-
-If you are coming from ROS, the big shift is this: Viam keeps no persistent
-world representation between motion-planning calls. There is no Octomap voxel
-grid, no costmap layer, no Planning Scene held between calls.
+Viam keeps no persistent world representation between motion-planning
+calls. There is no Octomap voxel grid, no costmap layer, no Planning
+Scene held between calls.
 
 Every `Move` starts with the `WorldState` you pass in. Static obstacles
 from component frame configs are always included; dynamic obstacles
@@ -137,9 +130,9 @@ one `Move` is forgotten by the next unless you pass it again.
 
 `MoveOnGlobe` and `MoveOnMap` do maintain some state during a single
 execution: configured obstacle detectors poll vision services and feed
-new detections to the planner for as long as the execution runs. But
-that state is bounded to the execution; it does not persist once the
-plan completes.
+new detections to the planner for as long as the execution runs. That
+state is bounded to the execution; it does not persist once the plan
+completes.
 
 Practical consequences:
 
@@ -147,13 +140,15 @@ Practical consequences:
   one `Move` and omit from the next simply disappears from the
   planner's world. There is no "clear costmap" step to run.
 - **Your application is the source of truth for the world.** Whatever
-  your code tracks about the environment — object positions, operator
-  no-go zones, expired grasp targets — is what the planner sees. The
+  your code tracks about the environment (object positions, operator
+  no-go zones, expired grasp targets) is what the planner sees. The
   motion service does not build its own picture over time.
-- **For dynamic obstacle avoidance with arms**, check the world between calls
-  and call `Move` again with an updated `WorldState`. `Move` does not
-  re-evaluate obstacles during execution. For the per-method behavior, see
-  [Replanning behavior](/motion-planning/replanning-behavior/).
+- **For dynamic obstacle avoidance with arms,** check the world between
+  calls and call `Move` again with an updated `WorldState`. `Move` does
+  not re-evaluate obstacles during execution. For the per-method
+  behavior, see [Replanning behavior](/motion-planning/replanning-behavior/).
+
+{{< /expand >}}
 
 ## Steps
 

--- a/docs/motion-planning/obstacles/_index.md
+++ b/docs/motion-planning/obstacles/_index.md
@@ -97,9 +97,9 @@ Transforms merge into the frame system by addition only. The motion
 service builds a fresh frame system for each call, appends the configured
 parts, then appends each transform from `WorldState.transforms`. A
 transform with a name that already exists in the configured frame system
-causes the call to fail with a `frame already exists` error. Use
-transforms to introduce new frames (a detected object, a picked-up
-workpiece), not to rewrite the pose of an existing component.
+causes the call to fail with `frame with name "<name>" already in frame
+system`. Use transforms to introduce new frames (a detected object, a
+picked-up workpiece), not to rewrite the pose of an existing component.
 
 ### Keep-out zones
 

--- a/docs/motion-planning/obstacles/_index.md
+++ b/docs/motion-planning/obstacles/_index.md
@@ -93,6 +93,14 @@ to the motion service at call time. It contains:
 
 You construct a WorldState in your code and pass it to the `Move` call.
 
+Transforms merge into the frame system by addition only. The motion
+service builds a fresh frame system for each call, appends the configured
+parts, then appends each transform from `WorldState.transforms`. A
+transform with a name that already exists in the configured frame system
+causes the call to fail with a `frame already exists` error. Use
+transforms to introduce new frames (a detected object, a picked-up
+workpiece), not to rewrite the pose of an existing component.
+
 ### Keep-out zones
 
 A keep-out zone is a region of space where the robot should never enter. Define

--- a/docs/motion-planning/obstacles/_index.md
+++ b/docs/motion-planning/obstacles/_index.md
@@ -36,13 +36,15 @@ dangerous motion.
 Viam supports five geometry types for defining obstacles. The three primitives
 are the most commonly used:
 
-| Type        | JSON `type` | Config fields                          | Best for                                      |
-| ----------- | ----------- | -------------------------------------- | --------------------------------------------- |
-| **Box**     | `"box"`     | `x`, `y`, `z` (dimensions in mm)       | Tables, walls, shelves, rectangular equipment |
-| **Sphere**  | `"sphere"`  | `r` (radius in mm)                     | Balls, rounded objects, keep-out zones        |
-| **Capsule** | `"capsule"` | `r` (radius in mm), `l` (length in mm) | Posts, pipes, cylindrical objects             |
-| **Point**   | `"point"`   | (none, position only)                  | Single points in space                        |
-| **Mesh**    | `"mesh"`    | `mesh_data`, `mesh_content_type`       | Complex shapes from STL/PLY files             |
+| Type        | JSON `type` | Config fields                          | Best for                                                                                                                                         |
+| ----------- | ----------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Box**     | `"box"`     | `x`, `y`, `z` (dimensions in mm)       | Tables, shelves, walls, rectangular equipment. Match surface dimensions; include thickness if the arm could approach from below.                 |
+| **Sphere**  | `"sphere"`  | `r` (radius in mm)                     | Balls, round obstacles, keep-out zones. Use the bounding radius.                                                                                 |
+| **Capsule** | `"capsule"` | `r` (radius in mm), `l` (length in mm) | Posts, columns, pipes. Set the radius to match the column width and length to the height.                                                        |
+| **Point**   | `"point"`   | (none, position only)                  | Single points in space.                                                                                                                          |
+| **Mesh**    | `"mesh"`    | `mesh_data`, `mesh_content_type`       | Complex shapes from STL/PLY files when no primitive fits. More expensive to collision-check; use a primitive bounding shape if accuracy permits. |
+
+For irregular objects, use a Box that fully encloses the object (over-approximation is safer than under-approximation, even though it shrinks the planner's solution space).
 
 Each geometry has a center point (pose) that defines where it sits in space. The
 pose is relative to a reference frame, typically the world frame. Geometry
@@ -468,6 +470,10 @@ Check the Viam app to see your obstacle geometry:
 2. Click the **3D SCENE** tab.
 3. Obstacles defined in component frame configurations appear as translucent
    shapes in the 3D view.
+
+For the full visualization-and-verification workflow (orbit checks,
+coverage checklist, choosing the right geometry per physical object), see
+[Set up obstacle avoidance](/motion-planning/3d-scene/set-up-obstacle-avoidance/).
 
 {{< alert title="Dynamic obstacles are not visible in 3D SCENE" color="note" >}}
 

--- a/docs/motion-planning/obstacles/_index.md
+++ b/docs/motion-planning/obstacles/_index.md
@@ -461,8 +461,14 @@ Check the Viam app to see your obstacle geometry:
 3. Obstacles defined in component frame configurations appear as translucent
    shapes in the 3D view.
 
-Dynamic obstacles (defined through WorldState in code) do not appear in the
-3D SCENE tab because they only exist during the `Move` call.
+{{< alert title="Dynamic obstacles are not visible in 3D SCENE" color="note" >}}
+
+Obstacles defined through `WorldState` in code exist only for the duration of a
+single `Move` call and are not drawn in the 3D SCENE tab. To verify a dynamic
+obstacle's position, log its pose from your code or add a temporary static
+geometry with the same dimensions to the component frame configuration.
+
+{{< /alert >}}
 
 ## Try it
 

--- a/docs/motion-planning/obstacles/allow-frame-collisions.md
+++ b/docs/motion-planning/obstacles/allow-frame-collisions.md
@@ -126,6 +126,13 @@ For most allow-list use cases, the parent component name (`"my-arm"`,
 know the exact sub-frame and other sub-frames must continue to be
 collision-checked.
 
+Passing the same name for both `frame1` and `frame2` (for example
+`AllowedFrameCollisions(frame1="my-arm", frame2="my-arm")`) disables all
+self-collision checks within that component: every link is whitelisted
+against every other link. Use this when the kinematic model reports
+false self-collisions between adjacent links but the arm is mechanically
+safe.
+
 ## Use case: arm detects itself through a vision service
 
 The single most common reason to reach for `CollisionSpecification`: an
@@ -202,6 +209,8 @@ collision_spec = CollisionSpecification(
 After the grasp, if you want to move the gripper plus its held object
 as one unit, attach the object to the gripper frame system through
 `WorldState.transforms` on subsequent Move requests. See
+[Attach and detach geometries](/motion-planning/obstacles/attach-detach-geometries/)
+for the runtime-attach/detach pattern and
 [Define obstacles: passive objects attached to a component](/motion-planning/obstacles/#passive-objects-attached-to-a-component)
 for the permanent-attachment pattern.
 

--- a/docs/motion-planning/obstacles/allow-frame-collisions.md
+++ b/docs/motion-planning/obstacles/allow-frame-collisions.md
@@ -191,9 +191,9 @@ overlaps are expected.
 
 ## Use case: gripper grasping an object
 
-A grasp _requires_ contact between the gripper and the object. Without a
-`CollisionSpecification` allowing it, the planner rejects the final approach
-as a collision. Allow the gripper-object pair and the plan completes.
+The textbook use case: a pick motion ends with the gripper touching the
+target. Without an allow, the planner rejects the final approach as a
+collision; allow the gripper-object pair and the plan completes.
 
 ```python
 collision_spec = CollisionSpecification(
@@ -216,10 +216,11 @@ for the permanent-attachment pattern.
 
 ## Use case: adjacent arm links whose geometries overlap
 
-Some kinematic models have simplified collision geometry that causes
-adjacent links to register as colliding in certain joint configurations,
-even though the real hardware does not. If you are sure the overlap is
-a modeling artifact and not a real collision:
+This is the rarest of the three cases, and the one most likely to mask a
+real problem. Reach for it only when you are sure the overlap is a
+modeling artifact (simplified collision geometry on adjacent links that
+the real hardware does not actually collide with) and not a genuine
+collision:
 
 ```python
 collision_spec = CollisionSpecification(

--- a/docs/motion-planning/obstacles/allow-frame-collisions.md
+++ b/docs/motion-planning/obstacles/allow-frame-collisions.md
@@ -241,7 +241,7 @@ silencing them can mask real hardware problems.
 2. Plan a motion you expect to fail for other reasons (target inside an
    unrelated obstacle, target outside reach). The planner should still
    reject those.
-3. Visually confirm the motion in the 3D scene tab before running on
+3. Visually confirm the motion in the **3D SCENE** tab before running on
    hardware. See
    [Debug a motion plan](/motion-planning/3d-scene/debug-motion-plan/).
 
@@ -288,4 +288,4 @@ geometry is usually the right answer.
 - [Define obstacles](/motion-planning/obstacles/): the obstacle geometry
   that the planner checks against.
 - [Debug a motion plan](/motion-planning/3d-scene/debug-motion-plan/):
-  visualize frame overlaps in the 3D scene.
+  visualize frame overlaps in the **3D SCENE** tab.

--- a/docs/motion-planning/obstacles/avoid-obstacles.md
+++ b/docs/motion-planning/obstacles/avoid-obstacles.md
@@ -16,10 +16,17 @@ can plan around these obstacles, but only if you describe them in a
 bench setup, running a plan against it, and verifying that the planner actually
 routes around each obstacle.
 
+This page covers dynamic `WorldState` obstacles passed at call time. For
+permanent fixtures (the table the arm is bolted to, the back wall, a
+mounted tool), configure the obstacle in the component's frame
+configuration once instead of re-sending it on every `Move`. See
+[Define obstacles](/motion-planning/obstacles/).
+
 ## Prerequisites
 
-- [Frame system](/motion-planning/frame-system/) configured
-- [Obstacles concept](/motion-planning/obstacles/) understood
+- An arm or gantry configured on a machine.
+- [Frame system](/motion-planning/frame-system/) configured.
+- [Obstacles concept](/motion-planning/obstacles/) understood.
 
 ## Steps
 
@@ -139,23 +146,13 @@ _, err = motionService.Move(ctx, motion.MoveReq{
 
 ### 3. Verify the planner is actually routing around obstacles
 
-The quickest sanity check is a before-and-after comparison. Run the motion with
-a box placed directly between the arm's start pose and the target, and the arm
-should take an indirect path around it. Remove the box, rerun the same motion,
-and the arm should take a more direct path. If the paths look the same with and
-without the obstacle, the `WorldState` is not reaching the planner.
-
-### 4. Use frame geometry for permanent obstacles
-
-`WorldState` is re-sent with every `Move` call, which is useful when obstacles
-come and go but wasteful for things that never move. Permanent obstacles (the
-table the arm is bolted to, the back wall, a mounted tool) belong in the
-component's frame configuration instead. The planner reads frame geometry from
-the config on every plan, so you describe those obstacles once and forget about
-them.
-
-See [Define Obstacles](/motion-planning/obstacles/) for the full configuration
-reference.
+You need a concrete test that proves `WorldState` reached the planner.
+A before-and-after with an obstacle placed between start and target works:
+run the motion with a box placed directly between the arm's start pose
+and the target, and the arm should take an indirect path around it.
+Remove the box, rerun the same motion, and the arm should take a more
+direct path. If the paths look the same with and without the obstacle,
+the `WorldState` is not reaching the planner.
 
 ## What's next
 

--- a/docs/motion-planning/obstacles/avoid-obstacles.md
+++ b/docs/motion-planning/obstacles/avoid-obstacles.md
@@ -159,5 +159,6 @@ reference.
 
 ## What's next
 
-- [Move an Arm to a Target Pose](/motion-planning/move-an-arm/move-to-pose/)
-- [Pick an Object](/motion-planning/pick-and-place/pick-an-object/)
+- [Move an arm to a target pose](/motion-planning/move-an-arm/move-to-pose/)
+- [Pick an object](/motion-planning/pick-and-place/pick-an-object/)
+- [Allow frame collisions](/motion-planning/obstacles/allow-frame-collisions/) — when the planner rejects expected contact

--- a/docs/motion-planning/pick-and-place/_index.md
+++ b/docs/motion-planning/pick-and-place/_index.md
@@ -7,9 +7,13 @@ type: "docs"
 description: "End-to-end manipulation: detect, grasp, move, and release an object."
 ---
 
-Manipulation combines motion planning, vision, and gripper control.
-Pick and place break the workflow into two stages so each stage can be
-developed and debugged independently.
+Pick-and-place is the point where motion planning, vision, and gripper
+control meet. Each service works on its own, but the failure modes that
+matter most (the gripper closing on air, a depth estimate that crashes
+the arm into the table) only appear when all three run together.
+
+The workflow splits into two stages so each can be developed and
+debugged independently:
 
 - **Pick** covers detection, approach, and grasp. The arm moves to a
   pre-grasp pose above the object, descends, closes the gripper on the
@@ -18,10 +22,9 @@ developed and debugged independently.
   object to a target location, descends, opens the gripper, and
   retreats.
 
-Both stages depend on the obstacle and geometry-attachment patterns
-covered under [Obstacles](/motion-planning/obstacles/), plus the
-typical arm-motion and gripper-contact constraints under
-[Move an arm](/motion-planning/move-an-arm/).
+Both stages reuse the obstacle definitions and geometry-attachment
+patterns from [Define obstacles](/motion-planning/obstacles/) and the
+arm-motion patterns from [Move an arm](/motion-planning/move-an-arm/).
 
 ## How-tos
 

--- a/docs/motion-planning/pick-and-place/pick-an-object.md
+++ b/docs/motion-planning/pick-and-place/pick-an-object.md
@@ -209,7 +209,7 @@ print("Object lifted")
 
 ## What's next
 
-- [Place an Object](/motion-planning/pick-and-place/place-an-object/):
+- [Place an object](/motion-planning/pick-and-place/place-an-object/):
   move the grasped object to a target location.
-- [Configure Motion Constraints](/motion-planning/move-an-arm/constraints/):
+- [Configure motion constraints](/motion-planning/move-an-arm/constraints/):
   use CollisionSpecification to allow gripper-object contact.

--- a/docs/motion-planning/pick-and-place/pick-an-object.md
+++ b/docs/motion-planning/pick-and-place/pick-an-object.md
@@ -35,8 +35,8 @@ ready for the
 Detection tells you _which_ object the camera sees; localization tells you
 _where_ it is in 3D. For grasping, you need both. 2D detections from
 `GetDetections` are not enough on their own: use `GetObjectPointClouds`, which
-returns 3D geometries in the camera's frame, then `TransformPose` into the
-world frame so the motion service can plan against the result.
+returns 3D geometries in the camera's frame, then `TransformPose` the result
+into the world frame so the motion service can plan against the pose.
 
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/motion-planning/pick-and-place/place-an-object.md
+++ b/docs/motion-planning/pick-and-place/place-an-object.md
@@ -19,8 +19,11 @@ just set down.
 
 ## Prerequisites
 
-- Object already grasped (see [Pick an Object](/motion-planning/pick-and-place/pick-an-object/))
-- Placement location known in world coordinates
+- Object already grasped (see [Pick an object](/motion-planning/pick-and-place/pick-an-object/)).
+- Placement location known in world coordinates.
+
+The code below continues from [Pick an object](/motion-planning/pick-and-place/pick-an-object/);
+`motion_service`, `gripper`, and `world_state` are already defined in that script.
 
 ## Steps
 
@@ -129,7 +132,7 @@ print("Retreated from placement")
 
 ## What's next
 
-- [Pick an Object](/motion-planning/pick-and-place/pick-an-object/):
+- [Pick an object](/motion-planning/pick-and-place/pick-an-object/):
   the pick half of the pick-and-place workflow.
 - [Monitor a running plan](/motion-planning/monitor-a-running-plan/):
   track plan status during execution.

--- a/docs/motion-planning/pick-and-place/place-an-object.md
+++ b/docs/motion-planning/pick-and-place/place-an-object.md
@@ -67,7 +67,7 @@ a detected surface, set it from the vision result.
 # Place: at the surface.
 # Set z to the height of the placement surface in your workspace.
 # For example, if you detected the target location, use its z coordinate.
-SURFACE_HEIGHT = 50  # mm, adjust for your setup
+SURFACE_HEIGHT = 50  # mm: world-frame z of the surface plus half the object's height
 place_pose = PoseInFrame(
     reference_frame="world",
     pose=Pose(
@@ -120,15 +120,16 @@ print("Retreated from placement")
 
 - **Keep the object level on the way down.** A carried object with an open
   top (a cup, an open box) spills if the gripper tilts during descent. Add an
-  `OrientationConstraint` with a tight tolerance (3-5 degrees) for the
-  descent segment; remove it for the retreat.
+  [`OrientationConstraint`](/motion-planning/move-an-arm/constraints/),
+  which locks the end effector's tilt, with a tolerance of 3 to 5 degrees
+  for the descent segment; remove it for the retreat.
 - **Retreat straight up.** Any lateral motion during retreat can catch the
   object the gripper just released. Plan the retreat pose with the same x
   and y as the place pose and only the z raised.
 - **Update `WorldState` after release.** The placed object is now a static
-  obstacle. If the next motion passes near the placement location, add the
-  object's footprint to `WorldState.obstacles` so the planner routes around
-  it.
+  obstacle. If the next motion passes near the placement location, add a
+  `Geometry` matching the placed object to `WorldState.obstacles` so the
+  planner routes around it.
 
 ## What's next
 

--- a/docs/motion-planning/quickstarts/_index.md
+++ b/docs/motion-planning/quickstarts/_index.md
@@ -7,16 +7,31 @@ type: "docs"
 description: "Short end-to-end tutorials that take a first-time user from zero to a working motion example. Each tutorial uses fake components so it runs without specific hardware."
 ---
 
-Each quickstart takes you from zero to a working example in about 10 to 15 minutes, using fake components so nothing depends on specific hardware. When you swap in a real arm or camera later, the change is in machine configuration, not in your code.
+Start with [Move your first arm](/motion-planning/quickstarts/first-arm/)
+to see the motion service drive an arm end-to-end. Then do
+[Configure a frame system](/motion-planning/quickstarts/frame-system/)
+to see how Viam ties arms, grippers, and cameras into one coordinate tree:
+the foundation everything else in this section builds on.
+
+Both quickstarts run on fake components, so you can do them on any
+laptop without hardware. When you swap in a real arm or camera later,
+the machine configuration changes; your code does not.
 
 {{< cards >}}
 {{% card link="/motion-planning/quickstarts/first-arm/" noimage="true" %}}
 {{% card link="/motion-planning/quickstarts/frame-system/" noimage="true" %}}
 {{< /cards >}}
 
-For base motion and GPS waypoint navigation, fake components cannot
-localize or drive, so a first-time walkthrough needs real hardware.
-The corresponding how-tos cover those flows end-to-end:
+## Related
+
+Base-motion and GPS-waypoint quickstarts live in
+[Navigation](/navigation/), because a first-time walkthrough of
+localization or GPS navigation needs real hardware.
+
+{{< cards >}}
+{{% card link="/navigation/how-to/drive-a-base/" noimage="true" %}}
+{{% card link="/navigation/how-to/navigate-to-waypoint/" noimage="true" %}}
+{{< /cards >}}
 
 {{< cards >}}
 {{% card link="/navigation/how-to/drive-a-base/" noimage="true" %}}

--- a/docs/motion-planning/quickstarts/first-arm.md
+++ b/docs/motion-planning/quickstarts/first-arm.md
@@ -14,6 +14,12 @@ machine that has `viam-server`; no physical arm required. When you
 have a real UR5e (or any other arm with a Viam module) later, the only
 change is the component model name in config.
 
+You could drive an arm by writing joint angles directly. The motion
+service adds the layer that matters as soon as you care about
+obstacles, frames other than the arm's base, or coordinating an arm
+with a gripper and a camera. This quickstart gives you the minimum
+working version so later sections can add those pieces one at a time.
+
 By the end you will have:
 
 - A fake arm running on your machine.
@@ -86,8 +92,8 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-Replace the three placeholder strings with your machine's address and
-API key values from the **CONNECT** tab. Then run:
+Replace `YOUR-API-KEY`, `YOUR-API-KEY-ID`, and `YOUR-MACHINE-ADDRESS`
+with the values from the **CONNECT** tab. Then run:
 
 ```sh
 pip install viam-sdk
@@ -105,8 +111,10 @@ What matters is that the arm responds and returns a pose.
 
 ## 4. Command a motion
 
-Now extend the script to plan and execute a motion through the motion
-service. Replace the `main` function with:
+You now have a script that connects to the machine and reads the arm's
+pose. Next you will add the motion service call that plans a path and
+executes it, plus a verification read after the motion completes.
+Replace the `main` function with:
 
 ```python
 async def main():

--- a/docs/motion-planning/quickstarts/frame-system.md
+++ b/docs/motion-planning/quickstarts/frame-system.md
@@ -7,9 +7,19 @@ type: "docs"
 description: "Set up a table-mounted arm with a gripper and a wrist camera, and verify the frame configuration with TransformPose."
 ---
 
-You will configure three components with a parent-child frame hierarchy (a table-mounted UR5e arm, a gripper attached to its end effector, and a wrist-mounted camera) and verify the hierarchy two ways: by printing each component's world-frame pose, and by transforming a detected object from the camera frame into the world frame.
+Every multi-component machine eventually hits the same question: when the
+camera sees an object, where is it in the arm's world? Frames answer that.
 
-Everything runs on fake components. When you later replace any of them with real hardware, the frame configuration and the verification code stay the same.
+This quickstart configures three components in a parent-child frame
+hierarchy (see the tree below) and shows how a point detected in the
+camera's frame becomes coordinates the arm can reach. You verify the
+hierarchy two ways: by printing each component's world-frame pose, and
+by transforming a detected point from the camera frame into the world
+frame.
+
+Everything runs on fake components. When you later replace any of them
+with real hardware, the frame configuration and the verification code
+stay the same.
 
 Expected time: about 15 minutes.
 
@@ -31,8 +41,8 @@ In the [Viam app](https://app.viam.com), go to your machine's
 2. Choose the **fake** model.
 3. Name it **my-arm**.
 4. In the arm's attributes, set `arm-model` to `"ur5e"`.
-5. Click **Frame** on the arm's card. The Frame section opens a JSON
-   editor (there is no form, parent dropdown, or geometry-type picker).
+5. Click **Frame** on the arm's card. The Frame section is a JSON
+   editor with no form, parent dropdown, or geometry-type picker.
    Edit the JSON so the frame sits at the world origin:
 
 ```json
@@ -91,7 +101,13 @@ pose moves with the arm automatically.
 }
 ```
 
-Click **Save**.
+In `ov_degrees`, `(x, y, z)` names the rotation axis and `th` is the
+angle. `(1, 0, 0), -30` rotates 30 degrees about the camera's x axis,
+which tilts the camera downward when its parent's z is up.
+
+Click **Save**. You now have three components in a frame tree: the arm
+at the world origin, the gripper 110 mm above its end effector, and the
+camera offset to the side and tilted down.
 
 ## 4. Verify with the CLI
 

--- a/docs/motion-planning/reference/_index.md
+++ b/docs/motion-planning/reference/_index.md
@@ -7,14 +7,28 @@ type: "docs"
 description: "Configuration, API, and technical reference for the motion service."
 ---
 
+The motion service turns a high-level "move to this pose" request into a
+collision-free joint trajectory. This reference documents what you
+configure, what the API exposes, and the formats and algorithms it uses
+under the hood. For conceptual background, see
+[How motion planning works](/motion-planning/how-planning-works/); for
+task-based guidance, start from the [section landing](/motion-planning/).
+
+**Configuration and API**: where most readers start.
+
 {{< cards >}}
 {{% card link="/motion-planning/reference/motion-service/" noimage="true" %}}
-{{% card link="/motion-planning/reference/api/" noimage="true" %}}
 {{% card link="/motion-planning/reference/motion-configuration/" noimage="true" %}}
+{{% card link="/motion-planning/reference/api/" noimage="true" %}}
 {{% card link="/motion-planning/reference/cli-commands/" noimage="true" %}}
-{{% card link="/motion-planning/reference/kinematics/" noimage="true" %}}
-{{% card link="/motion-planning/reference/frame-system-api/" noimage="true" %}}
-{{% card link="/motion-planning/reference/algorithms/" noimage="true" %}}
 {{% card link="/motion-planning/reference/plan-monitoring/" noimage="true" %}}
+{{< /cards >}}
+
+**Formats and machinery**: the underlying schemas the service operates on.
+
+{{< cards >}}
+{{% card link="/motion-planning/reference/frame-system-api/" noimage="true" %}}
+{{% card link="/motion-planning/reference/kinematics/" noimage="true" %}}
 {{% card link="/motion-planning/reference/orientation-vectors/" noimage="true" %}}
+{{% card link="/motion-planning/reference/algorithms/" noimage="true" %}}
 {{< /cards >}}

--- a/docs/motion-planning/reference/algorithms.md
+++ b/docs/motion-planning/reference/algorithms.md
@@ -11,7 +11,7 @@ aliases:
   - /mobility/motion/algorithms/
 ---
 
-The builtin motion service uses one planning algorithm: cBiRRT. This page lists its identifying details, the defaults, and where each tunable is exposed to callers. For how cBiRRT works, its limits, and what to try when it fails, see [How motion planning works](/motion-planning/how-planning-works/).
+The builtin motion service uses one planning algorithm: cBiRRT. When you need to change how the motion service plans, this page tells you what algorithm is running, what the defaults are, and where each tunable lives. For how cBiRRT works, its limits, and what to try when it fails, see [How motion planning works](/motion-planning/how-planning-works/).
 
 ## Algorithm
 

--- a/docs/motion-planning/reference/algorithms.md
+++ b/docs/motion-planning/reference/algorithms.md
@@ -1,5 +1,5 @@
 ---
-linkTitle: "Algorithms"
+linkTitle: "Motion planning algorithms"
 title: "Motion planning algorithms"
 weight: 50
 layout: "docs"
@@ -15,12 +15,12 @@ The builtin motion service uses one planning algorithm: cBiRRT. This page lists 
 
 ## Algorithm
 
-| Field        | Value                                                                  |
-| ------------ | ---------------------------------------------------------------------- |
-| Name         | cBiRRT (Constrained Bidirectional Rapidly-Exploring Random Tree)       |
-| Source code  | `rdk/motionplan/armplanning/cBiRRT.go`                                 |
-| Source paper | Berenson et al., _Manipulation planning on constraint manifolds_, 2009 |
-| Properties   | Sampling-based, bidirectional, probabilistic                           |
+| Field        | Value                                                                                                                                        |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Name         | cBiRRT (Constrained Bidirectional Rapidly-Exploring Random Tree)                                                                             |
+| Source code  | `rdk/motionplan/armplanning/cBiRRT.go`                                                                                                       |
+| Source paper | Berenson et al., [_Manipulation planning on constraint manifolds_](https://www.ri.cmu.edu/pub_files/2009/5/berenson_dmitry_2009_2.pdf), 2009 |
+| Properties   | Sampling-based, bidirectional, probabilistic                                                                                                 |
 
 ## Planning defaults
 

--- a/docs/motion-planning/reference/algorithms.md
+++ b/docs/motion-planning/reference/algorithms.md
@@ -15,12 +15,12 @@ The builtin motion service uses one planning algorithm: cBiRRT. This page lists 
 
 ## Algorithm
 
-| Field        | Value                                                                                                                                        |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| Name         | cBiRRT (Constrained Bidirectional Rapidly-Exploring Random Tree)                                                                             |
-| Source code  | `rdk/motionplan/armplanning/cBiRRT.go`                                                                                                       |
-| Source paper | Berenson et al., [_Manipulation planning on constraint manifolds_](https://www.ri.cmu.edu/pub_files/2009/5/berenson_dmitry_2009_2.pdf), 2009 |
-| Properties   | Sampling-based, bidirectional, probabilistic                                                                                                 |
+| Field        | Value                                                                                                                                                        |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Name         | cBiRRT (Constrained Bidirectional Rapidly-Exploring Random Tree)                                                                                             |
+| Source code  | `rdk/motionplan/armplanning/cBiRRT.go`                                                                                                                       |
+| Source paper | Berenson et al., [_Manipulation planning on constraint manifolds_](https://www.ri.cmu.edu/publications/manipulation-planning-on-constraint-manifolds/), 2009 |
+| Properties   | Sampling-based, bidirectional, probabilistic                                                                                                                 |
 
 ## Planning defaults
 
@@ -40,10 +40,10 @@ The planner-relevant entries are:
 
 Callers override a default in one of two places: persistently in the motion service config, or per call through the `extra` map on a `Move` request. The table below shows which tunables live where.
 
-| Where                                | Scope                   | Example tunables                                                    |
-| ------------------------------------ | ----------------------- | ------------------------------------------------------------------- |
-| Motion service config (`attributes`) | Persistent, per-service | `num_threads`, `input_range_override`, planner-diagnostic flags     |
-| `extra` map on a Move request        | Per-request             | `collision_buffer_mm`, `max_ik_solutions`, `timeout`, `smooth_iter` |
+| Where                                | Scope                   | Example tunables                                                |
+| ------------------------------------ | ----------------------- | --------------------------------------------------------------- |
+| Motion service config (`attributes`) | Persistent, per-service | `num_threads`, `input_range_override`, planner-diagnostic flags |
+| `extra` map on a Move request        | Per-request             | `collision_buffer_mm`, `max_ik_solutions`, `timeout`            |
 
 See [Motion service configuration](/motion-planning/reference/motion-service/)
 for the full list of configuration attributes.

--- a/docs/motion-planning/reference/api.md
+++ b/docs/motion-planning/reference/api.md
@@ -10,7 +10,7 @@ aliases:
   - /appendix/apis/services/motion/
 ---
 
-The motion service exposes the methods below for planning and executing component motion. Most methods are implemented only by module-based motion services; the builtin service supports `Move`, `DoCommand`, and `GetStatus`.
+The motion service exposes the methods below for planning and executing component motion. Most methods are implemented only by module-based motion services. The builtin service supports `Move`, `DoCommand`, and `GetStatus`, and nothing else.
 
 {{< readfile "/static/include/services/apis/generated/motion-table.md" >}}
 
@@ -36,7 +36,7 @@ Plans and executes motion on a SLAM map.
 
 ### MoveOnGlobe
 
-Plans and executes motion to a GPS coordinate. Use the [navigation service](/navigation/) for GPS-based navigation.
+Plans and executes motion to a GPS coordinate. Most GPS use cases go through the [navigation service](/navigation/), which wraps `MoveOnGlobe` with replanning and configuration.
 
 ### GetPlan
 
@@ -52,7 +52,7 @@ Stops an executing plan.
 
 ### GetPose (deprecated)
 
-Returns a component's pose. Deprecated: the robot service's `GetPose` replaces it. (Python callers currently still use this motion-service method; see the frame system API reference.)
+Returns a component's pose. Deprecated in favor of the robot service's `GetPose`. Python callers still use this motion-service method today; see the [Frame system API reference](/motion-planning/reference/frame-system-api/).
 
 ### DoCommand
 

--- a/docs/motion-planning/reference/frame-system-api.md
+++ b/docs/motion-planning/reference/frame-system-api.md
@@ -38,7 +38,9 @@ command prints.
 ```python
 parts = await machine.get_frame_system_config()
 for part in parts:
-    print(part.name, "parent:", part.pose_in_parent_frame.reference_frame)
+    name = part.frame.reference_frame
+    parent = part.frame.pose_in_observer_frame.reference_frame
+    print(name, "parent:", parent)
 ```
 
 {{% /tab %}}
@@ -245,11 +247,11 @@ Transform a point cloud from one reference frame to another. Useful for
 aligning point clouds from multiple cameras into a common frame, or for
 expressing lidar scans in world coordinates.
 
-| Parameter      | Description                                                 |
-| -------------- | ----------------------------------------------------------- |
-| `source`       | The source point cloud (bytes, PCD format).                 |
-| `source_frame` | The reference frame the source point cloud is expressed in. |
-| `destination`  | The reference frame to express the point cloud in.          |
+| Parameter         | Description                                                                        |
+| ----------------- | ---------------------------------------------------------------------------------- |
+| `point_cloud_pcd` | The source point cloud (bytes, PCD format).                                        |
+| `source`          | The reference frame the source point cloud is expressed in.                        |
+| `destination`     | The reference frame to express the point cloud in. Defaults to `"world"` if unset. |
 
 Returns the transformed point cloud (bytes).
 

--- a/docs/motion-planning/reference/frame-system-api.md
+++ b/docs/motion-planning/reference/frame-system-api.md
@@ -167,6 +167,78 @@ modify the stored frame system configuration.
 
 **Python kwarg naming.** In Python, `MotionClient.get_pose` takes `supplemental_transforms`; `RobotClient.transform_pose` and `RobotClient.get_frame_system_config` take `additional_transforms`. The proto field and all Go methods use `supplemental_transforms`. Pass the kwarg that matches the client class you call.
 
+#### Worked example: transform a detected object to the world frame
+
+Suppose a camera at frame `my-camera` has detected a box 400 mm in
+front of it. The box is not configured in the machine's frame system,
+but you want to compute its world-frame pose so an arm can plan a
+motion to it.
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+```python
+from viam.proto.common import PoseInFrame, Pose, Transform
+
+# 1. Declare the detected box as a supplemental transform.
+#    The Transform's reference_frame is the parent; the pose is the
+#    box's position in that parent.
+detected_box = Transform(
+    reference_frame="detected-box",
+    pose_in_observer_frame=PoseInFrame(
+        reference_frame="my-camera",
+        pose=Pose(x=0, y=0, z=400, o_x=0, o_y=0, o_z=1, theta=0),
+    ),
+)
+
+# 2. Ask the motion service where the box sits in the world frame.
+box_in_world = await motion_service.get_pose(
+    component_name="detected-box",
+    destination_frame="world",
+    supplemental_transforms=[detected_box],
+)
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+```go
+import (
+    "github.com/golang/geo/r3"
+    "go.viam.com/rdk/referenceframe"
+    "go.viam.com/rdk/spatialmath"
+)
+
+// 1. Build a LinkInFrame: detected-box is parented to my-camera,
+//    sitting 400 mm in front along camera z.
+detectedBox := referenceframe.NewLinkInFrame(
+    "my-camera",
+    spatialmath.NewPose(
+        r3.Vector{X: 0, Y: 0, Z: 400},
+        &spatialmath.OrientationVectorDegrees{OZ: 1},
+    ),
+    "detected-box",
+    nil, // optional geometry
+)
+
+// 2. Ask the robot service for its world-frame pose.
+boxInWorld, err := machine.GetPose(
+    ctx,
+    "detected-box",
+    referenceframe.World,
+    []*referenceframe.LinkInFrame{detectedBox},
+    nil, // extra
+)
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+The transform is discarded after this call. If you want the box to
+participate in a motion plan (as an obstacle, or as a component the
+arm navigates relative to), pass the same transform on the motion
+`Move` request through `WorldState.transforms`.
+
 ## TransformPCD
 
 Transform a point cloud from one reference frame to another. Useful for

--- a/docs/motion-planning/reference/frame-system-api.md
+++ b/docs/motion-planning/reference/frame-system-api.md
@@ -22,7 +22,7 @@ and so on). You do not instantiate a separate frame system client.
 
 ## Service names
 
-Inside RDK, the frame system is registered under two names: `builtin` (the default instance that ships with `viam-server`) and `$framesystem` (the name modules use to resolve a dependency on the frame system). SDK callers do not reference either; the RPCs on the robot/machine client hit the frame system transparently.
+You do not reference these names directly when calling the frame system from an SDK. They appear here so you can recognize them in error messages or module configuration: inside RDK, the frame system is registered under `builtin` (the default instance that ships with `viam-server`) and `$framesystem` (the name modules use to resolve a dependency on it). The RPCs on the robot/machine client hit the frame system transparently.
 
 ## FrameSystemConfig
 

--- a/docs/motion-planning/reference/kinematics.md
+++ b/docs/motion-planning/reference/kinematics.md
@@ -46,13 +46,15 @@ A robot arm is modeled as a chain of rigid bodies (links) connected by joints:
   optionally a geometry (for collision checking). Links do not move on their
   own. They are moved by the joints that connect them.
 - **Joints** connect two links and define how they can move relative to each
-  other. Viam supports four joint types:
+  other. Viam's SVA JSON format supports two joint types directly:
   - **Revolute**: rotates around an axis (like an elbow or shoulder). Limits in
     degrees.
   - **Prismatic**: slides along an axis (like a linear actuator). Limits in
     millimeters.
-  - **Continuous**: like revolute, but with no joint limits (full rotation).
-  - **Fixed**: no degrees of freedom (used in URDF files for rigid attachments).
+- URDF files may also declare **continuous** and **fixed** joints. Viam's URDF
+  importer converts continuous joints to revolute joints with infinite limits
+  and folds fixed joints into static link offsets. SVA JSON rejects either
+  type with an unsupported-joint-type error.
 
 ### Joint limits
 
@@ -197,6 +199,12 @@ Each field:
 - **`joints[].axis`**: the axis of rotation or translation (unit vector)
 - **`joints[].min`** / **`joints[].max`**: joint limits in degrees (revolute)
   or mm (prismatic)
+- **`joints[].mimic`** (optional): make this joint follow another joint at a
+  fixed multiplier and offset, for parallel-jaw grippers and other mechanically
+  coupled axes. The mimic object takes `joint` (the source joint's `id`),
+  `multiplier`, and `offset`; the joint's value is computed as
+  `multiplier * source_value + offset`. Mimic joints must not declare their own
+  `min`/`max`; the source joint's limits apply.
 
 ### 3. Import a URDF file
 

--- a/docs/motion-planning/reference/kinematics.md
+++ b/docs/motion-planning/reference/kinematics.md
@@ -303,9 +303,9 @@ have incorrect link lengths, joint axes, or joint limits.
 
 ## What's next
 
-- [Define Obstacles](/motion-planning/obstacles/): add collision geometry to
+- [Define obstacles](/motion-planning/obstacles/): add collision geometry to
   your workspace so the motion planner avoids collisions.
-- [Move an Arm to a Target Pose](/motion-planning/move-an-arm/move-to-pose/):
+- [Move an arm to a target pose](/motion-planning/move-an-arm/move-to-pose/):
   use the motion service to move the arm to a position in 3D space.
-- [Camera Calibration](/motion-planning/frame-system/camera-calibration/): calibrate your
+- [Camera calibration](/motion-planning/frame-system/camera-calibration/): calibrate your
   camera for accurate 3D position estimation.

--- a/docs/motion-planning/reference/kinematics.md
+++ b/docs/motion-planning/reference/kinematics.md
@@ -10,18 +10,16 @@ aliases:
   - /build/work-cell-layout/configure-robot-kinematics/
 ---
 
-A kinematics file describes your arm's physical structure (link lengths, joint axes, joint limits) so the motion planner can solve the inverse kinematics problem: given a target pose, find joint angles that reach it. Most registry arm modules ship this file; you only need to write one when building a custom arm.
+A kinematics file describes your arm's physical structure (link lengths, joint axes, joint limits) so the motion planner can solve the inverse kinematics problem: given a target pose, find joint angles that reach it.
 
 {{< alert title="Most arms handle this automatically" color="tip" >}}
 
-Most arm modules in the Viam registry include a kinematics file that describes
-this structure. For standard commercial arms like the UR5e, xArm6, or Viam Arm,
-the module handles kinematics automatically. You do not need to provide or
-configure a kinematics file for these arms.
-
-This page is relevant if you are building a custom arm, using a module without a
-built-in kinematics file, or need to verify that a kinematics model matches your
-physical arm.
+Most arm modules in the Viam registry include a kinematics file. For standard
+commercial arms like the UR5e, xArm6, or Viam Arm, the module handles
+kinematics automatically; you do not need to provide or configure a
+kinematics file. Read this page if you are building a custom arm, using a
+module without a built-in kinematics file, or verifying that a kinematics
+model matches your physical arm.
 
 {{< /alert >}}
 
@@ -258,15 +256,9 @@ Verify the visualization by comparing it to the physical arm:
 If the visualization does not match the physical arm, the kinematics file may
 have incorrect link lengths, joint axes, or joint limits.
 
-## Try it
-
-1. Run the kinematics check from step 1 to confirm your arm module has a
-   built-in kinematics file.
-2. Open the 3D SCENE tab and compare the rendered arm to the physical arm. Move
-   individual joints using the CONTROL tab and verify the visualization matches.
-3. For reading joint positions and controlling the arm, see
-   [Add an Arm](/hardware/common-components/add-an-arm/) and the
-   [Arm API reference](/reference/apis/components/arm/).
+For reading joint positions and controlling the arm directly, see
+[Add an arm](/hardware/common-components/add-an-arm/) and the
+[Arm API reference](/reference/apis/components/arm/).
 
 ## Troubleshooting
 

--- a/docs/motion-planning/reference/kinematics.md
+++ b/docs/motion-planning/reference/kinematics.md
@@ -1,6 +1,6 @@
 ---
-linkTitle: "Arm kinematics"
-title: "Arm kinematics"
+linkTitle: "Kinematics"
+title: "Kinematics"
 weight: 25
 layout: "docs"
 type: "docs"

--- a/docs/motion-planning/reference/motion-configuration.md
+++ b/docs/motion-planning/reference/motion-configuration.md
@@ -13,7 +13,7 @@ and [`MoveOnMap`](/motion-planning/reference/api/#moveonmap) calls to
 override defaults for a single execution. It is not used with `Move`,
 which is synchronous and does not expose per-call motion parameters.
 
-The navigation service uses `MoveOnGlobe` internally and builds a `MotionConfiguration` from its own attributes. The Navigation service correspondence table at the bottom of this page shows which navigation attribute maps to which `MotionConfiguration` field.
+The navigation service uses `MoveOnGlobe` internally and builds a `MotionConfiguration` from its own attributes; see [Navigation service correspondence](#navigation-service-correspondence) below for the mapping.
 
 ## Fields
 
@@ -41,7 +41,7 @@ planner for the remainder of the current execution.
 
 ## Units
 
-`plan_deviation_m` is meters at the API boundary. Internally the motion service stores it as millimeters (`PlanDeviationMM`), applying a x1000 conversion; the Go SDK exposes the millimeter form directly.
+`plan_deviation_m` is meters at the API boundary. The motion service stores the value internally as millimeters, and the Go SDK's `MotionConfiguration` struct exposes that millimeter form as `PlanDeviationMM`.
 
 ## Usage
 
@@ -103,10 +103,6 @@ executionID, err := motionService.MoveOnGlobe(ctx, motion.MoveOnGlobeReq{
 
 {{% /tab %}}
 {{< /tabs >}}
-
-The Go SDK's `MotionConfiguration` struct stores deviation as
-`PlanDeviationMM` (millimeters); the proto and Python SDK use
-`plan_deviation_m` (meters).
 
 ## Navigation service correspondence
 

--- a/docs/motion-planning/reference/motion-service.md
+++ b/docs/motion-planning/reference/motion-service.md
@@ -13,14 +13,9 @@ aliases:
 
 The motion service plans and executes component motion: arm end-effector moves, base moves across a SLAM map, and base moves to a GPS coordinate. The builtin service ships with every machine running `viam-server`, so you do not need to add it to your configuration.
 
-## Builtin service limitations
-
-The builtin service implements only `Move` (plus `DoCommand` and `GetStatus`). The other motion RPCs return "not supported" errors; to use them, install a module that implements them or, for GPS navigation, use the navigation service.
-
-- `MoveOnMap()`: requires a SLAM service (not recommended)
-- `MoveOnGlobe()`: use the [navigation service](/navigation/) instead
-- `GetPlan()`, `ListPlanStatuses()`, `StopPlan()`: only available with
-  implementations that support `MoveOnMap` or `MoveOnGlobe`
+Most users never configure the motion service. Read this page if you need
+to log planning errors, cap planning threads, or narrow a joint's range
+below its kinematic limits.
 
 ## Access the motion service
 
@@ -82,6 +77,14 @@ Example configuration:
 ## Per-request configuration
 
 Pass a `MotionConfiguration` on a `MoveOnGlobe` or `MoveOnMap` call to override per-request settings. See [MotionConfiguration](/motion-planning/reference/motion-configuration/) for the full field reference.
+
+## Builtin service limitations
+
+The builtin service implements only `Move` (plus `DoCommand` and `GetStatus`). The other motion RPCs return "not supported" errors; to use them, install a module that implements them or, for GPS navigation, use the navigation service.
+
+- `MoveOnMap()`: requires a SLAM service. The builtin implementation is legacy; use a module that implements `MoveOnMap` or the navigation service instead.
+- `MoveOnGlobe()`: use the [navigation service](/navigation/) instead.
+- `GetPlan()`, `ListPlanStatuses()`, `StopPlan()`: only available with implementations that support `MoveOnMap` or `MoveOnGlobe`.
 
 ## Planning defaults
 

--- a/docs/motion-planning/reference/motion-service.md
+++ b/docs/motion-planning/reference/motion-service.md
@@ -113,8 +113,8 @@ The Viam CLI provides `print-config`, `print-status`, `get-pose`, and `set-pose`
 
 ## What's next
 
-- [Motion Service API](/motion-planning/reference/api/): full API reference.
+- [Motion service API](/motion-planning/reference/api/): full API reference.
 - [How motion planning works](/motion-planning/how-planning-works/):
   how the planner searches for collision-free paths.
-- [Configure Motion Constraints](/motion-planning/move-an-arm/constraints/): restrict arm
+- [Configure motion constraints](/motion-planning/move-an-arm/constraints/): restrict arm
   movement during planning.

--- a/docs/motion-planning/reference/orientation-vectors.md
+++ b/docs/motion-planning/reference/orientation-vectors.md
@@ -14,6 +14,9 @@ aliases:
 
 When you specify a pose in Viam (in frame system configuration, a motion planning destination, or any other `Pose` payload), the orientation is expressed as one of five rotation formats. This page lists those formats, their schemas, common orientations, and validation rules.
 
+Viam's default format, the orientation vector (OV), is a variant of the
+[axis-angle representation](https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation): `(x, y, z)` is the rotation axis, and `th` is the rotation angle.
+
 ## Supported orientation formats
 
 Viam supports five orientation formats, specified with the `type` field in
@@ -32,9 +35,13 @@ The orientation vector format (axis plus angle in degrees). Use this for most co
 
 - `x`, `y`, `z`: components of the rotation axis vector (must be non-zero;
   normalized internally)
-- `th`: rotation angle in degrees
+- `th`: rotation angle in degrees. Values wrap every 360 degrees, so
+  `th: 370` and `th: 10` describe the same orientation.
 
 Default (identity): `{"x": 0, "y": 0, "z": 1, "th": 0}`. This represents no rotation.
+
+The axis must be a non-zero vector. `(x, y, z) = (0, 0, 0)` is a
+singularity: the rotation axis is undefined and validation rejects it.
 
 ### `ov_radians`
 

--- a/docs/motion-planning/reference/orientation-vectors.md
+++ b/docs/motion-planning/reference/orientation-vectors.md
@@ -12,7 +12,7 @@ aliases:
   - /operate/reference/orientation-vector/
 ---
 
-When you specify a pose in Viam (in frame system configuration, a motion planning destination, or any other `Pose` payload), the orientation is expressed as one of five rotation formats. This page lists those formats, their schemas, common orientations, and validation rules.
+When you write a `Pose` payload (in frame system configuration, a motion planning destination, or anywhere else), the orientation format you choose affects validation and gimbal-lock behavior. The sections below cover the five supported formats, their schemas, common orientations, and validation rules.
 
 Viam's default format, the orientation vector (OV), is structured similarly
 to the

--- a/docs/motion-planning/reference/orientation-vectors.md
+++ b/docs/motion-planning/reference/orientation-vectors.md
@@ -92,8 +92,6 @@ Rotation axis plus angle in radians, using the R4AA (Rotation 4 Axis Angle) repr
 
 Default: `{"x": 0, "y": 0, "z": 1, "th": 0}`.
 
-The axis must have a non-zero norm. A zero-norm axis causes a runtime error.
-
 ### `quaternion`
 
 Unit quaternion. Values are auto-normalized.

--- a/docs/motion-planning/reference/orientation-vectors.md
+++ b/docs/motion-planning/reference/orientation-vectors.md
@@ -14,8 +14,13 @@ aliases:
 
 When you specify a pose in Viam (in frame system configuration, a motion planning destination, or any other `Pose` payload), the orientation is expressed as one of five rotation formats. This page lists those formats, their schemas, common orientations, and validation rules.
 
-Viam's default format, the orientation vector (OV), is a variant of the
-[axis-angle representation](https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation): `(x, y, z)` is the rotation axis, and `th` is the rotation angle.
+Viam's default format, the orientation vector (OV), is structured similarly
+to the
+[axis-angle representation](https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation)
+but interpreted differently: `(x, y, z)` is the unit vector along which the
+component points (for an arm, the direction the end effector points from the
+origin), and `th` is the rotation around that pointing direction. The
+pointing direction and the rotation axis coincide.
 
 ## Supported orientation formats
 

--- a/docs/motion-planning/reference/plan-monitoring.md
+++ b/docs/motion-planning/reference/plan-monitoring.md
@@ -11,15 +11,15 @@ description: "Reference for the motion service methods, types, and states used t
 
 ## Which implementations track plans
 
-| Motion service implementation                                                          | Tracks plans?                                                             |
-| -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| Builtin                                                                                | No. `Move` is synchronous; the plan-tracking RPCs return "not supported". |
-| Module implementations (for example, modules that implement `MoveOnGlobe`/`MoveOnMap`) | Yes — typical case                                                        |
+| Motion service implementation                       | Tracks plans?                                                             |
+| --------------------------------------------------- | ------------------------------------------------------------------------- |
+| Builtin                                             | No. `Move` is synchronous; the plan-tracking RPCs return "not supported". |
+| Modules that implement `MoveOnGlobe` or `MoveOnMap` | Yes (typical case).                                                       |
 
-The navigation service uses a motion service internally. When you configure
-navigation with a plan-tracking motion service, navigation's own
-`GetPaths`, `GetLocation`, and mode transitions expose progress without
-calling `GetPlan` directly.
+If you are using navigation: the navigation service uses a motion
+service internally. When you configure navigation with a plan-tracking
+motion service, navigation's own `GetPaths`, `GetLocation`, and mode
+transitions expose progress without calling `GetPlan` directly.
 
 ## PlanState
 

--- a/docs/motion-planning/replanning-behavior.md
+++ b/docs/motion-planning/replanning-behavior.md
@@ -87,9 +87,8 @@ robot's reported position is farther than this threshold from the nearest
 point on the current plan, the service triggers a replan.
 
 Tune the threshold to match your movement sensor's accuracy. Standard GPS
-typically reports positional error of 3-5 m, so a 2.6 m deviation threshold
-produces frequent replans; raise the threshold for standard GPS and lower it
-for RTK.
+reports positional error of 3-5 m, so the 2.6 m default triggers frequent
+replans. Raise the threshold for standard GPS and lower it for RTK.
 
 ### Transient obstacles
 
@@ -98,9 +97,9 @@ service queries these detectors at `obstacle_polling_frequency_hz`. When a
 detector reports a new obstacle, the motion service transforms the obstacle
 into the planner's frame, then triggers a replan that accounts for it.
 
-Detectors are only active during execution. They do not contribute to
-initial planning; that picture of the world comes from the obstacles
-you passed in the request or configured statically on the machine.
+Detectors are only active during execution, not initial planning.
+Initial obstacles come from the `WorldState` in the request or from
+static machine config.
 
 ### Replan cost factor (navigation service only)
 
@@ -125,10 +124,9 @@ motion service does not do:
 - **Undo completed motion.** A replan always starts from the robot's current
   position. If conditions change behind the robot after it has passed
   through, the new plan does not go back.
-- **Replace a failed plan.** If the planner cannot find a path from
-  the robot's current position (after a deviation or obstacle trigger),
-  the execution transitions to `FAILED` rather than trying different
-  approaches automatically.
+- **Recover automatically from a failed replan.** If the new plan also
+  cannot find a path from the robot's current position, the execution
+  transitions to `FAILED`. The service does not try different approaches.
 
 ## Practical consequences
 


### PR DESCRIPTION
## Summary

Addresses the quickest items from Brandon's review of the motion-planning section. Factual corrections verified against source (rdk/motionplan, motion-tools); wording and link fixes applied in one batch. Medium-scope items (frame-system deepening, orientation box-check semantics, obstacles per-type expansion, kinematics URDF/TCP details, monitor safety pattern) will follow in thematic PRs.

**Factual corrections (verified in source):**
- 3D scene \`Escape\` row: key exits focus mode, doesn't deselect (\`KeyboardControls.svelte:137\`, \`PointerMissBox.svelte:35\`).
- AllowedFrameCollisions with same frame for both \`frame1\` and \`frame2\` disables all self-collisions within that component (\`rdk/motionplan/collision.go\` \`allowNameToSubGeoms\` + cross product). Now documented.

**Wording and link fixes:**
- Landing: \`positions\` → \`poses\`.
- Reference/kinematics: linkTitle \"Arm kinematics\" → \"Kinematics\" (covers gantries).
- Reference/algorithms: linkTitle matches title; Berenson cBiRRT paper linked (also from how-planning-works).
- Orientation vectors: note axis-angle lineage, theta wrapping, zero-axis singularity.
- Obstacles: dynamic-obstacles 3D SCENE caveat promoted to an alert block with mitigation.
- Constraints: CollisionSpecification section now links to Allow frame collisions instead of restating hierarchical-matching.
- Allow frame collisions: cross-link to Attach and detach geometries.
- Frame system: new \"Verify visually with the 3D scene\" section before the CLI section.
- Camera calibration: recommend the viam-labs A4 8x6 25 mm checkerboard PDF; point to 3D SCENE + Calibrate frame offsets for visual sanity check.

## Test plan

- [x] \`npx prettier --write\` on all 11 changed files
- [x] \`npx markdownlint-cli\` with repo config (no errors)
- [x] \`vale\` on all 11 changed files (0 errors, 0 warnings)
- [x] \`make build-prod\` succeeds (1056 pages, 1010 aliases)
- [ ] Netlify deploy preview renders the changed pages cleanly