### PR TITLE
Remove /dev/ from no-more-404 skipPatterns

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -737,7 +737,7 @@
   # (for development) turn true for extra diagnostic logging
   debug = true
 
-  skipPatterns = ["/dev/", "/reference/components/", "/reference/services/", "/tags/"]
+  skipPatterns = ["/reference/components/", "/reference/services/", "/tags/"]
 
 [[context.deploy-preview.plugins]]
   package = "@eggnstone/netlify-plugin-no-more-404"
@@ -746,7 +746,7 @@
 
   failBuildOnError = true
   failPluginOnError = true
-  skipPatterns = ["/dev/", "/reference/components/", "/reference/services/", "/tags/"]
+  skipPatterns = ["/reference/components/", "/reference/services/", "/tags/"]
 
 
 [[context.branch-deploy.plugins]]
@@ -756,4 +756,4 @@
 
   failBuildOnError = true
   failPluginOnError = true
-  skipPatterns = ["/dev/", "/reference/components/", "/reference/services/", "/tags/"]
+  skipPatterns = ["/reference/components/", "/reference/services/", "/tags/"]


### PR DESCRIPTION
## Summary

Sixth cleanup in the skipPattern series. \`/dev/*\` has wildcard redirects already (plus more specific ones for \`/dev/reference/apis/*\` and \`/dev/reference/sdks/*\`), so the skip should be redundant.

## Test plan

- [ ] Deploy preview passes (wildcards catch everything)
- [ ] If URLs surface, add specific redirects

🤖 Generated with [Claude Code](https://claude.com/claude-code)