### PR TITLE
Add skipPatterns to default no-more-404 block for production

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -534,6 +534,8 @@
   # (for development) turn true for extra diagnostic logging
   debug = true
 
+  skipPatterns = ["/dev/", "/reference/components/", "/reference/services/", "/reference/account/", "/reference/advanced-modules/", "/reference/glossary_tmp/", "/reference/module-configuration/", "/reference/configuration/", "/tags/"]
+
 [[context.deploy-preview.plugins]]
   package = "@eggnstone/netlify-plugin-no-more-404"
 


### PR DESCRIPTION
## Summary

Production deploy is failing on 12 auto-generated \`/tags/*\` paths. PR #4986 reverted the bloated skipPatterns in deploy-preview and branch-deploy contexts to just \`/tags/\` (plus the 8 legitimate originals), but the default \`[plugins.inputs]\` block used by production still had empty skipPatterns.

This adds the same slim skipPatterns list to the default block.

## Test plan

- [ ] Production deploy succeeds on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)