### PR TITLE
Hardware: link add-a-{type} how-tos to per-model reference

### DIFF
--- a/docs/hardware/common-components/add-a-base.md
+++ b/docs/hardware/common-components/add-a-base.md
@@ -25,6 +25,21 @@ For accurate distance and angle calculations, the `wheeled` model needs two phys
 - **Wheel circumference**: how far the robot travels per wheel revolution.
 - **Width**: the distance between the left and right wheel centers.
 
+### Built-in models
+
+- [`boat`](/reference/components/base/boat/) — _(no description)_.
+- [`fake`](/reference/components/base/fake/) — A model used for testing, with no physical hardware.
+- [`sensor-controlled`](/reference/components/base/sensor-controlled/) — Wrap other base models and add feedback control using a movement sensor.
+- [`wheeled`](/reference/components/base/wheeled/) — Supports mobile wheeled robotic bases with motors on both sides for differential steering.
+
+Micro-RDK:
+
+- [`two_wheeled_base`](/reference/components/base/micro-rdk/two_wheeled_base/) — _(no description)_.
+
+### Registry modules
+
+For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=base). Each module's configuration is documented on its registry page.
+
 ## Steps
 
 ### 1. Prerequisites
@@ -254,6 +269,8 @@ go run main.go
   match exactly (names are case-sensitive).
 
 {{< /expand >}}
+
+{{< readfile "/static/include/components/troubleshoot/base.md" >}}
 
 ## What's next
 

--- a/docs/hardware/common-components/add-a-base.md
+++ b/docs/hardware/common-components/add-a-base.md
@@ -27,7 +27,6 @@ For accurate distance and angle calculations, the `wheeled` model needs two phys
 
 ### Built-in models
 
-- [`boat`](/reference/components/base/boat/) — _(no description)_.
 - [`fake`](/reference/components/base/fake/) — A model used for testing, with no physical hardware.
 - [`sensor-controlled`](/reference/components/base/sensor-controlled/) — Wrap other base models and add feedback control using a movement sensor.
 - [`wheeled`](/reference/components/base/wheeled/) — Supports mobile wheeled robotic bases with motors on both sides for differential steering.

--- a/docs/hardware/common-components/add-a-board.md
+++ b/docs/hardware/common-components/add-a-board.md
@@ -24,6 +24,18 @@ The board doesn't represent external hardware. It represents the I/O
 capabilities of the computer itself. Motors, encoders, and servos reference
 the board by name to access the pins they're wired to. Browse all available board models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=board).
 
+### Built-in models
+
+- [`fake`](/reference/components/board/fake/) — A model used for testing, with no physical hardware.
+
+Micro-RDK:
+
+- [`esp32`](/reference/components/board/micro-rdk/esp32/) — _(no description)_.
+
+### Registry modules
+
+For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=board). Each module's configuration is documented on its registry page.
+
 ## Steps
 
 ### 1. Open your machine in the Viam app
@@ -257,6 +269,8 @@ go run main.go
   through SPI or I2C. Check the model's reference page for ADC configuration.
 
 {{< /expand >}}
+
+{{< readfile "/static/include/components/troubleshoot/board.md" >}}
 
 ## What's next
 

--- a/docs/hardware/common-components/add-a-button.md
+++ b/docs/hardware/common-components/add-a-button.md
@@ -21,6 +21,12 @@ and exposes it as a button component.
 
 The `fake` built-in model is useful for testing code without physical hardware.
 
+### Built-in models
+
+### Registry modules
+
+For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=button). Each module's configuration is documented on its registry page.
+
 ## Steps
 
 ### 1. Add a button component

--- a/docs/hardware/common-components/add-a-camera.md
+++ b/docs/hardware/common-components/add-a-camera.md
@@ -18,14 +18,21 @@ Add a camera to your machine's configuration so you can capture images and video
 
 ## Concepts
 
-The camera API gives you `GetImages` (capture frames), `GetPointCloud` (depth data), and stream access regardless of the underlying hardware. Common models include:
+The camera API gives you `GetImages` (capture frames), `GetPointCloud` (depth data), and stream access regardless of the underlying hardware.
 
-- **webcam** (built-in): USB cameras and built-in laptop cameras. Auto-detects available devices.
-- **ffmpeg** (built-in): IP cameras and RTSP streams.
-- **realsense**: Intel RealSense depth cameras (module).
-- **transform**: Applies transformations (crop, resize, overlay) to another camera's output.
+### Built-in models
 
-Browse all available camera models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=camera).
+- [**webcam**](/reference/components/camera/webcam/): USB cameras and built-in laptop cameras. Auto-detects available devices.
+- [**ffmpeg**](/reference/components/camera/ffmpeg/): a camera device, video file, or stream.
+- [**transform**](/reference/components/camera/transform/): applies transformations (crop, resize, rotate, overlay) to another camera's output.
+- [**fake**](/reference/components/camera/fake/): a camera model for testing.
+- [**image_file**](/reference/components/camera/image-file/): serves color or depth image frames from a file path.
+
+For Micro-RDK, see [Micro-RDK camera models](/reference/components/camera/micro-rdk/).
+
+### Registry modules
+
+For hardware the built-in models don't cover, browse [all available camera models in the Viam registry](https://app.viam.com/registry?type=component&subtype=camera). Common Viam-maintained modules include `realsense` (Intel RealSense depth cameras) and `viamrtsp` (IP cameras over RTSP).
 
 ## Steps
 
@@ -274,6 +281,38 @@ go run main.go
 
 - Some cameras need a few seconds to adjust exposure after starting. Try adding a short delay before capturing, or capture and discard a few frames first.
 - Check if the camera has a physical lens cap or privacy shutter.
+
+{{< /expand >}}
+
+{{< expand "No visible live video feed" >}}
+
+Restart `viam-server`:
+
+1. Navigate to your machine's page.
+1. Select the part status dropdown to the right of your machine's name on the top of the page.
+1. If you installed `viam-server` with `viam-agent` you will see a **Restart** button. Click it.
+   Both `viam-server` and `viam-agent` will restart.
+
+   If you do not see the **Restart** button, click the **...** menu on the right side of the machine part's card, and select **Restart part**.
+   If restarting the machine part does not resolve the issue, ssh into the machine and stop and restart `viam-server` manually.
+
+If this doesn't work, you can reboot your machine by running the following command on the machine:
+
+```sh {class="command-line" data-prompt="$"}
+sudo reboot
+```
+
+{{< /expand >}}
+
+{{< expand "Images are dim on start up when capturing data" >}}
+
+If you are capturing camera data, it can happen that the camera captures and syncs discolored or dark images upon start up. The camera typically stabilizes after a short warm-up period.
+
+{{< /expand >}}
+
+{{< expand "High CPU usage" >}}
+
+Camera streams use a significant amount of CPU resources. The more CPU resources a device has, the more camera streams you can run simultaneously. If your device doesn't have enough CPU resources to support your use case, try lowering the image resolution to decrease the CPU load of the camera streams.
 
 {{< /expand >}}
 

--- a/docs/hardware/common-components/add-a-gantry.md
+++ b/docs/hardware/common-components/add-a-gantry.md
@@ -32,6 +32,16 @@ Viam includes two built-in gantry models:
 
 The `fake` built-in model is useful for testing without hardware. Browse all available gantry models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=gantry).
 
+### Built-in models
+
+- [`fake`](/reference/components/gantry/fake/) — A model used for testing, with no physical hardware.
+- [`multi-axis`](/reference/components/gantry/multi-axis/) — Supports a gantry with multiple linear rails. Composed of multiple single-axis gantries.
+- [`single-axis`](/reference/components/gantry/single-axis/) — Supports a gantry with a singular linear rail.
+
+### Registry modules
+
+For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=gantry). Each module's configuration is documented on its registry page.
+
 ## Steps
 
 ### 1. Prerequisites
@@ -273,6 +283,8 @@ go run main.go
 - Test the switch by reading the GPIO pin directly from the board's test panel.
 
 {{< /expand >}}
+
+{{< readfile "/static/include/components/troubleshoot/gantry.md" >}}
 
 ## What's next
 

--- a/docs/hardware/common-components/add-a-generic.md
+++ b/docs/hardware/common-components/add-a-generic.md
@@ -31,6 +31,14 @@ types give you data capture, test panels, and SDK support automatically. Browse 
 
 The `fake` built-in model echoes commands back for testing.
 
+### Built-in models
+
+- [`fake`](/reference/components/generic/fake/) — A model used for testing, with no physical hardware.
+
+### Registry modules
+
+For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=generic). Each module's configuration is documented on its registry page.
+
 ## Steps
 
 ### 1. Add a generic component
@@ -199,6 +207,8 @@ go run main.go
 - Look at the machine's logs for module startup errors.
 
 {{< /expand >}}
+
+{{< readfile "/static/include/components/troubleshoot/generic.md" >}}
 
 ## What's next
 

--- a/docs/hardware/common-components/add-a-gripper.md
+++ b/docs/hardware/common-components/add-a-gripper.md
@@ -28,6 +28,14 @@ models for xArm parallel-jaw and vacuum grippers.
 
 The `fake` built-in model is useful for testing code without physical hardware.
 
+### Built-in models
+
+- [`fake`](/reference/components/gripper/fake/) — A model used for testing, with no physical hardware.
+
+### Registry modules
+
+For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=gripper). Each module's configuration is documented on its registry page.
+
 ## Steps
 
 ### 1. Add a gripper component
@@ -253,6 +261,8 @@ go run main.go
 - Some grippers support configurable open/close speed and grip force.
 
 {{< /expand >}}
+
+{{< readfile "/static/include/components/troubleshoot/gripper.md" >}}
 
 ## What's next
 

--- a/docs/hardware/common-components/add-a-motor.md
+++ b/docs/hardware/common-components/add-a-motor.md
@@ -25,6 +25,22 @@ GPIO motor drivers typically use one of two wiring schemes:
 - **PWM/DIR mode**: one PWM pin for speed and one direction pin.
   Common with many motor driver breakout boards.
 
+### Built-in models
+
+- [`dmc4000`](/reference/components/motor/dmc4000/) — Stepper motor driven by a DMC-40x0 series motion controller.
+- [`encoded-motor`](/reference/components/motor/encoded-motor/) — Standard brushed or brushless DC motor with an encoder.
+- [`fake`](/reference/components/motor/fake/) — A model for testing, with no physical hardware.
+- [`gpio`](/reference/components/motor/gpio/) — Supports standard brushed or brushless DC motors.
+- [`gpiostepper`](/reference/components/motor/gpiostepper/) — Supports stepper motors driven by basic GPIO-controlled stepper driver chips.
+
+Micro-RDK:
+
+- [`gpio`](/reference/components/motor/micro-rdk/gpio/) — _(no description)_.
+
+### Registry modules
+
+For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=motor). Each module's configuration is documented on its registry page.
+
 ## Steps
 
 ### 1. Prerequisites
@@ -267,6 +283,8 @@ go run main.go
   `encoder` and `ticks_per_rotation` on the motor.
 
 {{< /expand >}}
+
+{{< readfile "/static/include/components/troubleshoot/motor.md" >}}
 
 ## What's next
 

--- a/docs/hardware/common-components/add-a-movement-sensor.md
+++ b/docs/hardware/common-components/add-a-movement-sensor.md
@@ -30,13 +30,18 @@ methods a particular sensor supports.
 
 ### Built-in models
 
-| Model              | Use case                                                                                              |
-| ------------------ | ----------------------------------------------------------------------------------------------------- |
-| `wheeled-odometry` | Estimates position and velocity from motor encoders on a wheeled base. No additional hardware needed. |
-| `merged`           | Combines data from multiple movement sensors into one. For example, GPS position + IMU orientation.   |
+- [`wheeled-odometry`](/reference/components/movement-sensor/wheeled-odometry/) — Estimates position and velocity from motor encoders on a wheeled base. No additional hardware needed.
+- [`merged`](/reference/components/movement-sensor/merged/) — Combines data from multiple movement sensors into one. For example, GPS position + IMU orientation.
+- [`fake`](/reference/components/movement-sensor/fake/) — A model for testing, with no physical hardware.
 
-Hardware-specific models (GPS modules, IMUs, RTK receivers) are available as
-modules in the [Viam registry](https://app.viam.com/registry?type=component&subtype=movement_sensor).
+Micro-RDK:
+
+- [`accel-adxl345`](/reference/components/movement-sensor/micro-rdk/accel-adxl345/) — Analog Devices ADXL345 accelerometer.
+- [`gyro-mpu6050`](/reference/components/movement-sensor/micro-rdk/gyro-mpu6050/) — InvenSense MPU-6050 gyroscope and accelerometer.
+
+### Registry modules
+
+Hardware-specific models (GPS modules, IMUs, RTK receivers) are available as modules in the [Viam registry](https://app.viam.com/registry?type=component&subtype=movement_sensor). Each module's configuration is documented on its registry page.
 
 ## Steps
 
@@ -277,6 +282,8 @@ go run main.go
   `GetProperties` to see which methods your sensor supports.
 
 {{< /expand >}}
+
+{{< readfile "/static/include/components/troubleshoot/movement-sensor.md" >}}
 
 ## What's next
 

--- a/docs/hardware/common-components/add-a-power-sensor.md
+++ b/docs/hardware/common-components/add-a-power-sensor.md
@@ -22,14 +22,11 @@ A power sensor component provides three methods:
 
 ### Built-in models
 
-| Model          | Use case                                                                |
-| -------------- | ----------------------------------------------------------------------- |
-| `ina219`       | INA219 I2C current/voltage/power monitor. Common on breakout boards.    |
-| `ina226`       | INA226 I2C current/voltage/power monitor. Higher precision than INA219. |
-| `renogy-cc-ov` | Renogy solar charge controller.                                         |
+- [`fake`](/reference/components/power-sensor/fake/) — A model for testing, with no physical hardware.
 
-Additional models are available as modules in the
-[Viam registry](https://app.viam.com/registry).
+### Registry modules
+
+Hardware-specific power sensor models (INA219, INA226, Renogy controllers, etc.) are available as modules in the [Viam registry](https://app.viam.com/registry?type=component&subtype=power_sensor). Each module's configuration is documented on its registry page.
 
 ## Steps
 
@@ -237,6 +234,8 @@ go run main.go
   current must flow through it.
 
 {{< /expand >}}
+
+{{< readfile "/static/include/components/troubleshoot/power-sensor.md" >}}
 
 ## What's next
 

--- a/docs/hardware/common-components/add-a-sensor.md
+++ b/docs/hardware/common-components/add-a-sensor.md
@@ -23,6 +23,18 @@ built-in models. This is because the sensor ecosystem is enormous. Thousands
 of different devices with different communication protocols exist, and modules cover
 specific hardware while keeping the same `GetReadings` API.
 
+### Built-in models
+
+- [`fake`](/reference/components/sensor/fake/) — A model used for testing, with no physical hardware.
+
+Micro-RDK:
+
+- [`ultrasonic`](/reference/components/sensor/micro-rdk/ultrasonic/) — _(no description)_.
+
+### Registry modules
+
+For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=sensor). Each module's configuration is documented on its registry page.
+
 ## Steps
 
 ### 1. Add a sensor component
@@ -237,6 +249,8 @@ go run main.go
   generic module that works. Check the registry for protocol-based modules.
 
 {{< /expand >}}
+
+{{< readfile "/static/include/components/troubleshoot/sensor.md" >}}
 
 ## What's next
 

--- a/docs/hardware/common-components/add-a-servo.md
+++ b/docs/hardware/common-components/add-a-servo.md
@@ -21,6 +21,19 @@ angular positioning through PWM control.
 The servo component uses a single PWM-capable pin on a
 [board component](/hardware/common-components/add-a-board/). Browse all available servo models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=servo).
 
+### Built-in models
+
+- [`fake`](/reference/components/servo/fake/) — A model used for testing, with no physical hardware.
+- [`gpio`](/reference/components/servo/gpio/) — Supports a hobby servo wired to a board that supports PWM, for example Raspberry Pi 5, Orange Pi, Jetson, or PCAXXXX.
+
+Micro-RDK:
+
+- [`gpio`](/reference/components/servo/micro-rdk/gpio/) — _(no description)_.
+
+### Registry modules
+
+For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=servo). Each module's configuration is documented on its registry page.
+
 ## Steps
 
 ### 1. Prerequisites
@@ -227,6 +240,8 @@ go run main.go
 - Confirm the pin number in your config matches the physical wiring.
 
 {{< /expand >}}
+
+{{< readfile "/static/include/components/troubleshoot/servo.md" >}}
 
 ## What's next
 

--- a/docs/hardware/common-components/add-a-switch.md
+++ b/docs/hardware/common-components/add-a-switch.md
@@ -27,6 +27,14 @@ reads GPIO pins or communicates with a switch controller.
 The `fake` built-in model simulates a switch with configurable positions and
 is useful for testing. Browse available switch models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=switch).
 
+### Built-in models
+
+- [`fake`](/reference/components/switch/fake/) — A model used for testing, with no physical hardware.
+
+### Registry modules
+
+For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=switch). Each module's configuration is documented on its registry page.
+
 ## Steps
 
 ### 1. Add a switch component

--- a/docs/hardware/common-components/add-an-arm.md
+++ b/docs/hardware/common-components/add-an-arm.md
@@ -35,9 +35,7 @@ It supports kinematics for several arm models (ur5e, ur20, xarm6, xarm7, lite6).
 
 ### Built-in models
 
-- [`eva`](/reference/components/arm/eva/) — _(no description)_.
 - [`fake`](/reference/components/arm/fake/) — A model used for testing, with no physical hardware.
-- [`yahboom-dofbot`](/reference/components/arm/yahboom-dofbot/) — _(no description)_.
 
 ### Registry modules
 

--- a/docs/hardware/common-components/add-an-arm.md
+++ b/docs/hardware/common-components/add-an-arm.md
@@ -33,6 +33,16 @@ arm manufacturer has its own communication protocol. Common models include:
 The `fake` built-in model is useful for testing code without physical hardware.
 It supports kinematics for several arm models (ur5e, ur20, xarm6, xarm7, lite6).
 
+### Built-in models
+
+- [`eva`](/reference/components/arm/eva/) — _(no description)_.
+- [`fake`](/reference/components/arm/fake/) — A model used for testing, with no physical hardware.
+- [`yahboom-dofbot`](/reference/components/arm/yahboom-dofbot/) — _(no description)_.
+
+### Registry modules
+
+For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=arm). Each module's configuration is documented on its registry page.
+
 ## Steps
 
 ### 1. Add an arm component
@@ -292,6 +302,8 @@ You should see all zeros before the move, then joints 1 and 2 at 10 and -10 degr
   [Constraints](/motion-planning/move-an-arm/constraints/) for motion constraints.
 
 {{< /expand >}}
+
+{{< readfile "/static/include/components/troubleshoot/arm.md" >}}
 
 ## What's next
 

--- a/docs/hardware/common-components/add-an-encoder.md
+++ b/docs/hardware/common-components/add-an-encoder.md
@@ -30,7 +30,6 @@ feedback instead of time-based estimates. Browse all available encoder models in
 
 ### Built-in models
 
-- [`arduino`](/reference/components/encoder/arduino/) — _(no description)_.
 - [`fake`](/reference/components/encoder/fake/) — An encoder model for testing.
 - [`incremental`](/reference/components/encoder/incremental/) — Supports a two phase encoder, which can measure the speed and direction of rotation in relation to a given reference point.
 - [`single`](/reference/components/encoder/single/) — A single pin 'pulse output' encoder which returns its relative position but no direction.

--- a/docs/hardware/common-components/add-an-encoder.md
+++ b/docs/hardware/common-components/add-an-encoder.md
@@ -28,6 +28,22 @@ Once you configure an encoder and reference it from a motor component, the
 motor gains accurate position control. `GoFor` and `GoTo` use actual encoder
 feedback instead of time-based estimates. Browse all available encoder models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=encoder).
 
+### Built-in models
+
+- [`arduino`](/reference/components/encoder/arduino/) — _(no description)_.
+- [`fake`](/reference/components/encoder/fake/) — An encoder model for testing.
+- [`incremental`](/reference/components/encoder/incremental/) — Supports a two phase encoder, which can measure the speed and direction of rotation in relation to a given reference point.
+- [`single`](/reference/components/encoder/single/) — A single pin 'pulse output' encoder which returns its relative position but no direction.
+
+Micro-RDK:
+
+- [`incremental`](/reference/components/encoder/micro-rdk/incremental/) — _(no description)_.
+- [`single`](/reference/components/encoder/micro-rdk/single/) — _(no description)_.
+
+### Registry modules
+
+For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=encoder). Each module's configuration is documented on its registry page.
+
 ## Steps
 
 ### 1. Prerequisites
@@ -267,6 +283,8 @@ go run main.go
   count in the wrong direction.
 
 {{< /expand >}}
+
+{{< readfile "/static/include/components/troubleshoot/encoder.md" >}}
 
 ## What's next
 

--- a/docs/hardware/common-components/add-an-input-controller.md
+++ b/docs/hardware/common-components/add-an-input-controller.md
@@ -20,14 +20,15 @@ callbacks for these events and translates them into machine actions.
 
 ### Built-in models
 
-| Model        | Use case                                                                                                                     |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| `gamepad`    | USB gamepad or joystick. Works with most HID-compatible controllers.                                                         |
-| `webgamepad` | Browser-based gamepad input in the Viam app's CONTROL tab. No physical controller needed.                                    |
-| `gpio`       | Buttons and switches wired to GPIO pins on a board.                                                                          |
-| `mux`        | Multiplexes multiple input controllers, allowing one to override another (for example, safety controller overrides gamepad). |
+- [`gamepad`](/reference/components/input-controller/gamepad/) — USB gamepad or joystick. Works with most HID-compatible controllers.
+- [`webgamepad`](/reference/components/input-controller/webgamepad/) — Browser-based gamepad input in the Viam app's CONTROL tab. No physical controller needed.
+- [`gpio`](/reference/components/input-controller/gpio/) — Buttons and switches wired to GPIO pins on a board.
+- [`mux`](/reference/components/input-controller/mux/) — Multiplexes multiple input controllers, allowing one to override another (for example, safety controller overrides gamepad).
+- [`fake`](/reference/components/input-controller/fake/) — A model for testing, with no physical hardware.
 
-Browse all available input controller models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=input_controller).
+### Registry modules
+
+For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=input_controller). Each module's configuration is documented on its registry page.
 
 ## Steps
 
@@ -280,6 +281,8 @@ go run main.go
   control name, then update your callback registrations accordingly.
 
 {{< /expand >}}
+
+{{< readfile "/static/include/components/troubleshoot/input-controller.md" >}}
 
 ## What's next
 


### PR DESCRIPTION
## Summary

Wires each `add-a-{type}.md` how-to page on `/hardware/common-components/` to the new per-model configuration reference pages added in the companion PR (`content/reference` → #4942).

- Every how-to page gets a `### Built-in models` block after Concepts, with links to each model's reference page and a one-line description.
- Each page also gets a `### Registry modules` pointer for modules in the Viam registry that the built-in set doesn't cover.
- Generic troubleshooting previously scattered across per-model reference pages (via readfile includes) is surfaced on the how-to page so it reaches the how-to reader. Model-specific troubleshooting expands stay on the reference pages.
- `add-a-camera.md` picks up three expands moved over from the webcam reference page (`No visible live video feed`, `Images are dim on startup`, `High CPU usage`) and a Concepts reframe that links to the five built-in camera models plus calls out `realsense` and `viamrtsp` as common Viam-maintained registry modules.
- `add-a-power-sensor.md`: corrects the Built-in models list — `ina219`, `ina226`, and `renogy-cc-ov` are registry modules, not built-ins. Only `fake` ships with `viam-server` today.

Companion reference PR: #4942

## Test plan

- [x] `make build-prod` passes
- [x] `vale docs/hardware/` — 0 errors, 0 warnings, 0 suggestions
- [x] `prettier --write` applied
- [ ] Follow a link from each how-to to its model reference (depends on #4942)
- [ ] Spot-check the Concepts → Built-in models → Registry modules flow on one dense type (motor) and one minimal type (switch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)