### PR TITLE
Remove /reference/components/ from no-more-404 skipPatterns

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -737,7 +737,7 @@
   # (for development) turn true for extra diagnostic logging
   debug = true
 
-  skipPatterns = ["/reference/components/", "/tags/"]
+  skipPatterns = ["/tags/"]
 
 [[context.deploy-preview.plugins]]
   package = "@eggnstone/netlify-plugin-no-more-404"
@@ -746,7 +746,7 @@
 
   failBuildOnError = true
   failPluginOnError = true
-  skipPatterns = ["/reference/components/", "/tags/"]
+  skipPatterns = ["/tags/"]
 
 
 [[context.branch-deploy.plugins]]
@@ -756,4 +756,4 @@
 
   failBuildOnError = true
   failPluginOnError = true
-  skipPatterns = ["/reference/components/", "/tags/"]
+  skipPatterns = ["/tags/"]


### PR DESCRIPTION
## Summary

Final cleanup in the skipPattern series. Only \`/tags/\` remains in skipPatterns after this (Hugo auto-generates tag pages from frontmatter and they legitimately come and go with content).

\`/reference/components/*\` has a wildcard redirect to \`/reference/\`. Real component pages are served as files; removed pages will be caught by the wildcard.

## Test plan

- [ ] Deploy preview passes
- [ ] If URLs surface, add specific redirects to more appropriate destinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)