### PR TITLE
Hardware: add Configure a frame step to add-a-camera

### DIFF
--- a/docs/hardware/common-components/add-a-camera.md
+++ b/docs/hardware/common-components/add-a-camera.md
@@ -99,14 +99,47 @@ You can also set resolution and frame rate:
 }
 ```
 
-### 4. Save the configuration
+### 4. Configure a frame (recommended)
+
+If you plan to use motion planning, computer vision with spatial context, or pose queries that include the camera, add a frame to define where the camera sits in your workspace.
+
+Common mounting patterns:
+
+**Wrist-mounted on an arm.**
+Set `parent` to the arm's name so the camera's pose tracks the end effector as the arm moves.
+The translation offsets the camera's optical center from the arm's flange; measure your physical mount.
+
+```json
+{
+  "frame": {
+    "parent": "my-arm",
+    "translation": { "x": 0, "y": 0, "z": 0 },
+    "orientation": {
+      "type": "ov_degrees",
+      "value": { "x": 0, "y": 0, "z": 1, "th": 0 }
+    }
+  }
+}
+```
+
+**Mounted on a mobile base.**
+Set `parent` to the base's name so the camera moves with the robot.
+
+**Fixed in the workspace.**
+Set `parent` to `"world"` with the absolute position of the camera's mounting point.
+
+If the camera lives on a separate machine from the main compute (for example, an end-effector Raspberry Pi that exposes the camera as a remote), see [Frames across machines](/hardware/multi-machine/cross-machine-frames/) for the frame setup.
+
+See [Frame System](/motion-planning/frame-system/) for the full frame configuration reference.
+
+### 5. Save the configuration
 
 Click **Save** in the upper right of the configuration panel.
 
 When you save, `viam-server` automatically reloads the configuration and initializes the new component.
 You do not need to restart anything.
 
-### 5. Test the camera
+### 6. Test the camera
 
 Every component in Viam has a built-in **test panel** in the Configure tab.
 The test panel uses the exact same APIs your code will use, so if the camera works here, it will work in your programs.

--- a/docs/hardware/common-components/add-a-camera.md
+++ b/docs/hardware/common-components/add-a-camera.md
@@ -122,11 +122,11 @@ The translation offsets the camera's optical center from the arm's flange; measu
 }
 ```
 
-**Mounted on a mobile base.**
-Set `parent` to the base's name so the camera moves with the robot.
-
 **Fixed in the workspace.**
 Set `parent` to `"world"` with the absolute position of the camera's mounting point.
+
+**Mounted on a mobile base.**
+Set `parent` to the base's name. The camera's pose is then a static offset from the base's mounting frame. Unlike an arm (whose kinematics update the tip frame live from joint positions), a base's frame does not automatically track the robot's position as it drives; live world-space tracking requires a movement sensor or odometry that updates the base's frame.
 
 If the camera lives on a separate machine from the main compute (for example, an end-effector Raspberry Pi that exposes the camera as a remote), see [Frames across machines](/hardware/multi-machine/cross-machine-frames/) for the frame setup.
 


### PR DESCRIPTION
## Summary

The gripper and arm how-tos both have a \"Configure a frame (recommended)\" step that shows the JSON needed to attach the component to its parent in the frame tree. Camera was missing that step, even though wrist-mounted cameras on an arm (and cameras on a mobile base) are both common setups.

Adds a new step 4 \"Configure a frame (recommended)\" to \`add-a-camera.md\` with three patterns:

- **Wrist-mounted on an arm**: `parent` = arm name; the camera's pose tracks the end effector as the arm moves. JSON example included.
- **Mounted on a mobile base**: `parent` = base name.
- **Fixed in the workspace**: `parent` = `\"world\"` with an absolute translation.

Step numbering shifts: old step 4 (Save) → 5, old step 5 (Test) → 6.

Cross-links to:

- `/hardware/multi-machine/cross-machine-frames/` for cameras that live on a remote part (for example, an end-effector Raspberry Pi)
- `/motion-planning/frame-system/` for the full frame reference

Follows from the #4965 scope-down: the reviewer's arm-page comment about attaching accessories to the end effector is handled by the destination component's Configure-a-frame step (gripper already had it, now camera does too).

## Test plan

- [x] prettier + vale clean
- [ ] Netlify deploy preview: verify the new step 4 renders and the three subsections look right
- [ ] htmltest passes (the two outgoing links resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)