### PR TITLE
Fix 'Connect with code' steps to match actual app UI

### DIFF
--- a/docs/set-up-a-machine/overview.md
+++ b/docs/set-up-a-machine/overview.md
@@ -119,10 +119,10 @@ Your machine is online. Now connect to it programmatically.
 
 1. Go to your machine's page in the Viam app.
 2. Click the **CONNECT** tab.
-3. Select **API keys** and copy your **API key** and **API key ID**.
-4. Copy the **machine address** from the same tab.
-5. Choose your language (Python, TypeScript, Golang, C++, or Flutter).
-6. Copy the code sample, install the SDK, paste in your credentials, and run it.
+3. Select **SDK code sample**.
+4. Choose your language (Python, TypeScript, Golang, C++, or Flutter).
+5. Toggle **Include API key** to embed your credentials directly in the snippet.
+6. Copy the code sample, install the SDK, and run it.
 
 If the connection succeeds, the script prints your machine's available resources.
 


### PR DESCRIPTION
## Summary

- The SDK code sample subtab already includes an **Include API key** toggle that embeds credentials directly in the snippet — users don't need to visit the API keys subtab separately
- Updated steps 3–6 to reflect the actual flow: navigate to SDK code sample, pick a language, toggle Include API key, copy and run

## What changed

`docs/set-up-a-machine/overview.md` — section 7 "Connect with code" rewritten to direct users to the correct subtab and mention the credential toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)