### PR TITLE
Add video service reference for viam:viamrtsp:video-service

### DIFF
--- a/docs/hardware/common-components/add-a-camera.md
+++ b/docs/hardware/common-components/add-a-camera.md
@@ -342,3 +342,4 @@ If you are using a camera with the motion service for arm movement or pick-and-p
 - [Camera API reference](/reference/apis/components/camera/): full method documentation.
 - [Capture and Sync Data](/data/capture-sync/capture-and-sync-data/): configure your camera to automatically capture images and sync them to the cloud.
 - [Add Computer Vision](/vision/configure/): run ML models on your camera feed to detect or classify objects.
+- [Video service](/reference/services/video/): record RTSP video to disk and stream stored footage between timestamps.

--- a/docs/reference/apis/services/video.md
+++ b/docs/reference/apis/services/video.md
@@ -1,0 +1,74 @@
+---
+title: "Video service API"
+linkTitle: "Video"
+weight: 55
+type: "docs"
+tags: ["video", "services", "rtsp", "camera"]
+description: "Stream stored video from an RTSP camera between specified timestamps."
+date: "2026-04-23"
+---
+
+The video service API allows you to stream recorded video from an RTSP camera between two timestamps, and to manage stored video segments.
+
+The [Video service](/reference/services/video/) supports the following methods:
+
+<!-- prettier-ignore -->
+| Method Name | Description |
+| ----------- | ----------- |
+| [`GetVideo`](#getvideo) | Stream video chunks between two timestamps. |
+| [`DoCommand`](#docommand) | Execute model-specific commands, including `save`, `fetch`, and `get-storage-state`. |
+
+## API
+
+### GetVideo
+
+Stream video chunks between two timestamps.
+
+**Parameters:**
+
+- `start_time` [(timestamp)](https://pkg.go.dev/time#Time): Start of the video range, in RFC 3339 format.
+- `end_time` [(timestamp)](https://pkg.go.dev/time#Time): End of the video range, in RFC 3339 format.
+- `video_codec` (string): Requested video codec. Currently ignored; the server chooses the codec.
+- `video_container` (string): Container format. `mp4` for progressive playback or `fmp4` for streaming playback. Defaults to `mp4`.
+
+**Returns:**
+
+- A channel of `Chunk` objects. Each chunk has the following fields:
+
+<!-- prettier-ignore -->
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `data` | bytes | Video chunk data. |
+| `container` | string | Container format of the chunk (`mp4` or `fmp4`). |
+
+**Container formats:**
+
+<!-- prettier-ignore -->
+| Format | Description |
+| ------ | ----------- |
+| `mp4` | Standard MP4 with the `faststart` flag. The `moov` atom is placed at the beginning for progressive playback. Best for downloading complete files. |
+| `fmp4` | Fragmented MP4 with the `frag_keyframe+default_base_moof` flags. Optimized for streaming playback. Best for live or real-time consumption. |
+
+### DoCommand
+
+Execute model-specific commands.
+
+The `viam:viamrtsp:video-service` model supports the following commands:
+
+<!-- prettier-ignore -->
+| Command | Description |
+| ------- | ----------- |
+| `save` | Concatenate and save video clips to the configured `upload_path`. |
+| `fetch` | Retrieve video bytes directly. |
+| `get-storage-state` | Get storage status and available video ranges. |
+
+For request and response formats, see the [viamrtsp module README](https://github.com/viam-modules/viamrtsp).
+
+**Parameters:**
+
+- `command` [(map[string]interface{})](https://go.dev/blog/maps): The command to execute.
+
+**Returns:**
+
+- [(map[string]interface{})](https://pkg.go.dev/builtin#string): The command response.
+- [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.

--- a/docs/reference/services/_index.md
+++ b/docs/reference/services/_index.md
@@ -21,5 +21,6 @@ Configuration reference for Viam built-in services. Each page covers available m
 {{% card link="/reference/services/motion/" %}}
 {{% card link="/reference/services/navigation/" %}}
 {{% card link="/reference/services/vision/" %}}
+{{% card link="/reference/services/video/" %}}
 {{% card link="/reference/services/motion/" %}}
 {{< /cards >}}

--- a/docs/reference/services/video/_index.md
+++ b/docs/reference/services/video/_index.md
@@ -1,0 +1,119 @@
+---
+title: "Video service"
+linkTitle: "Video"
+description: "Stream stored video from an RTSP camera between specified timestamps."
+layout: "docs"
+type: "docs"
+weight: 80
+date: "2026-04-23"
+---
+
+The video service streams recorded video from an RTSP camera between two timestamps.
+It stores video segments on disk, optionally uploads them to the cloud through the [data management service](/data/capture-sync/capture-and-sync-data/), and serves the stored footage on request.
+
+Use the video service when you want to record continuous footage from an RTSP IP camera and retrieve it later by time range, for example to build a DVR-style playback feature, review footage around an alert, or archive clips to the cloud.
+
+## Configuration
+
+The video service requires a configured RTSP camera from the [`viam:viamrtsp`](https://app.viam.com/module/viam/viamrtsp) module.
+Add the camera first, then add the video service.
+
+### `viam:viamrtsp:video-service`
+
+The `viam:viamrtsp:video-service` model records video from a `viam:viamrtsp` camera and serves stored segments by time range.
+
+To configure it:
+
+{{< tabs >}}
+{{% tab name="Builder" %}}
+
+Navigate to the **CONFIGURE** tab of your machine's page.
+Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Select the `video` type and the `viam:viamrtsp:video-service` model.
+Enter a name or use the suggested name for your service and click **Create**.
+
+In your video service's configuration panel, copy and paste the following JSON object into the attributes field:
+
+```json {class="line-numbers linkable-line-numbers"}
+{
+  "camera": "<your-rtsp-camera-name>",
+  "storage": {
+    "size_gb": 10
+  }
+}
+```
+
+Edit the attributes as applicable to your machine, according to the table below.
+
+{{% /tab %}}
+{{% tab name="JSON Template" %}}
+
+```json {class="line-numbers linkable-line-numbers"}
+{
+  "name": "<your-video-service>",
+  "api": "rdk:service:video",
+  "model": "viam:viamrtsp:video-service",
+  "attributes": {
+    "camera": "<your-rtsp-camera-name>",
+    "storage": {
+      "size_gb": <integer>,
+      "upload_path": "<path>",
+      "storage_path": "<path>"
+    },
+    "video": {
+      "bitrate": <integer>,
+      "preset": "<preset>"
+    },
+    "framerate": <integer>
+  }
+}
+```
+
+{{% /tab %}}
+{{% tab name="JSON Example" %}}
+
+```json {class="line-numbers linkable-line-numbers"}
+{
+  "name": "video-service-1",
+  "api": "rdk:service:video",
+  "model": "viam:viamrtsp:video-service",
+  "attributes": {
+    "camera": "rtsp-cam-1",
+    "storage": {
+      "size_gb": 10
+    }
+  }
+}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+The following attributes are available for the `viam:viamrtsp:video-service` model:
+
+<!-- prettier-ignore -->
+| Name | Type | Required? | Description |
+| ---- | ---- | --------- | ----------- |
+| `camera` | string | Optional | Name of the camera component to use as the video source. If omitted, the service runs in read-only mode and serves existing stored video. |
+| `storage` | object | **Required** | Storage configuration. See the fields below. |
+| `storage.size_gb` | integer | **Required** | Maximum storage size in gigabytes. |
+| `storage.upload_path` | string | Optional | Path where uploaded video segments are saved. |
+| `storage.storage_path` | string | Optional | Path where video segments are stored on disk. |
+| `video` | object | Optional | Video encoding configuration. Only used when re-encoding is required. |
+| `video.bitrate` | integer | Optional | Bitrate for video encoding, in bits per second. Only applies to MPEG-4 and MJPEG inputs. |
+| `video.preset` | string | Optional | Encoding preset. Options: `ultrafast`, `superfast`, `veryfast`, `faster`, `fast`, `medium`, `slow`, `slower`, `veryslow`. |
+| `framerate` | integer | Optional | Frame rate to capture video at, in frames per second. Only applies to MPEG-4 and MJPEG inputs. |
+
+To sync captured video to the cloud, also configure the [data management service](/data/capture-sync/capture-and-sync-data/).
+
+## API
+
+The video service supports the following methods:
+
+<!-- prettier-ignore -->
+| Method Name | Description |
+| ----------- | ----------- |
+| [`GetVideo`](/reference/apis/services/video/#getvideo) | Stream video chunks between two timestamps. |
+| [`DoCommand`](/reference/apis/services/video/#docommand) | Execute model-specific commands, including `save`, `fetch`, and `get-storage-state`. |
+
+For full method reference, see the [Video service API](/reference/apis/services/video/).


### PR DESCRIPTION
## Summary

This PR adds a few pages for the RTSP Video Service based on Devin Hilly's [request](https://viaminc.slack.com/archives/C059QREJ6DR/p1776867020424529). This is probably not the extent they are looking for, but I was waiting on other claude sessions to finish, and assumed reference was a good start.

- Add a new reference page at `/reference/services/video/` documenting the `viam:viamrtsp:video-service` model (configuration, Builder/JSON tabs, attributes table).
- Add a new API page at `/reference/apis/services/video/` covering `GetVideo` (parameters, returns, `mp4`/`fmp4` container formats) and `DoCommand` operations (`save`, `fetch`, `get-storage-state`).
- Link the new service from the services index and from the "Related" list in the camera setup guide.

The video service implements the `rdk:service:video` API and streams stored video from an RTSP camera between two timestamps. Content sourced from the [viamrtsp module README](https://github.com/viam-modules/viamrtsp).

## Test plan

- [ ] `npx prettier --check` on the touched files — passes
- [ ] `npx markdownlint-cli --config .markdownlint.yaml` on the touched files — passes
- [ ] `vale` on the touched files — 0 errors / 0 warnings / 0 suggestions
- [ ] `make build-prod` — 795 pages, no errors (only expected stale-date warnings)
- [ ] Spot-check rendering at `/reference/services/video/`, `/reference/apis/services/video/`, `/reference/services/` (card appears), and `/hardware/common-components/add-a-camera/#related`

🤖 Generated with [Claude Code](https://claude.com/claude-code)