### PR TITLE
Remove /reference/services/ from no-more-404 skipPatterns

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -737,7 +737,7 @@
   # (for development) turn true for extra diagnostic logging
   debug = true
 
-  skipPatterns = ["/reference/components/", "/reference/services/", "/tags/"]
+  skipPatterns = ["/reference/components/", "/tags/"]
 
 [[context.deploy-preview.plugins]]
   package = "@eggnstone/netlify-plugin-no-more-404"
@@ -746,7 +746,7 @@
 
   failBuildOnError = true
   failPluginOnError = true
-  skipPatterns = ["/reference/components/", "/reference/services/", "/tags/"]
+  skipPatterns = ["/reference/components/", "/tags/"]
 
 
 [[context.branch-deploy.plugins]]
@@ -756,4 +756,4 @@
 
   failBuildOnError = true
   failPluginOnError = true
-  skipPatterns = ["/reference/components/", "/reference/services/", "/tags/"]
+  skipPatterns = ["/reference/components/", "/tags/"]


### PR DESCRIPTION
## Summary

Seventh cleanup in the skipPattern series. \`/reference/services/*\` has a wildcard redirect to \`/reference/\`. Real pages under this path (motion, vision) are served as files; removed pages would be caught by the wildcard.

## Test plan

- [ ] Deploy preview passes
- [ ] If URLs surface, add specific redirects to more appropriate destinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)