### PR TITLE
Redirect top-level landing pages to Overview pages

### DIFF
--- a/docs/hardware/_index.md
+++ b/docs/hardware/_index.md
@@ -9,5 +9,4 @@ description: "Understand how Viam represents hardware, add components to your ma
 manualLink: "/hardware/configure-hardware/"
 aliases:
   - /hardware-components/
-  - /hardware/
 ---

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,79 @@
   from = "/data/"
   to = "/data/overview/"
   status = 301
+  force = true
+
+[[redirects]]
+  from = "/cli/"
+  to = "/cli/overview/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/organization/"
+  to = "/organization/overview/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/vision/"
+  to = "/vision/overview/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/try/"
+  to = "/try/overview/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/hardware/"
+  to = "/hardware/configure-hardware/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/reference/"
+  to = "/reference/overview/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/build-modules/"
+  to = "/build-modules/overview/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/train/"
+  to = "/train/overview/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/set-up-a-machine/"
+  to = "/set-up-a-machine/overview/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/build-apps/"
+  to = "/build-apps/overview/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/monitor/"
+  to = "/monitor/overview/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/fleet/"
+  to = "/fleet/overview/"
+  status = 301
+  force = true
 
 [[redirects]]
   from = "/foundation/initialize-a-viam-machine/"


### PR DESCRIPTION
## Summary

- Adds 301 redirects for 12 top-level section landing pages (e.g. `/cli/` → `/cli/overview/`) so the URL itself lands on real content instead of a bare landing page that only works through the sidebar's `manualLink`.
- Adds `force = true` to the existing `/data/` redirect, which was shadowed by Hugo's built `/data/index.html` and never fired in production.
- `manualLink` entries in each section's `_index.md` are left in place — they become dead config once the URL redirects, but harmless.

Redirects added (all 301, all `force = true`):

| From | To |
|------|-----|
| `/cli/` | `/cli/overview/` |
| `/organization/` | `/organization/overview/` |
| `/vision/` | `/vision/overview/` |
| `/try/` | `/try/overview/` |
| `/hardware/` | `/hardware/configure-hardware/` |
| `/reference/` | `/reference/overview/` |
| `/build-modules/` | `/build-modules/overview/` |
| `/train/` | `/train/overview/` |
| `/set-up-a-machine/` | `/set-up-a-machine/overview/` |
| `/build-apps/` | `/build-apps/overview/` |
| `/monitor/` | `/monitor/overview/` |
| `/fleet/` | `/fleet/overview/` |

## Test plan

- [ ] Deploy preview: confirm each `/<section>/` URL returns `301` with `Location:` pointing to the mapped Overview (or equivalent) page.
- [ ] Confirm `/data/` now actually redirects (it was silently broken before this PR).
- [ ] Verify a representative sample of each destination returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)