### PR TITLE
Re-route /dev/ and /operate/get-started/other-hardware/micro-module/

### DIFF
--- a/docs/build-modules/write-a-driver-module.md
+++ b/docs/build-modules/write-a-driver-module.md
@@ -34,6 +34,7 @@ aliases:
   - /how-tos/hello-world-module/
   - /operate/get-started/other-hardware/
   - /operate/get-started/other-hardware/create-module/
+  - /operate/get-started/other-hardware/micro-module/
 ---
 
 You want to use hardware that Viam doesn't support out of the box. A driver

--- a/docs/reference/_index.md
+++ b/docs/reference/_index.md
@@ -11,7 +11,6 @@ manualLink: "/reference/overview/"
 description: "Technical reference documentation for the Viam platform: APIs, SDKs, components, services, and more."
 aliases:
   - /operate/reference/
-  - /dev/
   - /dev/reference/
   - /dev/reference/contributing/
   - /dev/tools/

--- a/docs/reference/device-setup/setup-micro/_index.md
+++ b/docs/reference/device-setup/setup-micro/_index.md
@@ -13,7 +13,6 @@ aliases:
   - /operate/install/setup-micro/
   - /set-up-a-machine/setup-micro/
   - /foundation/setup-micro/
-  - /operate/get-started/other-hardware/micro-module/
   - /reference/viam-micro-server/
   - /architecture/viam-micro-server/
   - /installation/microcontrollers/

--- a/docs/what-is-viam/_index.md
+++ b/docs/what-is-viam/_index.md
@@ -18,6 +18,7 @@ aliases:
   - /dev/reference/architecture/
   - /internals/robot-to-robot-comms/
   - /internals/machine-to-machine-comms/
+  - /dev/
   - /understand/
   - /understand/what-is-viam/
   - /what-is-viam/problems-viam-solves/


### PR DESCRIPTION
## Summary

Two URL routing fixes from the 80-URL audit:

1. **\`/dev/\`** was landing on \`/reference/\` (generic landing). Now lands on \`/what-is-viam/\` since /dev/ was the top-level developer landing.
2. **\`/operate/get-started/other-hardware/micro-module/\`** was landing on \`/reference/device-setup/setup-micro/\`. Now lands on \`/build-modules/write-a-driver-module/\` to match its sibling URLs (\`/operate/get-started/other-hardware/\` and \`/operate/get-started/other-hardware/create-module/\` already go there).

## Test plan

- [ ] Deploy preview passes
- [ ] After merge: curl each URL and confirm correct destination

🤖 Generated with [Claude Code](https://claude.com/claude-code)