### PR TITLE
Fleet section review: accuracy fixes, landscape framing, rollout verification

### DIFF
--- a/docs/fleet/change-network.md
+++ b/docs/fleet/change-network.md
@@ -36,7 +36,7 @@ If you cannot shell into the machine, power cycle it. If the current network is 
 If the machine is still connected to its current network and you want to add a second network (for example, when moving between locations):
 
 1. Add the new network credentials in the machine's system settings. See [configure additional networks](/fleet/system-settings/#configure-additional-networks).
-1. Set the `priority` value higher than the current network if you want the machine to prefer the new one.
+1. Set the `priority` value higher than the current network's priority if you want the machine to prefer the new one. Priority is an integer; higher values win. Default is `0`.
 1. Save the configuration. The machine picks up the new network on its next config sync.
 
 ## Option 3: Pre-configure multiple networks during provisioning

--- a/docs/fleet/deploy-ml-models.md
+++ b/docs/fleet/deploy-ml-models.md
@@ -58,13 +58,15 @@ Apply the fragment to your machines through the Viam app, provisioning, or CLI. 
 1. Find the vision service card and test it with a live camera feed to confirm detections or classifications appear.
 1. Check the **LOGS** tab for errors from the ML model service or vision service.
 
-## Update a model across the fleet
+## Update or roll back a model across the fleet
 
 When you retrain and upload a new model version:
 
 - **Tracking latest**: machines update on their next config sync (or within the maintenance window).
 - **Using fragment tags**: update the fragment configuration with the new model version, save to create a new revision, then move the `stable` tag to the new revision.
 - **Pinned to a version**: update the version string in the fragment and save.
+
+Rolling back follows the same pattern in reverse: change the version pin or move the tag back to a previous revision. Viam does not automatically roll back if a new model performs worse, so you change the pin or tag manually.
 
 ## Related pages
 

--- a/docs/fleet/deploy-software.md
+++ b/docs/fleet/deploy-software.md
@@ -64,7 +64,7 @@ To find your part ID, run `viam machines part list --machine=<machine-id>`. To f
 1. Go to the **CONTROL** tab and test the deployed components or services.
 1. Check the **LOGS** tab for any errors from the module.
 
-On the fleet dashboard at [app.viam.com/fleet/machines](https://app.viam.com/fleet/machines), confirm your machines are online and showing the expected viam-server version.
+On the fleet dashboard at [app.viam.com/fleet/machines](https://app.viam.com/fleet/machines), confirm your machines are online. The dashboard does not currently show per-machine module versions; to verify the rollout reached every machine, see [verify a rollout across the fleet](/fleet/manage-versions/#verify-a-rollout-across-the-fleet).
 
 ## Related pages
 

--- a/docs/fleet/end-user-setup.md
+++ b/docs/fleet/end-user-setup.md
@@ -37,12 +37,15 @@ Use this method if the device manufacturer configured WiFi hotspot provisioning.
 1. On your laptop or mobile device, open WiFi settings and connect to the device's hotspot. The hotspot name begins with `viam-setup-` by default. The password is `viamsetup` unless the manufacturer changed it.
 1. A captive portal opens automatically. If it does not, open [http://viam.setup/](http://viam.setup/) in a browser.
 1. Enter your WiFi network name and password.
-1. If the captive portal asks for machine cloud credentials, this means the device was not pre-configured with a fragment during provisioning. You need a Viam account to complete this step:
+1. If the captive portal asks for machine cloud credentials, the device was not pre-configured with a fragment by the manufacturer. This is intentional for devices that ship without a fixed configuration so you can assign them to your own Viam organization. You need a Viam account to complete this step:
+
    - Log into [app.viam.com](https://app.viam.com) and create a new machine (or use an existing one).
    - On the machine's page, click the part status dropdown next to the machine name.
    - Click the copy icon next to **Machine cloud credentials**.
    - Paste the credentials into the captive portal.
-     Most devices provisioned by a manufacturer skip this step automatically.
+
+   If the manufacturer pre-configured a fragment, the captive portal skips this step automatically.
+
 1. Wait for the device to connect to WiFi and complete setup.
 
 If the device cannot connect, it recreates the hotspot so you can try again.

--- a/docs/fleet/manage-versions.md
+++ b/docs/fleet/manage-versions.md
@@ -1,13 +1,13 @@
 ---
-linkTitle: "Manage versions"
-title: "Manage software versions"
+linkTitle: "Manage versions and rollouts"
+title: "Manage software versions and rollouts"
 weight: 35
 layout: "docs"
 type: "docs"
-description: "Control when and how software updates reach your machines with version pinning, fragment tags, and maintenance windows."
+description: "Control which software versions reach your machines, stage rollouts with fragment tags, and verify what each machine is running."
 ---
 
-Control which software versions your machines run and when updates are applied. By default, machines track the latest version of every module and model. Use version pinning, fragment tags, and maintenance windows to control rollouts more precisely.
+Control which software versions your machines run, when updates are applied, and how to confirm a rollout actually reached every machine. By default, machines track the latest version of every module and model. Use version pinning, fragment tags, and maintenance windows to control rollouts more precisely.
 
 ## Version pinning options
 
@@ -42,7 +42,7 @@ While the maintenance window is closed (sensor returns `false`), `viam-server` c
 
 ## Staged rollouts with fragment tags
 
-For fleets where you want to test changes before deploying to all machines, use the fragment tag workflow:
+For fleets where you want to test changes before deploying to all machines, use the fragment tag workflow. This is the closest equivalent to a canary deployment in Viam: instead of allocating a percentage of devices automatically, you assign tags to fragment revisions and re-tag to promote.
 
 1. Create `stable` and `development` tags on your fragment. See [fragment tags](/fleet/reuse-configuration/#create-a-tag).
 2. Pin production machines to the `stable` tag.
@@ -54,17 +54,42 @@ For fleets where you want to test changes before deploying to all machines, use 
 
 This gives you a manual gate between development and production without maintaining separate fragments.
 
-## Check what versions your machines are running
+## Verify a rollout across the fleet
 
-The fleet dashboard at [app.viam.com/fleet/machines](https://app.viam.com/fleet/machines) shows the `viam-server` version and `viam-agent` version for each machine part.
+After you push an update, you need to confirm every machine actually received it. The fleet dashboard at [app.viam.com/fleet/machines](https://app.viam.com/fleet/machines) shows whether each machine is online but does not currently display per-machine version or config information. To check what each machine is running, query the machines directly.
 
-To check programmatically, iterate over your machines using the fleet management API, connect to each machine, and use `GetMachineStatus` to retrieve the current configuration and version information.
+### Check that machines picked up a config change
+
+Most rollouts change a fragment that machines depend on, which means the goal is to confirm each machine pulled the new config revision. Use the Python SDK's `get_machine_status` on each machine to read its current revision.
+
+```python
+from viam.robot.client import RobotClient
+from viam.rpc.dial import Credentials, DialOptions
+
+async def get_revision(machine_address, api_key, api_key_id):
+    creds = Credentials(type="api-key", payload=api_key)
+    opts = DialOptions(auth_entity=api_key_id, credentials=creds)
+    machine = await RobotClient.at_address(machine_address, opts)
+    status = await machine.get_machine_status()
+    return status.config.revision
+```
+
+Find each machine's address, API key, and API key ID on the machine's **CONNECT** tab in the Viam app. To check the entire fleet, list machines with `AppClient.list_robots`, connect to each, and compare the returned revision to the one you expect.
+
+### Check viam-server or viam-agent version
+
+The per-part `viam_server_version` and `viam_agent_version` fields are populated in the cloud through the `ListMachineSummaries` RPC on `app.proto`, but this RPC is not yet wrapped in the Python SDK or exposed through the CLI. To read it today, make a direct gRPC call to the app service.
+
+If a deployed agent or `viam-server` version fails to start, viam-agent does not automatically roll back to the previous version. It will keep retrying that version until you change the cloud config to pin an older one. See [Limitations](#limitations).
 
 ## Limitations
 
 - Maintenance windows require a sensor that produces a boolean reading. There is no built-in time-based scheduling for maintenance windows; you need a sensor module or logic module that returns `true` during your desired maintenance period.
-- There is no built-in canary or percentage-based rollout. Use fragment tags to control which machines receive updates.
-- Rollback is manual: revert the fragment to a previous revision or pin machines to an older version.
+- There is no built-in canary or percentage-based rollout. Use fragment tags as a manual gate.
+- Rollback is manual at every layer:
+  - Fragment-level rollback: revert the fragment to a previous revision, or pin machines to an older version.
+  - Agent and `viam-server` rollback: viam-agent does not automatically revert when a deployed version fails to start. Edit the cloud config to pin a known-good version.
+- Per-machine version status is not displayed in the fleet dashboard today. Use the Python SDK or direct gRPC (see [Verify a rollout across the fleet](#verify-a-rollout-across-the-fleet)) to find machines stuck on an old version.
 
 ## Related pages
 

--- a/docs/fleet/manage-versions.md
+++ b/docs/fleet/manage-versions.md
@@ -66,6 +66,7 @@ Most rollouts change a fragment that machines depend on, which means the goal is
 from viam.robot.client import RobotClient
 from viam.rpc.dial import Credentials, DialOptions
 
+
 async def get_revision(machine_address, api_key, api_key_id):
     creds = Credentials(type="api-key", payload=api_key)
     opts = DialOptions(auth_entity=api_key_id, credentials=creds)

--- a/docs/fleet/overview.md
+++ b/docs/fleet/overview.md
@@ -9,6 +9,12 @@ description: "Scale from one machine to a fleet: templatize configuration with f
 
 You have a single machine working. Now you need 10, or 100, or 1,000 machines running the same software with the same configuration. Fleet deployment is how you get there without configuring each machine by hand.
 
+The shift from one machine to a fleet usually starts to matter around 50 machines, when manually tracking which machine runs which version stops being feasible. Three properties change when Viam runs your fleet:
+
+- **The cloud config is the source of truth.** Each machine pulls its configuration from Viam Cloud and converges to it. A local edit on a single device cannot silently drift the device away from the rest of the fleet.
+- **Machines connect outbound.** Each machine reaches Viam Cloud over an outbound gRPC connection. No port-forwarding, reverse SSH tunnels, or VPN setup is required at customer sites.
+- **Rollouts are central, not per-device.** Modules and ML models are versioned packages in the registry. Rolling out a change is a tag move on a fragment, not a script that runs against each device.
+
 ## Three core mechanisms
 
 Viam's fleet deployment is built on three mechanisms that work together:
@@ -21,11 +27,11 @@ Fragments support **variables** for per-machine customization (different sensor 
 
 ### Provisioning: automated first-boot setup
 
-For machines you ship to customers or deploy in the field, provisioning automates the first-boot experience. You install `viam-agent` on a device during manufacturing with a defaults file that specifies which fragment to use. When someone powers on the device, `viam-agent` creates a WiFi hotspot or Bluetooth connection, the user provides network credentials through a mobile app or captive portal, and the machine configures itself from the fragment automatically.
+For machines you ship to customers or deploy in the field, provisioning (sometimes called zero-touch provisioning) automates the first-boot experience. You install `viam-agent` on a device during manufacturing with a defaults file that specifies which fragment to use. When someone powers on the device, `viam-agent` creates a WiFi hotspot or Bluetooth connection, the user provides network credentials through a mobile app or captive portal, and the machine configures itself from the fragment automatically.
 
 ### The module registry: versioned software delivery
 
-Modules and ML models are stored as versioned packages in the Viam registry. When you configure a module or model on a machine (directly or through a fragment), the machine downloads the correct version for its platform. When you upload a new version, machines configured to track that version update automatically. Maintenance windows let you control when updates happen so machines are not interrupted during operation.
+Modules and ML models are stored as versioned packages in the Viam registry. When you configure a module or model on a machine (directly or through a fragment), the machine downloads the correct version for its platform. When you upload a new version, machines configured to track that version update over the air automatically. Maintenance windows let you control when updates happen so machines are not interrupted during operation.
 
 ## What you can do
 
@@ -48,4 +54,6 @@ Modules and ML models are stored as versioned packages in the Viam registry. Whe
 - **[Configure hardware](/hardware/)** covers adding components and services to a machine. Use fragments to templatize those configurations for your fleet.
 - **[Build and deploy modules](/build-modules/)** covers writing and uploading modules. This section covers deploying those modules to machines.
 - **[Train ML models](/train/)** covers training models. This section covers deploying trained models fleet-wide.
+- **[Monitor and operate](/monitor/)** covers per-machine logs, metrics, and live operation. This section covers fleet-wide rollout state and version management.
+- **[Admin and access](/organization/)** covers organizations, members, and role-based access. This section covers what runs on machines, not who can change it.
 - **[Viam CLI](/cli/manage-your-fleet/)** covers fleet operations from the command line: checking machine status, viewing logs, shell access, and file transfer.

--- a/docs/fleet/provision-devices.md
+++ b/docs/fleet/provision-devices.md
@@ -101,7 +101,7 @@ Run the script from the same directory that contains your `viam-defaults.json` f
 sudo ./preinstall.sh
 ```
 
-The script picks up `viam-defaults.json` from the current directory and copies it along with `viam-agent` to the appropriate locations on the device. For Raspberry Pi, it modifies the first-run script to start `viam-agent` on boot.
+The script picks up `viam-defaults.json` from the current directory and copies it along with `viam-agent` to the appropriate locations on the device. For Raspberry Pi, it modifies the first-run script to start `viam-agent` on boot. The exact mechanism depends on the image: cloud-init-based images get an entry added to the cloud-init `user-data` file; older images get an entry in `firstrun.sh`.
 
 To install onto an external rootfs (for example, a mounted SD card image):
 

--- a/docs/fleet/reuse-configuration.md
+++ b/docs/fleet/reuse-configuration.md
@@ -16,6 +16,8 @@ Create a fragment (a reusable configuration template), add the components, servi
 
 ## When to use fragments
 
+As a fleet grows, machines tend to drift into unique, undocumented configurations (often called "snowflake robots") because each one was set up by hand. Fragments prevent this by giving every machine the same authoritative configuration source.
+
 Use fragments when you have multiple machines that share the same configuration, either entirely or with small per-machine differences. Common examples:
 
 - A fleet of identical robots that all need the same camera, motor, and control logic
@@ -40,12 +42,14 @@ The fragment editor works just like the machine configuration editor. You can us
 
 In the fragment editor sidebar, click **+** to add:
 
-- Components and services (cameras, motors, sensors, vision services, etc.)
+- Components and services (cameras, motors, sensors, vision services, and so on)
 - Control code modules
 - Nested fragments (fragments can include other fragments, up to 5 levels deep)
 - Maintenance windows
 - Jobs
 - Triggers
+
+Nested fragments let you compose configuration libraries. For example, a `base-robot` fragment can include separate `motor-pair` and `camera-array` fragments, so you can swap out the camera array without rewriting the base.
 
 Click **Save** after adding and configuring your resources.
 
@@ -65,6 +69,8 @@ To apply a fragment to many machines, use the CLI in a loop or script:
 ```sh {class="command-line" data-prompt="$"}
 viam machines part fragments add --part=<part-id> --fragment=<fragment-id>
 ```
+
+To find your part ID, run `viam machines part list --machine=<machine-id>`. To find your fragment ID, copy it from the fragment's page in the Viam app (it appears in the URL and under the fragment name).
 
 See [automate with scripts](/cli/automate-with-scripts/) for examples of scripting fleet operations.
 
@@ -167,6 +173,12 @@ On the machine's **CONFIGURE** tab, find the fragment card and look for the **Up
 5. Point `development` at the new revision.
 6. Pin a few test machines to `development` and verify the changes work.
 7. When validated, move `stable` to the new revision. All production machines update.
+
+## Find which machines use a fragment
+
+Before changing or removing a fragment, you usually want to know which machines currently use it. Viam exposes this through the `GetFragmentUsage` RPC on `app.proto`, which returns the count of machines on each revision. A related RPC, `ListMachineSummaries`, returns the full list of machines and their resolved fragments.
+
+Both RPCs are defined in the proto bindings but are not yet wrapped as high-level methods on the Python SDK's `AppClient`. To use them today, call the gRPC stubs from the proto bindings directly, or use any other gRPC client.
 
 ## Set default fragments for an organization
 

--- a/docs/fleet/system-settings.md
+++ b/docs/fleet/system-settings.md
@@ -11,14 +11,14 @@ Configure system-level settings for deployed machines. These settings are manage
 
 ## Agent version control
 
-Control which versions of `viam-agent` and `viam-server` run on the machine.
+Control which versions of `viam-agent` and `viam-server` run on each machine.
 
-In the machine settings card, open **Settings** and expand **Software Updates**:
+Version selection is managed in the Viam app, not in the machine's JSON configuration. In the machine settings card, open **Settings** and expand **Software Updates**:
 
-| Field         | Type   | Default    | Description                                                                                            |
-| ------------- | ------ | ---------- | ------------------------------------------------------------------------------------------------------ |
-| `agent`       | string | `"stable"` | Version of viam-agent. Options: a semver string (`"5.6.77"`), `"stable"`, or a URL to a custom binary. |
-| `viam-server` | string | `"stable"` | Version of viam-server. Same options as agent.                                                         |
+- **Agent version**: choose `stable`, a specific semver release such as `5.6.77`, or a URL to a custom binary.
+- **viam-server version**: choose `stable`, a specific semver release, or a URL to a custom binary.
+
+When you change a version, the cloud sends an update instruction to viam-agent on the machine. The agent downloads and installs the new version on its next check cycle. To control when the new version actually starts, configure a [maintenance window](/fleet/manage-versions/#maintenance-windows). To verify the new version landed across the fleet, see [verify a rollout across the fleet](/fleet/manage-versions/#verify-a-rollout-across-the-fleet).
 
 ## Agent advanced settings
 


### PR DESCRIPTION
## Summary

Section-level review of `docs/fleet/` per the section-review playbook. Findings derived from a 142-feature inventory across rdk/api/app/python-sdk/viam-agent and a practitioner-problems landscape with 11 problems sourced from 48 verified web queries. Pure accuracy fixes and landscape framing — no new pages added.

## Per-page changes

- **`overview.md`** — added landscape framing (cloud-config-as-truth, outbound-only connections, central rollouts), named the 50-machine inflection point, added boundary statements for monitor + organization sections, bridged practitioner vocabulary (zero-touch provisioning, OTA)
- **`reuse-configuration.md`** — named the "snowflake robot" anti-pattern, added "Find which machines use a fragment" subsection covering `GetFragmentUsage` and `ListMachineSummaries`, sourced CLI placeholders, added nested-fragments example
- **`provision-devices.md`** — clarified Raspberry Pi cloud-init vs firstrun.sh fork
- **`end-user-setup.md`** — reframed fragment-vs-no-fragment branch as a design choice (not a failure mode)
- **`deploy-software.md`** — corrected fleet dashboard claim in Step 4; pointer to the new verification subsection
- **`deploy-ml-models.md`** — renamed "Update a model" to "Update or roll back a model" and named rollback explicitly
- **`manage-versions.md`** — linkTitle renamed to "Manage versions and rollouts"; added "Verify a rollout across the fleet" subsection with Python SDK example; documented no-automatic-rollback behavior; added "canary deployment" framing for fragment-tag rollouts
- **`system-settings.md`** — reframed "Agent version control": version selection is managed in the Viam app, not in machine JSON

`schedule-jobs.md`, `metadata.md`, and `_index.md` were verified accurate; no changes.

## Code findings that drove the review

- **viam-agent uses atomic symlink swaps with offline-validated downloads**, not A/B partitions (`viam-agent/version_control.go:373-381`, `:303-309`). Power loss mid-download leaves an incomplete cache that gets retried; the running symlink never breaks. **Rollback is not automatic** — TODO at `version_control.go:74-79`.
- **Fragment-tag staged rollout works by re-tagging revisions**: `SetFragmentTag` assigns a tag to a fragment `revision`; the backend resolves tag → revision at config-pull time. Promotion = repoint the tag.
- **`PartSummary` includes `viam_server_version` and `viam_agent_version`**, but `app/ui/src/lib/components/location/machine-row.svelte` only renders name + online state. Per-machine version status is not in the UI today; the `ListMachineSummaries` and `GetFragmentUsage` RPCs are not yet wrapped on the high-level Python `AppClient`.

## Out of scope (follow-up PRs)

- New page #13 "Rotate machine secrets and API keys" (Phase 2 approved as a new page; deferred for cleaner review)
- A `playbook-diataxis` + `playbook-writing` pass on the section (prose-level edits; section-review playbook covers high-level Diataxis classification only)

## Test plan

- [x] `npx prettier --write docs/fleet/` clean
- [x] `npx markdownlint-cli` clean
- [x] `vale docs/fleet/` — 0 errors, 0 warnings, 0 suggestions
- [x] `make build-prod` — 1071 pages, 0 errors
- [ ] Netlify deploy preview links resolve for each changed page

🤖 Generated with [Claude Code](https://claude.com/claude-code)