### PR TITLE
Hardware: catalog features column, audio types, fragment variable example

### DIFF
--- a/docs/hardware/common-components/_index.md
+++ b/docs/hardware/common-components/_index.md
@@ -19,55 +19,62 @@ Pick the type whose API best describes what your hardware does, then use the per
 The general add-a-component process is the same for every type.
 For the universal steps, see [Configure hardware components](/hardware/configure-hardware/).
 
+The **Features** column lists platform integrations the type is part of.
+Every type supports `DoCommand` and shows a test panel on its configuration card, so those aren't repeated in the column; exceptions are called out where they apply.
+**Data capture** means the built-in data manager can capture this type's output to the Viam cloud.
+**Readings** means the type returns a flat key-value snapshot through the `GetReadings` method, on top of its type-specific API.
+
 ## Control an arm, gripper, or gantry
 
-| Component                                             | What it does                                                                                               | Examples                                    |
-| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
-| [Arm](/hardware/common-components/add-an-arm/)        | Control a multi-joint robotic arm: move joints, position the end effector, integrate with motion planning. | xArm, UR5, custom serial arms               |
-| [Gripper](/hardware/common-components/add-a-gripper/) | Open, close, and grasp objects with a gripper mounted on an arm or gantry.                                 | Parallel-jaw grippers, vacuum grippers      |
-| [Gantry](/hardware/common-components/add-a-gantry/)   | Move a tool head, camera, or sensor to precise coordinates along one or more linear axes.                  | Single-axis stages, multi-axis CNC gantries |
+| Component                                             | What it does                                                                                               | Examples                                    | Features |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------- | -------- |
+| [Arm](/hardware/common-components/add-an-arm/)        | Control a multi-joint robotic arm: move joints, position the end effector, integrate with motion planning. | xArm, UR5, custom serial arms               | —        |
+| [Gripper](/hardware/common-components/add-a-gripper/) | Open, close, and grasp objects with a gripper mounted on an arm or gantry.                                 | Parallel-jaw grippers, vacuum grippers      | —        |
+| [Gantry](/hardware/common-components/add-a-gantry/)   | Move a tool head, camera, or sensor to precise coordinates along one or more linear axes.                  | Single-axis stages, multi-axis CNC gantries | —        |
 
 ## Sensing
 
 Components that read data from the physical world.
 
-| Component                                                             | What it does                                                                                 | Examples                                             |
-| --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| [Camera](/hardware/common-components/add-a-camera/)                   | Capture images or video from a USB webcam, IP camera, or depth sensor.                       | USB webcams, IP cameras, depth cameras, lidar        |
-| [Sensor](/hardware/common-components/add-a-sensor/)                   | Read environmental data: temperature, humidity, distance, air quality, and more.             | Temperature, humidity, air quality, distance sensors |
-| [Movement sensor](/hardware/common-components/add-a-movement-sensor/) | Get position, velocity, orientation, or compass heading from a GPS, IMU, or odometry source. | GPS, IMU, accelerometer, gyroscope, odometry         |
-| [Power sensor](/hardware/common-components/add-a-power-sensor/)       | Monitor voltage, current, and power consumption.                                             | INA219, INA226, current clamps                       |
-| [Encoder](/hardware/common-components/add-an-encoder/)                | Track how far a motor has turned and how fast it's spinning.                                 | Incremental encoders, absolute encoders              |
+| Component                                                             | What it does                                                                                 | Examples                                             | Features                     |
+| --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------- | ---------------------------- |
+| [Camera](/hardware/common-components/add-a-camera/)                   | Capture images or video from a USB webcam, IP camera, or depth sensor.                       | USB webcams, IP cameras, depth cameras, lidar        | Data capture                 |
+| [Sensor](/hardware/common-components/add-a-sensor/)                   | Read environmental data: temperature, humidity, distance, air quality, and more.             | Temperature, humidity, air quality, distance sensors | Data capture · Readings      |
+| [Movement sensor](/hardware/common-components/add-a-movement-sensor/) | Get position, velocity, orientation, or compass heading from a GPS, IMU, or odometry source. | GPS, IMU, accelerometer, gyroscope, odometry         | Data capture · Readings      |
+| [Power sensor](/hardware/common-components/add-a-power-sensor/)       | Monitor voltage, current, and power consumption.                                             | INA219, INA226, current clamps                       | Data capture · Readings      |
+| [Encoder](/hardware/common-components/add-an-encoder/)                | Track how far a motor has turned and how fast it's spinning.                                 | Incremental encoders, absolute encoders              | Data capture                 |
+| [Audio input](/reference/apis/components/audio-in/)                   | Stream audio from a microphone or audio-in device.                                           | USB microphones, Pi audio-in HATs                    | Data capture · No test panel |
 
 ## Drive a mobile robot
 
-| Component                                       | What it does                                                                                                                                        | Examples                                              |
-| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| [Base](/hardware/common-components/add-a-base/) | Drive a mobile robot with movement commands like "move forward 300mm" or "spin 90 degrees." A base wraps your drive system into a single interface. | Wheeled rovers, tracked vehicles, holonomic platforms |
+| Component                                       | What it does                                                                                                                                        | Examples                                              | Features |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | -------- |
+| [Base](/hardware/common-components/add-a-base/) | Drive a mobile robot with movement commands like "move forward 300mm" or "spin 90 degrees." A base wraps your drive system into a single interface. | Wheeled rovers, tracked vehicles, holonomic platforms | —        |
 
 ## Control motors and servos
 
-| Component                                         | What it does                                                        | Examples                                    |
-| ------------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------- |
-| [Motor](/hardware/common-components/add-a-motor/) | Control a DC or stepper motor through a motor driver and GPIO pins. | DC motors, stepper motors, brushless motors |
-| [Servo](/hardware/common-components/add-a-servo/) | Set the angular position of a hobby servo with a PWM pin.           | Hobby servos, PWM-controlled actuators      |
+| Component                                         | What it does                                                        | Examples                                    | Features     |
+| ------------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------- | ------------ |
+| [Motor](/hardware/common-components/add-a-motor/) | Control a DC or stepper motor through a motor driver and GPIO pins. | DC motors, stepper motors, brushless motors | Data capture |
+| [Servo](/hardware/common-components/add-a-servo/) | Set the angular position of a hobby servo with a PWM pin.           | Hobby servos, PWM-controlled actuators      | —            |
 
 ## Inputs and GPIO
 
 Components for physical I/O and user input.
 
-| Component                                                                | What it does                                                                                                                    | Examples                                      |
-| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| [Board](/hardware/common-components/add-a-board/)                        | Expose GPIO pins, analog readers, and digital interrupts from a single-board computer. Many other components depend on a board. | Raspberry Pi GPIO, ESP32, PCA9685 IO expander |
-| [Button](/hardware/common-components/add-a-button/)                      | Detect presses from a physical button to trigger actions.                                                                       | Momentary switches, push buttons              |
-| [Switch](/hardware/common-components/add-a-switch/)                      | Read or set the position of a toggle or selector switch.                                                                        | Toggle switches, selector switches            |
-| [Input controller](/hardware/common-components/add-an-input-controller/) | Use a gamepad, joystick, or other input device for manual machine control.                                                      | Gamepads, joysticks, custom button panels     |
+| Component                                                                | What it does                                                                                                                    | Examples                                      | Features |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | -------- |
+| [Board](/hardware/common-components/add-a-board/)                        | Expose GPIO pins, analog readers, and digital interrupts from a single-board computer. Many other components depend on a board. | Raspberry Pi GPIO, ESP32, PCA9685 IO expander | —        |
+| [Button](/hardware/common-components/add-a-button/)                      | Detect presses from a physical button to trigger actions.                                                                       | Momentary switches, push buttons              | —        |
+| [Switch](/hardware/common-components/add-a-switch/)                      | Read or set the position of a toggle or selector switch.                                                                        | Toggle switches, selector switches            | —        |
+| [Input controller](/hardware/common-components/add-an-input-controller/) | Use a gamepad, joystick, or other input device for manual machine control.                                                      | Gamepads, joysticks, custom button panels     | —        |
 
 ## Other
 
-| Component                                             | What it does                                                          | Examples                                    |
-| ----------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------- |
-| [Generic](/hardware/common-components/add-a-generic/) | Interface with hardware that doesn't fit any standard component type. | Custom devices with non-standard interfaces |
+| Component                                             | What it does                                                          | Examples                                    | Features      |
+| ----------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------- | ------------- |
+| [Generic](/hardware/common-components/add-a-generic/) | Interface with hardware that doesn't fit any standard component type. | Custom devices with non-standard interfaces | —             |
+| [Audio output](/reference/apis/components/audio-out/) | Play audio on a speaker or audio-out device.                          | USB speakers, audio-out HATs                | No test panel |
 
 ## Choosing a type
 

--- a/docs/hardware/fragments.md
+++ b/docs/hardware/fragments.md
@@ -21,15 +21,13 @@ automatically on its next config sync.
 
 ## Use existing fragments
 
-When you search for a configuration block in the Viam app, fragments appear
-alongside individual models. If a fragment matches your hardware combination,
-use it. Someone has already figured out the right configuration for those
-components working together.
+When you search for a configuration block in the Viam app, fragments appear alongside individual models.
+If a fragment matches your hardware combination, use it.
+Someone has already figured out the right configuration for those components working together.
 
-For example, if you're setting up an xArm 6 with a wrist-mounted RealSense
-camera, a fragment for that combination configures both components and their
-spatial relationship in one step, rather than adding and configuring each one
-individually.
+For example, if you're setting up a UFactory xArm 6 with a wrist-mounted Intel RealSense camera, a fragment for that combination configures both components and their spatial relationship in one step, rather than adding and configuring each one individually.
+
+You can browse every fragment in your organization on the [FRAGMENTS page](https://app.viam.com/fragments), and search community fragments from the configuration block search in the Viam app.
 
 ## Save your own configurations
 
@@ -47,22 +45,33 @@ fragment instead of configuring each component from scratch.
 
 ### Fragment variables
 
-If part of the configuration varies between machines, use a **fragment
-variable** instead of a fixed value. For example, if the arm's IP address
-differs per machine:
+If part of the configuration varies between machines, use a **fragment variable** instead of a fixed value.
+For example, when the arm's IP address differs per machine, the fragment references the IP as a variable named `arm_ip`:
 
 ```json
 {
-  "host": {
-    "$variable": {
-      "name": "arm_ip"
+  "components": [
+    {
+      "name": "my-arm",
+      "api": "rdk:component:arm",
+      "model": "viam:ufactory:xArm6",
+      "attributes": {
+        "host": {
+          "$variable": {
+            "name": "arm_ip"
+          }
+        },
+        "speed_degs_per_sec": 60
+      }
     }
-  }
+  ]
 }
 ```
 
-Each machine sets the `arm_ip` variable to its own arm's address. Everything
-else comes from the fragment.
+Each machine that uses this fragment sets `arm_ip` to its own arm's address in the fragment card's **Variables** section on the **CONFIGURE** tab: `192.168.1.100` on one machine, `192.168.1.101` on another.
+Every other attribute (`speed_degs_per_sec` above, plus frames, dependencies, and so on) comes from the fragment and stays identical across machines.
+
+See [Reuse machine configuration](/fleet/reuse-configuration/) for the full variable syntax and for overriding individual fields without writing a new fragment.
 
 ### How fragments merge
 


### PR DESCRIPTION
## Summary

Third feedback pass on Configure hardware. Small surgical additions from the reviewer backlog.

### Add a component landing — Features column

Added a **Features** column to every catalog table. The column lists Data capture and Readings (GetReadings) support because those vary per type. DoCommand and test panel are universal for every existing type, so they're explained once in the intro paragraph rather than repeated per row.

Feature assignments verified against `~/viam/rdk/services/datamanager/` (data capture collectors) and `~/viam/app/test-cards/src/lib/components/` (test-card views):

- Data capture + Readings: sensor, movement sensor, power sensor
- Data capture: camera, motor, encoder, audio input
- Neither: arm, base, gripper, gantry, button, switch, input controller, board, servo, audio output, generic

### Missing component types

- **Audio input** and **Audio output** rows added. Audio input slots under Sensing; Audio output under Other. Both link to their API-reference pages (`/reference/apis/components/audio-in/` and `/audio-out/`) since no per-type add-*.md guide exists yet.
- Both are flagged "No test panel" because the app currently has no test card for audio components (verified against `~/viam/app/test-cards/src/lib/components/`).
- **Pose tracker** is still missing from the catalog. There is no API reference page or per-type guide for it on new-docs-site to link to, so adding a row would produce a dead end. Deferred to a future pass that creates proper docs for it.

### Fragments

- Prefix naming per the reviewer: "xArm 6" → "UFactory xArm 6", "RealSense" → "Intel RealSense".
- Added a pointer to the organization [FRAGMENTS page](https://app.viam.com/fragments) and noted that community fragments are searchable from the configuration block search.
- Expanded the `arm_ip` variable example into a full component block so a reader can see where the variable is referenced in context (inside `attributes.host`) and what stays fixed (other attributes like `speed_degs_per_sec`). Added the specific UI instruction for setting the variable per machine (fragment card's Variables section on the CONFIGURE tab).

## Test plan

- [x] prettier + vale clean
- [ ] Netlify deploy preview:
  - [ ] `/hardware/common-components/` — Features column renders across every table, audio input/output rows visible
  - [ ] `/hardware/fragments/` — UFactory/Intel prefixes, expanded variable example with full JSON block
- [ ] htmltest passes (audio-in/audio-out API references exist, so refs should resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)