### PR TITLE
Fix MD001 heading-increment errors in 12 pages

### DIFF
--- a/docs/operate/reference/components/board/esp32.md
+++ b/docs/operate/reference/components/board/esp32.md
@@ -116,7 +116,7 @@ The following attributes are available for `esp32` boards:
 Any pin not specified in either `"pins"` or `"digital_interrupts"` cannot be interacted with through the [board API](/reference/apis/components/board/#api).
 Interaction with digital interrupts is only supported with the [board API](/reference/apis/components/board/#api); these digital interrupts cannot be used as software interrupts in driver implementations.
 
-### `analogs`
+## `analogs`
 
 The following properties are available for `analogs`:
 

--- a/docs/operate/reference/components/camera/calibrate.md
+++ b/docs/operate/reference/components/camera/calibrate.md
@@ -16,7 +16,7 @@ date: "2024-01-01"
 To calibrate a camera, you can use the classical example of a [chessboard](https://en.wikipedia.org/wiki/Chessboard_detection).
 The chessboard is often used because the geometry makes it a good test case for detection and processing.
 
-### Prerequisites
+## Prerequisites
 
 The calibration code uses the `numpy` and `opencv-python` packages.
 To follow along, install the libraries:

--- a/docs/operate/reference/components/camera/transform.md
+++ b/docs/operate/reference/components/camera/transform.md
@@ -117,7 +117,7 @@ The following attributes are available for `transform` views:
 
 The following are the transformation objects available for the `pipeline`:
 
-### Classifications
+## Classifications
 
 Classifications overlay text from the `GetClassifications` method of the [vision service](/reference/services/vision/) onto the image.
 

--- a/docs/operate/reference/components/input-controller/gamepad.md
+++ b/docs/operate/reference/components/input-controller/gamepad.md
@@ -63,7 +63,7 @@ The following attributes are available for `gamepad` input controllers:
 
 {{< readfile "/static/include/components/test-control/input-controller-control.md" >}}
 
-### Work in progress models
+## Work in progress models
 
 Mappings are currently available for a wired XBox 360 controller, and wireless XBox Series X|S, along with the 8bitdo Pro 2 Bluetooth gamepad (which works great with the Raspberry Pi).
 

--- a/docs/operate/reference/components/motor/fake.md
+++ b/docs/operate/reference/components/motor/fake.md
@@ -99,7 +99,7 @@ Nested within `pins`:
 | `dir` | string | Optional | See [Pin Information](#pin-information). {{< glossary_tooltip term_id="pin-number" text="Pin number" >}} of the GPIO pin this is wired to on the [board](/operate/reference/components/board/). |
 |`pwm` | string | Optional | See [Pin Information](#pin-information). {{< glossary_tooltip term_id="pin-number" text="Pin number" >}} of the GPIO pin this is wired to on the [board](/operate/reference/components/board/). |
 
-#### Pin Information
+## Pin Information
 
 There are three common ways for the computing device to communicate with a brushed DC motor driver chip.
 The driver data sheet (for a real, not fake, motor) will specify which one to use.

--- a/docs/operate/reference/components/servo/gpio-micro-rdk.md
+++ b/docs/operate/reference/components/servo/gpio-micro-rdk.md
@@ -130,7 +130,7 @@ The following attributes are available for `gpio` servos:
 | `max_period_us` | int | Optional | Override the safe maximum [PWM](https://docs.arduino.cc/learn/microcontrollers/analog-output) pulse width in microseconds. <br> Default: `2500` |
 | `pwm_resolution` | int | Optional | The resolution of the [PWM](https://docs.arduino.cc/learn/microcontrollers/analog-output) driver (for example, the number of ticks for a full period). <br> Default: `0` |
 
-### PWM frequency and `esp32` boards
+## PWM frequency and `esp32` boards
 
 A `gpio` servo using a PWM pin leaves you with three remaining PWM frequencies for use on an `esp32`.
 If the frequency of another PWM signal is unimportant, it can also be set to the same frequency as your servo.

--- a/docs/operate/reference/services/slam/cloudslam/_index.md
+++ b/docs/operate/reference/services/slam/cloudslam/_index.md
@@ -34,7 +34,7 @@ See Viam's [Pricing](https://www.viam.com/product/pricing) for more information.
 
 {{% /alert %}}
 
-### Supported algorithms
+## Supported algorithms
 
 Currently CloudSLAM only supports the [cartographer module](../cartographer/) as a SLAM algorithm.
 

--- a/docs/operate/reference/services/slam/orbslamv3/_index.md
+++ b/docs/operate/reference/services/slam/orbslamv3/_index.md
@@ -20,7 +20,7 @@ date: "2022-01-01"
 While ORB-SLAM3 does support the use of monocular cameras, for best results it is recommended that you use an RGB-D camera.
 {{% /alert %}}
 
-### Requirements
+## Requirements
 
 Install the binary required to use `orbslamv3` on your machine and make it executable by running the following commands according to your machine's architecture:
 

--- a/docs/reference/components/board/micro-rdk/esp32.md
+++ b/docs/reference/components/board/micro-rdk/esp32.md
@@ -116,7 +116,7 @@ The following attributes are available for `esp32` boards:
 Any pin not specified in either `"pins"` or `"digital_interrupts"` cannot be interacted with through the [board API](/reference/apis/components/board/#api).
 Interaction with digital interrupts is only supported with the [board API](/reference/apis/components/board/#api); these digital interrupts cannot be used as software interrupts in driver implementations.
 
-### `analogs`
+## `analogs`
 
 The following properties are available for `analogs`:
 

--- a/docs/reference/components/input-controller/gamepad.md
+++ b/docs/reference/components/input-controller/gamepad.md
@@ -50,7 +50,7 @@ The following attributes are available for `gamepad` input controllers:
 
 {{< readfile "/static/include/components/test-control/input-controller-control.md" >}}
 
-### Work in progress models
+## Work in progress models
 
 Mappings are currently available for a wired XBox 360 controller, and wireless XBox Series X|S, along with the 8bitdo Pro 2 Bluetooth gamepad (which works great with the Raspberry Pi).
 

--- a/docs/reference/components/motor/fake.md
+++ b/docs/reference/components/motor/fake.md
@@ -87,7 +87,7 @@ Nested within `pins`:
 | `dir` | string | Optional | See [Pin Information](#pin-information). {{< glossary_tooltip term_id="pin-number" text="Pin number" >}} of the GPIO pin this is wired to on the [board](/reference/components/board/). |
 |`pwm` | string | Optional | See [Pin Information](#pin-information). {{< glossary_tooltip term_id="pin-number" text="Pin number" >}} of the GPIO pin this is wired to on the [board](/reference/components/board/). |
 
-#### Pin Information
+## Pin Information
 
 There are three common ways for the computing device to communicate with a brushed DC motor driver chip.
 The driver data sheet (for a real, not fake, motor) will specify which one to use.

--- a/docs/reference/components/servo/micro-rdk/gpio.md
+++ b/docs/reference/components/servo/micro-rdk/gpio.md
@@ -96,7 +96,7 @@ The following attributes are available for `gpio` servos:
 | `max_period_us` | int | Optional | Override the safe maximum [PWM](https://docs.arduino.cc/learn/microcontrollers/analog-output) pulse width in microseconds. <br> Default: `2500` |
 | `pwm_resolution` | int | Optional | The resolution of the [PWM](https://docs.arduino.cc/learn/microcontrollers/analog-output) driver (for example, the number of ticks for a full period). <br> Default: `0` |
 
-### PWM frequency and `esp32` boards
+## PWM frequency and `esp32` boards
 
 A `gpio` servo using a PWM pin leaves you with three remaining PWM frequencies for use on an `esp32`.
 If the frequency of another PWM signal is unimportant, it can also be set to the same frequency as your servo.


### PR DESCRIPTION
## Summary

- Promote 12 skipped h3/h4 section headings to h2 so page TOCs and sidebar nesting render correctly.
- No content or URL changes — only heading levels.
- Clears all 12 MD001/heading-increment errors from markdownlint.

## Test plan

- [x] `markdownlint-cli --config .markdownlint.yaml docs/` — 0 MD001 errors remaining (down from 12)
- [x] `prettier --write docs/**/*.md` — clean, no extra changes
- [x] `vale docs/` — 0 errors in 149 affected files
- [x] `make build-prod` — 1160 pages built, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)