### PR TITLE
Fix architecture/parts URL routing (17 URLs)

### DIFF
--- a/docs/hardware/multi-machine/overview.md
+++ b/docs/hardware/multi-machine/overview.md
@@ -12,8 +12,7 @@ aliases:
   - /configure/parts/
   - /build/configure/parts/
   - /architecture/parts/
-  - /operate/reference/architecture/
-  - /operate/reference/architecture/machine-to-machine-comms/
+  - /reference/architecture/parts/
   - /operate/reference/architecture/parts/
 ---
 

--- a/docs/reference/_index.md
+++ b/docs/reference/_index.md
@@ -11,23 +11,6 @@ manualLink: "/reference/overview/"
 description: "Technical reference documentation for the Viam platform: APIs, SDKs, components, services, and more."
 aliases:
   - /operate/reference/
-  - /operate/reference/controls-package/
-  - /reference/architecture/
-  - /reference/architecture/parts/
-  - /reference/architecture/machine-to-machine-comms/
-  - /architecture/
-  - /architecture/parts/
-  - /architecture/machine-to-machine-comms/
-  - /operate/reference/architecture/
-  - /operate/reference/architecture/parts/
-  - /operate/reference/architecture/machine-to-machine-comms/
-  - /dev/reference/architecture/
-  - /internals/robot-to-robot-comms/
-  - /internals/machine-to-machine-comms/
-  - /manage/parts-and-remotes/
-  - /build/configure/parts-and-remotes/
-  - /configure/parts/
-  - /build/configure/parts/
   - /dev/
   - /dev/reference/
   - /dev/reference/contributing/

--- a/docs/what-is-viam/_index.md
+++ b/docs/what-is-viam/_index.md
@@ -9,7 +9,15 @@ images: ["/general/understand.png"]
 imageAlt: "Viam platform overview"
 description: "Viam is a software platform for building, deploying, and managing robotics applications."
 aliases:
+  - /architecture/
+  - /architecture/machine-to-machine-comms/
+  - /reference/architecture/
+  - /reference/architecture/machine-to-machine-comms/
   - /operate/reference/architecture/
+  - /operate/reference/architecture/machine-to-machine-comms/
+  - /dev/reference/architecture/
+  - /internals/robot-to-robot-comms/
+  - /internals/machine-to-machine-comms/
   - /understand/
   - /understand/what-is-viam/
   - /what-is-viam/problems-viam-solves/


### PR DESCRIPTION
## Summary

17 URLs were aliased on \`reference/_index.md\` AND on more specific destination pages. Hugo picked \`reference/_index.md\` as the winner, so all 17 landed on the generic \`/reference/\` landing instead of their topical destinations.

This PR removes the duplicates from \`reference/_index.md\` and ensures each URL lands on the right page.

## URL routing changes (all currently → \`/reference/\`)

**To \`/what-is-viam/\` (9 URLs — architecture overviews + machine-to-machine comms):**
- \`/architecture/\`
- \`/architecture/machine-to-machine-comms/\`
- \`/reference/architecture/\`
- \`/reference/architecture/machine-to-machine-comms/\`
- \`/operate/reference/architecture/\`
- \`/operate/reference/architecture/machine-to-machine-comms/\`
- \`/dev/reference/architecture/\`
- \`/internals/robot-to-robot-comms/\`
- \`/internals/machine-to-machine-comms/\`

**To \`/hardware/multi-machine/overview/\` (7 URLs — parts/remotes):**
- \`/architecture/parts/\`
- \`/reference/architecture/parts/\`
- \`/operate/reference/architecture/parts/\`
- \`/manage/parts-and-remotes/\`
- \`/build/configure/parts-and-remotes/\`
- \`/configure/parts/\`
- \`/build/configure/parts/\`

**To \`/reference/controls-package/\` (1 URL):**
- \`/operate/reference/controls-package/\` (alias was already there, just blocked by reference/_index.md)

## Test plan

- [ ] Deploy preview passes
- [ ] After merge: curl each URL and confirm correct destination

🤖 Generated with [Claude Code](https://claude.com/claude-code)