### PR TITLE
Reference: add landing page

### DIFF
--- a/docs/reference/_index.md
+++ b/docs/reference/_index.md
@@ -7,6 +7,7 @@ type: "docs"
 no_list: true
 noedit: true
 open_on_desktop: true
+manualLink: "/reference/overview/"
 description: "Technical reference documentation for the Viam platform: APIs, SDKs, components, services, and more."
 aliases:
   - /reference/architecture/

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -1,0 +1,23 @@
+---
+linkTitle: "Overview"
+title: "Reference"
+weight: 1
+layout: "docs"
+type: "docs"
+description: "Technical reference for the Viam platform: APIs, SDKs, built-in components and services, runtime behavior, supported hardware, and term definitions."
+date: "2026-04-18"
+---
+
+Technical reference for the Viam platform. Use this section when you need authoritative details on APIs, built-in models, SDKs, runtime behavior, or supported hardware.
+
+| Section                                  | Use it for                                                                        |
+| ---------------------------------------- | --------------------------------------------------------------------------------- |
+| [APIs](/reference/apis/)                 | Method reference for component, service, robot, and app APIs                      |
+| [Components](/reference/components/)     | Per-model reference for built-in components: attributes, behavior, caveats        |
+| [Services](/reference/services/)         | Per-model reference for built-in services: attributes, behavior, caveats          |
+| [SDKs](/reference/sdks/)                 | Python, Go, TypeScript, Flutter, and C++ SDK reference                            |
+| [viam-server](/reference/viam-server/)   | viam-server runtime: lifecycle, configuration, logging, CLI options               |
+| [viam-agent](/reference/viam-agent/)     | viam-agent reference: subsystems, version control, system configuration           |
+| [Triggers](/reference/triggers/)         | Trigger configuration reference                                                   |
+| [Device setup](/reference/device-setup/) | Hardware-specific setup for supported single-board computers and microcontrollers |
+| [Glossary](/reference/glossary/)         | Term definitions for the Viam platform                                            |

--- a/docs/reference/viam-server.md
+++ b/docs/reference/viam-server.md
@@ -476,5 +476,5 @@ Note that this method may not work for versions that are too old, as Homebrew do
 {{< cards >}}
 {{% card link="/reference/apis/" %}}
 {{% card link="/hardware/configure-hardware/" %}}
-{{% card link="/foundation/" %}}
+{{% card link="/set-up-a-machine/" %}}
 {{< /cards >}}

--- a/docs/reference/viam-server.md
+++ b/docs/reference/viam-server.md
@@ -294,7 +294,7 @@ Enabling debug level logs will take precedence over all logging configuration se
 ## Install `viam-server` without the web UI
 
 {{% alert title="Tip" color="tip" %}}
-The recommended way to install `viam-server` and connect your machine to Viam is covered in the [Set up a machine](/foundation/).
+The recommended way to install `viam-server` and connect your machine to Viam is covered in the [Set up a machine](/set-up-a-machine/).
 {{% /alert %}}
 
 If you need to install `viam-server` without the web UI, you can run the following commands.


### PR DESCRIPTION
## Summary

- New `docs/reference/overview.md` with a one-paragraph intro and a 9-row table mapping each subsection to what it's for (APIs, Components, Services, SDKs, viam-server, viam-agent, Triggers, Device setup, Glossary).
- Stubbed `docs/reference/_index.md` with `manualLink: "/reference/overview/"`. All existing aliases preserved.

Before this PR `/reference/` rendered an empty page and the sidebar section header had nothing to click.

## Scope expansion (flagged)

`docs/reference/viam-server.md` (merged in #4971, before the foundation → set-up-a-machine rename in #4972) had a card linking to `/foundation/`. Hugo's card shortcode validates canonical URLs, not aliases, so `make build-prod` errored with `Card has a bad link: /foundation`. Updated the link to `/set-up-a-machine/`. Gap surfaced during verification, not introduced by this PR.

## Verification

Confirmed each of the nine destinations resolves (frontmatter inspection + build):

- `/reference/apis/`, `/reference/components/`, `/reference/services/`, `/reference/sdks/`, `/reference/viam-server/`, `/reference/viam-agent/`, `/reference/triggers/`, `/reference/device-setup/`, `/reference/glossary/`

## Test plan

- [x] `npx prettier --write` clean
- [x] `vale docs/reference/` clean
- [x] `make build-prod` clean
- [x] `/reference/`, `/reference/overview/`, all 9 subsection URLs, and `/set-up-a-machine/` return 200 locally
- [ ] Netlify deploy preview loads the landing page and each table row links to a live page

🤖 Generated with [Claude Code](https://claude.com/claude-code)