### PR TITLE
Migrate SLAM service reference to reference/services/slam/

### DIFF
--- a/docs/reference/services/slam/_index.md
+++ b/docs/reference/services/slam/_index.md
@@ -1,0 +1,71 @@
+---
+title: "SLAM service reference"
+linkTitle: "SLAM"
+weight: 60
+layout: "docs"
+type: "docs"
+description: "Simultaneous localization and mapping (SLAM) allows your machine to create a map of its surroundings and find its location within that map."
+date: "2026-04-18"
+aliases:
+  - /operate/reference/services/slam/
+  - /services/slam/
+  - /mobility/slam/
+---
+
+{{% alert title="Stability Notice" color="note" %}}
+The SLAM service is an experimental feature.
+Stability is not guaranteed.
+Breaking changes are likely to occur, and occur often.
+{{% /alert %}}
+
+[Simultaneous Localization And Mapping (SLAM)](https://en.wikipedia.org/wiki/Simultaneous_localization_and_mapping) allows your machine to create a map of its surroundings and find its location within that map.
+SLAM is an important area of ongoing research in robotics, particularly for mobile applications such as drones, boats, and rovers.
+
+The Viam SLAM service supports the integration of SLAM as a service on your machine.
+You can conduct SLAM with data collected live by a [RPlidar](https://github.com/viamrobotics/rplidar) or with LIDAR data you provide in configuration, and easily view the map you build by clicking on **View SLAM library** on your location's page:
+
+![Completed SLAM maps in the SLAM library tab](/services/slam/view-map-page.png)
+
+## Used with
+
+<!-- markdownlint-disable MD034 -->
+
+{{< cards >}}
+{{< relatedcard link="/reference/components/camera/" alt_title="RPlidar" alt_link="https://github.com/viamrobotics/rplidar" required="yes">}}
+{{< relatedcard link="/reference/components/movement-sensor/" required="no" >}}
+{{< relatedcard link="/reference/components/base/" required="no" >}}
+{{< /cards >}}
+
+{{% snippet "required-legend.md" %}}
+
+## Configuration
+
+Integrated SLAM libraries include the following.
+Click the model name for configuration instructions.
+
+<!-- prettier-ignore -->
+| Model | Description |
+| ----- | ----------- |
+| [`viam:slam:cartographer`](cartographer/) | [The Cartographer Project](https://github.com/cartographer-project) performs dense SLAM using LIDAR data. |
+| [`viam:cloudslam-wrapper:cloudslam`](cloudslam/) | [cloudslam-wrapper](https://github.com/viam-modules/cloudslam-wrapper) Allows you to run supported SLAM algorithms in the cloud. |
+
+## API
+
+The [SLAM service API](/reference/apis/services/slam/) supports the following methods:
+
+{{< readfile "/static/include/services/apis/generated/slam-table.md" >}}
+
+## SLAM mapping best practices
+
+The best way to improve map quality is by taking extra care when creating the initial map.
+While in a slam session, you should:
+
+- turn gently and gradually, completely avoiding sudden quick turns
+- make frequent loop closures, arriving back at a previously mapped area so the machine can correct for errors in the map layout
+- stay relatively (but not extremely) close to walls
+- use a machine that can go smoothly over bumps and transitions between flooring areas
+- drive at a moderate speed
+- when using a wheeled base, try to include an [odometry movement sensor](/reference/components/movement-sensor/wheeled-odometry/). This helps the SLAM algorithm keep track of where the machine is moving.
+- it is important to note that the [adxl345 accelerometer](https://github.com/viam-modules/analog-devices/) on the [Viam Rover 1](/try/rover-resources/rover-tutorial-1/) **will not** satisfy the movement sensor requirement.
+
+You can find additional assistance in the [Troubleshooting section](/monitor/troubleshoot/).

--- a/docs/reference/services/slam/_index.md
+++ b/docs/reference/services/slam/_index.md
@@ -51,9 +51,21 @@ Click the model name for configuration instructions.
 
 ## API
 
-The [SLAM service API](/reference/apis/services/slam/) supports the following methods:
+The SLAM service API supports the following methods:
 
-{{< readfile "/static/include/services/apis/generated/slam-table.md" >}}
+<!-- Method links point to /reference/apis/services/slam/ which does not exist yet.
+     Using inline table until the API page is created. -->
+
+<!-- prettier-ignore -->
+| Method Name | Description |
+| ----------- | ----------- |
+| `GetPosition` | Get the current position of the component the SLAM service is configured to source point cloud data from in the SLAM map as a `Pose`. |
+| `GetPointCloudMap` | Get the point cloud map. |
+| `GetInternalState` | Get the internal state of the SLAM algorithm required to continue mapping/localization. |
+| `GetProperties` | Get information about the current SLAM session. |
+| `Reconfigure` | Reconfigure this resource. |
+| `DoCommand` | Execute model-specific commands that are not otherwise defined by the service API. |
+| `Close` | Safely shut down the resource and prevent further use. |
 
 ## SLAM mapping best practices
 
@@ -66,6 +78,6 @@ While in a slam session, you should:
 - use a machine that can go smoothly over bumps and transitions between flooring areas
 - drive at a moderate speed
 - when using a wheeled base, try to include an [odometry movement sensor](/reference/components/movement-sensor/wheeled-odometry/). This helps the SLAM algorithm keep track of where the machine is moving.
-- it is important to note that the [adxl345 accelerometer](https://github.com/viam-modules/analog-devices/) on the [Viam Rover 1](/try/rover-resources/rover-tutorial-1/) **will not** satisfy the movement sensor requirement.
+- it is important to note that the [adxl345 accelerometer](https://github.com/viam-modules/analog-devices/) on the [Viam Rover 1](/try/) **will not** satisfy the movement sensor requirement.
 
 You can find additional assistance in the [Troubleshooting section](/monitor/troubleshoot/).

--- a/docs/reference/services/slam/cartographer/_index.md
+++ b/docs/reference/services/slam/cartographer/_index.md
@@ -1,0 +1,471 @@
+---
+title: "Cartographer"
+linkTitle: "Cartographer"
+weight: 70
+layout: "docs"
+type: "docs"
+description: "Configure a SLAM service with the Cartographer modular resource."
+date: "2026-04-18"
+aliases:
+  - /operate/reference/services/slam/cartographer/
+  - /services/slam/run-slam-cartographer/
+  - /services/slam/cartographer/
+  - /mobility/slam/cartographer/
+---
+
+[The Cartographer Project](https://github.com/cartographer-project) contains a C++ library that performs dense Simultaneous Localization And Mapping (SLAM).
+
+To use Cartographer with the Viam {{< glossary_tooltip term_id="slam" text="SLAM" >}} service, you can use the [`cartographer`](https://app.viam.com/module/viam/cartographer) {{< glossary_tooltip term_id="modular-resource" text="modular resource" >}}.
+
+The source code for this module is available on the [`viam-cartographer` GitHub repository](https://github.com/viamrobotics/viam-cartographer).
+
+{{% alert title="Info" color="info" %}}
+
+Currently, the `cartographer` modular resource supports taking 2D LiDAR and optionally IMU and/or odometry data as input.
+
+Support for taking 3D LiDAR data as input may be added in the future.
+
+{{% /alert %}}
+
+## Using Cartographer
+
+The `cartographer` module supports three modes of operation:
+
+- [Create a new map](#create-a-new-map)
+- [Update an existing map](#update-an-existing-map)
+- [Pure localization](#localize-only)
+
+### Hardware requirements
+
+{{% alert title="Running cartographer in the cloud" color="info" %}}
+
+Creating and updating SLAM maps with Cartographer is especially CPU-intensive.
+If you do not have enough resources locally, you can use the [cloudslam wrapper module](../cloudslam/) to move computation to the cloud.
+
+Running `cartographer` in the cloud incurs cost for Data Management, Cloud Data Upload, and Cloud Data Egress. Currently, you incur no cost for compute.
+See Viam's [Pricing](https://www.viam.com/product/pricing) for more information.
+
+{{% /alert %}}
+
+#### RPLidar
+
+- You must have an RPlidar, such as the [RPlidar A1](https://www.slamtec.com/en/Lidar/A1) or [RPlidar A3](https://www.slamtec.com/en/Lidar/A3), physically connected to your machine.
+
+  Be sure to position the RPlidar so that it **faces forward in the direction of travel**. For example, if you are using a [Viam Rover](https://www.viam.com/resources/rover) and the [RPlidar A1](https://www.slamtec.com/en/Lidar/A1) model, mount it to the Rover so that the **pointed** end of the RPlidar mount housing is facing in the same direction as the webcam.
+
+  Furthermore, ensure that the center of the RPlidar is mounted at the center of your machine's [base](/reference/components/base/).
+  In the case of the Viam Rover the center is in the middle between the wheels.
+
+  If you need a **mount plate** for your RPlidar A1 or A3 model, you can 3D print an adapter plate using the following:
+
+  - [RPlidar A1 adapter STL](https://github.com/viamrobotics/Rover-VR1/blob/master/CAD/RPIidarA1_adapter.STL)
+  - [RPlidar A3 adapter STL](https://github.com/viamrobotics/Rover-VR1/blob/master/CAD/RPIidarA3_adapter.STL)
+
+- In addition, you must [add the `rplidar` module to your machine](https://github.com/viamrobotics/rplidar) to support the RPlidar hardware, if you have not done so already.
+
+  {{< alert title="SUPPORT" color="note" >}}
+
+  Currently, the `rplidar` and `cartographer` modules only support the Linux platform.
+
+  {{< /alert >}}
+
+#### Movement sensors (optional)
+
+You can use data from one or more movement sensors on your machine to supplement the required LiDAR data.
+If you choose to use movement sensor data for SLAM, you can:
+
+- Add only inertial measurement unit (IMU) data
+  - Requires a movement sensor that supports [`AngularVelocity`](/operate/reference/services/navigation/#angular-velocity) and [`LinearAcceleration`](/operate/reference/services/navigation/#linear-acceleration) readings
+- Add only odometry data
+  - Requires a movement sensor that collects [`Position`](/operate/reference/services/navigation/#position) and [`Orientation`](/operate/reference/services/navigation/#orientation) data (for example, [`wheeled-odometry`](/operate/reference/components/movement-sensor/wheeled-odometry/))
+- Add both IMU _and_ odometry data
+  - Requires all four of the above kinds of data, merged together using the [`merged` movement sensor model](/operate/reference/components/movement-sensor/merged/)
+  - If you choose this option, be sure to configure data capture on the `merged` sensor and not on the individual movement sensors when following the steps below.
+
+### Create a new map
+
+To create a new map, follow the instructions below.
+
+{{< tabs name="Create new map">}}
+{{% tab name="Config Builder" %}}
+
+1. Ensure any sensors you wish to use are configured on the machine. See the [Hardware Requirements](#hardware-requirements) above.
+
+2. Set up the `cartographer` module on your machine:
+
+   Navigate to the **CONFIGURE** tab of your machine's page.
+
+   Click the **+** icon next to your machine part in the left-hand menu and select **Service**.
+   Select **SLAM**, then select `cartographer`.
+   You can also search for "cartographer".
+
+   Click **Add module**, give your service a name of your choice, then click **Create**.
+
+   In the resulting `SLAM` service configuration pane, choose `Create new map` as the **Mapping mode**, then configure the rest of the **Attributes** for that mapping mode:
+
+   - **Camera**: Select the `name` of the camera component that you created when you [added the `rplidar` module to your machine](https://github.com/viamrobotics/rplidar).
+     Example: "my-rplidar". Then set the `Data polling rate (Hz)` for retrieving pointclouds from the camera. For RPLidar A1 and A3 we recommend a frequency of 5 Hz.
+   - **Movement Sensor (Optional)**: Select the `name` of the movement sensor component that you want to use for SLAM.
+     If you are using both an IMU _and_ an odometer, select the `name` of the `merged` movement sensor, _not_ the `name` of either of the individual movement sensors.
+     Examples: "my-imu", "MyOdometer," or "merged-ms". Then set the `Data polling rate (Hz)` for retrieving readings from the movement sensor. We recommend a frequency of 20 Hz.
+   - **Minimum range (meters)**: Set the minimum range of your `rplidar`.
+     See [config params](#config_params) for suggested values for RPLidar A1 and A3.
+   - **Maximum range (meters)**: Set the maximum range of your `rplidar`.
+     See [config params](#config_params) for suggested values for RPLidar A1 and A3.
+
+   If you would like to tune additional Cartographer parameters, click the **JSON** button to switch to the JSON editor, then edit the `config_params` from there.
+   See the [`config_params`](#config_params) section for more information on the other parameters.
+
+   To save your changes, click the **Save** button in the top right corner of the page.
+
+   Check the **LOGS** tab of your machine to make sure your RPlidar has connected and no errors are being raised.
+
+3. (Optional) Configure cartographer to use cloudSLAM:
+
+   On the `SLAM` service configuration pane, click the **JSON** button to switch to the JSON editor and set the `use_cloud_slam` field to **true**. This setting disables local mapping to limit CPU usage in favor of using cloudSLAM.
+
+   In addition, your configured LiDAR camera and movement sensor must have data capture enabled. See the [cloudSLAM](../cloudslam/) documentation for more information on how to configure the feature on your machine and how to use cloudSLAM.
+
+{{% /tab %}}
+{{% tab name="JSON Example" %}}
+
+This example JSON configuration:
+
+- adds the `viam:rplidar` and the `viam:cartographer` modules
+- configures the `viam:slam:cartographer` service
+
+```json {class="line-numbers linkable-line-numbers"}
+{
+  "modules": [
+    {
+      "type": "registry",
+      "name": "viam_rplidar",
+      "module_id": "viam:rplidar",
+      "version": "0.1.16"
+    },
+    {
+      "type": "registry",
+      "name": "viam_cartographer",
+      "module_id": "viam:cartographer",
+      "version": "0.3.45"
+    }
+  ],
+  "services": [
+    {
+      "attributes": {
+        "config_params": {
+          "max_range_meters": "25",
+          "mode": "2d",
+          "min_range_meters": "0.2"
+        },
+        "camera": {
+          "name": "rplidar",
+          "data_frequency_hz": "5"
+        },
+        "enable_mapping": true,
+        "use_cloud_slam": false
+      },
+      "name": "slam",
+      "api": "rdk:service:slam",
+      "model": "viam:slam:cartographer"
+    }
+  ],
+  "components": [
+    {
+      "attributes": {},
+      "depends_on": [],
+      "name": "rplidar",
+      "model": "viam:lidar:rplidar",
+      "api": "rdk:component:camera"
+    }
+  ]
+}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+For more information about the configuration attributes, see [Attributes](#attributes).
+
+After configuring cartographer the machine should begin mapping automatically. Navigate to the **CONTROL** tab on your machine's page and click on the dropdown menu matching the `name` of the service you created. See our [tips](../#slam-mapping-best-practices) for making good maps. If you want to save your locally built map, you can use the **GetInternalState API** or use the local map uploading feature of the [cloudslam wrapper module](../cloudslam/).
+
+### Update an existing map
+
+To update an existing map with new pointcloud data from a new SLAM session, follow the instructions below.
+
+1. Configure your `cartographer` SLAM service using a map from your location:
+
+   {{< tabs name="Update existing map">}}
+   {{% tab name="Config Builder" %}}
+
+   1. Select the Mapping mode dropdown and choose the **Update existing map** option.
+   2. Configure **Select map** and **Map version** with the name and version of the map you would like to update.
+      For the other attributes, review the information in [Create a new map](#create-a-new-map).
+      You can see more details about the available maps from your machine's **Location** page by clicking **View SLAM library**.
+
+   {{% /tab %}}
+   {{% tab name="JSON Example" %}}
+
+   This example JSON configuration:
+
+   - adds the `viam:rplidar` and the `viam:cartographer` modules
+   - configures the `viam:slam:cartographer` service
+   - adds an `viam:lidar:rplidar` camera
+   - specifies the `slam_map` to be updated in the `packages`
+
+   <br>
+
+   ```json {class="line-numbers linkable-line-numbers"}
+   {
+     "modules": [
+       {
+         "type": "registry",
+         "name": "viam_rplidar",
+         "module_id": "viam:rplidar",
+         "version": "0.1.16"
+       },
+       {
+         "type": "registry",
+         "name": "viam_cartographer",
+         "module_id": "viam:cartographer",
+         "version": "0.3.45"
+       }
+     ],
+     "services": [
+       {
+         "attributes": {
+           "config_params": {
+             "max_range_meters": "25",
+             "mode": "2d",
+             "min_range_meters": "0.2"
+           },
+           "camera": {
+             "name": "rplidar",
+             "data_frequency_hz": "5"
+           },
+           "enable_mapping": true,
+           "use_cloud_slam": false,
+           "existing_map": "${packages.slam_map.test-map-1}/internalState.pbstream"
+         },
+         "name": "slam",
+         "api": "rdk:service:slam",
+         "model": "viam:slam:cartographer"
+       }
+     ],
+     "components": [
+       {
+         "attributes": {},
+         "depends_on": [],
+         "name": "rplidar",
+         "model": "viam:lidar:rplidar",
+         "api": "rdk:component:camera"
+       }
+     ],
+     "packages": [
+       {
+         "name": "test-map-1",
+         "version": "1697208847",
+         "package": "d1c224e8-483e-4cc7-980f-76b89d8fb507/test-map-1",
+         "type": "slam_map"
+       }
+     ]
+   }
+   ```
+
+   {{% /tab %}}
+   {{< /tabs >}}
+
+   For more information about the configuration attributes, see [Attributes](#attributes).
+
+   If you want to configure cartographer to use a locally saved map instead, see [Using locally built maps](#using-locally-built-maps).
+
+2. After configuring cartographer the machine should begin mapping automatically. Navigate to the **CONTROL** tab on your machine's page and click on the dropdown menu matching the `name` of the service you created.
+
+See our [tips](../#slam-mapping-best-practices) for making a good map! If you want to save your locally built map, you can use the **GetInternalState API** or use the local map uploading feature of the [cloudslam wrapper module](../cloudslam/)
+
+{{% alert title="Info" color="info" %}}
+
+Cartographer may take several minutes to find your machine's position on the existing map.
+In the meantime, your machine will show up at the map's origin (with the `(x,y)` coordinates `(0,0)`).
+
+{{% /alert %}}
+
+### Localize only
+
+In this mode, the `cartographer` module on your machine executes the Cartographer algorithm to find its position on a map. This mode is better when using [motion planning's MoveOnMap](/reference/apis/services/motion/#moveonmap) because the map will not be modified.
+
+1.  Configure your `cartographer` SLAM service:
+
+    {{< tabs name="Localize only">}}
+    {{% tab name="Config Builder" %}}
+
+1.  Select the Mapping mode dropdown and choose the **Update existing map** option.
+1.  Configure **Select map** and **Map version** with the name and version of the map you would like to localize on.
+    For the other attributes, review the information in [Create a new map](#create-a-new-map).
+    You can see more details about the available maps from your machine's **Location** page by clicking **View SLAM library**.
+
+    {{% /tab %}}
+    {{% tab name="JSON Example" %}}
+
+This example JSON configuration:
+
+- adds the `viam:rplidar` and the `viam:cartographer` modules
+- configures the `viam:slam:cartographer` service
+- adds an `viam:lidar:rplidar`
+- specifies the `slam_map` for localization in the `packages`
+
+<br>
+
+```json {class="line-numbers linkable-line-numbers"}
+{
+  "modules": [
+    {
+      "type": "registry",
+      "name": "viam_rplidar",
+      "module_id": "viam:rplidar",
+      "version": "0.1.16"
+    },
+    {
+      "type": "registry",
+      "name": "viam_cartographer",
+      "module_id": "viam:cartographer",
+      "version": "0.3.45"
+    }
+  ],
+  "services": [
+    {
+      "api": "rdk:service:slam",
+      "model": "viam:slam:cartographer",
+      "attributes": {
+        "config_params": {
+          "min_range_meters": "0.2",
+          "max_range_meters": "25",
+          "mode": "2d"
+        },
+        "camera": {
+          "name": "rplidar",
+          "data_frequency_hz": "5"
+        },
+        "enable_mapping": false,
+        "use_cloud_slam": false,
+        "existing_map": "${packages.slam_map.test-map-1}/internalState.pbstream"
+      },
+      "name": "slam"
+    }
+  ],
+  "components": [
+    {
+      "model": "viam:lidar:rplidar",
+      "api": "rdk:component:camera",
+      "attributes": {},
+      "depends_on": [],
+      "name": "rplidar"
+    }
+  ],
+  "packages": [
+    {
+      "type": "slam_map",
+      "name": "test-map-1",
+      "version": "1697208847",
+      "package": "d1c224e8-483e-4cc7-980f-76b89d8fb507/test-map-1"
+    }
+  ]
+}
+```
+
+    {{% /tab %}}
+    {{< /tabs >}}
+
+    For more information about the configuration attributes, see [Attributes](#attributes).
+
+    If you want to configure cartographer to use a locally saved map instead, see [Using locally built maps](#using-locally-built-maps).
+
+2. After configuring cartographer on the machine, the map should appear automatically. Navigate to the **CONTROL** tab on your machine's page and click on the dropdown menu matching the `name` of the service you created.
+
+   {{% alert title="Info" color="info" %}}
+
+Cartographer may take several minutes to find your machine's position on the existing map.
+In the meantime, your machine will show up at the map's origin (with the `(x,y)` coordinates `(0,0)`).
+
+If you move your machine, it will appear to be moving in a trajectory from the map's origin.
+
+    {{% /alert %}}
+
+### Attributes
+
+<!-- prettier-ignore -->
+| Name | Data Type | Required? | Description |
+| ---- | --------- | --------- | ----------- |
+| `use_cloud_slam` | boolean | **Required** | If `true`, the Cartographer algorithm will disable mapping on the machine. This feature should only be used when trying to use [cloudslam](../cloudslam/). |
+| `camera` | obj | **Required** | An object of the form `{ "name": <string>, "data_frequency_hz": <int> }` where `name` is the name of the LiDAR camera component to use as input and `data_frequency_hz` is the rate at which to capture (in "Create new map" or "Update existing map" modes) or poll (in "Localize only" mode) data from that camera component. |
+| `movement_sensor` | obj | Optional | An object of the form `{ "name": <string>, "data_frequency_hz": <int> }` where `name` is the name of the IMU movement sensor (that is, a movement sensor that supports the `GetAngularVelocity` and `GetLinearAcceleration` API methods) to use as additional input and `data_frequency_hz` is the rate at which to capture (in "Create new map" or "Update existing map" modes) or poll (in "Localize only" mode) data from that movement sensor component. |
+| `enable_mapping` | boolean | Optional | If `true`, Cartographer will build the map in addition to doing localization. <ul> Default: `true` </ul> |
+| `existing_map` | string | Optional | The alias of the package containing the existing map to build on (in "Update existing map" mode) or localize on (in "Localize only" mode). Can also point to a locally saved `.pbstream` file. |
+| `config_params` |  obj | Optional | Parameters available to fine-tune the `cartographer` algorithm: [read more below](#config_params). |
+
+#### `config_params`
+
+{{< readfile "/static/include/services/cartographer/configparams.md" >}}
+
+### Using locally built maps
+
+You can see details about the available maps from your machine's **Location** page by clicking **View SLAM library**.
+If you do not have any maps, and you do not wish to use [cloudslam](../cloudslam/), but you still want to use localizing and updating modes with cartographer, you can take the following steps.
+
+1. Save a `.pbstream` file by using the [GetInternalState or InternalStateFull APIs](../#api) by using one of the SDKs. Note, `InternalStateFull` is currently only implemented in Go.
+2. Ensure the `.pbstream` file is located somewhere on the machine, and note the directory path to that file.
+3. In your cartographer's config, update the `existing_map` field with the path to the file that was noted in #2.
+
+your config should look something like the following:
+
+```json {class="line-numbers linkable-line-numbers"}
+{
+  "modules": [
+    {
+      "type": "registry",
+      "name": "viam_rplidar",
+      "module_id": "viam:rplidar",
+      "version": "0.1.16"
+    },
+    {
+      "type": "registry",
+      "name": "viam_cartographer",
+      "module_id": "viam:cartographer",
+      "version": "0.3.45"
+    }
+  ],
+  "services": [
+    {
+      "attributes": {
+        "config_params": {
+          "max_range_meters": "25",
+          "mode": "2d",
+          "min_range_meters": "0.2"
+        },
+        "camera": {
+          "name": "rplidar",
+          "data_frequency_hz": "5"
+        },
+        "enable_mapping": true,
+        "use_cloud_slam": false,
+        "existing_map": "/PATH/TO/FILE/<INTERNAL-STATE-NAME>.pbstream"
+      },
+      "name": "slam",
+      "api": "rdk:service:slam",
+      "model": "viam:slam:cartographer"
+    }
+  ],
+  "components": [
+    {
+      "attributes": {},
+      "depends_on": [],
+      "name": "rplidar",
+      "model": "viam:lidar:rplidar",
+      "api": "rdk:component:camera"
+    }
+  ],
+  "packages": []
+}
+```
+
+Now your `cartographer` service should be running using your locally saved map.

--- a/docs/reference/services/slam/cloudslam/_index.md
+++ b/docs/reference/services/slam/cloudslam/_index.md
@@ -1,0 +1,439 @@
+---
+title: "CloudSLAM"
+linkTitle: "CloudSLAM"
+weight: 70
+layout: "docs"
+type: "docs"
+description: "Configure a SLAM service that runs in the cloud."
+date: "2026-04-18"
+aliases:
+  - /operate/reference/services/slam/cloudslam/
+  - /services/slam/cloudslam/
+---
+
+SLAM Algorithms can have varying levels of resource requirements in order to run effectively.
+`Cartographer` in particular can require a significant amount of CPU resources to build and manage large maps.
+In order to better support running SLAM on resource limited machines, Viam provides a service to run SLAM algorithms for machines in the cloud as well as management of the maps generated in their location.
+
+CloudSLAM can be used with both a live machine or with previously captured data in your location.
+In [live mode](#mapping-with-a-live-machine-online-mode) using the [data management service](/data/capture-sync/capture-and-sync-data/) and the [cloudslam-wrapper](https://github.com/viam-modules/cloudslam-wrapper) module, Viam takes your LiDAR camera and movement sensor data from your local machine and sends it to the cloudslam server.
+The CloudSLAM server will then process that data and produce a map that can then be used on any machine in your location.
+When using an [offline machine](#using-previously-captured-data-offline-mode), you can select data from specific sensors over a period of time to build a map with.
+
+You can view and delete maps built in a location by going to the [SLAM library](#the-slam-library-page), which provides a summary of active jobs in the location as well as a list of all maps built in that location.
+
+If you have your own SLAM algorithm that we do not currently support or if you built a map on your local machine already and want to skip running CloudSLAM, you can [upload a locally built map](#upload-a-locally-built-map) to your location using the `cloudslam-wrapper` module.
+
+{{% alert title="About Pricing" color="info" %}}
+
+Running `cloudslam` incurs cost for Data Management, Cloud Data Upload, and Cloud Data Egress. Currently, you incur no cost for compute.
+See Viam's [Pricing](https://www.viam.com/product/pricing) for more information.
+
+{{% /alert %}}
+
+## Supported algorithms
+
+Currently CloudSLAM only supports the [cartographer module](../cartographer/) as a SLAM algorithm.
+
+## The SLAM library page
+
+You can see details about the available maps from your machine's **Location** page by clicking **View SLAM library**.
+From here, you can find:
+
+1.  A list of all maps generated in that location. The list shows the name and version of the map, which machine was used for mapping, and when the map was created. You can also view previous versions of a map, if a map has been updated multiple times.
+    ![offline mapping available maps](/services/slam/offline-mapping-available-maps.png)
+
+2.  You can create or update a map using a previously collected dataset by clicking the **Make new map** on the top right and specify a map name or click **Update map** next to an existing map. See [using previously captured data](#using-previously-captured-data-offline-mode) for more information on how to do this.
+
+3.  A table showing active and failed CloudSLAM sessions.
+    The table highlights the name of the map, which machine is currently mapping, and whether the map is in progress or has failed.
+    You can also use the table view to stop active mapping sessions.
+    ![offline mapping maps computing table](/services/slam/offline-mapping-maps-computing-table.png)
+
+4.  You can view maps in more detail in a dynamic pointcloud viewer by selecting the `View Map` button on one
+    ![slam library view map](/services/slam/slam-library-view-map.png)
+
+5.  You can delete maps by clicking on the trash can icon in the upper right-hand corner of a map's card.
+
+## Mapping with a live machine (Online Mode)
+
+To run SLAM in the cloud, configure the [`cloudslam-wrapper`](https://app.viam.com/module/viam/cloudslam-wrapper) module and data capture on your machine.
+
+### Requirements
+
+To use CloudSLAM on a live machine, you must meet the following requirements:
+
+1. A cloudslam supported algorithm must be configured on the machine. Currently only the [cartographer module](../cartographer/) is supported.
+   Please configure a supported algorithm on the machine before continuing.
+
+2. A location owner [API key](/organization/access/) or higher.
+
+### Configuration
+
+To use CloudSLAM you must enable data capture and configure your `cloudslam-wrapper` SLAM service:
+
+{{< alert title="Tip: Managing Data Capture" color="tip" >}}
+Note that when the [data management service](/data/capture-sync/capture-and-sync-data/) is enabled, it continuously monitors and syncs your machine’s sensor data while the machine is running.
+To avoid incurring charges while not in use, [turn off data capture for your sensors](/data/capture-sync/capture-and-sync-data/#stop-data-capture-or-data-sync) once you have finished your SLAM session.
+{{< /alert >}}
+
+{{< tabs name="Create new map">}}
+{{% tab name="Config Builder" %}}
+
+1. Add the data management service to your machine:
+
+   Navigate to the **CONFIGURE** tab of your machine's page.
+   Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+   Choose **Data Management** as the type and either use the suggested name or specify a name for your data management service, for example `data_manager-1`.
+   Click **Create**.
+
+   On the panel that appears, you can manage the capturing and syncing functions.
+   You can also specify the **directory**, the sync **interval**, and any **tags** to apply to captured data.
+   See the [data management service](/data/capture-sync/capture-and-sync-data/) for more information.
+
+2. Enable data capture for your camera, and for your movement sensor if you would like to use IMU data, odometry data, or both:
+
+   Find the component's card on your machine's **CONFIGURE** tab.
+   Click **Add Method**, then select the method type and specify the capture frequency.
+
+   - For the required LiDAR camera, choose the `NextPointCloud` method.
+     Then set the capture frequency.
+     `5 Hz` is a good starting place for most applications.
+
+     {{<imgproc src="/services/slam/rplidar-capture.png" resize="x1100" declaredimensions=true alt="An R P lidar camera configured with next point cloud configured for capture at 5 Hz." class="shadow"  >}}
+
+   - To capture data from one or more movement sensors:
+
+{{< tabs name="Movement sensor options" >}}
+{{% tab name="IMU only" %}}
+
+For an IMU, choose the `AngularVelocity` and `LinearAcceleration` methods and set the capture frequency.
+`20 Hz` is a good starting place for most applications.
+
+{{<imgproc src="/services/slam/imu-capture.png" resize="x1100" declaredimensions=true alt="An IMU configured with angular velocity and linear acceleration both configured for capture at 20 Hz." class="shadow" >}}
+
+{{% /tab %}}
+{{% tab name="Odometry only" %}}
+
+For a movement sensor that supports odometry, choose the `Position` and `Orientation` methods and set the capture frequency.
+`20 Hz` is a good starting place for most applications.
+
+{{<imgproc src="/services/slam/odometer-capture.png" resize="x1100" declaredimensions=true alt="A wheeled odometer configured with position and orientation both configured for capture at 20 Hz." class="shadow" >}}
+
+{{% /tab %}}
+{{% tab name="Both (merged)" %}}
+
+For a `merged` movement sensor, choose all four methods (`AngularVelocity`, `LinearAcceleration`, `Position`, and `Orientation`) and set the capture frequency.
+`20 Hz` is a good starting place for most applications.
+You _do not_ need to configure data capture on the individual IMU and odometer.
+
+{{<imgproc src="/services/slam/merged-capture.png" resize="x1100" declaredimensions=true alt="An IMU configured with angular velocity, linear acceleration, position, and orientation all configured for capture at 20 Hz." class="shadow" >}}
+
+{{% /tab %}}
+{{< /tabs >}}
+<br>
+
+3. Set up the `cloudslam-wrapper` module on your machine:
+
+   Navigate to the **CONFIGURE** tab of your machine's page.
+
+   Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+   Select **SLAM**, then select `cloudslam-wrapper`.
+   You can also search for "cloudslam".
+
+   Click **Add module**, give your service a name of your choice, then click **Create**.
+
+   In the resulting `SLAM` service configuration pane, add the following **Attributes**:
+
+   ```json
+   {
+     "slam_service": "<slam-service-name>",
+     "api_key": "<location-api-key>",
+     "api_key_id": "<location-api-key-id>",
+     "organization_id": "<organization_id>",
+     "location_id": "<location_id>",
+     "machine_id": "<machine_id>"
+   }
+   ```
+
+   where
+
+   - `slam_service` is the name of the slam service that you want to run with cloudslam.
+   - `api_key` and `api_key_id` are for the location owner API key described in the [requirements](#requirements).
+   - `organization_id`, `location_id`, and `machine_id` describe which location and organization you want to run cloudslam in. These are needed so we can fully tie the map you make to the machine running cloudslam.
+
+4. (Optional) configure the `cloudslam-wrapper` to use updating mode.
+   If you want cloudslam to update a `slam_map` rather than create a new map, do the following:
+
+   - configure the `slam_map` on your wrapped SLAM service
+   - add a `machine_part_id` to your `cloudslam-wrapper` config.
+
+   This informs the module to use the configured `slam_map` on your machine.
+
+5. Configure Cartographer to use cloudslam.
+
+   In your `cartographer` config card, click the **JSON** button to switch to the JSON editor and set the `use_cloud_slam` field to **true**. This setting disables local mapping to limit CPU usage in favor of using cloudslam.
+
+{{% /tab %}}
+{{% tab name="JSON Example" %}}
+
+This example JSON configuration:
+
+- adds the `viam:rplidar`, `viam:cartographer`, and `viam:cloudslam-wrapper` modules
+- configures the `viam:slam:cartographer`, `viam:cloudslam-wrapper:cloudslam`, and the [data management](/data/capture-sync/capture-and-sync-data/) services
+- adds a `viam:lidar:rplidar` camera with data capture configured
+
+  ```json {class="line-numbers linkable-line-numbers"}
+  {
+    "components": [
+      {
+        "name": "rplidar",
+        "api": "rdk:component:camera",
+        "model": "viam:lidar:rplidar",
+        "attributes": {},
+        "service_configs": [
+          {
+            "type": "data_manager",
+            "attributes": {
+              "capture_methods": [
+                {
+                  "method": "NextPointCloud",
+                  "capture_frequency_hz": 5,
+                  "additional_params": {}
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "services": [
+      {
+        "name": "carto",
+        "api": "rdk:service:slam",
+        "model": "viam:slam:cartographer",
+        "attributes": {
+          "enable_mapping": true,
+          "use_cloud_slam": true,
+          "existing_map": "",
+          "camera": {
+            "data_frequency_hz": "5",
+            "name": "rplidar"
+          }
+        }
+      },
+      {
+        "name": "data_manager-1",
+        "api": "rdk:service:data_manager",
+        "model": "rdk:builtin:builtin",
+        "attributes": {
+          "capture_dir": "",
+          "capture_disabled": false,
+          "sync_disabled": false,
+          "tags": [],
+          "additional_sync_paths": [],
+          "sync_interval_mins": 0.1
+        }
+      },
+      {
+        "name": "cloudslam",
+        "api": "rdk:service:slam",
+        "model": "viam:cloudslam-wrapper:cloudslam",
+        "attributes": {
+          "slam_service": "carto",
+          "api_key": "<location-api-key>",
+          "api_key_id": "<location-api-key-id>",
+          "organization_id": "<organization_id>",
+          "location_id": "<location_id>",
+          "machine_id": "<machine_id>",
+          "machine_part_id": "<machine-part-id>"
+        }
+      }
+    ],
+    "modules": [
+      {
+        "type": "registry",
+        "name": "viam_rplidar",
+        "module_id": "viam:rplidar",
+        "version": "0.1.16"
+      },
+      {
+        "type": "registry",
+        "name": "viam_cartographer",
+        "module_id": "viam:cartographer",
+        "version": "0.3.45"
+      },
+      {
+        "type": "registry",
+        "name": "viam_cloudslam-wrapper",
+        "module_id": "viam:cloudslam-wrapper",
+        "version": "0.0.3"
+      }
+    ]
+  }
+  ```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+For more information about the configuration attributes, see [Attributes](#attributes).
+
+### Running CloudSLAM
+
+Navigate to the **CONTROL** tab on your machine's page. Then check the following things:
+
+- (optional) change the refresh frequency on the `cartographer` card to **Manual Refresh**. Since you want to use CloudSLAM, you do not need to refresh the underlying SLAM algorithm's map.
+- the `cloudslam-wrapper` card should be displaying its default map.
+
+To start the mapping session, do the following:
+
+1. Scroll down to the **DoCommand** card
+2. Select your `cloudslam-wrapper` service name from the **Selected component** dropdown
+
+3. In the **Input** section, enter the following command:
+
+   ```json
+   { "start": "<MAPPING-SESSION-NAME>" }
+   ```
+
+   where `<MAPPING-SESSION-NAME>` is the name you want to give the map you wish to generate.
+
+4. Click the **Execute** button.
+
+   If everything is configured correctly, you should receive a success message.
+   The DoCommand card should look something like:
+   ![cloudslam wrapper docommand start](/services/slam/cloudslam-module-docommand-start.png)
+
+5. After roughly 1 minute, your map should appear on the `cloudslam-wrapper` card. The displayed map will now update roughly every 5 seconds with the current progress of the mapping session.
+
+You have now successfully built your map using CloudSLAM.
+Please review the [tips](../#slam-mapping-best-practices) for making good maps.
+![cloudslam wrapper map mapping](/services/slam/cloudslam-module-live-withmap.png)
+
+### Stopping cloudslam
+
+To stop a CloudSLAM mapping session, do the following:
+
+1. Scroll down to the **DoCommand** card
+2. Select your `cloudslam-wrapper` service name from the **Selected component** dropdown
+3. In the **Input** section, enter the following command:
+
+   ```json
+   { "stop": "" }
+   ```
+
+   You do not need to specify the map name or job ID here, as the module is already aware of any active mapping sessions for the machine.
+
+4. Click the **Execute** button.
+   If everything is configured correctly, you will receive a success message.
+   The DoCommand card should look something like:
+   ![cloudslam wrapper docommand start](/services/slam/cloudslam-module-docommand-stop.png)
+
+Once completed, you can view the final map in the `cloudslam-wrapper` card, or view the map in the [SLAM library](#the-slam-library-page).
+
+## Using previously captured data (Offline mode)
+
+You can specify a range of **previously captured** LiDAR and optional IMU data to create a map or update an existing map in the cloud.
+You can browse your previously captured data from the **Data** page under the **Point clouds** tab (for LiDAR data) and **Sensors** tab (for IMU data).
+
+### Requirements
+
+To create a map, you must have already captured LiDAR data in the location in which you would like to create the map.
+
+The following example shows the previously-captured LiDAR data under the **Point clouds** tab for a machine named `test`.
+Selecting a row opens a pane to the right that contains more information, such as the Machine ID of the machine the component belongs to:
+
+{{<imgproc src="/services/slam/offline-mapping-pointcloud-data.png" resize="1200x" declaredimensions=true alt="UI showing captured point clouds">}}
+
+Example of previously captured IMU data:
+
+{{<imgproc src="/services/slam/offline-mapping-imu-data.png" resize="1200x" declaredimensions=true alt="UI showing captured sensor data">}}
+
+### Create or update a map
+
+From your machine's **Location** page, click **View SLAM library**, and click **Make new map** on the top right and specify a map name or click **Update map** next to an existing map.
+
+1. Enter the **Machine name**, **Camera name**, and optionally the **Movement Sensor name** of the components whose previously captured data you want to use to create or update a map.
+   If your machine has been deleted, you can alternatively specify the [**machine ID**](/reference/apis/fleet/#find-machine-id).
+2. Select the timeframe of the data you'd like to use.
+3. At the bottom, you can see the total number of PCD files and movement sensor data points that will be processed.
+4. Click **Generate map**.
+
+{{<imgproc src="/services/slam/offline-mapping-generate-map.png" resize="1200x" declaredimensions=true alt="UI for creating a new map from captured data">}}
+
+### End a session with previously captured data
+
+Unlike in `Online` mode, you cannot see the map being created while the slam session is in progress, but similar to when creating or updating a map in `Online` mode, you can see that your cloud slam session is in progress from your **Location** page by clicking **View SLAM library**.
+When all the data has been processed (or 45 minutes have passed, whichever occurs first), the map will be saved to your location's **SLAM library**.
+You can see details about the it from your machine's **Location** page by clicking **View SLAM library**.
+
+## Upload a locally built map
+
+If you want to skip using CloudSLAM and build the map on your local machine, the [`cloudslam-wrapper`](https://app.viam.com/module/viam/cloudslam-wrapper) module also allows you to upload a locally built map to your **Location**.
+This lets you share locally built maps across machines in a location easily.
+
+This feature can also be used with SLAM algorithms that CloudSLAM does not currently support. As long as the algorithm implements the SLAM API, you can upload your maps.
+
+### Requirements
+
+- A SLAM algorithm must be configured on the machine. This algorithm does **not** need to be supported by cloudslam to work.
+
+- A location owner API Key or higher. See [Add an API key](/organization/access/) to learn how to create a key!
+
+### Configuration
+
+Add the `cloudslam-wrapper` module to your machine.
+You do **not** need data management configured on the machine.
+Configuring the module will not affect any currently running local SLAM maps.
+Add the following **Attributes**:
+
+```json
+{
+  "slam_service": "<slam-service-name>",
+  "api_key": "<location-api-key>",
+  "api_key_id": "<location-api-key-id>",
+  "organization_id": "<organization_id>",
+  "location_id": "<location_id>",
+  "machine_id": "<machine_id>",
+  "machine_part_id": "<machine_part_id>"
+}
+```
+
+### Upload the map
+
+Navigate to the **CONTROL** tab on your machine's page.
+
+1. Scroll down to the **DoCommand** card
+2. Select your `cloudslam-wrapper` service name from the **Selected component** dropdown
+3. In the **Input** section, enter the following command:
+
+   ```json
+   { "save-local-map": "<MAP-NAME>" }
+   ```
+
+   where `<MAP-NAME>` is the name you want to give the map you wish to generate. 4. Click the **Execute** button.
+   If everything is configured correctly, you should receive a success message.
+   The DoCommand card should look something like:
+
+   ![cloudslam wrapper docommand local upload](/services/slam/cloudslam-module-docommand-local-upload.png)
+
+   Once completed, you can view the final map in the [SLAM library](#the-slam-library-page).
+
+## Attributes
+
+The following attributes are available for `viam:cloudslam-wrapper:cloudslam`
+
+<!-- prettier-ignore -->
+| Name    | Type   | Required?    | Description |
+| ------- | ------ | ------------ | ----------- |
+| `slam_service` | string | **Required** | The name of the SLAM Service on the machine to use with cloudslam. |
+| `api_key` | string | **Required** | An [API key](/organization/access/) with location owner or higher permission. |
+| `api_key_id` | string | **Required** | The associated API key ID with the API key. |
+| `organization_id` | string | **Required** | The organization ID of your [organization](/reference/glossary/#organization). |
+| `location_id` | string | **Required** | The location ID of your [location](/reference/glossary/#location). |
+| `machine_id` | string | **Required** | The machine ID of your [machine](/reference/apis/fleet/#find-machine-id). |
+| `machine_part_id` | string | Optional | The machine part ID of your [machine part](/reference/apis/fleet/#find-machine-id). Used for local package creation and updating mode. |
+| `viam_version` | string | Optional | The version of viam-server to use with CloudSLAM. Defaults to `stable`. |
+| `slam_version` | string | Optional | The version of cartographer to use with CloudSLAM. Defaults to `stable`. |
+| `camera_freq_hz` | float | Optional | The expected capture frequency for your camera/lidar components. Defaults to `5`. |
+| `movement_sensor_freq_hz` | float | Optional | The expected capture frequency for your movement sensor components. Defaults to `20`. |


### PR DESCRIPTION
## Summary

Copy SLAM service reference from `operate/reference/services/slam/` to `reference/services/slam/`:
- `_index.md` — SLAM service overview
- `cartographer/_index.md` — Cartographer configuration
- `cloudslam/_index.md` — CloudSLAM configuration

Skipped `orbslamv3/` (draft page). Fixed stale UI label ("Component or service" → "Configuration block"). Internal links updated to new-IA paths.

Closes the `/operate/reference/services/slam/cloudslam` app-link gap (the last AT-RISK URL from the app audit).

## Test plan

- [x] `vale` 0 errors
- [x] `make build-prod` clean
- [x] Pre-commit UI label hook passes
- [ ] Netlify deploy preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)