### PR TITLE
Hardware: list Viam-maintained registry modules on per-component pages

### DIFF
--- a/docs/hardware/common-components/add-a-base.md
+++ b/docs/hardware/common-components/add-a-base.md
@@ -37,7 +37,13 @@ Micro-RDK:
 
 ### Registry modules
 
-For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=base). Each module's configuration is documented on its registry page.
+Viam-maintained base modules:
+
+| Module                                                                                 | Bases supported                                                                      |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [`viam:controlled-components`](https://app.viam.com/module/viam/controlled-components) | Sensor-controlled base that adds PID feedback from a movement sensor to another base |
+
+For bases not covered above, browse [all base modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=base).
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-board.md
+++ b/docs/hardware/common-components/add-a-board.md
@@ -40,7 +40,16 @@ Micro-RDK:
 
 ### Registry modules
 
-For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=board). Each module's configuration is documented on its registry page.
+Viam-maintained board modules:
+
+| Module                                                                         | Boards supported                                                  |
+| ------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
+| [`viam:raspberry-pi`](https://app.viam.com/module/viam/raspberry-pi)           | Raspberry Pi variants: rpi5, rpi4, rpi3, rpi2, rpi1, rpi0, rpi0_2 |
+| [`viam:nvidia`](https://app.viam.com/module/viam/nvidia)                       | NVIDIA Jetson Orin, AGX, and Nano                                 |
+| [`viam:texas-instruments`](https://app.viam.com/module/viam/texas-instruments) | Texas Instruments TDA4VM board                                    |
+| [`viam:pca`](https://app.viam.com/module/viam/pca)                             | PCA9685 16-channel PWM IO expander                                |
+
+For boards not covered above, browse [all board modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=board).
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-camera.md
+++ b/docs/hardware/common-components/add-a-camera.md
@@ -32,7 +32,17 @@ For Micro-RDK, see [Micro-RDK camera models](/reference/components/camera/micro-
 
 ### Registry modules
 
-For hardware the built-in models don't cover, browse [all available camera models in the Viam registry](https://app.viam.com/registry?type=component&subtype=camera). Common Viam-maintained modules include `realsense` (Intel RealSense depth cameras) and `viamrtsp` (IP cameras over RTSP).
+Viam-maintained camera modules:
+
+| Module                                                           | Cameras supported                                                                       |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| [`viam:viamrtsp`](https://app.viam.com/module/viam/viamrtsp)     | RTSP IP cameras (autodetect, H.264, H.265, MJPEG, MPEG-4) plus ONVIF and UPnP discovery |
+| [`viam:realsense`](https://app.viam.com/module/viam/realsense)   | Intel RealSense depth cameras                                                           |
+| [`viam:orbbec`](https://app.viam.com/module/viam/orbbec)         | Orbbec 3D cameras                                                                       |
+| [`viam:csi-cam-pi`](https://app.viam.com/module/viam/csi-cam-pi) | Raspberry Pi CSI cameras                                                                |
+| [`viam:rplidar`](https://app.viam.com/module/viam/rplidar)       | RPLidar 2D lidar (exposed as a point-cloud camera)                                      |
+
+For cameras not covered above, browse [all camera modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=camera).
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-gantry.md
+++ b/docs/hardware/common-components/add-a-gantry.md
@@ -40,7 +40,13 @@ The `fake` built-in model is useful for testing without hardware. Browse all ava
 
 ### Registry modules
 
-For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=gantry). Each module's configuration is documented on its registry page.
+Viam-maintained gantry modules:
+
+| Module                                                                   | Gantries supported                                                                     |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| [`viam:generic-gantry`](https://app.viam.com/module/viam/generic-gantry) | Single- and multi-axis gantries with motor control, limit switches, and encoder homing |
+
+For gantries not covered above, browse [all gantry modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=gantry). Each module's configuration is documented on its registry page.
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-gripper.md
+++ b/docs/hardware/common-components/add-a-gripper.md
@@ -34,7 +34,14 @@ The `fake` built-in model is useful for testing code without physical hardware.
 
 ### Registry modules
 
-For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=gripper). Each module's configuration is documented on its registry page.
+Viam-maintained gripper modules:
+
+| Module                                                       | Grippers supported                                     |
+| ------------------------------------------------------------ | ------------------------------------------------------ |
+| [`viam:ufactory`](https://app.viam.com/module/viam/ufactory) | xArm finger gripper, xArm Lite gripper, vacuum gripper |
+| [`viam:robotiq`](https://app.viam.com/module/viam/robotiq)   | Robotiq 2F-series two-finger grippers                  |
+
+For grippers not covered above, browse [all gripper modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=gripper). Each module's configuration is documented on its registry page.
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-motor.md
+++ b/docs/hardware/common-components/add-a-motor.md
@@ -39,7 +39,15 @@ Micro-RDK:
 
 ### Registry modules
 
-For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=motor). Each module's configuration is documented on its registry page.
+Viam-maintained motor modules:
+
+| Module                                                                   | Motors supported                                         |
+| ------------------------------------------------------------------------ | -------------------------------------------------------- |
+| [`viam:analog-devices`](https://app.viam.com/module/viam/analog-devices) | Stepper motors through the Analog Devices TMC5072 driver |
+| [`viam:odrive`](https://app.viam.com/module/viam/odrive)                 | ODrive brushless motor controllers (serial)              |
+| [`viam:uln2003`](https://app.viam.com/module/viam/uln2003)               | 28BYJ-48 stepper motor through the ULN2003 driver        |
+
+For motors not covered above, browse [all motor modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=motor).
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-movement-sensor.md
+++ b/docs/hardware/common-components/add-a-movement-sensor.md
@@ -41,7 +41,16 @@ Micro-RDK:
 
 ### Registry modules
 
-Hardware-specific models (GPS modules, IMUs, RTK receivers) are available as modules in the [Viam registry](https://app.viam.com/registry?type=component&subtype=movement_sensor). Each module's configuration is documented on its registry page.
+Viam-maintained movement-sensor modules:
+
+| Module                                                                   | Sensors supported                                       |
+| ------------------------------------------------------------------------ | ------------------------------------------------------- |
+| [`viam:analog-devices`](https://app.viam.com/module/viam/analog-devices) | Analog Devices ADXL345 accelerometer and similar IMUs   |
+| [`viam:tdk-invensense`](https://app.viam.com/module/viam/tdk-invensense) | TDK InvenSense MPU-6050 IMU                             |
+| [`viam:gps`](https://app.viam.com/module/viam/gps)                       | NMEA GPS, RTK GPS (serial / PMTK), and dual-antenna RTK |
+| [`viam:wit-motion`](https://app.viam.com/module/viam/wit-motion)         | Wit-Motion multi-axis tilt and IMU sensors              |
+
+For movement sensors not covered above, browse [all movement-sensor modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=movement_sensor).
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-power-sensor.md
+++ b/docs/hardware/common-components/add-a-power-sensor.md
@@ -26,7 +26,13 @@ A power sensor component provides three methods:
 
 ### Registry modules
 
-Hardware-specific power sensor models (INA219, INA226, Renogy controllers, etc.) are available as modules in the [Viam registry](https://app.viam.com/registry?type=component&subtype=power_sensor). Each module's configuration is documented on its registry page.
+Viam-maintained power-sensor modules:
+
+| Module                                                                         | Sensors supported                            |
+| ------------------------------------------------------------------------------ | -------------------------------------------- |
+| [`viam:texas-instruments`](https://app.viam.com/module/viam/texas-instruments) | Texas Instruments INA219 and INA226 monitors |
+
+For power sensors not covered above (Renogy controllers, other chips), browse [all power-sensor modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=power_sensor).
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-sensor.md
+++ b/docs/hardware/common-components/add-a-sensor.md
@@ -33,7 +33,16 @@ Micro-RDK:
 
 ### Registry modules
 
-For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=sensor). Each module's configuration is documented on its registry page.
+Viam-maintained sensor modules:
+
+| Module                                                                               | Sensors supported                                               |
+| ------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
+| [`viam:ultrasonic`](https://app.viam.com/module/viam/ultrasonic)                     | HC-SR04 and similar ultrasonic distance sensors                 |
+| [`viam:event-manager`](https://app.viam.com/module/viam/event-manager)               | Event management and notifications for Viam resources           |
+| [`viam:viam-telegraf-sensor`](https://app.viam.com/module/viam/viam-telegraf-sensor) | Machine metrics through Telegraf                                |
+| [`viam:lorawan`](https://app.viam.com/module/viam/lorawan)                           | LoRaWAN gateway and node sensors (Milesight, Dragino, and more) |
+
+For sensors not covered above, browse [all sensor modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=sensor).
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-servo.md
+++ b/docs/hardware/common-components/add-a-servo.md
@@ -31,7 +31,13 @@ Micro-RDK:
 
 ### Registry modules
 
-For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=servo). Each module's configuration is documented on its registry page.
+Viam-maintained servo modules:
+
+| Module                                                               | Servos supported                                            |
+| -------------------------------------------------------------------- | ----------------------------------------------------------- |
+| [`viam:raspberry-pi`](https://app.viam.com/module/viam/raspberry-pi) | `rpi-servo` model for hobby servos on Raspberry Pi variants |
+
+For servos not covered above, browse [all servo modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=servo).
 
 ## Steps
 

--- a/docs/hardware/common-components/add-an-arm.md
+++ b/docs/hardware/common-components/add-an-arm.md
@@ -22,13 +22,8 @@ An arm component controls a multi-jointed robotic arm. The API provides:
 - **Motion planning integration**: the motion service can plan
   collision-free paths for the arm.
 
-Arm models almost always come from **modules in the registry** because each
-arm manufacturer has its own communication protocol. Common models include:
-
-| Module                                                                | Models                       |
-| --------------------------------------------------------------------- | ---------------------------- |
-| [UFactory](https://app.viam.com/module/viam/ufactory)                 | xArm6, xArm7, xArm850, lite6 |
-| [Universal Robots](https://app.viam.com/module/viam/universal-robots) | ur3e, ur5e, ur7e, ur20       |
+Arm models almost always come from **modules in the registry** because each arm manufacturer has its own communication protocol.
+See the Registry modules list below for Viam-maintained arm modules.
 
 The `fake` built-in model is useful for testing code without physical hardware.
 It supports kinematics for several arm models (ur5e, ur20, xarm6, xarm7, lite6).
@@ -39,7 +34,15 @@ It supports kinematics for several arm models (ur5e, ur20, xarm6, xarm7, lite6).
 
 ### Registry modules
 
-For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=arm). Each module's configuration is documented on its registry page.
+Viam-maintained arm modules:
+
+| Module                                                                       | Arms supported               |
+| ---------------------------------------------------------------------------- | ---------------------------- |
+| [`viam:ufactory`](https://app.viam.com/module/viam/ufactory)                 | xArm6, xArm7, xArm850, Lite6 |
+| [`viam:universal-robots`](https://app.viam.com/module/viam/universal-robots) | UR3e, UR5e, UR7e, UR20       |
+| [`viam:yaskawa`](https://app.viam.com/module/viam/yaskawa)                   | GP12, GP180-120              |
+
+For arms not covered above, browse [all arm modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=arm). Each module's configuration is documented on its registry page.
 
 ## Steps
 

--- a/docs/hardware/common-components/add-an-encoder.md
+++ b/docs/hardware/common-components/add-an-encoder.md
@@ -41,7 +41,13 @@ Micro-RDK:
 
 ### Registry modules
 
-For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=encoder). Each module's configuration is documented on its registry page.
+Viam-maintained encoder modules:
+
+| Module                                             | Encoders supported                          |
+| -------------------------------------------------- | ------------------------------------------- |
+| [`viam:ams`](https://app.viam.com/module/viam/ams) | AMS AS5048 magnetic rotary absolute encoder |
+
+For encoders not covered above, browse [all encoder modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=encoder).
 
 ## Steps
 


### PR DESCRIPTION
## Summary

Adds a Viam-maintained Registry modules table to twelve per-component pages. Addresses the reviewer ask: the registry filter URL parameters don't actually narrow results by subtype, so a generic "browse the registry" link does not land readers on the right modules. Naming the Viam modules directly gets the reader where they need to go.

## Research method

Queried the public Typesense `resources` index (the one the docs site's registry widget uses) filtered by `api:rdk:component:<type>` and restricted to `namespace:viam`, sorted by deployment count. Per-type top modules:

| Page | Modules added |
|---|---|
| add-an-arm | viam:ufactory, viam:universal-robots, viam:yaskawa |
| add-a-base | viam:controlled-components |
| add-a-board | viam:raspberry-pi, viam:nvidia, viam:texas-instruments, viam:pca |
| add-a-camera | viam:viamrtsp, viam:realsense, viam:orbbec, viam:csi-cam-pi, viam:rplidar |
| add-an-encoder | viam:ams |
| add-a-gantry | viam:generic-gantry |
| add-a-gripper | viam:ufactory, viam:robotiq |
| add-a-motor | viam:analog-devices, viam:odrive, viam:uln2003 |
| add-a-movement-sensor | viam:analog-devices, viam:tdk-invensense, viam:gps, viam:wit-motion |
| add-a-power-sensor | viam:texas-instruments |
| add-a-sensor | viam:ultrasonic, viam:event-manager, viam:viam-telegraf-sensor, viam:lorawan |
| add-a-servo | viam:raspberry-pi (rpi-servo) |

Pages not updated: button (no Viam modules in the registry), input-controller and switch (one or two low-deployment modules each; not worth listing), generic (Viam's generic-typed modules are video-store / windows-autoupdate / rustdesk-server — not a useful list for someone adding custom hardware).

## Small cleanup

add-an-arm had an older "Common models include" table listing UFactory and Universal Robots. Removed it; the new Registry modules section carries the same information plus Yaskawa.

## Test plan

- [x] prettier + vale clean across all 17 files in common-components/
- [ ] Netlify deploy preview: spot-check that the module-table links render and resolve
  - [ ] `/hardware/common-components/add-a-camera/`
  - [ ] `/hardware/common-components/add-a-board/`
  - [ ] `/hardware/common-components/add-an-arm/`
  - [ ] `/hardware/common-components/add-a-sensor/`
- [ ] htmltest passes (all links point to `app.viam.com/module/...` URLs, which htmltest treats as external)

🤖 Generated with [Claude Code](https://claude.com/claude-code)