### PR TITLE
Remove /reference/module-configuration/ from no-more-404 skipPatterns

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -680,7 +680,7 @@
   # (for development) turn true for extra diagnostic logging
   debug = true
 
-  skipPatterns = ["/dev/", "/reference/components/", "/reference/services/", "/reference/account/", "/reference/advanced-modules/", "/reference/module-configuration/", "/tags/"]
+  skipPatterns = ["/dev/", "/reference/components/", "/reference/services/", "/reference/account/", "/reference/advanced-modules/", "/tags/"]
 
 [[context.deploy-preview.plugins]]
   package = "@eggnstone/netlify-plugin-no-more-404"
@@ -689,7 +689,7 @@
 
   failBuildOnError = true
   failPluginOnError = true
-  skipPatterns = ["/dev/", "/reference/components/", "/reference/services/", "/reference/account/", "/reference/advanced-modules/", "/reference/module-configuration/", "/tags/"]
+  skipPatterns = ["/dev/", "/reference/components/", "/reference/services/", "/reference/account/", "/reference/advanced-modules/", "/tags/"]
 
 
 [[context.branch-deploy.plugins]]
@@ -699,4 +699,4 @@
 
   failBuildOnError = true
   failPluginOnError = true
-  skipPatterns = ["/dev/", "/reference/components/", "/reference/services/", "/reference/account/", "/reference/advanced-modules/", "/reference/module-configuration/", "/tags/"]
+  skipPatterns = ["/dev/", "/reference/components/", "/reference/services/", "/reference/account/", "/reference/advanced-modules/", "/tags/"]


### PR DESCRIPTION
## Summary

Third cleanup in the skipPattern series. \`/reference/module-configuration/\` has an exact redirect to \`/reference/\` already in netlify.toml.

Heads up: my earlier rebase resolution for #4991 was imperfect — I should double-check that \`/reference/configuration/\` (removed by #4989) didn't get accidentally reintroduced. Looking at upstream main now, it has the correct slim list, so we're good.

## Test plan

- [ ] Deploy preview passes (existing redirect catches the URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)