### PR TITLE
Hardware: document arm-contributed frames, end-effector attachment, and URDF

### DIFF
--- a/docs/hardware/common-components/add-an-arm.md
+++ b/docs/hardware/common-components/add-an-arm.md
@@ -104,7 +104,7 @@ For two-arm setups, one arm is typically at the world origin and the other is of
 
 To attach a gripper, camera, or other tool to the end effector, set the attached component's frame `parent` to the arm's name. See [Add a gripper](/hardware/common-components/add-a-gripper/#3-configure-a-frame-recommended) for a worked example.
 
-If you're writing a driver module for an arm that isn't in the registry, the module's `Kinematics` method supplies the arm's URDF or SVA JSON. See [Write a driver module](/build-modules/write-a-driver-module/) and [Frame System](/motion-planning/frame-system/) for the kinematics file formats Viam accepts.
+If you're writing a driver module for an arm that isn't in the registry, the module implements the arm's `Kinematics` method to return the arm's kinematic model. See [Kinematics](/motion-planning/reference/kinematics/) for the URDF and SVA JSON formats Viam accepts, and [Write a driver module](/build-modules/write-a-driver-module/) for the module-code side.
 
 ### 4. Save and test
 

--- a/docs/hardware/common-components/add-an-arm.md
+++ b/docs/hardware/common-components/add-an-arm.md
@@ -289,7 +289,7 @@ For an arm configured as `my-arm`, the frame system includes:
 - **`my-arm_origin`** — a static mounting frame at the arm's base, independent of joint positions. Use this when you need a fixed reference that stays put while the arm moves.
 - **`my-arm:<link-name>`** — one frame per link in the arm's URDF / kinematics model. For a UFactory xArm 6 the list looks roughly like `my-arm:base_link`, `my-arm:link1`, … `my-arm:link6`. The exact names come from whatever the arm module's kinematics file declares.
 
-To see the full list for your specific arm, call `GetFrameSystemConfig` from the SDK or open the **FRAME SYSTEM** tab in the Viam app.
+To see the full list for your specific arm, call `GetFrameSystemConfig` from the SDK. The **3D scene** tab on the machine page also visualizes the frame tree.
 
 ### Attach a gripper or camera to the end effector
 
@@ -317,7 +317,7 @@ The same pattern applies to a wrist-mounted camera, a tool changer, or any other
 ### Attach to an intermediate link
 
 For accessories mounted partway along the arm (a light or sensor on a specific link), use the link's namespaced frame name as the parent: `"parent": "my-arm:link3"`.
-Look up the available link names by calling `GetFrameSystemConfig` or by inspecting the arm module's kinematics JSON.
+Look up the available link names by calling `GetFrameSystemConfig`, inspecting the arm module's kinematics JSON, or checking the 3D scene visualization.
 
 ### Custom kinematics and URDF
 

--- a/docs/hardware/common-components/add-an-arm.md
+++ b/docs/hardware/common-components/add-an-arm.md
@@ -102,8 +102,9 @@ This frame places the arm's base at the world origin, which is common for single
 
 For two-arm setups, one arm is typically at the world origin and the other is offset by its distance from the first arm in the x and y directions using the `translation` field.
 
-For how the arm itself contributes frames (base, joints, end effector), and how to attach a gripper or camera to the arm, see [Frames](#frames) below.
-See [Frame System](/motion-planning/frame-system/) for the full frame configuration reference.
+To attach a gripper, camera, or other tool to the end effector, set the attached component's frame `parent` to the arm's name. See [Add a gripper](/hardware/common-components/add-a-gripper/#3-configure-a-frame-recommended) for a worked example.
+
+If you're writing a driver module for an arm that isn't in the registry, the module's `Kinematics` method supplies the arm's URDF or SVA JSON. See [Write a driver module](/build-modules/write-a-driver-module/) and [Frame System](/motion-planning/frame-system/) for the kinematics file formats Viam accepts.
 
 ### 4. Save and test
 
@@ -276,55 +277,6 @@ You should see all zeros before the move, then joints 1 and 2 at 10 and -10 degr
 
 {{% /tab %}}
 {{< /tabs >}}
-
-## Frames
-
-Once the arm is configured, its kinematics model contributes a chain of frames to your machine's frame system, not just the single `parent` frame you configured on the arm component.
-
-### What appears in the frame system
-
-For an arm configured as `my-arm`, the frame system includes:
-
-- **`my-arm`** — the arm's root frame. Attach things to this name and they follow the tip of the arm's kinematic chain as the joints move. This is what you want for a gripper or wrist camera.
-- **`my-arm_origin`** — a static mounting frame at the arm's base, independent of joint positions. Use this when you need a fixed reference that stays put while the arm moves.
-- **`my-arm:<link-name>`** — one frame per link in the arm's URDF / kinematics model. For a UFactory xArm 6 the list looks roughly like `my-arm:base_link`, `my-arm:link1`, … `my-arm:link6`. The exact names come from whatever the arm module's kinematics file declares.
-
-To see the full list for your specific arm, call `GetFrameSystemConfig` from the SDK. The **3D scene** tab on the machine page also visualizes the frame tree.
-
-### Attach a gripper or camera to the end effector
-
-Use `"parent": "my-arm"` on the attached component. Its position is computed from the current joint positions, so it tracks the tip as the arm moves.
-
-```json
-{
-  "name": "my-gripper",
-  "api": "rdk:component:gripper",
-  "model": "viam:ufactory:vacuum_gripper",
-  "frame": {
-    "parent": "my-arm",
-    "translation": { "x": 0, "y": 0, "z": 50 },
-    "orientation": {
-      "type": "ov_degrees",
-      "value": { "x": 0, "y": 0, "z": 1, "th": 0 }
-    }
-  }
-}
-```
-
-The 50mm Z offset accounts for the distance from the arm's flange to the gripper's contact point; measure from your own setup.
-The same pattern applies to a wrist-mounted camera, a tool changer, or any other component physically attached to the arm's end effector.
-
-### Attach to an intermediate link
-
-For accessories mounted partway along the arm (a light or sensor on a specific link), use the link's namespaced frame name as the parent: `"parent": "my-arm:link3"`.
-Look up the available link names by calling `GetFrameSystemConfig`, inspecting the arm module's kinematics JSON, or checking the 3D scene visualization.
-
-### Custom kinematics and URDF
-
-The Viam-maintained arm modules (UFactory, Universal Robots, Yaskawa) ship with kinematics tuned to the physical hardware, so you do not need to provide a URDF for those.
-
-If you are writing a driver module for an arm that isn't in the registry, the module contributes its kinematics by implementing the arm's `Kinematics` method, returning either a URDF (`.urdf`) or Viam's SVA JSON format.
-See [Write a driver module](/build-modules/write-a-driver-module/) for the module side, and [Frame System](/motion-planning/frame-system/) for the kinematics file formats Viam accepts.
 
 ## Troubleshooting
 

--- a/docs/hardware/common-components/add-an-arm.md
+++ b/docs/hardware/common-components/add-an-arm.md
@@ -102,7 +102,8 @@ This frame places the arm's base at the world origin, which is common for single
 
 For two-arm setups, one arm is typically at the world origin and the other is offset by its distance from the first arm in the x and y directions using the `translation` field.
 
-See [Frame System](/motion-planning/frame-system/) for details on configuring frames.
+For how the arm itself contributes frames (base, joints, end effector), and how to attach a gripper or camera to the arm, see [Frames](#frames) below.
+See [Frame System](/motion-planning/frame-system/) for the full frame configuration reference.
 
 ### 4. Save and test
 
@@ -275,6 +276,55 @@ You should see all zeros before the move, then joints 1 and 2 at 10 and -10 degr
 
 {{% /tab %}}
 {{< /tabs >}}
+
+## Frames
+
+Once the arm is configured, its kinematics model contributes a chain of frames to your machine's frame system, not just the single `parent` frame you configured on the arm component.
+
+### What appears in the frame system
+
+For an arm configured as `my-arm`, the frame system includes:
+
+- **`my-arm`** — the arm's root frame. Attach things to this name and they follow the tip of the arm's kinematic chain as the joints move. This is what you want for a gripper or wrist camera.
+- **`my-arm_origin`** — a static mounting frame at the arm's base, independent of joint positions. Use this when you need a fixed reference that stays put while the arm moves.
+- **`my-arm:<link-name>`** — one frame per link in the arm's URDF / kinematics model. For a UFactory xArm 6 the list looks roughly like `my-arm:base_link`, `my-arm:link1`, … `my-arm:link6`. The exact names come from whatever the arm module's kinematics file declares.
+
+To see the full list for your specific arm, call `GetFrameSystemConfig` from the SDK or open the **FRAME SYSTEM** tab in the Viam app.
+
+### Attach a gripper or camera to the end effector
+
+Use `"parent": "my-arm"` on the attached component. Its position is computed from the current joint positions, so it tracks the tip as the arm moves.
+
+```json
+{
+  "name": "my-gripper",
+  "api": "rdk:component:gripper",
+  "model": "viam:ufactory:vacuum_gripper",
+  "frame": {
+    "parent": "my-arm",
+    "translation": { "x": 0, "y": 0, "z": 50 },
+    "orientation": {
+      "type": "ov_degrees",
+      "value": { "x": 0, "y": 0, "z": 1, "th": 0 }
+    }
+  }
+}
+```
+
+The 50mm Z offset accounts for the distance from the arm's flange to the gripper's contact point; measure from your own setup.
+The same pattern applies to a wrist-mounted camera, a tool changer, or any other component physically attached to the arm's end effector.
+
+### Attach to an intermediate link
+
+For accessories mounted partway along the arm (a light or sensor on a specific link), use the link's namespaced frame name as the parent: `"parent": "my-arm:link3"`.
+Look up the available link names by calling `GetFrameSystemConfig` or by inspecting the arm module's kinematics JSON.
+
+### Custom kinematics and URDF
+
+The Viam-maintained arm modules (UFactory, Universal Robots, Yaskawa) ship with kinematics tuned to the physical hardware, so you do not need to provide a URDF for those.
+
+If you are writing a driver module for an arm that isn't in the registry, the module contributes its kinematics by implementing the arm's `Kinematics` method, returning either a URDF (`.urdf`) or Viam's SVA JSON format.
+See [Write a driver module](/build-modules/write-a-driver-module/) for the module side, and [Frame System](/motion-planning/frame-system/) for the kinematics file formats Viam accepts.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Addresses the reviewer question on add-an-arm.md: \"Can we describe the after arm frame here, the json, urdf, etc?\"

Adds a new \"## Frames\" section to the Arm page that explains what most readers currently have to reverse-engineer from the motion-planning docs: what frames the arm actually contributes to the frame system, and how to attach things to the end effector.

Covers:

1. **What frames the arm puts in the frame system**
   - `<arm-name>` — the arm's root/tip frame (tracks the end effector as joints move)
   - `<arm-name>_origin` — the static mounting base frame
   - `<arm-name>:<link-name>` — one frame per kinematic link (base_link, link1, link2, …)

2. **Attaching a gripper or camera to the end effector**
   - Use `\"parent\": \"<arm-name>\"`; worked example with a vacuum gripper and a 50mm Z offset for the flange-to-contact distance

3. **Attaching to an intermediate link**
   - Use the `<arm-name>:<link-name>` namespaced form for accessories mounted partway along the arm

4. **Custom kinematics**
   - Noting that Viam-maintained arm modules (UFactory, Universal Robots, Yaskawa) already ship with tuned kinematics
   - Pointing module authors at the arm's `Kinematics` method for URDF or SVA JSON

Also cross-links from the existing \"Configure a frame (recommended)\" step so readers setting up the arm's mounting frame discover the new content.

## Verification

Ground truth from:
- `rdk/robot/impl/local_robot.go` — `createFramesFromPart` and `getLocalFrameSystemParts` (naming convention for arm-contributed frames)
- `rdk/referenceframe/frame_system.go` — flattening that produces the `<arm>:<link>` names
- `rdk/components/arm/fake/kinematics/` — embedded kinematics JSON catalog (ur5e, ur20, xarm6, xarm7, lite6)
- Link naming confirmed against the URDF files; the exact link names (\"base_link\", \"link1\", etc.) come from whatever the arm module's kinematics file declares, so the doc phrases the list as an example with a pointer to `GetFrameSystemConfig` for specifics

## Test plan

- [x] prettier + vale clean
- [ ] Netlify deploy preview: confirm the new section renders and the in-page anchor link `#frames` resolves
- [ ] htmltest passes (internal links go to `/motion-planning/frame-system/` and `/build-modules/write-a-driver-module/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)