### PR TITLE
CLI section: address reviewer feedback

### DIFF
--- a/docs/cli/automate-with-scripts.md
+++ b/docs/cli/automate-with-scripts.md
@@ -39,39 +39,33 @@ viam machines list --all
 
 ## CI/CD: upload a module on release
 
-A GitHub Actions workflow that builds and uploads a module when you push a version tag:
+Viam publishes two official GitHub Actions for building and uploading modules. Prefer these over invoking the CLI by hand in a workflow:
+
+- [`viamrobotics/build-action`](https://github.com/viamrobotics/build-action) triggers a cloud build for every platform declared in your module's `meta.json` and uploads each artifact to the registry.
+- [`viamrobotics/upload-module`](https://github.com/viamrobotics/upload-module) uploads a tarball you built yourself. Use this when you need custom runners or only target one platform.
+
+A minimal workflow that runs a cloud build and uploads to the registry on every release:
 
 ```yaml
-# .github/workflows/upload-module.yml
-name: Upload module
+# .github/workflows/publish.yml
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 jobs:
-  upload:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Viam CLI
-        run: |
-          sudo curl --compressed -o /usr/local/bin/viam \
-            https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-linux-amd64
-          sudo chmod a+rx /usr/local/bin/viam
-
-      - name: Authenticate
-        run: viam login api-key --key-id=${{ secrets.VIAM_KEY_ID }} --key=${{ secrets.VIAM_KEY }}
-
-      - name: Build
-        run: viam module build local
-
-      - name: Upload
-        run: |
-          VERSION=${GITHUB_REF_NAME#v}
-          viam module upload --version=$VERSION --platform=linux/amd64 dist/archive.tar.gz
+      - uses: viamrobotics/build-action@v1
+        with:
+          version: ${{ github.ref_name }}
+          ref: ${{ github.sha }}
+          key-id: ${{ secrets.VIAM_KEY_ID }}
+          key-value: ${{ secrets.VIAM_KEY }}
 ```
+
+`build-action` reads the `build` block in `meta.json` to determine target platforms and build commands. For the full setup, including `meta.json` configuration and an example that uses `upload-module` instead, see [Deploy a module](/build-modules/deploy-a-module/).
 
 ## CI/CD: retrain a model on new data
 

--- a/docs/cli/build-and-deploy-modules.md
+++ b/docs/cli/build-and-deploy-modules.md
@@ -63,16 +63,16 @@ viam module generate \
 
 ## Iterate during development
 
-After making code changes, reload your module on a running machine without restarting the entire machine:
-
-```sh {class="command-line" data-prompt="$"}
-viam module reload-local --part-id=<part-id>
-```
-
-To reload a module from the registry (after uploading a new version):
+After making code changes, reload your module on a running machine without restarting the entire machine. By default, the CLI builds the module in the cloud and syncs the new binary to the target:
 
 ```sh {class="command-line" data-prompt="$"}
 viam module reload --part-id=<part-id>
+```
+
+If your development machine is also running the module (for example, developing a macOS module on the Mac that runs `viam-server`), use `reload-local` to build and reload without a cloud build:
+
+```sh {class="command-line" data-prompt="$"}
+viam module reload-local --part-id=<part-id>
 ```
 
 If a reload is not sufficient, restart the module process:
@@ -171,13 +171,13 @@ viam module build list
 View build logs:
 
 ```sh {class="command-line" data-prompt="$"}
-viam module build logs --build-id=<build-id>
+viam module build logs --id=<build-id>
 ```
 
 Wait for a build to complete and stream logs:
 
 ```sh {class="command-line" data-prompt="$"}
-viam module build logs --build-id=<build-id> --wait
+viam module build logs --id=<build-id> --wait
 ```
 
 ## Download a module

--- a/docs/cli/overview.md
+++ b/docs/cli/overview.md
@@ -43,7 +43,7 @@ Some operations are only available through the CLI:
 - **Shell access** (`viam machines part shell`) opens an interactive terminal on a remote machine.
 - **File transfer** (`viam machines part cp`) copies files to and from machines.
 - **Port tunneling** (`viam machines part tunnel`) forwards a local port to a remote machine.
-- **Module hot-reload** (`viam module reload-local`) reloads a module during development without restarting the machine.
+- **Module hot-reload** (`viam module reload`) builds a module and syncs it to a running machine without restarting the machine.
 
 ## Install
 
@@ -89,14 +89,23 @@ viam login print-access-token
 
 ### Authenticate in scripts and CI/CD
 
-Interactive login opens a browser, which does not work in headless environments.
-Use API key authentication instead:
+Scripts and CI/CD pipelines cannot complete an interactive login. Use API key authentication instead:
 
 ```sh {class="command-line" data-prompt="$"}
 viam login api-key --key-id=<key-id> --key=<key>
 ```
 
 To create an API key, see [Manage API keys](/cli/administer-your-organization/#manage-api-keys).
+
+### Authenticate on a machine without a local browser
+
+Interactive login normally opens a browser on the current machine. To log in on a machine without a local browser (for example, over SSH), pass `--no-browser`:
+
+```sh {class="command-line" data-prompt="$"}
+viam login --no-browser
+```
+
+The CLI prints an authentication URL. Open it in a browser on any machine to complete login.
 
 ## Set defaults
 


### PR DESCRIPTION
## Summary

Addresses reviewer feedback on the CLI section.

- **Overview**: list `viam module reload` (not `reload-local`) as the primary hot-reload command. `reload-local` is only for the case where the development machine is also running the module.
- **Overview**: add a section covering `viam login --no-browser` for interactive login on machines without a local browser (for example, over SSH). Clarify that scripts and CI/CD should still use API key auth.
- **Build and deploy modules**: rewrite the "Iterate during development" section. `reload` is now described as the default — builds in the cloud by default and syncs the new binary to the target. `reload-local` is the fallback for dev-on-target. The previous text incorrectly said `reload` pulls from the registry.
- **Build and deploy modules**: switch `viam module build logs` examples from `--build-id` to `--id` (the canonical flag is `--build-id`; `--id` is the documented alias and matches usage elsewhere on the page).
- **Automate with scripts**: replace the hand-rolled CLI-in-a-workflow example with one using the official `viamrobotics/build-action`. Mention `viamrobotics/upload-module` as the alternative for custom builds. Link to `/build-modules/deploy-a-module/` for full setup.

## Test plan

- [ ] Netlify deploy preview renders the three pages without errors
- [ ] `/cli/` overview: the Authenticate section reads cleanly with two subsections (scripts/CI, headless interactive)
- [ ] `/cli/build-and-deploy-modules/`: Iterate during development section puts `reload` first, `reload-local` as the dev-on-target case
- [ ] `/cli/automate-with-scripts/`: CI/CD section uses `viamrobotics/build-action@v1` with no bare CLI steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)