### PR TITLE
Reference components: replace remaining /operate/ links ahead of operate/ removal

### DIFF
--- a/docs/reference/components/arm/fake.md
+++ b/docs/reference/components/arm/fake.md
@@ -55,6 +55,6 @@ The following attributes are available for `fake` arms:
 | Name | Type | Required? | Description |
 | ---- | ---- | --------- | ----------- |
 | `arm-model` | string | Optional | Model name of the robotic arm model you want your fake arm to act as. See [built-in arm models](../) for supported model names. |
-| `model-path` | string | Optional | The path to the [kinematic configuration file](/operate/reference/kinematic-chain-config/) of the arm driver you want your fake arm to act as. This path should point to the exact location where the file is located on your computer running `viam-server`. |
+| `model-path` | string | Optional | The path to the [kinematic configuration file](/motion-planning/frame-system/) of the arm driver you want your fake arm to act as. This path should point to the exact location where the file is located on your computer running `viam-server`. |
 
 {{< readfile "/static/include/components/test-control/arm-control.md" >}}

--- a/docs/reference/components/board/micro-rdk/esp32.md
+++ b/docs/reference/components/board/micro-rdk/esp32.md
@@ -18,7 +18,7 @@ micrordk_component: true
 
 {{% alert title="REQUIREMENTS" color="caution" %}}
 
-Follow the [setup guide](/operate/install/setup/) to install and run `viam-micro-server` before configuring an `esp32` board.
+Follow the [setup guide](/foundation/) to install and run `viam-micro-server` before configuring an `esp32` board.
 
 Viam recommends purchasing the ESP32 with a development board.
 The following ESP32 microcontrollers are supported:

--- a/docs/reference/components/camera/micro-rdk/esp32-camera.md
+++ b/docs/reference/components/camera/micro-rdk/esp32-camera.md
@@ -30,7 +30,7 @@ aliases:
 {{< imgproc src="/components/camera/esp32-camera-2640.png" alt="Fake Camera on the ESP32" resize="300x" class="shadow" >}}
 
 {{< alert title="Software requirements" color="note" >}}
-To use this model, you must follow the [Set up an ESP32 guide](/operate/install/setup-micro/#build-and-flash-custom-firmware), which enables you to install and activate the ESP-IDF.
+To use this model, you must follow the [Set up an ESP32 guide](/reference/device-setup/setup-micro/#build-and-flash-custom-firmware), which enables you to install and activate the ESP-IDF.
 When you create a new project with `cargo generate`, select the option to include camera module traits when prompted.
 Finish building and flashing custom firmware, then return to this guide.
 {{< /alert >}}

--- a/docs/reference/components/camera/micro-rdk/fake.md
+++ b/docs/reference/components/camera/micro-rdk/fake.md
@@ -18,7 +18,7 @@ A `fake` camera is a camera model for testing.
 The camera always returns the same image, which is an image of a circle inside a diamond.
 
 {{< alert title="Software requirements" color="note" >}}
-To use this model, you must follow the [Set up an ESP32 guide](/operate/install/setup-micro/#build-and-flash-custom-firmware), which enables you to install and activate the ESP-IDF.
+To use this model, you must follow the [Set up an ESP32 guide](/reference/device-setup/setup-micro/#build-and-flash-custom-firmware), which enables you to install and activate the ESP-IDF.
 When you create a new project with `cargo generate`, select the option to include camera module traits when prompted.
 Finish building and flashing custom firmware, then return to this guide.
 {{< /alert >}}

--- a/docs/reference/components/movement-sensor/merged.md
+++ b/docs/reference/components/movement-sensor/merged.md
@@ -17,9 +17,9 @@ This allows you to aggregate the API methods supported by multiple sensors into 
 
 This is especially useful if you want to get readings of position and orientation _or_ linear and angular velocity at the same time, which are normally separately supported and returned by [`GPS`](/reference/components/movement-sensor/) or [`IMU`](/reference/components/movement-sensor/) models, respectively.
 
-To reduce velocity error when your machine is using the [navigation service](/operate/reference/services/navigation/), aggregate `Position()` from a [`GPS`](/reference/components/movement-sensor/) and `Orientation()` from an [`IMU`](/reference/components/movement-sensor/) movement sensor in a `merged` model.
+To reduce velocity error when your machine is using the [navigation service](/navigation/), aggregate `Position()` from a [`GPS`](/reference/components/movement-sensor/) and `Orientation()` from an [`IMU`](/reference/components/movement-sensor/) movement sensor in a `merged` model.
 
-Configure a [navigation service](/operate/reference/services/navigation/) to use your merged sensor to navigate.
+Configure a [navigation service](/navigation/) to use your merged sensor to navigate.
 
 Before configuring a `merged` movement sensor, configure each movement sensor you want to merge as an individual component according to its [model's configuration instructions](/reference/components/movement-sensor/).
 Reference the `name` you configure for each individual component in the `merged` sensor's configuration attributes:

--- a/docs/reference/components/movement-sensor/wheeled-odometry.md
+++ b/docs/reference/components/movement-sensor/wheeled-odometry.md
@@ -31,7 +31,7 @@ With a configured `wheeled-odometry` movement sensor, your machine calculates an
 You can access these readings through the [movement sensor API](/reference/apis/components/movement-sensor/#api).
 For the best accuracy with odometry calculations, it is recommended you configure a time interval of less than `1000` milliseconds.
 
-After configuring a `wheeled-odometry` movement sensor, you can operate your base with Viam's built-in services like the [navigation service](/operate/reference/services/navigation/).
+After configuring a `wheeled-odometry` movement sensor, you can operate your base with Viam's built-in services like the [navigation service](/navigation/).
 
 ## Set-up requirements
 


### PR DESCRIPTION
## Summary

Six pages in `/reference/components/` (just merged as part of #4945) still link to legacy `/operate/...` paths. Those links resolve today because the legacy tree is still in the branch, but they will 404 once #4934 removes the `operate/` tree. Replace them with their new-IA equivalents:

- `/operate/reference/services/navigation/` → `/navigation/`
- `/operate/install/setup-micro/` → `/reference/device-setup/setup-micro/`
- `/operate/install/setup/` → `/foundation/`
- `/operate/reference/kinematic-chain-config/` → `/motion-planning/frame-system/`

Touches: `arm/fake.md`, `board/micro-rdk/esp32.md`, `camera/micro-rdk/esp32-camera.md`, `camera/micro-rdk/fake.md`, `movement-sensor/merged.md`, `movement-sensor/wheeled-odometry.md`.

## Test plan

- [x] `make build-prod` passes
- [x] No remaining `/operate/...` links in `docs/reference/components/` (`grep -rnE '\]\(/operate/' docs/reference/components/` returns 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)