### PR TITLE
Fix stale Desk Safari tutorial references

### DIFF
--- a/docs/build-modules/dependencies.md
+++ b/docs/build-modules/dependencies.md
@@ -199,4 +199,4 @@ Then resolve it the same way as any other dependency.
 - [Write a Driver Module](/build-modules/write-a-driver-module/) -- full walkthrough including dependency handling in context.
 - [Write a Logic Module](/build-modules/write-a-logic-module/) -- build a module that coordinates multiple resources.
 - [Access platform APIs](/build-modules/platform-apis/) -- access fleet management, data, and ML training APIs from within a module.
-- For full examples, see the [Desk Safari tutorial](/try/) or [complex module examples on GitHub](https://github.com/viamrobotics/viam-python-sdk/tree/main/examples/complex_module/src).
+- For full examples, see the [Try Viam tutorial](/try/) or [complex module examples on GitHub](https://github.com/viamrobotics/viam-python-sdk/tree/main/examples/complex_module/src).

--- a/docs/tutorials/control/control-motor.md
+++ b/docs/tutorials/control/control-motor.md
@@ -608,4 +608,4 @@ int main() {
 
 You now know how to build a machine that controls two {{< glossary_tooltip term_id="component" text="components" >}}.
 
-For a more elaborate tutorial using more componenst, see the [Desk Safari Tutorial](/try/).
+For a more elaborate tutorial using more componenst, see the [Try Viam tutorial](/try/).

--- a/docs/what-is-viam/_index.md
+++ b/docs/what-is-viam/_index.md
@@ -165,6 +165,6 @@ Viam provides these so you can focus on your product.
 
 ## Next steps
 
-We recommend putting these concepts into practice by following the [Desk Safari tutorial](/try/) to build your first machine.
+We recommend putting these concepts into practice by following the [Try Viam tutorial](/try/) to build your first machine.
 
 For more information on cloud capabilities like fleet management and provisioning, see [Monitor Air Quality with a Fleet of Sensors](/tutorials/control/air-quality-fleet/).


### PR DESCRIPTION
## Summary

Three pages link to a \"Desk Safari tutorial\" that was replaced by the current Try Viam tutorial (canning inspection scenario). The links resolve but the link text promises different content than the destination delivers.

Fixes:
- \`docs/what-is-viam/_index.md:168\` — landing-page call-to-action
- \`docs/build-modules/dependencies.md:202\` — full examples link
- \`docs/tutorials/control/control-motor.md:611\` — \"more elaborate tutorial\" link

Replaces \"Desk Safari tutorial\" with \"Try Viam tutorial\" in all three, matching the current section title.

## Out of scope

Noted but not fixed in this PR:
- Typo \"componenst\" → \"components\" on line 611 of \`control-motor.md\`.

## Test plan

- [x] \`npx prettier --write\` on all three files (no changes)
- [x] \`npx markdownlint-cli\` passes
- [x] \`vale\` passes (0 errors, warnings, or suggestions)
- [x] \`make build-prod\` succeeds
- [ ] Netlify deploy preview — verify the three links render with the new text