### PR TITLE
Vision section: post-merge fixes (reviewer feedback + accuracy)

### DIFF
--- a/docs/reference/services/vision/detections-to-segments.md
+++ b/docs/reference/services/vision/detections-to-segments.md
@@ -86,9 +86,9 @@ The module downloads and starts automatically when you save the configuration.
 | Attribute | Type | Required? | Description |
 | --------- | ---- | --------- | ----------- |
 | `detector_name` | string | **Required** | Name of a configured 2D detector vision service. Detections from this service are the input to the segmenter. |
-| `camera_name` | string | **Required** | Name of the depth-capable camera. Must support point clouds (`supports_pcd` in `GetProperties`). |
-| `mean_k` | int | **Required** | Point-cloud noise-filtering parameter (from the [PCL statistical outlier removal subroutine](https://pcl.readthedocs.io/projects/tutorials/en/latest/statistical_outlier.html)). Set to roughly 5 to 10 percent of the minimum expected segment size. Set to `0` or less to disable filtering. |
-| `sigma` | float | **Required** | Point-cloud noise-filtering parameter. Typical values are `1.0` to `2.0`; `1.25` is a good default. Lower values produce less noisy objects at the risk of losing points near edges. |
+| `mean_k` | int | **Required** | Point-cloud noise-filtering parameter (from the [PCL statistical outlier removal subroutine](https://pcl.readthedocs.io/projects/tutorials/en/latest/statistical_outlier.html)). Must be greater than 0. Set to roughly 5 to 10 percent of the minimum expected segment size. |
+| `sigma` | float | **Required** | Point-cloud noise-filtering parameter. Must be greater than 0. Typical values are `1.0` to `2.0`; `1.25` is a good default. Lower values produce less noisy objects at the risk of losing points near edges. |
+| `camera_name` | string | Optional | Default camera for `GetObjectPointClouds` calls that do not pass a camera name. If set, the camera becomes a required dependency of the segmenter and must support point clouds (check `supports_pcd` through [`GetProperties`](/reference/apis/components/camera/#getproperties) on the camera). |
 | `confidence_threshold_pct` | float | Optional | Detections below this confidence are filtered out before 3D projection. Must be between `0.0` and `1.0`. <br> Default: `0.5` |
 
 ## Test your segmenter

--- a/docs/vision/3d-vision/measure-depth.md
+++ b/docs/vision/3d-vision/measure-depth.md
@@ -74,7 +74,15 @@ Step 5 of this guide shows how to combine detections with depth data to measure 
 
 Go to [app.viam.com](https://app.viam.com), navigate to your machine, and verify your depth camera appears in the component list. Open the test panel and confirm it is producing images.
 
-For Intel RealSense cameras, the `webcam` model or the `realsense` module is commonly used. Check that the depth stream is enabled in the camera configuration.
+Common depth-capable cameras and the modules that wrap them:
+
+- Intel RealSense D400 series, through the [RealSense module](https://github.com/viamrobotics/viam-camera-realsense)
+- Luxonis OAK-D series, through the [OAK camera module](https://github.com/viamrobotics/viam-camera-oak)
+- Orbbec cameras, through the [Orbbec module](https://github.com/viam-modules/orbbec)
+- Stereolabs ZED cameras, through a community module on the [registry](https://app.viam.com/registry)
+- The `fake` camera model, for development without hardware (returns synthetic but structurally correct point clouds)
+
+Check that the depth stream is enabled in the camera's configuration, and confirm the camera reports `supports_pcd: true` through [`GetProperties`](/reference/apis/components/camera/#getproperties). Without depth support, none of the steps below will work.
 
 ### 2. Get a point cloud
 
@@ -98,11 +106,12 @@ async def main():
 
     camera = Camera.from_robot(robot, "my-depth-camera")
 
-    # Get a point cloud
-    point_cloud, _ = await camera.get_point_cloud()
+    # get_point_cloud returns (point_cloud_bytes, mime_type).
+    # The MIME type (for example, "pointcloud/pcd") is not needed here.
+    point_cloud, mime_type = await camera.get_point_cloud()
 
     print("Point cloud retrieved")
-    print(f"Type: {type(point_cloud)}")
+    print(f"MIME type: {mime_type}, payload type: {type(point_cloud)}")
 
     await robot.close()
 

--- a/docs/vision/3d-vision/measure-depth.md
+++ b/docs/vision/3d-vision/measure-depth.md
@@ -79,8 +79,9 @@ Common depth-capable cameras and the modules that wrap them:
 - Intel RealSense D400 series, through the [RealSense module](https://github.com/viamrobotics/viam-camera-realsense)
 - Luxonis OAK-D series, through the [OAK camera module](https://github.com/viamrobotics/viam-camera-oak)
 - Orbbec cameras, through the [Orbbec module](https://github.com/viam-modules/orbbec)
-- Stereolabs ZED cameras, through a community module on the [registry](https://app.viam.com/registry)
 - The `fake` camera model, for development without hardware (returns synthetic but structurally correct point clouds)
+
+For other depth cameras, search the [registry](https://app.viam.com/registry?type=component&subtype=camera) for a matching module.
 
 Check that the depth stream is enabled in the camera's configuration, and confirm the camera reports `supports_pcd: true` through [`GetProperties`](/reference/apis/components/camera/#getproperties). Without depth support, none of the steps below will work.
 

--- a/docs/vision/3d-vision/measure-depth.md
+++ b/docs/vision/3d-vision/measure-depth.md
@@ -428,7 +428,47 @@ for _, d := range detections {
 {{% /tab %}}
 {{< /tabs >}}
 
-### 6. Use a fake camera for testing
+### 6. Convert depth + pixel coordinates to a 3D position
+
+A distance reading tells you how far something is, but not where it is in space. To plan a motion to a detected object you need a 3D position (x, y, z) in a frame another component can use.
+
+Two steps: unproject the pixel to a point in the **camera frame**, then transform that point into whichever frame the consuming component (arm base, robot base, map) expects.
+
+**Unproject pixel + depth to camera frame:**
+
+Given the pixel `(u, v)` where your detection centered, a depth reading `d` in millimeters, and the camera's intrinsics `fx`, `fy`, `ppx`, `ppy`:
+
+```python
+x_camera = (u - ppx) * d / fx
+y_camera = (v - ppy) * d / fy
+z_camera = d
+```
+
+The result is a point in millimeters, in the camera's frame (x right, y down, z forward).
+
+**Transform to a shared frame:**
+
+Use the motion service's [`TransformPose`](/reference/apis/services/motion/) method to convert the camera-frame pose into whatever frame your application uses (arm base, robot base, world). `TransformPose` uses the [frame system](/motion-planning/frame-system/) configuration, which records where the camera is mounted relative to other components:
+
+```python
+from viam.services.motion import MotionClient
+from viam.proto.common import Pose, PoseInFrame
+
+motion = MotionClient.from_robot(robot, "builtin")
+
+camera_pose = PoseInFrame(
+    reference_frame="my-depth-camera",
+    pose=Pose(x=x_camera, y=y_camera, z=z_camera, o_x=0, o_y=0, o_z=1, theta=0),
+)
+arm_pose = await motion.transform_pose(camera_pose, "my-arm")
+print(f"Object at arm-frame position: ({arm_pose.pose.x:.0f}, {arm_pose.pose.y:.0f}, {arm_pose.pose.z:.0f}) mm")
+```
+
+For this to work, your machine configuration must declare frames for the camera and the target component. See [Frame system](/motion-planning/frame-system/) for the full setup.
+
+If your vision service model supports it, [`GetObjectPointClouds`](/reference/apis/services/vision/#getobjectpointclouds) returns the 3D center for each detected object directly, skipping the manual unprojection. See [Segment 3D objects](/vision/3d-vision/segment-3d/).
+
+### 7. Use a fake camera for testing
 
 If you do not have a depth camera, configure a `fake` camera that generates simulated point cloud data. This lets you develop and test your depth-related code without hardware.
 
@@ -443,9 +483,11 @@ If you do not have a depth camera, configure a `fake` camera that generates simu
 
 The fake camera generates both color images and simulated point cloud data. The depth values are synthetic but structurally correct, so your code will work the same way with real hardware.
 
-### 7. Configure camera intrinsic parameters
+### 8. Configure camera intrinsic parameters
 
-If your camera does not automatically provide intrinsic parameters, you can set them manually in the configuration. These parameters are needed for accurate 2D-to-3D projection.
+Intrinsic parameters apply to camera-based depth sensors (structured light cameras like the Intel RealSense D400 series, stereo cameras like the OAK-D) where depth data arrives as a 2D depth map that gets projected into 3D using the camera's internal geometry. LiDAR and time-of-flight sensors that return 3D points directly (Intel RealSense L515, solid-state lidars) don't use intrinsics the same way. Check your sensor's datasheet if you're not sure.
+
+If your camera does not automatically provide intrinsic parameters, you can set them manually in the configuration.
 
 ```json
 {
@@ -482,8 +524,29 @@ If your camera does not automatically provide intrinsic parameters, you can set 
 
 Most depth cameras (Intel RealSense, Oak-D) provide these automatically. You only need to set them manually for cameras without built-in calibration data.
 
+**Intrinsics vs extrinsics.** Intrinsics describe the camera's internal geometry (how pixels map to rays). Extrinsics describe where the camera is mounted relative to other things on the machine (the arm base, the robot base). Viam handles extrinsics through the [frame system](/motion-planning/frame-system/), not through camera attributes. Step 6 above uses extrinsics (through `TransformPose`) to move a 3D point from the camera frame into another component's frame.
+
 {{< alert title="Tip" color="tip" >}}
-If you need an image, its detections, and a point cloud together in one call, use [`CaptureAllFromCamera`](/reference/apis/services/vision/#captureallfromcamera). This is more efficient than separate calls and ensures all results correspond to the same frame. See [Detect objects, step 7](/vision/object-detection/detect/#7-get-everything-in-one-call-with-captureallfromcamera) for a full example.
+To fetch an image, detections, and point cloud objects together in one call (rather than separate `get_images` and detector calls), use [`CaptureAllFromCamera`](/reference/apis/services/vision/#captureallfromcamera). All three results come from the same captured frame, so they stay in sync:
+
+```python
+from viam.services.vision import VisionClient
+
+detector = VisionClient.from_robot(robot, "my-detector")
+
+result = await detector.capture_all_from_camera(
+    "my-depth-camera",
+    return_image=True,
+    return_detections=True,
+    return_object_point_clouds=True,
+)
+
+image = result.image
+detections = result.detections
+point_clouds = result.objects  # list of 3D objects, one per detection
+```
+
+This matters for fused results: if you call `get_images()` and `get_detections_from_camera()` separately on a running stream, the detections come from a later frame than the image. `CaptureAllFromCamera` avoids the race.
 {{< /alert >}}
 
 ## Try it

--- a/docs/vision/3d-vision/measure-depth.md
+++ b/docs/vision/3d-vision/measure-depth.md
@@ -449,19 +449,16 @@ The result is a point in millimeters, in the camera's frame (x right, y down, z 
 
 **Transform to a shared frame:**
 
-Use the motion service's [`TransformPose`](/reference/apis/services/motion/) method to convert the camera-frame pose into whatever frame your application uses (arm base, robot base, world). `TransformPose` uses the [frame system](/motion-planning/frame-system/) configuration, which records where the camera is mounted relative to other components:
+Call `transform_pose` on your `RobotClient` to convert the camera-frame pose into whatever frame your application uses: the arm base, the robot base, the world. `transform_pose` reads the [frame system](/motion-planning/frame-system/) configuration, which records where the camera is mounted relative to other components:
 
 ```python
-from viam.services.motion import MotionClient
 from viam.proto.common import Pose, PoseInFrame
-
-motion = MotionClient.from_robot(robot, "builtin")
 
 camera_pose = PoseInFrame(
     reference_frame="my-depth-camera",
     pose=Pose(x=x_camera, y=y_camera, z=z_camera, o_x=0, o_y=0, o_z=1, theta=0),
 )
-arm_pose = await motion.transform_pose(camera_pose, "my-arm")
+arm_pose = await robot.transform_pose(camera_pose, "my-arm")
 print(f"Object at arm-frame position: ({arm_pose.pose.x:.0f}, {arm_pose.pose.y:.0f}, {arm_pose.pose.z:.0f}) mm")
 ```
 
@@ -486,7 +483,7 @@ The fake camera generates both color images and simulated point cloud data. The 
 
 ### 8. Configure camera intrinsic parameters
 
-Intrinsic parameters apply to camera-based depth sensors (structured light cameras like the Intel RealSense D400 series, stereo cameras like the OAK-D) where depth data arrives as a 2D depth map that gets projected into 3D using the camera's internal geometry. LiDAR and time-of-flight sensors that return 3D points directly (Intel RealSense L515, solid-state lidars) don't use intrinsics the same way. Check your sensor's datasheet if you're not sure.
+Intrinsic parameters apply to camera-based depth sensors that capture depth as a 2D map and then project it into 3D using the camera's internal geometry. This covers structured light cameras like the Intel RealSense D400 series and stereo cameras like the OAK-D. Sensors that return 3D points directly, such as the Intel RealSense L515 and solid-state lidars, don't use intrinsics the same way. Check your sensor's datasheet if you're not sure.
 
 If your camera does not automatically provide intrinsic parameters, you can set them manually in the configuration.
 

--- a/docs/vision/classify.md
+++ b/docs/vision/classify.md
@@ -34,9 +34,9 @@ A single classification call returns multiple results ranked by confidence. The 
 
 The API is the same for both. The difference is in how the model was trained and how you interpret the results.
 
-### The count parameter
+### The `count` parameter (SDK call)
 
-The `count` parameter tells the vision service how many top classifications to return. If `count=3`, you get the three highest-confidence labels. This is useful for:
+`count` is an argument on the SDK's `GetClassifications` and `GetClassificationsFromCamera` calls (for example, `classifier.get_classifications_from_camera("my-camera", count=3)`). It tells the vision service how many top classifications to return. If `count=3`, you get the three highest-confidence labels. This is useful for:
 
 - Understanding what else the model considered (was it confused between two classes?)
 - Multi-label classification where you want all relevant labels

--- a/docs/vision/configure.md
+++ b/docs/vision/configure.md
@@ -37,7 +37,7 @@ Two things matter here:
 - **The model file itself** (`model_path` in the JSON) — the weights the service loads.
 - **The label file** (`label_path`) — a plain text file that maps the numeric class IDs the model outputs to human-readable names. A detector that outputs class `3` doesn't mean anything on its own; the label file translates that to `dog` or whatever class 3 was at training time. Registry models ship with this file; for local models you provide your own.
 
-Both paths resolve to whatever you give them: a package reference like `${packages.my-model}/labels.txt` for registry models, or an absolute path on the machine for local files. You can inspect a registry model's bundled `labels.txt` by looking in `${packages.my-model}/` after first deploy, or by opening the model's detail view on [app.viam.com/models](https://app.viam.com/models).
+Both paths resolve to whatever you give them: a package reference like `${packages.ml_model.my-model}/labels.txt` for registry models, or an absolute path on the machine for local files. You can inspect a registry model's bundled `labels.txt` by looking in `${packages.ml_model.my-model}/` after first deploy, or by opening the model's detail view on [app.viam.com/models](https://app.viam.com/models).
 
 {{< tabs >}}
 {{% tab name="Builder" %}}
@@ -55,17 +55,30 @@ Behind the scenes the builder adds a `packages` entry for the model and sets `mo
 
 ```json
 {
-  "name": "my-ml-model",
-  "api": "rdk:service:mlmodel",
-  "model": "tflite_cpu",
-  "attributes": {
-    "model_path": "${packages.my-model}/model.tflite",
-    "label_path": "${packages.my-model}/labels.txt"
-  }
+  "packages": [
+    {
+      "name": "my-model",
+      "package": "<org-id>/my-model",
+      "version": "latest",
+      "type": "ml_model"
+    }
+  ],
+  "services": [
+    {
+      "name": "my-ml-model",
+      "api": "rdk:service:mlmodel",
+      "model": "tflite_cpu",
+      "attributes": {
+        "package_reference": "<org-id>/my-model",
+        "model_path": "${packages.ml_model.my-model}/my-model.tflite",
+        "label_path": "${packages.ml_model.my-model}/labels.txt"
+      }
+    }
+  ]
 }
 ```
 
-`${packages.my-model}` resolves to the directory where the [registry](https://app.viam.com/registry) package was downloaded. Replace `my-model` with the name of your deployed model package. The `packages` array at the top level of the machine config (not shown here) names the package to download.
+`${packages.ml_model.my-model}` resolves to the directory where the [registry](https://app.viam.com/registry) package was downloaded. Replace `my-model` with the name of your deployed model package and `<org-id>` with the UUID of the organization that owns it. `package_reference` is the same `<org-id>/my-model` identifier. The file name inside the placeholder (`my-model.tflite`, `labels.txt`) matches the actual file names inside the package; the Builder flow in the previous tab fills these in automatically based on what the registry model contains.
 
 {{% /tab %}}
 {{% tab name="JSON — local model file" %}}
@@ -146,14 +159,23 @@ With both services saved, a minimal end-to-end configuration (camera + ML model 
       "attributes": {}
     }
   ],
+  "packages": [
+    {
+      "name": "my-model",
+      "package": "<org-id>/my-model",
+      "version": "latest",
+      "type": "ml_model"
+    }
+  ],
   "services": [
     {
       "name": "my-ml-model",
       "api": "rdk:service:mlmodel",
       "model": "tflite_cpu",
       "attributes": {
-        "model_path": "${packages.my-model}/model.tflite",
-        "label_path": "${packages.my-model}/labels.txt"
+        "package_reference": "<org-id>/my-model",
+        "model_path": "${packages.ml_model.my-model}/my-model.tflite",
+        "label_path": "${packages.ml_model.my-model}/labels.txt"
       }
     },
     {

--- a/docs/vision/configure.md
+++ b/docs/vision/configure.md
@@ -11,7 +11,7 @@ aliases:
   - /vision-detection/add-computer-vision/
 ---
 
-You have a camera on your machine, and you have an ML model. The model came from the [registry](https://app.viam.com/registry), from the [Train ML Models section](/train/) (either [managed training](/train/train-a-model/) or a [custom training script](/train/custom-training-scripts/)), or from somewhere else entirely (GitHub, Hugging Face, your own training run). This how-to wires them together: an ML model service loads the model and a vision service turns the model's output into detections, classifications, or 3D point cloud objects.
+You have a camera on your machine, and you have an ML model. The model could have come from the [registry](https://app.viam.com/registry), from the [Train ML Models section](/train/) through [managed training](/train/train-a-model/) or a [custom training script](/train/custom-training-scripts/), or from elsewhere entirely: GitHub, Hugging Face, or your own training run outside Viam. This how-to wires the pieces together: an ML model service loads the model, and a vision service turns the model's output into detections, classifications, or 3D point cloud objects.
 
 Downstream how-tos ([detect](/vision/object-detection/detect/), [classify](/vision/classify/), [track](/vision/object-detection/track/), [measure depth](/vision/3d-vision/measure-depth/)) assume the pipeline described here is running.
 

--- a/docs/vision/configure.md
+++ b/docs/vision/configure.md
@@ -17,7 +17,19 @@ Downstream how-tos ([detect](/vision/object-detection/detect/), [classify](/visi
 
 ## What you are configuring, in one paragraph
 
-Viam splits ML inference into two services. The **ML model service** loads the model file and runs tensors through it. The **vision service** turns those tensors into structured detections and classifications and ties them to a specific camera. Your application code talks to the vision service; the ML model service is a building block underneath. For the longer explanation and when the split matters, see [How a vision service works](/vision/how-it-works/).
+Viam splits ML inference into two services. The **ML model service** loads the model file and runs tensors through it. The **vision service** turns those tensors into structured detections and classifications and ties them to a specific camera. Your application code talks to the vision service; the ML model service is a building block underneath.
+
+```text
+    Camera ─── image ───► Vision service ─── tensor ───► ML model service
+                               │                             │
+                               ▼                             ▼
+                       Detections,                      Raw output
+                       classifications,                 tensor
+                       point cloud objects    ◄──────────────┘
+                       (what your code uses)
+```
+
+Three resources (camera, vision service, ML model service) plus the model file itself. The steps below add each piece. For the longer explanation and when the split matters, see [How a vision service works](/vision/how-it-works/).
 
 ## 1. Add an ML model service
 

--- a/docs/vision/configure.md
+++ b/docs/vision/configure.md
@@ -11,7 +11,7 @@ aliases:
   - /vision-detection/add-computer-vision/
 ---
 
-You have a camera on your machine, and you have an ML model: either a pre-trained one from the [registry](https://app.viam.com/registry), one you trained yourself ([managed training](/train/train-a-model/) or a [custom training script](/train/custom-training-scripts/)), or one you brought from elsewhere. This how-to wires them up: an ML model service loads the model and a vision service turns the model's output into detections, classifications, or 3D point cloud objects.
+You have a camera on your machine, and you have an ML model. The model came from the [registry](https://app.viam.com/registry), from the [Train ML Models section](/train/) (either [managed training](/train/train-a-model/) or a [custom training script](/train/custom-training-scripts/)), or from somewhere else entirely (GitHub, Hugging Face, your own training run). This how-to wires them together: an ML model service loads the model and a vision service turns the model's output into detections, classifications, or 3D point cloud objects.
 
 Downstream how-tos ([detect](/vision/object-detection/detect/), [classify](/vision/classify/), [track](/vision/object-detection/track/), [measure depth](/vision/3d-vision/measure-depth/)) assume the pipeline described here is running.
 
@@ -21,7 +21,7 @@ Viam splits ML inference into two services. The **ML model service** loads the m
 
 ## 1. Add an ML model service
 
-The ML model service matches your model file's framework. For most tasks, `tflite_cpu` is the right starting point.
+The ML model service matches your model file's framework. For most tasks, `tflite_cpu` is the right starting point: it runs on almost any CPU and keeps hardware costs down. When you need GPU acceleration (larger models, higher frame rates, Nvidia Jetson hardware), use [`triton`](https://app.viam.com/module/viam/mlmodelservice-triton-jetpack) instead. The framework-support table in [Deploy a model from the registry](/vision/deploy-and-maintain/deploy-from-registry/#model-framework-support) lists which implementations support which frameworks and hardware paths.
 
 1. Navigate to the **CONFIGURE** tab of your machine in the Viam app.
 2. Click the **+** icon next to your machine part and select **Configuration block**.
@@ -32,6 +32,13 @@ The ML model service matches your model file's framework. For most tasks, `tflit
 
 Point the service at your model file. The Builder flow populates the config for you; the JSON tab shows what you end up with (or what to write manually, for example for a local model file).
 
+Two things matter here:
+
+- **The model file itself** (`model_path` in the JSON) — the weights the service loads.
+- **The label file** (`label_path`) — a plain text file that maps the numeric class IDs the model outputs to human-readable names. A detector that outputs class `3` doesn't mean anything on its own; the label file translates that to `dog` or whatever class 3 was at training time. Registry models ship with this file; for local models you provide your own.
+
+Both paths resolve to whatever you give them: a package reference like `${packages.my-model}/labels.txt` for registry models, or an absolute path on the machine for local files. You can inspect a registry model's bundled `labels.txt` by looking in `${packages.my-model}/` after first deploy, or by opening the model's detail view on [app.viam.com/models](https://app.viam.com/models).
+
 {{< tabs >}}
 {{% tab name="Builder" %}}
 
@@ -41,7 +48,7 @@ Point the service at your model file. The Builder flow populates the config for 
 4. Click a model card to open its details view. Pick a **Version** from the dropdown: **Latest** (auto-updates when a newer version is published) or a specific timestamp version (recommended for production).
 5. Click **Choose**. The dialog closes and the service panel now shows the selected model as a pill with its version and author.
 
-Behind the scenes the builder adds a `packages` entry for the model and sets `model_path` and `label_path` on the service attributes to point into the package. Registry models ship with their own `labels.txt`, so you do not create one yourself.
+Behind the scenes the builder adds a `packages` entry for the model and sets `model_path` and `label_path` on the service attributes to point into the package.
 
 {{% /tab %}}
 {{% tab name="JSON — registry model" %}}
@@ -58,7 +65,7 @@ Behind the scenes the builder adds a `packages` entry for the model and sets `mo
 }
 ```
 
-`${packages.my-model}` resolves to the directory where the [registry](https://app.viam.com/registry) package was downloaded. Replace `my-model` with the name of your deployed model package. Registry models ship with their own `labels.txt`, so the `label_path` above resolves to the labels file inside the package. You do not need to create one yourself. The `packages` array at the top level of the machine config (not shown here) names the package to download.
+`${packages.my-model}` resolves to the directory where the [registry](https://app.viam.com/registry) package was downloaded. Replace `my-model` with the name of your deployed model package. The `packages` array at the top level of the machine config (not shown here) names the package to download.
 
 {{% /tab %}}
 {{% tab name="JSON — local model file" %}}
@@ -75,7 +82,7 @@ Behind the scenes the builder adds a `packages` entry for the model and sets `mo
 }
 ```
 
-For local models, `label_path` is optional but recommended: it maps the numeric class IDs the model outputs to human-readable names like `person` or `car`. Provide a `.txt` file with one label per line, in class-ID order (line 0 is class 0).
+For local models, `label_path` is optional but recommended. The file is plain text, one label per line, in class-ID order (line 0 is class 0, line 1 is class 1, and so on).
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -116,9 +123,10 @@ The fastest check is the Viam app's live overlay:
 
 1. Go to the **CONTROL** tab.
 2. Find your vision service in the component list and open it.
-3. In the **Camera** dropdown, select the camera whose feed you want the vision service to run on. Detections appear as an overlay on the live camera feed and refresh automatically.
+3. In the **Camera** dropdown, select the camera whose feed you want the vision service to run on. Detections appear as an overlay on the live camera feed.
+4. The overlay refreshes automatically once per second. To adjust, use the dropdown next to the Camera selector (**Live**, **Refresh every second**, **Refresh every 5 seconds**, or **Manual refresh**).
 
-Bounding boxes or classification labels should appear on the live camera feed within a second or two. If you are using a COCO-class general-purpose model, point the camera at a person, a cup, or a keyboard.
+Bounding boxes or classification labels should appear within a second or two. If you are using a COCO-class general-purpose model, point the camera at a person, a cup, or a keyboard.
 
 If the camera feed appears but no detections are shown, see [Tune detection quality](/vision/object-detection/tune/).
 

--- a/docs/vision/deploy-and-maintain/available-models.md
+++ b/docs/vision/deploy-and-maintain/available-models.md
@@ -12,9 +12,9 @@ The [Viam registry](https://app.viam.com/registry) has three kinds of entries yo
 
 ## Three kinds of entries
 
-- **ML model service implementations.** There is one ML model service API (`Infer`); multiple module implementations target different frameworks (TFLite, ONNX, TensorFlow, PyTorch) and sometimes specific hardware (CPU, GPU on Jetson). When you add an ML model service to your machine, you pick one of these implementations.
-- **Vision service models.** There is one vision service API (`GetDetections`, `GetClassifications`, `GetObjectPointClouds`, `CaptureAllFromCamera`, `GetProperties`); three models ship built in (`mlmodel`, `color_detector`, `viam:vision:detections-to-segments`) and registry modules add more for specialized tasks. You pick a vision service model when you configure a vision service.
-- **Public ML models.** Model artifacts (weights plus metadata) published to the registry so any machine can deploy them without training. Your ML model service loads one of these.
+- **ML model service implementations.** The ML model service has one API method, `Infer`, but the registry offers multiple module implementations of that service. Each implementation targets a specific framework: TFLite, ONNX, TensorFlow, or PyTorch. Some also target specific hardware like CPU or GPU on Jetson. When you add an ML model service to your machine, you pick one implementation.
+- **Vision service models.** The vision service has one API that covers detection, classification, and 3D segmentation (see the [full API reference](/reference/apis/services/vision/)). Multiple models implement that API. Three ship built into Viam: `mlmodel`, `color_detector`, and `viam:vision:detections-to-segments`. Registry modules add more for specialized tasks. You pick a vision service model when you configure a vision service.
+- **Public ML models.** Model artifacts (the weights plus metadata) published to the registry so any machine can deploy them without training. Your ML model service loads one of these.
 
 A typical pipeline uses one of each: a camera → an ML model service implementation running a public ML model → a vision service model interpreting its output.
 

--- a/docs/vision/deploy-and-maintain/batch-inference.md
+++ b/docs/vision/deploy-and-maintain/batch-inference.md
@@ -66,13 +66,13 @@ viam infer \
 
 ### Flag reference
 
-| Flag               | Required | Description                                                                                                |
-| ------------------ | -------- | ---------------------------------------------------------------------------------------------------------- |
-| `--binary-data-id` | Yes      | ID of the image to run the model against. From the **DATA** tab.                                           |
-| `--model-name`     | Yes      | Model name as it appears in the **MODELS** tab.                                                            |
-| `--model-org-id`   | Yes      | ID of the organization that owns the model.                                                                |
-| `--model-version`  | Yes      | Specific model version to use, typically a timestamp like `2025-04-14T16-38-25`. Does not accept `latest`. |
-| `--org-id`         | No       | ID of the organization that runs the inference. Defaults to the model's organization.                      |
+| Flag               | Required | Description                                                                                                                          |
+| ------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `--binary-data-id` | Yes      | ID of the image to run the model against. From the **DATA** tab.                                                                     |
+| `--model-name`     | Yes      | Model name as it appears in the **MODELS** tab.                                                                                      |
+| `--model-org-id`   | Yes      | ID of the organization that owns the model.                                                                                          |
+| `--model-version`  | Yes      | Specific model version to use, typically a timestamp like `2025-04-14T16-38-25`. Does not accept `latest`.                           |
+| `--org-id`         | Yes      | ID of the organization that runs the inference. This can be a different organization from the model's owner; both must be specified. |
 
 ### Example output
 

--- a/docs/vision/deploy-and-maintain/batch-inference.md
+++ b/docs/vision/deploy-and-maintain/batch-inference.md
@@ -81,7 +81,7 @@ Inference Response:
 Output Tensors:
   Tensor Name: num_detections
     Shape: [1]
-    Values: [1.0000]
+    Values: [...]
   Tensor Name: classes
     Shape: [32 1]
     Values: [...]
@@ -93,8 +93,12 @@ Output Tensors:
     Values: [...]
 Annotations:
 Bounding Box Format: [x_min, y_min, x_max, y_max]
-  No annotations.
+  Bounding Box ID: 0, Label: person
+    Coordinates: [0.071400, 0.203500, 0.938500, 0.855100]
+    Confidence: 0.9765
 ```
+
+Output tensors are model-specific. The tensor names, shapes, and values shown above come from a typical TFLite object detector (fields: `classes`, `boxes`, `confidence`, `num_detections`). Your model's output shape will differ if it uses different tensor names. The `Annotations` block appears only when the model has bounding-box or classification metadata registered with the registry item; models without annotations skip the block entirely.
 
 Bounding box coordinates are returned as proportions between `0` and `1`, with `(0, 0)` in the top-left and `(1, 1)` in the bottom-right. Multiply by the image width and height to get pixel coordinates.
 

--- a/docs/vision/deploy-and-maintain/roll-out-to-fleet.md
+++ b/docs/vision/deploy-and-maintain/roll-out-to-fleet.md
@@ -28,24 +28,38 @@ Before updating any production machine:
 
 ## Pin the new version in a fragment
 
-If your fleet shares a [fragment](/hardware/fragments/), update the ML model service's `model_version` attribute in the fragment:
+If your fleet shares a [fragment](/hardware/fragments/), update the `version` field on the ML model package in the fragment's `packages` array:
 
 ```json
 {
-  "name": "my-ml-model",
-  "api": "rdk:service:mlmodel",
-  "model": "tflite_cpu",
-  "attributes": {
-    "model_path": "${packages.my-model}/model.tflite",
-    "label_path": "${packages.my-model}/labels.txt",
-    "model_version": "2025-04-14T16-38-25"
-  }
+  "packages": [
+    {
+      "name": "my-model",
+      "package": "<org-id>/my-model",
+      "version": "2025-04-14T16-38-25",
+      "type": "ml_model"
+    }
+  ],
+  "services": [
+    {
+      "name": "my-ml-model",
+      "api": "rdk:service:mlmodel",
+      "model": "tflite_cpu",
+      "attributes": {
+        "package_reference": "<org-id>/my-model",
+        "model_path": "${packages.ml_model.my-model}/my-model.tflite",
+        "label_path": "${packages.ml_model.my-model}/labels.txt"
+      }
+    }
+  ]
 }
 ```
 
+The service attributes (`package_reference`, `model_path`, `label_path`) stay the same across versions. The version is pinned at the package level.
+
 Save the fragment. Every machine using it picks up the change on its next config sync (within seconds under normal operation).
 
-Tracking "latest" is simpler but less safe for production. Any new version published to the [registry](https://app.viam.com/registry) auto-deploys. Pin specific versions when you want to control when rollouts happen.
+Tracking `latest` (set `"version": "latest"`) is simpler but less safe for production: any new version published to the [registry](https://app.viam.com/registry) auto-deploys. Pin specific timestamps when you want to control when rollouts happen.
 
 ## Stage the rollout
 

--- a/docs/vision/object-detection/act-on-detections.md
+++ b/docs/vision/object-detection/act-on-detections.md
@@ -21,6 +21,18 @@ You have a vision service detecting or classifying objects, but you need your ma
 
 The most common approach is to create a module that wraps an existing resource. The wrapper intercepts API calls, checks vision results, and decides whether to pass the call through or block it.
 
+```text
+   Your code                Wrapper module                  Real resource
+  ────────────────────►  ─────────────────────────────►  ──────────────────
+   arm.move_to_position   1. Query vision service         arm.move_to_position
+                          2. Decide based on result        (runs or doesn't)
+                          3. Pass through OR raise error
+                                     │
+                                     ▼
+                             Vision service
+                          (detections / classifications)
+```
+
 For example, a "safe arm" module wraps a real arm. When your code calls `move_to_position`, the wrapper first checks the vision service for people in the frame. If no one is detected, it passes the command to the real arm. If a person is detected, it raises an error.
 
 This pattern works with any resource type: arms, bases, motors, or even other services.

--- a/docs/vision/object-detection/alert-on-detections.md
+++ b/docs/vision/object-detection/alert-on-detections.md
@@ -105,7 +105,7 @@ To verify your confidence threshold, expand the **TEST** panel on your vision se
 Add the data management service to capture and sync filtered images:
 
 1. Click **+** and select **Configuration block**.
-2. In the search field, type `data management` and select the matching result.
+2. In the search field, type `data management` and select `data_manager/builtin` from the results.
 3. Click **Add component**, name the service `data-manager`, and click **Add component** again to confirm.
 4. Leave the default attributes and click **Save**.
 
@@ -139,6 +139,8 @@ Add a trigger to send alerts when filtered images sync:
 7. Click **Save**.
 
 ## Try it
+
+Before trying the end-to-end flow, confirm you have all three pieces from above saved on the machine: the filtered camera (step 1), the data management service plus data capture on the filtered camera (step 2), and the trigger with at least one notification method (step 3). The flow does not work unless all three are configured together.
 
 1. Point your camera at an object your model recognizes and wait for the capture interval to pass.
 2. Check the **TEST** panel on your vision service to confirm detections are occurring with sufficient confidence.

--- a/docs/vision/object-detection/detect.md
+++ b/docs/vision/object-detection/detect.md
@@ -20,18 +20,20 @@ Your vision service is configured and running, but you need to do something usef
 
 A detection is a single recognized object in an image. Each detection includes:
 
-| Field        | Type            | Description                                                                 |
-| ------------ | --------------- | --------------------------------------------------------------------------- |
-| `class_name` | String          | The label assigned by the model (for example, "person", "dog", "stop-sign") |
-| `confidence` | Float (0.0-1.0) | How confident the model is in this detection                                |
-| `x_min`      | Integer         | Left edge of the bounding box in pixels                                     |
-| `y_min`      | Integer         | Top edge of the bounding box in pixels                                      |
-| `x_max`      | Integer         | Right edge of the bounding box in pixels                                    |
-| `y_max`      | Integer         | Bottom edge of the bounding box in pixels                                   |
+| Field              | Type            | Description                                                                 |
+| ------------------ | --------------- | --------------------------------------------------------------------------- |
+| `class_name`       | String          | The label assigned by the model (for example, "person", "dog", "stop-sign") |
+| `confidence`       | Float (0.0-1.0) | How confident the model is in this detection                                |
+| `x_min`            | Integer         | Left edge of the bounding box in pixels                                     |
+| `y_min`            | Integer         | Top edge of the bounding box in pixels                                      |
+| `x_max`            | Integer         | Right edge of the bounding box in pixels                                    |
+| `y_max`            | Integer         | Bottom edge of the bounding box in pixels                                   |
+| `x_min_normalized` | Float (0.0-1.0) | Left edge as a fraction of image width                                      |
+| `y_min_normalized` | Float (0.0-1.0) | Top edge as a fraction of image height                                      |
+| `x_max_normalized` | Float (0.0-1.0) | Right edge as a fraction of image width                                     |
+| `y_max_normalized` | Float (0.0-1.0) | Bottom edge as a fraction of image height                                   |
 
-The bounding box coordinates use the image coordinate system: (0,0) is the top-left corner, x increases to the right, y increases downward. The bounding box is axis-aligned (not rotated).
-
-Detections also include normalized coordinates (`x_min_normalized`, `y_min_normalized`, `x_max_normalized`, `y_max_normalized`) as floats between 0.0 and 1.0, representing positions relative to image dimensions. These are useful when you need resolution-independent coordinates.
+The bounding box coordinates use the image coordinate system: (0,0) is the top-left corner, x increases to the right, y increases downward. The bounding box is axis-aligned (not rotated). Use the normalized fields when you need resolution-independent positions.
 
 A single call to the detection API can return zero, one, or many detections. The number depends on how many objects the model finds in the frame.
 
@@ -41,6 +43,8 @@ The vision service provides two methods for getting detections:
 
 - **GetDetectionsFromCamera** takes a camera name and handles everything: it captures an image from the camera, runs it through the model, and returns detections. This is the simplest approach and the one you should use in most cases.
 - **GetDetections** takes an image you already have and runs it through the model. Use this when you need to run detection on an image you captured separately, an image from a file, or an image you have preprocessed.
+
+For full parameter lists and language-specific signatures, see the vision service API reference for [GetDetectionsFromCamera](/reference/apis/services/vision/#getdetectionsfromcamera) and [GetDetections](/reference/apis/services/vision/#getdetections).
 
 ### Confidence thresholds
 

--- a/docs/vision/object-detection/track.md
+++ b/docs/vision/object-detection/track.md
@@ -65,7 +65,7 @@ Set the required attributes:
 | `chosen_labels`         | object | No       | None    | Map of class names to confidence thresholds. Only detections matching these labels are tracked. |
 | `trigger_cool_down_s`   | float  | No       | 5       | Seconds before a trigger resets after firing.                                                   |
 | `buffer_size`           | int    | No       | 30      | Number of frames to buffer lost detections before removing a track (1 to 256).                  |
-| `min_track_persistence` | int    | No       | 1       | Number of consecutive frames a track must appear in before it is returned in detection results. |
+| `min_track_persistence` | int    | No       | 3       | Number of consecutive frames a track must appear in before it is returned in detection results. |
 
 Click **Save**.
 

--- a/docs/vision/object-detection/tune.md
+++ b/docs/vision/object-detection/tune.md
@@ -42,7 +42,9 @@ Set `xmin_ymin_xmax_ymax_order` to the permutation that reorders the model's out
 }
 ```
 
-The example above says "my model's output position 1 holds xmin, position 0 holds ymin, position 3 holds xmax, position 2 holds ymax." Use `[0, 1, 2, 3]` (the default) when the model already outputs in `xmin, ymin, xmax, ymax` order.
+The example above says "my model's output position 1 holds xmin, position 0 holds ymin, position 3 holds xmax, position 2 holds ymax." Use `[0, 1, 2, 3]` when the model already outputs in `xmin, ymin, xmax, ymax` order.
+
+If you leave this attribute unset, the vision service first reads the box order from the model's output-tensor metadata (if the model publishes it). If no metadata is available, it falls back to `[1, 0, 3, 2]` (the YOLO-style `[ymin, xmin, ymax, xmax]` default). Set `xmin_ymin_xmax_ymax_order` explicitly when your model doesn't publish metadata AND doesn't follow that convention.
 
 **How to diagnose:** Run the Control tab overlay and compare box locations to what is actually in the image. If boxes look rotated, mirrored, or shifted by half the frame, this is almost always the coordinate order.
 


### PR DESCRIPTION
## Summary

Follow-up PR to [#4933](https://github.com/viamrobotics/docs/pull/4933) with fixes found after the merge. 8 commits, each with a clear rationale in its message.

### Reviewer feedback items addressed
- **F6**: configure.md intro now explicitly references the Train ML Models section as a doc-flow entry point
- **F8**: configure.md §1 adds a GPU/triton callout pointing to the framework table
- **F9**: ML model service JSON format corrected — `\${packages.ml_model.<name>}` two-level namespace, `package_reference` attribute included, top-level `packages` array shown in registry-model and complete-configuration examples
- **F10, F11**: label-file concept promoted out of the Local-model tab into shared prose; inspection instructions added
- **F17**: configure.md §6 names the refresh-rate dropdown options
- **F28**: detect.md normalized-coordinate fields promoted into the detection-fields table
- **F29**: detect.md `GetDetections` vs `GetDetectionsFromCamera` section links to API reference
- **F31**: classify.md `count` parameter section explicitly flags it's an SDK argument
- **F43**: measure-depth.md §1 lists RealSense, OAK-D, Orbbec, fake with module links
- **F45**: measure-depth.md §2 names the discarded tuple member (was `_`, now `mime_type`)
- **F5**: configure.md adds an inline data-flow diagram (camera → vision service → ML model service)
- **F46**: measure-depth.md new step 6 converts 2D detection + depth to a 3D world position, then uses `transform_pose` to move it into another component's frame
- **F47/48**: measure-depth.md §8 clarifies that intrinsics apply to camera-based depth sensors (not LiDAR or direct-3D ToF); adds an intrinsics-vs-extrinsics note
- **F49**: point-cloud-specific `CaptureAllFromCamera` example replaces the stale cross-reference
- **F51**: act-on-detections.md adds a wrapper-pattern ASCII diagram
- **F56**: alert-on-detections.md §2 names the actual search result (`data_manager/builtin`)
- **F57**: alert-on-detections.md Try It opens with a prerequisites note

### Correctness bugs caught by Playbook 1 accuracy pass
- `batch-inference.md` — `--org-id` was marked optional; CLI source requires it (`rdk/cli/ml_inference.go`)
- `batch-inference.md` — example output showed `No annotations.` line the CLI doesn't print
- `tune.md` — claimed `[0, 1, 2, 3]` was the default box order; fallback is actually `[1, 0, 3, 2]` (`mlvision/detector.go:45`)
- `measure-depth.md` — unverified ZED module mention removed (Typesense registry query returned zero hits)

### Correctness bugs caught against cloned module sources
- `detections-to-segments.md` — `camera_name` was marked Required; `Validate()` treats it as optional. `mean_k`/`sigma` said "0 or less disables"; source rejects values ≤ 0
- `track.md` — `min_track_persistence` default was 1; source constant is 3

### Correctness bug caught by second writing-playbook pass
- `measure-depth.md` §6 Python example called `MotionClient.transform_pose` — `transform_pose` is a `RobotClient` method, verified in `viam-python-sdk/src/viam/robot/client.py:685`. Rewrote to use `robot.transform_pose`

### Prose density fixes (writing playbook)
- `configure.md` intro: two nested parentheticals + third in one sentence split into cleaner structure
- `measure-depth.md` §8 intrinsics intro: two multi-item parentheticals in one sentence split into three sentences
- `available-models.md` "Three kinds of entries" had double parentheticals and a 5-item API-method list; rewritten

## Test plan

- [ ] Hugo `make build-prod` clean locally
- [ ] Vale clean
- [ ] htmltest 1451 / 1451 pass
- [ ] Check that renamed/restructured pages resolve from aliases (internal test passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)