### PR TITLE
3D scene tab: move Debug a motion plan above Edit frames visually

### DIFF
--- a/docs/motion-planning/3d-scene/_index.md
+++ b/docs/motion-planning/3d-scene/_index.md
@@ -100,9 +100,9 @@ This is useful for comparing point clouds that should align (a registered scan a
 ## How-to guides
 
 {{< cards >}}
-{{% card link="/motion-planning/3d-scene/debug-motion-plan/" noimage="true" %}}
 {{% card link="/motion-planning/3d-scene/calibrate-frame-offsets/" noimage="true" %}}
 {{% card link="/motion-planning/3d-scene/verify-point-cloud-alignment/" noimage="true" %}}
 {{% card link="/motion-planning/3d-scene/set-up-obstacle-avoidance/" noimage="true" %}}
+{{% card link="/motion-planning/3d-scene/debug-motion-plan/" noimage="true" %}}
 {{% card link="/motion-planning/3d-scene/edit-frames/" noimage="true" %}}
 {{< /cards >}}

--- a/docs/motion-planning/3d-scene/debug-motion-plan.md
+++ b/docs/motion-planning/3d-scene/debug-motion-plan.md
@@ -71,7 +71,7 @@ Verify that:
   table collisions.
 
 If obstacles are missing or misplaced, see
-[Set up obstacle avoidance](/motion-planning/3d-scene/set-up-obstacle-avoidance/).
+[Verify obstacles](/motion-planning/3d-scene/set-up-obstacle-avoidance/).
 
 ### 4. Look for impossible targets
 

--- a/docs/motion-planning/3d-scene/debug-motion-plan.md
+++ b/docs/motion-planning/3d-scene/debug-motion-plan.md
@@ -1,7 +1,7 @@
 ---
 linkTitle: "Debug a motion plan"
 title: "Debug a motion plan"
-weight: 10
+weight: 45
 layout: "docs"
 type: "docs"
 description: "Use the 3D scene to inspect the frame system and obstacle geometry behind a motion plan that failed or produced unexpected results."

--- a/docs/motion-planning/3d-scene/set-up-obstacle-avoidance.md
+++ b/docs/motion-planning/3d-scene/set-up-obstacle-avoidance.md
@@ -1,6 +1,6 @@
 ---
-linkTitle: "Set up obstacle avoidance"
-title: "Set up obstacle avoidance"
+linkTitle: "Verify obstacles"
+title: "Verify obstacles"
 weight: 40
 layout: "docs"
 type: "docs"

--- a/docs/motion-planning/obstacles/configure-workspace-obstacles.md
+++ b/docs/motion-planning/obstacles/configure-workspace-obstacles.md
@@ -327,7 +327,7 @@ For objects the robot grasps and releases dynamically, see [Attach and detach ge
 3. Orbit the scene. Each configured obstacle appears as a translucent shape at the position you configured. Each component shows up under the **World** panel; click a component to see its pose and geometry in the **Details** panel.
 4. Check coverage against the physical workspace. If the arm can reach past an obstacle into the physical object, the geometry is too small.
 
-For the full visualization and verification workflow, see [Set up obstacle avoidance](/motion-planning/3d-scene/set-up-obstacle-avoidance/).
+For the full visualization and verification workflow, see [Verify obstacles](/motion-planning/3d-scene/set-up-obstacle-avoidance/).
 
 ## Try it
 
@@ -377,6 +377,6 @@ Fix the geometry in the component's attributes and save again.
 ## What's next
 
 - [Plan collision-free paths](/motion-planning/obstacles/avoid-obstacles/): pass runtime obstacles through `WorldState` for objects that change between calls.
-- [Set up obstacle avoidance](/motion-planning/3d-scene/set-up-obstacle-avoidance/): full verification workflow in the **3D SCENE** tab.
+- [Verify obstacles](/motion-planning/3d-scene/set-up-obstacle-avoidance/): full verification workflow in the **3D SCENE** tab.
 - [Attach and detach geometries](/motion-planning/obstacles/attach-detach-geometries/): attach a grasped object to the gripper frame for the duration of a pickup.
 - [Allow specific frames to collide](/motion-planning/obstacles/allow-frame-collisions/): permit expected contact between frames.


### PR DESCRIPTION
## Summary

Reorder pages within the **3D scene tab** section. Debug a motion plan moves from first to fourth, just above Edit frames visually. New section order:

1. Calibrate frame offsets
2. Verify point cloud alignment
3. Set up obstacle avoidance
4. Debug a motion plan
5. Edit frames visually

Changes: `debug-motion-plan.md` weight 10 → 45. Cards on the section landing page reordered to match.

## Test plan

- [ ] Deploy preview: left-nav under "3D scene tab" shows pages in the new order
- [ ] Cards on `/motion-planning/3d-scene/` match the new order