### PR TITLE
Fix broken /foundation/ links in viam-server reference

### DIFF
--- a/docs/reference/viam-server.md
+++ b/docs/reference/viam-server.md
@@ -294,7 +294,7 @@ Enabling debug level logs will take precedence over all logging configuration se
 ## Install `viam-server` without the web UI
 
 {{% alert title="Tip" color="tip" %}}
-The recommended way to install `viam-server` and connect your machine to Viam is covered in the [Set up a machine](/foundation/).
+The recommended way to install `viam-server` and connect your machine to Viam is covered in the [Set up a machine](/set-up-a-machine/).
 {{% /alert %}}
 
 If you need to install `viam-server` without the web UI, you can run the following commands.
@@ -476,5 +476,5 @@ Note that this method may not work for versions that are too old, as Homebrew do
 {{< cards >}}
 {{% card link="/reference/apis/" %}}
 {{% card link="/hardware/configure-hardware/" %}}
-{{% card link="/foundation/" %}}
+{{% card link="/set-up-a-machine/" %}}
 {{< /cards >}}


### PR DESCRIPTION
One-line fix: PR #4972 renamed the foundation section to `/set-up-a-machine/`. Updates the body link and card link in `reference/viam-server.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)