### PR TITLE
Redirect subsection category pages to their new-IA destinations

### DIFF
--- a/docs/reference/_index.md
+++ b/docs/reference/_index.md
@@ -41,7 +41,6 @@ aliases:
   - /reference/advanced-modules/create-subtype/
   - /reference/advanced-modules/custom-components-remotes/
   - /reference/advanced-modules/docker-modules/
-  - /reference/components/
   - /reference/configuration/
   - /reference/configuration/controls-package/
   - /reference/configuration/kinematic-chain-config/

--- a/netlify.toml
+++ b/netlify.toml
@@ -152,6 +152,68 @@
   status = 301
   force = true
 
+# Subsection category pages that used layout: "empty" + canonical for a
+# client-side meta-refresh. Upgrading to a real 301 for SEO and UX.
+[[redirects]]
+  from = "/tutorials/configure/"
+  to = "/hardware/configure-hardware/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/tutorials/control/"
+  to = "/hardware/configure-hardware/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/tutorials/custom/"
+  to = "/build-modules/overview/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/tutorials/get-started/"
+  to = "/try/overview/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/tutorials/projects/"
+  to = "/try/overview/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/tutorials/services/"
+  to = "/reference/services/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/reference/apis/components/"
+  to = "/reference/apis/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/reference/apis/services/"
+  to = "/reference/apis/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/reference/components/"
+  to = "/hardware/common-components/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/reference/sdks/python/"
+  to = "https://python.viam.dev/"
+  status = 301
+  force = true
+
 [[redirects]]
   from = "/foundation/initialize-a-viam-machine/"
   to = "/foundation/"


### PR DESCRIPTION
## Summary

Ten subsection landing pages used \`layout: \"empty\"\` + \`canonical:\` to meta-refresh the URL client-side. Upgrades each to a Netlify 301 so the URL itself redirects (better for SEO and UX).

The six \`/tutorials/<category>/\` destinations point to the corresponding section in the new IA, since the tutorials tree is being deprecated. The \`/reference/\` category destinations point to the practitioner-facing pages people actually want, which aren't always where the meta-refresh sent them.

| From | To |
|------|-----|
| \`/tutorials/configure/\` | \`/hardware/configure-hardware/\` |
| \`/tutorials/control/\` | \`/hardware/configure-hardware/\` |
| \`/tutorials/custom/\` | \`/build-modules/overview/\` |
| \`/tutorials/get-started/\` | \`/try/overview/\` |
| \`/tutorials/projects/\` | \`/try/overview/\` |
| \`/tutorials/services/\` | \`/reference/services/\` |
| \`/reference/apis/components/\` | \`/reference/apis/\` |
| \`/reference/apis/services/\` | \`/reference/apis/\` |
| \`/reference/components/\` | \`/hardware/common-components/\` |
| \`/reference/sdks/python/\` | \`https://python.viam.dev/\` |

## Test plan

- [ ] Deploy preview: each \`from\` URL returns 301 with the expected \`Location\` header.
- [ ] Each destination returns 200 (or the external Python SDK site, for the last entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)