### PR TITLE
Hardware: accuracy and copy pass from reviewer feedback

### DIFF
--- a/docs/hardware/common-components/_index.md
+++ b/docs/hardware/common-components/_index.md
@@ -52,13 +52,13 @@ Components that read data from the physical world.
 | [Motor](/hardware/common-components/add-a-motor/) | Control a DC or stepper motor through a motor driver and GPIO pins. | DC motors, stepper motors, brushless motors |
 | [Servo](/hardware/common-components/add-a-servo/) | Set the angular position of a hobby servo with a PWM pin.           | Hobby servos, PWM-controlled actuators      |
 
-## Control
+## Inputs and GPIO
 
-Components for physical I/O and user interaction.
+Components for physical I/O and user input.
 
 | Component                                                                | What it does                                                                                                                    | Examples                                      |
 | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| [Board](/hardware/common-components/add-a-board/)                        | Expose GPIO pins, analog readers, and digital interrupts from a single-board computer. Many other components depend on a board. | Raspberry Pi GPIO, Arduino, custom I/O boards |
+| [Board](/hardware/common-components/add-a-board/)                        | Expose GPIO pins, analog readers, and digital interrupts from a single-board computer. Many other components depend on a board. | Raspberry Pi GPIO, ESP32, PCA9685 IO expander |
 | [Button](/hardware/common-components/add-a-button/)                      | Detect presses from a physical button to trigger actions.                                                                       | Momentary switches, push buttons              |
 | [Switch](/hardware/common-components/add-a-switch/)                      | Read or set the position of a toggle or selector switch.                                                                        | Toggle switches, selector switches            |
 | [Input controller](/hardware/common-components/add-an-input-controller/) | Use a gamepad, joystick, or other input device for manual machine control.                                                      | Gamepads, joysticks, custom button panels     |

--- a/docs/hardware/common-components/add-a-base.md
+++ b/docs/hardware/common-components/add-a-base.md
@@ -23,7 +23,7 @@ This page covers the `wheeled` model. You configure your motors first, then the 
 For accurate distance and angle calculations, the `wheeled` model needs two physical measurements:
 
 - **Wheel circumference**: how far the robot travels per wheel revolution.
-- **Width**: the distance between the left and right wheel centers.
+- **Track width** (`width_mm` in the config): the distance between the left and right wheel centers. Not the outside edges of the wheels, and not the robot's overall body width.
 
 ### Built-in models
 
@@ -81,8 +81,8 @@ motor names for that side:
 
 ```json
 {
-  "left": ["front-left-motor", "rear-left-motor"],
-  "right": ["front-right-motor", "rear-right-motor"],
+  "left": ["front-left-motor", "mid-left-motor", "rear-left-motor"],
+  "right": ["front-right-motor", "mid-right-motor", "rear-right-motor"],
   "wheel_circumference_mm": 220,
   "width_mm": 300
 }
@@ -110,7 +110,7 @@ Drive the base forward, spin it, and stop.
 
 To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
 Copy the **API key** and **API key ID**.
-Copy the **machine address** from the same tab.
+Copy the **machine address** from the **Connection details** section on the same tab.
 If you're using real hardware, you'll see the robot drive forward and spin when you run the code below.
 With a fake base, the commands complete without physical motion.
 {{< tabs >}}

--- a/docs/hardware/common-components/add-a-board.md
+++ b/docs/hardware/common-components/add-a-board.md
@@ -20,9 +20,15 @@ A board component exposes the low-level I/O on your single-board computer:
 - **Analog readers**: read analog voltage values from ADC-capable pins.
 - **Digital interrupts**: react to signal changes on a pin.
 
-The board doesn't represent external hardware. It represents the I/O
-capabilities of the computer itself. Motors, encoders, and servos reference
-the board by name to access the pins they're wired to. Browse all available board models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=board).
+Most of the time a board represents the single-board computer itself (Raspberry Pi, Jetson, Orange Pi). A board can also represent an IO expander such as the [PCA9685](https://app.viam.com/module/viam/pca) or a microcontroller connected over serial that exposes GPIO-like interfaces. In both cases, motors, encoders, and servos reference the board by name to access the pins they're wired to.
+
+Browse all available board models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=board).
+
+{{< alert title="Pin numbering" color="note" >}}
+
+Viam uses the **board pin number** (the physical pin number printed on the header) in GPIO configuration, not the GPIO/BCM number or alternate schemes. When a model's docs show a pinout, confirm which numbering scheme matches the number you configure.
+
+{{< /alert >}}
 
 ### Built-in models
 
@@ -47,10 +53,11 @@ Confirm it shows as **Live** in the upper left.
 
 1. Click the **+** button.
 2. Select **Configuration block**.
-3. Search for the model that matches your single-board computer:
-   - For a Raspberry Pi (any model), search for **pi**.
+3. Search for the model that matches your hardware:
+   - For a Raspberry Pi, search for **raspberry pi** and pick the model that matches your Pi version (for example, `viam:raspberry-pi:rpi5`).
    - For an NVIDIA Jetson, search for **jetson**.
    - For an Orange Pi, search for **orangepi**.
+   - For an IO expander, search for it by chip name (for example, **pca9685**).
 4. Name your board (for example, `my-board`) and click **Create**.
 
 ### 3. Configure board attributes
@@ -109,7 +116,7 @@ Toggle a GPIO pin and read its state programmatically.
 
 To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
 Copy the **API key** and **API key ID**.
-Copy the **machine address** from the same tab.
+Copy the **machine address** from the **Connection details** section on the same tab.
 If you have an LED wired to pin 11, you'll see it turn on and off when you run the code below.
 {{< tabs >}}
 {{% tab name="Python" %}}
@@ -255,11 +262,8 @@ go run main.go
 
 {{< expand "GPIO pin doesn't respond" >}}
 
-- Verify the pin number matches your board's pinout diagram. Viam uses the
-  **board pin number** (the physical pin on the header), not the GPIO/BCM
-  number.
-- Check that nothing else on the system is using the pin (another process,
-  a kernel driver).
+- Confirm the pin number follows the scheme the board model expects (see the Pin numbering note at the top of this page).
+- Check that nothing else on the system is using the pin (another process, a kernel driver).
 
 {{< /expand >}}
 

--- a/docs/hardware/common-components/add-a-button.md
+++ b/docs/hardware/common-components/add-a-button.md
@@ -10,14 +10,13 @@ aliases:
   - /hardware-components/add-a-button/
 ---
 
-Add a button to your machine's configuration so you can detect and respond to button presses from the Viam app and from code.
+Add a button to your machine's configuration so you can trigger button presses programmatically and represent a physical button in your machine config.
 
 ## Concepts
 
-A button component represents a momentary push button. The API is intentionally
-simple. It exposes a single `Push` method that triggers the button. Physical button
-hardware typically comes from a module in the [Viam registry](https://app.viam.com/registry?type=component&subtype=button) that reads a GPIO pin
-and exposes it as a button component.
+A button component represents a momentary push button. The API is intentionally simple: a single `Push` method that simulates pressing the button. The button API does not listen for or report incoming presses; a module can still react to real presses internally, but from SDK code you only initiate presses.
+
+Physical button hardware typically comes from a module in the [Viam registry](https://app.viam.com/registry?type=component&subtype=button) that watches a GPIO pin.
 
 The `fake` built-in model is useful for testing code without physical hardware.
 
@@ -70,7 +69,7 @@ Push the button programmatically.
 
 To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
 Copy the **API key** and **API key ID**.
-Copy the **machine address** from the same tab.
+Copy the **machine address** from the **Connection details** section on the same tab.
 When you run the code below, the button's Push method fires. With a physical button connected with a module, this triggers whatever action the module defines.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-camera.md
+++ b/docs/hardware/common-components/add-a-camera.md
@@ -23,7 +23,7 @@ The camera API gives you `GetImages` (capture frames), `GetPointCloud` (depth da
 ### Built-in models
 
 - [**webcam**](/reference/components/camera/webcam/): USB cameras and built-in laptop cameras. Auto-detects available devices.
-- [**ffmpeg**](/reference/components/camera/ffmpeg/): a camera device, video file, or stream.
+- [**ffmpeg**](/reference/components/camera/ffmpeg/): a camera device, video file, or stream that `ffmpeg` can read. For RTSP IP cameras, prefer the `viam:viamrtsp` registry module listed under Registry modules.
 - [**transform**](/reference/components/camera/transform/): applies transformations (crop, resize, rotate, overlay) to another camera's output.
 - [**fake**](/reference/components/camera/fake/): a camera model for testing.
 - [**image_file**](/reference/components/camera/image-file/): serves color or depth image frames from a file path.
@@ -48,9 +48,15 @@ If it shows as offline, verify that `viam-server` is running on your machine.
 2. Select **Configuration block**.
 3. Search for the model that matches your camera:
    - For a USB webcam or built-in laptop camera, search for **webcam**.
-   - For an IP camera that supports RTSP, search for **ffmpeg**.
+   - For an IP camera that supports RTSP, search for **rtsp** and pick one of the `viam:viamrtsp` models (`rtsp` autodetects codec; specific codecs like `rtsp-h264` or `rtsp-h265` are also available).
    - For an Intel RealSense depth camera, search for **realsense**.
 4. Name your camera (this guide uses `my-camera`) and click **Create**.
+
+{{< alert title="Finding your camera" color="tip" >}}
+
+For network cameras you can't locate manually, use a discovery module to find them for you: `viam:viamrtsp` supports ONVIF and UPnP discovery for RTSP cameras, and vendor-specific modules like `viam:realsense` and `viam:orbbec` discover their own cameras over USB.
+
+{{< /alert >}}
 
 ### 3. Configure camera attributes
 
@@ -97,7 +103,7 @@ The test panel uses the exact same APIs your code will use, so if the camera wor
 
 1. Find your camera component in the configuration view.
 2. Expand the **Test** section at the bottom of the component panel.
-3. Click **Toggle stream** to see a live video feed from the camera.
+3. Open the refresh-interval dropdown and select **Live** to see a live video feed from the camera.
 4. Click **Get image** to capture a single frame.
 
 You should see a live feed from the camera.
@@ -108,7 +114,7 @@ Capture an image from your camera programmatically.
 
 To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
 Copy the **API key** and **API key ID**.
-Copy the **machine address** from the same tab.
+Copy the **machine address** from the **Connection details** section on the same tab.
 
 When you run the code below, it saves an image file to your current directory. Check that the image shows what the camera sees.
 {{< tabs >}}

--- a/docs/hardware/common-components/add-a-gantry.md
+++ b/docs/hardware/common-components/add-a-gantry.md
@@ -115,7 +115,7 @@ Read the gantry's position and move it along the axis.
 
 To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
 Copy the **API key** and **API key ID**.
-Copy the **machine address** from the same tab.
+Copy the **machine address** from the **Connection details** section on the same tab.
 If you're using real hardware, you'll see the gantry move along its axis when you run the code below.
 With a fake gantry, position values update without physical motion.
 {{< tabs >}}

--- a/docs/hardware/common-components/add-a-generic.md
+++ b/docs/hardware/common-components/add-a-generic.md
@@ -24,10 +24,9 @@ Because the API is entirely model-defined, generic components almost always
 come from **modules in the registry** (or modules you write yourself). The
 module author defines what commands are supported and what they do.
 
-Use generic when no other component type fits. If your hardware produces
-images, use [camera](/hardware/common-components/add-a-camera/). If it produces
-readings, use [sensor](/hardware/common-components/add-a-sensor/). Standard
-types give you data capture, test panels, and SDK support automatically. Browse available generic models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=generic).
+Use generic when no other component type fits. If your hardware produces images, use [camera](/hardware/common-components/add-a-camera/). If it produces readings, use [sensor](/hardware/common-components/add-a-sensor/). Standard types give you typed SDK methods like `GetImage` or `GetReadings`, richer test-panel controls tailored to the component, and motion or vision services that know how to work with them. Generic exposes only `DoCommand`, so callers have to know the module-specific command shape.
+
+Browse available generic models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=generic).
 
 The `fake` built-in model echoes commands back for testing.
 
@@ -76,7 +75,7 @@ Send a command to the generic component and read the response.
 
 To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
 Copy the **API key** and **API key ID**.
-Copy the **machine address** from the same tab.
+Copy the **machine address** from the **Connection details** section on the same tab.
 With the fake model, you'll see your command echoed back. With a real module, the response depends on what commands the module supports.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-gripper.md
+++ b/docs/hardware/common-components/add-a-gripper.md
@@ -43,7 +43,7 @@ For hardware the built-in models don't cover, browse the [Viam registry](https:/
 1. Click the **+** button.
 2. Select **Configuration block**.
 3. Search for the model that matches your gripper hardware. Search by
-   manufacturer name or gripper type (for example, "parallel jaw", "vacuum").
+   manufacturer name or gripper type (for example, "gripper", "finger gripper", "vacuum").
 4. Name your gripper (for example, `my-gripper`) and click **Create**.
 
 ### 2. Configure gripper attributes
@@ -96,7 +96,7 @@ Open the gripper, grab an object, and check if it's held.
 
 To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
 Copy the **API key** and **API key ID**.
-Copy the **machine address** from the same tab.
+Copy the **machine address** from the **Connection details** section on the same tab.
 If you're using real hardware, you'll see the gripper open and close when you run the code below.
 With the fake model, Grab always returns true.
 {{< tabs >}}

--- a/docs/hardware/common-components/add-a-motor.md
+++ b/docs/hardware/common-components/add-a-motor.md
@@ -125,7 +125,7 @@ Spin the motor forward for 2 revolutions, then check if it's still moving.
 
 To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
 Copy the **API key** and **API key ID**.
-Copy the **machine address** from the same tab.
+Copy the **machine address** from the **Connection details** section on the same tab.
 If you're using real hardware, you'll see the motor spin when you run the code below.
 Without an encoder, position readings will be estimates based on time and max RPM.
 {{< tabs >}}

--- a/docs/hardware/common-components/add-a-movement-sensor.md
+++ b/docs/hardware/common-components/add-a-movement-sensor.md
@@ -123,7 +123,7 @@ Read position and velocity data from the movement sensor.
 
 To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
 Copy the **API key** and **API key ID**.
-Copy the **machine address** from the same tab.
+Copy the **machine address** from the **Connection details** section on the same tab.
 When you run the code below, you'll see which methods your sensor supports and the current readings for each.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-power-sensor.md
+++ b/docs/hardware/common-components/add-a-power-sensor.md
@@ -78,7 +78,7 @@ Read voltage, current, and power programmatically.
 
 To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
 Copy the **API key** and **API key ID**.
-Copy the **machine address** from the same tab.
+Copy the **machine address** from the **Connection details** section on the same tab.
 When you run the code below, you'll see voltage, current, and power readings. Verify the voltage matches your power supply.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-sensor.md
+++ b/docs/hardware/common-components/add-a-sensor.md
@@ -99,7 +99,7 @@ Read sensor data programmatically and print it.
 
 To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
 Copy the **API key** and **API key ID**.
-Copy the **machine address** from the same tab.
+Copy the **machine address** from the **Connection details** section on the same tab.
 When you run the code below, you'll see sensor readings printed once per second. Verify the values make sense for your environment.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-servo.md
+++ b/docs/hardware/common-components/add-a-servo.md
@@ -14,12 +14,11 @@ Add a servo to your machine's configuration so you can control its angular posit
 
 ## Concepts
 
-A servo moves to a specific angle (typically 0-180 degrees) and holds that
-position. Unlike a motor, which spins continuously, a servo provides precise
-angular positioning through PWM control.
+A servo moves to a specific angle (typically 0-180 degrees) and holds that position. Continuous-rotation servos also exist; they use the same `Move` API, but the angle value maps to speed and direction rather than absolute position. Check the specific servo model's reference page for how it interprets the value.
 
-The servo component uses a single PWM-capable pin on a
-[board component](/hardware/common-components/add-a-board/). Browse all available servo models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=servo).
+The built-in `gpio` servo model uses a single PWM-capable pin on a [board component](/hardware/common-components/add-a-board/). Other servo models in the registry support serial, I2C, or dedicated servo-driver boards.
+
+Browse all available servo models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=servo).
 
 ### Built-in models
 
@@ -81,7 +80,8 @@ the pulse width:
 
 Click **Save**, then expand the **Test** section.
 
-- Use the angle slider to move the servo to different positions.
+- Enter a value in the **Desired angle (º)** field (the built-in `gpio` model accepts 0-180), then click **Execute** to move the servo.
+- Use the **Zero** or **Current position** buttons to quickly fill the input.
 - The servo should move smoothly and hold its position.
 
 ## Try it
@@ -90,7 +90,7 @@ Sweep the servo through a range of positions.
 
 To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
 Copy the **API key** and **API key ID**.
-Copy the **machine address** from the same tab.
+Copy the **machine address** from the **Connection details** section on the same tab.
 If you're using real hardware, you'll see the servo sweep through positions when you run the code below.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-switch.md
+++ b/docs/hardware/common-components/add-a-switch.md
@@ -77,7 +77,7 @@ Read the switch position, cycle through positions, and read labels.
 
 To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
 Copy the **API key** and **API key ID**.
-Copy the **machine address** from the same tab.
+Copy the **machine address** from the **Connection details** section on the same tab.
 When you run the code below, you'll see the switch cycle through all positions. With the fake model, positions update in memory. With real hardware, verify the switch physically changes state.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-an-arm.md
+++ b/docs/hardware/common-components/add-an-arm.md
@@ -128,10 +128,11 @@ Read the arm's current joint positions, move two joints, and confirm the positio
 
 To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
 Copy the **API key** and **API key ID**.
-Copy the **machine address** from the same tab.
+Copy the **machine address** from the **Connection details** section on the same tab.
 
 If you're using a real arm, you'll see it physically move when you run the code below.
 With a fake arm, the positions update in memory without physical motion, but you can watch the joint values update in real time by expanding the **test** section on the arm's component card in the **CONFIGURE** tab.
+The **3D Scene** tab on your machine's page renders the arm's live pose, which also helps visualize simulated motion.
 
 {{< tabs >}}
 {{% tab name="Python" %}}
@@ -276,11 +277,10 @@ You should see all zeros before the move, then joints 1 and 2 at 10 and -10 degr
 
 {{< expand "Cannot connect to arm" >}}
 
-- Verify the arm is powered on and connected to the same network as your
-  machine.
+- Check the **Error logs** section on the arm's configuration card for initialization failures, and the **LOGS** tab for anything else `viam-server` printed on startup.
+- Verify the arm is powered on and connected to the same network as your machine.
 - Ping the arm's IP address from the machine to confirm network connectivity.
-- Check that no other software (manufacturer's own control software) has an
-  exclusive connection to the arm.
+- Check that no other software (manufacturer's own control software) has an exclusive connection to the arm.
 
 {{< /expand >}}
 

--- a/docs/hardware/common-components/add-an-encoder.md
+++ b/docs/hardware/common-components/add-an-encoder.md
@@ -131,7 +131,7 @@ Read the encoder position and reset it.
 
 To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
 Copy the **API key** and **API key ID**.
-Copy the **machine address** from the same tab.
+Copy the **machine address** from the **Connection details** section on the same tab.
 When you run the code below, you'll see the encoder's current position, then reset it to zero. Manually rotate the motor shaft to verify the count changes.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-an-input-controller.md
+++ b/docs/hardware/common-components/add-an-input-controller.md
@@ -108,7 +108,7 @@ List available controls and print events as they happen.
 
 To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
 Copy the **API key** and **API key ID**.
-Copy the **machine address** from the same tab.
+Copy the **machine address** from the **Connection details** section on the same tab.
 When you run the code below, press buttons on your gamepad and watch the events print in real time.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/configure-hardware.md
+++ b/docs/hardware/configure-hardware.md
@@ -146,20 +146,18 @@ correctly.
 
 {{< expand "Component not initializing (error in logs)" >}}
 
-- Check the **LOGS** tab in the Viam app for error messages from `viam-server`.
+- Expand the **Error logs** section on the component's configuration card in the **CONFIGURE** tab. Per-component errors appear there with the module name and error count, isolated from other resources.
+- For full `viam-server` logs across every resource, see the **LOGS** tab.
 - Verify that the device path or address in your attributes is correct.
-- If the component depends on another (for example, a motor depends on a board),
-  confirm the dependency is configured and working.
+- If the component depends on another (for example, a motor that references a board in its attributes), confirm the dependency is configured and working.
 
 {{< /expand >}}
 
-{{< expand "Model not appearing in the dropdown" >}}
+{{< expand "Model not appearing in search" >}}
 
-- **Built-in models** appear automatically. If you don't see the expected model,
-  confirm your `viam-server` version is up to date.
-- **Module models** appear in the configuration block search alongside
-  built-in models. If you don't see the model you expect, check that
-  your search terms match the model or module name.
+- The configuration block search covers both built-in models and every module in the Viam registry. Try shorter or broader search terms (for example, "raspberry pi" rather than "rpi5", or "rtsp" rather than a specific camera brand).
+- If the model is from a module, it appears in search results as soon as you start typing. Use the Task type, Framework, or Visibility filters to narrow results instead of relying on exact names.
+- For built-in models only: confirm your `viam-server` version is up to date if an expected built-in does not appear.
 
 {{< /expand >}}
 

--- a/docs/hardware/machine-configuration.md
+++ b/docs/hardware/machine-configuration.md
@@ -42,7 +42,7 @@ connected to its GPIO pins:
     {
       "name": "my-board",
       "api": "rdk:component:board",
-      "model": "pi",
+      "model": "viam:raspberry-pi:rpi5",
       "attributes": {}
     },
     {
@@ -56,8 +56,15 @@ connected to its GPIO pins:
           "pwm": "12"
         },
         "board": "my-board"
-      },
-      "depends_on": ["my-board"]
+      }
+    }
+  ],
+  "modules": [
+    {
+      "type": "registry",
+      "name": "viam_raspberry-pi",
+      "module_id": "viam:raspberry-pi",
+      "version": "latest"
     }
   ]
 }
@@ -65,13 +72,9 @@ connected to its GPIO pins:
 
 A few things to note:
 
-- **The board** uses `pi`, a built-in model. No attributes are needed
-  because the Pi's GPIO layout is known.
-- **The motor** uses `gpio`, a built-in model for DC motors driven by
-  GPIO pins. The `pins` attribute maps the motor's control wires to
-  specific board pins.
-- **`depends_on`** tells `viam-server` to initialize the board before
-  the motor, since the motor needs the board's GPIO pins to function.
+- **The board** uses `viam:raspberry-pi:rpi5` from the [Viam registry](https://app.viam.com/registry). The `modules` section tells `viam-server` to download and run that module. Other Pi variants (`rpi`, `rpi4`, `rpi3`, and so on) are available from the same module.
+- **The motor** uses `gpio`, a built-in model for DC motors driven by GPIO pins. The `pins` attribute maps the motor's control wires to specific board pins.
+- The motor's `board` attribute references `my-board`, so `viam-server` automatically initializes the board before the motor. An explicit `depends_on` field is not required when attributes already reference the other component.
 
 ### Modules section
 


### PR DESCRIPTION
## Summary

Second pass on Configure hardware reviewer feedback. All edits verified against current upstream rdk, the app's SvelteKit source, and the Viam module registry. Nineteen files changed.

### Overview page (\`configure-hardware.md\`)

- Rewrite \"Component not initializing\" troubleshooting to reference the per-block **Error logs** section on the component's configuration card (new app UX), with a pointer to the LOGS tab for full cross-resource logs.
- Rewrite \"Model not appearing in the dropdown\" for the current search-based picker. Mention the Task type / Framework / Visibility filter pills.

### Machine configuration

- Motor example now uses \`viam:raspberry-pi:rpi5\` for the board (built-in \`pi\` model removed from rdk; all Pi variants live in the \`viam:raspberry-pi\` registry module). Added a \`modules\` block to make the example runnable.
- Dropped \`depends_on\` from the motor — confirmed against \`rdk/resource/config.go\` that dependencies are now auto-inferred from attribute references (the motor's \`board\` attribute).

### Add a component landing

- Rename the \"Control\" section to \"Inputs and GPIO\" (the other two heading options discussed were kept as-is).
- Board examples drop Arduino (no supported Arduino board module exists in the registry as of today) and add PCA9685 IO expander.

### Cross-cutting machine-address fix

Sixteen per-component add-a-X pages had the instruction \"Copy the machine address from the same tab\" implying the API keys section. Updated to name the **Connection details** section, where the app actually shows \"Machine address (URI).\"

### Per-component pages

- **add-an-arm**: mention the 3D Scene tab for visualizing simulated motion; add Error-logs bullet under \"Cannot connect to arm.\"
- **add-a-base**: introduce and define \"track width\" (the prerequisites used the term without defining it); fix the six-wheel-drive example to list six motors instead of four.
- **add-a-board**: correct the \"board does not represent external hardware\" claim — IO expanders like PCA9685 and MCU daughter boards are legitimate Board implementations (registry confirms \`viam:pca:pca9685\`). Promoted the board-pin-numbering note out of Troubleshooting into a top-of-page alert. Updated search hints for the current registry.
- **add-a-button**: rewrite intro and Concepts — the API is Push-only, it does not listen for or report presses.
- **add-a-camera**: recommend \`viam:viamrtsp\` for RTSP IP cameras (not ffmpeg); add a \"Finding your camera\" tip that names ONVIF / UPnP discovery via viamrtsp and vendor-specific discovery via realsense / orbbec; fix the test-panel instruction from \"Toggle stream\" to selecting **Live** from the refresh-interval dropdown.
- **add-a-generic**: sharpen the standard-types-vs-generic trade-off — generic supports data capture and test panels too, so the real difference is typed SDK methods and component-aware services.
- **add-a-gripper**: drop \"parallel jaw\" from the search hint (not a term the registry uses).
- **add-a-servo**: acknowledge continuous-rotation servos through \`Move\`; note that the PWM-pin requirement only applies to the built-in \`gpio\` model (others use serial, I2C, or driver boards); fix the test-panel instruction from angle slider to the Desired angle input + Execute button.

## Scope of this PR

Intentionally not in this pass:

- Missing component types (audio input/output, pose tracker) on the Add a component landing
- Features column (test panel, data capture, DoCommand, GetReadings per type)
- Nomenclature cleanup across the section (component / module / model / driver consistency)
- viam-agent / viam-server explainer page, after-arm frame, state estimation

## Test plan

- [x] prettier + vale — clean across 26 files
- [ ] Netlify deploy preview spot-check:
  - [ ] \`/hardware/common-components/\` — Inputs and GPIO heading, updated Board examples
  - [ ] \`/hardware/configure-hardware/\` — Troubleshooting entries render
  - [ ] \`/hardware/machine-configuration/\` — rpi5 example + modules block render
  - [ ] \`/hardware/common-components/add-a-board/\` — Pin numbering alert visible at the top
  - [ ] \`/hardware/common-components/add-a-camera/\` — Finding your camera callout renders
  - [ ] \`/hardware/common-components/add-a-servo/\` — Desired angle instructions render
- [ ] htmltest passes (no broken references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)