### PR TITLE
Aliases for other-hardware and capture-annotate-images app links

### DIFF
--- a/docs/build-modules/write-a-driver-module.md
+++ b/docs/build-modules/write-a-driver-module.md
@@ -31,6 +31,8 @@ aliases:
   - /modular-resources/examples/
   - /registry/examples/
   - /how-tos/hello-world-module/
+  - /operate/get-started/other-hardware/
+  - /operate/get-started/other-hardware/create-module/
 ---
 
 You want to use hardware that Viam doesn't support out of the box. A driver

--- a/docs/train/annotate-images.md
+++ b/docs/train/annotate-images.md
@@ -6,6 +6,8 @@ layout: "docs"
 type: "docs"
 description: "Label images with tags or bounding boxes for training an ML model."
 date: "2025-01-30"
+aliases:
+  - /data-ai/train/capture-annotate-images/
 ---
 
 Label your images with tags for classification or bounding boxes for object


### PR DESCRIPTION
## Summary

Fixes 3 remaining app-linked URLs that had no alias or a bad redirect:

| URL | Fix | Destination |
|---|---|---|
| `/operate/get-started/other-hardware/` | Alias added | `build-modules/write-a-driver-module.md` |
| `/operate/get-started/other-hardware/create-module/` | Alias added | `build-modules/write-a-driver-module.md` |
| `/data-ai/train/capture-annotate-images/` | Alias added | `train/annotate-images.md` (was caught by Netlify wildcard `from = "/data-ai/*"` → `/data/`, sending user to the wrong section) |

## Test plan

- [x] `make build-prod` clean
- [ ] Netlify deploy preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)