### PR TITLE
Add skipPatterns to default no-more-404 block for production builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -199,6 +199,8 @@
   # (for development) turn true for extra diagnostic logging
   debug = true
 
+  skipPatterns = ["/dev/", "/reference/components/", "/reference/services/", "/reference/account/", "/reference/advanced-modules/", "/reference/glossary_tmp/", "/reference/module-configuration/", "/reference/configuration/", "/tags/", "/services/slam/", "/mobility/slam/", "/operate/reference/services/slam/", "/architecture/", "/build/micro-rdk/", "/micro-rdk/", "/internals/", "/components/camera/calibrate/", "/components/movement-sensor/set-up-base-station/", "/operate/get-started/", "/operate/hello-world/", "/operate/mobility/", "/operate/modules/", "/operate/reference/module-configuration/", "/operate/reference/naming-modules/", "/operate/reference/services/frame-system/frame-config/", "/tutorials/build-a-mock-robot/", "/tutorials/configure/build-a-mock-robot/", "/tutorials/configure-a-camera/", "/tutorials/how-to-build-a-mock-robot/"]
+
 [[context.deploy-preview.plugins]]
   package = "@eggnstone/netlify-plugin-no-more-404"
 


### PR DESCRIPTION
## Summary

Production deploy is failing with \`Plugin \"@eggnstone/netlify-plugin-no-more-404\" failed: 80 paths missing\`.

The operate-removal PR (#4983) added \`skipPatterns\` under \`[context.deploy-preview.plugins.inputs]\` and \`[context.branch-deploy.plugins.inputs]\` but missed the default \`[plugins.inputs]\` block used for production builds. The production deploy log shows \`skipPatterns:\` empty.

## Test plan

- [ ] Production deploy on merge succeeds (no \"paths missing\" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)