### PR TITLE
Data: document 100 TB monthly processing cap for tabular data queries

### DIFF
--- a/docs/data/query-data-from-code.md
+++ b/docs/data/query-data-from-code.md
@@ -29,6 +29,10 @@ Switch to **table view** to see nested fields as dot-notation column headers. Us
 SQL queries against `readings` currently return no rows unless the `WHERE` clause includes an explicit lower bound on `time_received`. Include `AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)` in any SQL example on this page if you copy it. MQL queries are not affected. Tracked as APP-10891.
 {{< /alert >}}
 
+{{% alert title="Note" color="note" %}}
+Tabular data queries (`TabularDataByMQL` and `TabularDataBySQL`) share a 100&nbsp;TB monthly processing limit across your organization. Queries that exceed the limit return an error. [Contact us](mailto:support@viam.com) to request an increase.
+{{% /alert %}}
+
 ## Set up a connection
 
 {{< readfile "/static/include/how-to/get-credentials.md" >}}

--- a/docs/data/query-data.md
+++ b/docs/data/query-data.md
@@ -20,6 +20,10 @@ Tabular data (sensor readings, motor positions, encoder ticks, and other structu
 SQL queries against `readings` currently return no rows unless the `WHERE` clause includes an explicit lower bound on `time_received`. Every SQL example and troubleshooting step on this page (including short inline examples) includes an explicit lower bound on `time_received` for this reason. When troubleshooting, do not remove the lower-bound filter entirely: widen it by using a broad lower bound such as `AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)`. MQL queries are not affected. Tracked as APP-10891.
 {{< /alert >}}
 
+{{% alert title="Note" color="note" %}}
+Tabular data queries (`TabularDataByMQL` and `TabularDataBySQL`) share a 100&nbsp;TB monthly processing limit across your organization. Queries that exceed the limit return an error. [Contact us](mailto:support@viam.com) to request an increase.
+{{% /alert %}}
+
 ## Open the query editor
 
 1. Go to [app.viam.com](https://app.viam.com).

--- a/docs/data/reference.md
+++ b/docs/data/reference.md
@@ -26,6 +26,10 @@ For the full schema of the `readings` table (document format, column reference, 
 
 ## Query reference
 
+{{% alert title="Note" color="note" %}}
+Tabular data queries (`TabularDataByMQL` and `TabularDataBySQL`) share a 100&nbsp;TB monthly processing limit across your organization. Queries that exceed the limit return an error. [Contact us](mailto:support@viam.com) to request an increase.
+{{% /alert %}}
+
 ### Indexed fields and query optimization
 
 You can improve query performance by filtering on indexed fields early in your query. Viam stores data in blob storage using the path pattern:


### PR DESCRIPTION
## Summary

Documents the 100 TB shared monthly processing cap that applies across \`TabularDataByMQL\` and \`TabularDataBySQL\`, and the escalation path for organizations that hit it. Adds a note to each of the three tabular-data query pages:

- \`/data/query-data/\`
- \`/data/query-data-from-code/\`
- \`/data/reference/\` (Query reference section)

## Replaces PR #4921

This replaces PR #4921 (APP-16023), which was opened against \`new-docs-site\` before the 2026-04-17 cutover and can no longer merge cleanly. The net change is the same — Katie's three commits plus the two fixes from @shannonbradshaw (vale-compliant non-breaking space and tightened wording). Katie is credited as co-author.

The insertion point in \`reference.md\` is the \"Query reference\" section. The old \"Data schema and querying\" section that Katie originally anchored against was split into \`/data/schema/\` during the cutover, so the note now lives with the query-performance content instead of with the schema content.

Close PR #4921 after this merges.

## Test plan

- [x] prettier + vale clean across all three pages
- [ ] Netlify deploy preview: confirm the note renders as an alert block at the expected location on each page
  - [ ] \`/data/query-data/\` — after the APP-10891 known-issue alert
  - [ ] \`/data/query-data-from-code/\` — after the APP-10891 known-issue alert
  - [ ] \`/data/reference/\` — immediately under the \"Query reference\" heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)