### PR TITLE
Hardware: tighten component / model / module / driver nomenclature

### DIFF
--- a/docs/hardware/common-components/add-a-generic.md
+++ b/docs/hardware/common-components/add-a-generic.md
@@ -49,7 +49,7 @@ For hardware the built-in models don't cover, browse the [Viam registry](https:/
 4. Name your component (for example, `my-device`) and click **Create**.
 
 If no model exists for your hardware, you can
-[write a driver module](/build-modules/write-a-driver-module/) that implements
+[write your own module](/build-modules/write-a-driver-module/) that implements
 the generic component API.
 
 ### 2. Configure attributes
@@ -212,7 +212,7 @@ go run main.go
 ## Related
 
 - [Generic API reference](/reference/apis/components/generic/): full method documentation.
-- [Write a driver module](/build-modules/write-a-driver-module/): create a
+- [Write a module](/build-modules/write-a-driver-module/): create a
   module for your custom hardware.
 - [Add a component](/hardware/common-components/): check if a more specific
   component type fits your hardware before using generic.

--- a/docs/hardware/common-components/add-a-sensor.md
+++ b/docs/hardware/common-components/add-a-sensor.md
@@ -56,7 +56,7 @@ For sensors not covered above, browse [all sensor modules in the Viam registry](
 4. Name your sensor (for example, `temperature-sensor`) and click **Create**.
 
 If no model exists for your sensor, you can
-[write a driver module](/build-modules/write-a-driver-module/) to add support.
+[write your own module](/build-modules/write-a-driver-module/) to add support.
 
 ### 2. Configure sensor attributes
 

--- a/docs/hardware/configure-hardware.md
+++ b/docs/hardware/configure-hardware.md
@@ -22,11 +22,11 @@ Each component has three things:
 - A **type** that defines what it can do: camera, motor, sensor, arm, and so on.
   Every component of the same type exposes the same API, regardless of the
   underlying hardware.
-- A **model** that provides the driver for your specific hardware.
+- A **model** that implements the component API for your specific hardware.
   For example, the camera type has models for USB webcams, IP cameras through
   FFmpeg, and others.
 - **Attributes** that configure how the model talks to your hardware:
-  a device path, a baud rate, a pin mapping, or whatever else the driver needs.
+  a device path, a baud rate, a pin mapping, or whatever else the model needs.
 
 In your machine's configuration, each component is a JSON block.
 The type appears in the `api` field as `rdk:component:<type>`:
@@ -50,11 +50,11 @@ For the full JSON structure and dependencies, see [Machine configuration](/hardw
 
 ## Models
 
-When you add a component, you search for a **model** that matches your hardware. Models are drivers that know how to communicate with specific devices. Some models ship with `viam-server` (like `webcam` for USB cameras or `gpio` for motors wired to GPIO pins). Most hardware-specific models (arms, grippers, specialized sensors, motor controllers) come from **modules** in the [Viam registry](https://app.viam.com/registry).
+When you add a component, you search for a **model** that matches your hardware. A model is an implementation of a component API for one piece of hardware (or class of hardware). Some models ship with `viam-server` (like `webcam` for USB cameras or `gpio` for motors wired to GPIO pins). Most hardware-specific models (arms, grippers, specialized sensors, motor controllers) come from **modules** in the [Viam registry](https://app.viam.com/registry); a module is a code package that provides one or more models.
 
 You don't need to think about where a model comes from. The Viam app shows all available models in one search, and they all work the same way: same API, same data capture, same test sections, same SDKs.
 
-If no model exists for your hardware, you can [write a driver module](/build-modules/write-a-driver-module/) that implements the Viam API for your device.
+If no model exists for your hardware, you can [write your own module](/build-modules/write-a-driver-module/) that provides a model implementing the component API.
 
 ## Switching hardware without changing code
 
@@ -95,7 +95,7 @@ If it shows as offline, verify that `viam-server` is running on your machine.
 ### 3. Configure attributes
 
 After creating the component, you'll see its configuration panel.
-Every model has its own set of attributes. These settings tell the driver
+Every model has its own set of attributes. These settings tell the model
 how to communicate with your specific hardware.
 
 Common attributes include:

--- a/docs/hardware/machine-configuration.md
+++ b/docs/hardware/machine-configuration.md
@@ -22,14 +22,14 @@ issues by reading the raw config.
 Every component in your machine's configuration is a JSON block with these
 fields:
 
-| Field        | What it does                                                                                       |
-| ------------ | -------------------------------------------------------------------------------------------------- |
-| `name`       | A unique name for this component on this machine. Your code references the component by this name. |
-| `api`        | The component type, in the form `rdk:component:<type>` (for example, `rdk:component:arm`).         |
-| `model`      | The specific driver, in the form `namespace:family:name` (for example, `viam:ufactory:xArm6`).     |
-| `attributes` | Model-specific settings that control how to connect to the hardware and how it should behave.      |
-| `depends_on` | Other components this one requires (for example, a motor depends on a board).                      |
-| `frame`      | Optional spatial relationship to a parent component, used by the motion service.                   |
+| Field        | What it does                                                                                                                                                                     |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`       | A unique name for this component on this machine. Your code references the component by this name.                                                                               |
+| `api`        | The component type, in the form `rdk:component:<type>` (for example, `rdk:component:arm`).                                                                                       |
+| `model`      | The specific implementation, in the form `namespace:family:name` (for example, `viam:ufactory:xArm6`). Built-in models use `rdk:builtin:name` (for example, `rdk:builtin:gpio`). |
+| `attributes` | Model-specific settings that control how to connect to the hardware and how it should behave.                                                                                    |
+| `depends_on` | Other components this one requires (for example, a motor depends on a board).                                                                                                    |
+| `frame`      | Optional spatial relationship to a parent component, used by the motion service.                                                                                                 |
 
 ### Example: a motor controlled by a board
 


### PR DESCRIPTION
## Summary

Reviewer feedback addressed:

> **Nomenclature:**
> A component is described a few different ways with respect to modules, models, drivers, etc. It's defined in the glossary, but only became clear after reviewing https://github.com/viamrobotics/api/tree/main/proto/viam/component.
>
> Models didn't become clear until after claude explained. Configure Hardware->Models has a section that says \"if no model exists you can write a new driver module\" Which is correct, but maybe should say write a new module to run your custom model? It's wordy.

Tightens the hardware section's use of \"driver,\" \"driver module,\" and \"model\" so they match the glossary canonical terms (component = resource typed by a proto API; model = implementation of a component API; module = code package providing one or more models). \"Driver\" is not in the glossary.

## Verification

Grepped \`~/viam/viam-docs-hardware/docs/reference/glossary/\` for the canonical definitions (component.md, model.md, module.md, model-namespace-triplet.md). Grepped \`docs/hardware/\` for every \`driver\` usage; classified each as either Viam nomenclature (to fix) or genuine hardware/OS terminology (motor driver, stepper driver, kernel driver, ffmpeg driver error — kept).

## Changes

### configure-hardware.md (Overview)

- Bullet: \"A model that provides the driver for your specific hardware\" → \"A model that implements the component API for your specific hardware.\" Traces to: the reviewer flagging models as confusingly defined.
- Bullet: \"whatever else the driver needs\" → \"whatever else the model needs.\" Same concept, wrong word.
- Models section: rewrite the paragraph so it defines \"model\" and \"module\" inline instead of calling models \"drivers.\" Traces to: \"Models didn't become clear until after claude explained.\"
- Anchor: \"write a driver module\" → \"write your own module\" + tightened surrounding sentence. Traces to: \"maybe should say write a new module to run your custom model.\"
- Attributes text: \"These settings tell the driver how to communicate\" → \"These settings tell the model how to communicate.\"

### machine-configuration.md

- \`model\` field description in the configuration-blocks table: \"The specific driver\" → \"The specific implementation,\" with a parenthetical noting built-in models use \`rdk:builtin:name\`. Matches the glossary's model-namespace-triplet definition.

### add-a-sensor.md

- \"write a driver module\" → \"write your own module\" in the \"no model exists\" sentence.

### add-a-generic.md

- \"write a driver module\" → \"write your own module\" in the \"no model exists\" sentence.
- Related-links: \"Write a driver module\" → \"Write a module.\"

## Deliberately out of scope

- The destination URL \`/build-modules/write-a-driver-module/\` and the destination page's title. Renaming either is a build-modules-section change, not a hardware-section change.
- Hardware/OS terminology uses of \"driver\" (motor driver, stepper driver, servo-driver boards, kernel driver, ffmpeg driver errors). These are physical hardware and OS terms and changing them would confuse readers.

## Test plan

- [x] prettier + vale clean
- [ ] Netlify deploy preview: spot-check Overview \"Models\" section and the four changed anchor texts render correctly
- [ ] htmltest passes (anchor-text changes keep the URLs intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)