### PR TITLE
Replace broken registry filter URLs with search guidance

### DIFF
--- a/docs/hardware/common-components/add-a-base.md
+++ b/docs/hardware/common-components/add-a-base.md
@@ -18,7 +18,7 @@ Add a base to your machine's configuration to drive a mobile robot with movement
 
 A base component gives you a movement API (`MoveStraight`, `Spin`, `SetVelocity`, `Stop`) regardless of the underlying drive system. The most common model is `wheeled`, which handles differential steering for robots with left and right motors. Other models exist for different platforms, including `sensor-controlled` (adds IMU feedback to improve accuracy) and module-based models for specific hardware.
 
-Browse all available base models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=base).
+Search for `base` in the [Viam registry](https://app.viam.com/registry) to see available models.
 
 This page covers the `wheeled` model. You configure your motors first, then the base references them.
 
@@ -45,7 +45,7 @@ Viam-maintained base modules:
 | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | [`viam:controlled-components`](https://app.viam.com/module/viam/controlled-components) | Sensor-controlled base that adds PID feedback from a movement sensor to another base |
 
-For bases not covered above, browse [all base modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=base).
+For bases not covered above, search for `base` in the [Viam registry](https://app.viam.com/registry).
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-board.md
+++ b/docs/hardware/common-components/add-a-board.md
@@ -23,7 +23,7 @@ A board component exposes the low-level I/O on your single-board computer:
 
 Most of the time a board represents the single-board computer itself (Raspberry Pi, Jetson, Orange Pi). A board can also represent an IO expander such as the [PCA9685](https://app.viam.com/module/viam/pca) or a microcontroller connected over serial that exposes GPIO-like interfaces. In both cases, motors, encoders, and servos reference the board by name to access the pins they're wired to.
 
-Browse all available board models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=board).
+Search for `board` in the [Viam registry](https://app.viam.com/registry) to see available models.
 
 {{< alert title="Pin numbering" color="note" >}}
 
@@ -50,7 +50,7 @@ Viam-maintained board modules:
 | [`viam:texas-instruments`](https://app.viam.com/module/viam/texas-instruments) | Texas Instruments TDA4VM board                                    |
 | [`viam:pca`](https://app.viam.com/module/viam/pca)                             | PCA9685 16-channel PWM IO expander                                |
 
-For boards not covered above, browse [all board modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=board).
+For boards not covered above, search for `board` in the [Viam registry](https://app.viam.com/registry).
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-button.md
+++ b/docs/hardware/common-components/add-a-button.md
@@ -17,7 +17,7 @@ Add a button to your machine's configuration so you can trigger button presses p
 
 A button component represents a momentary push button. The API is intentionally simple: a single `Push` method that simulates pressing the button. The button API does not listen for or report incoming presses; a module can still react to real presses internally, but from SDK code you only initiate presses.
 
-Physical button hardware typically comes from a module in the [Viam registry](https://app.viam.com/registry?type=component&subtype=button) that watches a GPIO pin.
+Physical button hardware typically comes from a module in the [Viam registry](https://app.viam.com/registry) (search for `button`) that watches a GPIO pin.
 
 The `fake` built-in model is useful for testing code without physical hardware.
 
@@ -25,7 +25,7 @@ The `fake` built-in model is useful for testing code without physical hardware.
 
 ### Registry modules
 
-For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=button). Each module's configuration is documented on its registry page.
+For hardware the built-in models don't cover, search for `button` in the [Viam registry](https://app.viam.com/registry). Each module's configuration is documented on its registry page.
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-camera.md
+++ b/docs/hardware/common-components/add-a-camera.md
@@ -43,7 +43,7 @@ Viam-maintained camera modules:
 | [`viam:csi-cam-pi`](https://app.viam.com/module/viam/csi-cam-pi) | Raspberry Pi CSI cameras                                                                |
 | [`viam:rplidar`](https://app.viam.com/module/viam/rplidar)       | RPLidar 2D lidar (exposed as a point-cloud camera)                                      |
 
-For cameras not covered above, browse [all camera modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=camera).
+For cameras not covered above, search for `camera` in the [Viam registry](https://app.viam.com/registry).
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-gantry.md
+++ b/docs/hardware/common-components/add-a-gantry.md
@@ -31,7 +31,7 @@ Viam includes two built-in gantry models:
 | `single-axis` | Controls one linear rail driven by a motor.                       |
 | `multi-axis`  | Composes multiple single-axis gantries into a coordinated system. |
 
-The `fake` built-in model is useful for testing without hardware. Browse all available gantry models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=gantry).
+The `fake` built-in model is useful for testing without hardware. Search for `gantry` in the [Viam registry](https://app.viam.com/registry) to see available models.
 
 ### Built-in models
 
@@ -47,7 +47,7 @@ Viam-maintained gantry modules:
 | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
 | [`viam:generic-gantry`](https://app.viam.com/module/viam/generic-gantry) | Single- and multi-axis gantries with motor control, limit switches, and encoder homing |
 
-For gantries not covered above, browse [all gantry modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=gantry). Each module's configuration is documented on its registry page.
+For gantries not covered above, search for `gantry` in the [Viam registry](https://app.viam.com/registry). Each module's configuration is documented on its registry page.
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-generic.md
+++ b/docs/hardware/common-components/add-a-generic.md
@@ -27,7 +27,7 @@ module author defines what commands are supported and what they do.
 
 Use generic when no other component type fits. If your hardware produces images, use [camera](/hardware/common-components/add-a-camera/). If it produces readings, use [sensor](/hardware/common-components/add-a-sensor/). Standard types give you typed SDK methods like `GetImage` or `GetReadings`, richer test-panel controls tailored to the component, and motion or vision services that know how to work with them. Generic exposes only `DoCommand`, so callers have to know the module-specific command shape.
 
-Browse available generic models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=generic).
+Search for `generic` in the [Viam registry](https://app.viam.com/registry) to see available models.
 
 The `fake` built-in model echoes commands back for testing.
 
@@ -37,7 +37,7 @@ The `fake` built-in model echoes commands back for testing.
 
 ### Registry modules
 
-For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=generic). Each module's configuration is documented on its registry page.
+For hardware the built-in models don't cover, search for `generic` in the [Viam registry](https://app.viam.com/registry). Each module's configuration is documented on its registry page.
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-gripper.md
+++ b/docs/hardware/common-components/add-a-gripper.md
@@ -22,7 +22,7 @@ A gripper component controls a grasping device. The API provides:
 - **IsHoldingSomething**: checks whether the gripper currently holds an object.
 - **Stop**: stops any in-progress motion.
 
-Gripper models almost always come from modules in the [Viam registry](https://app.viam.com/registry?type=component&subtype=gripper) because each
+Gripper models almost always come from modules in the [Viam registry](https://app.viam.com/registry) (search for `gripper`) because each
 gripper has its own communication protocol and control logic. For example, the
 [UFactory module](https://app.viam.com/module/viam/ufactory) includes gripper
 models for xArm parallel-jaw and vacuum grippers.
@@ -42,7 +42,7 @@ Viam-maintained gripper modules:
 | [`viam:ufactory`](https://app.viam.com/module/viam/ufactory) | xArm finger gripper, xArm Lite gripper, vacuum gripper |
 | [`viam:robotiq`](https://app.viam.com/module/viam/robotiq)   | Robotiq 2F-series two-finger grippers                  |
 
-For grippers not covered above, browse [all gripper modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=gripper). Each module's configuration is documented on its registry page.
+For grippers not covered above, search for `gripper` in the [Viam registry](https://app.viam.com/registry). Each module's configuration is documented on its registry page.
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-motor.md
+++ b/docs/hardware/common-components/add-a-motor.md
@@ -15,7 +15,7 @@ Add a motor to your machine's configuration so you can control it from the Viam 
 
 ## Concepts
 
-The motor API gives you `SetPower`, `GoFor` (rotate a number of revolutions at a given speed), `GoTo` (move to an absolute position), and `Stop`. Other models exist as modules for network-controlled motors and specific motor controllers. Browse available motor models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=motor).
+The motor API gives you `SetPower`, `GoFor` (rotate a number of revolutions at a given speed), `GoTo` (move to an absolute position), and `Stop`. Other models exist as modules for network-controlled motors and specific motor controllers. Search for `motor` in the [Viam registry](https://app.viam.com/registry) to see available models.
 
 This page covers the `gpio` model, which controls a motor through a motor driver wired to GPIO pins on a [board](/hardware/common-components/add-a-board/). You need to add a board first.
 
@@ -48,7 +48,7 @@ Viam-maintained motor modules:
 | [`viam:odrive`](https://app.viam.com/module/viam/odrive)                 | ODrive brushless motor controllers (serial)              |
 | [`viam:uln2003`](https://app.viam.com/module/viam/uln2003)               | 28BYJ-48 stepper motor through the ULN2003 driver        |
 
-For motors not covered above, browse [all motor modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=motor).
+For motors not covered above, search for `motor` in the [Viam registry](https://app.viam.com/registry).
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-movement-sensor.md
+++ b/docs/hardware/common-components/add-a-movement-sensor.md
@@ -52,7 +52,7 @@ Viam-maintained movement-sensor modules:
 | [`viam:gps`](https://app.viam.com/module/viam/gps)                       | NMEA GPS, RTK GPS (serial / PMTK), and dual-antenna RTK |
 | [`viam:wit-motion`](https://app.viam.com/module/viam/wit-motion)         | Wit-Motion multi-axis tilt and IMU sensors              |
 
-For movement sensors not covered above, browse [all movement-sensor modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=movement_sensor).
+For movement sensors not covered above, search for `movement sensor` in the [Viam registry](https://app.viam.com/registry).
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-power-sensor.md
+++ b/docs/hardware/common-components/add-a-power-sensor.md
@@ -33,7 +33,7 @@ Viam-maintained power-sensor modules:
 | ------------------------------------------------------------------------------ | -------------------------------------------- |
 | [`viam:texas-instruments`](https://app.viam.com/module/viam/texas-instruments) | Texas Instruments INA219 and INA226 monitors |
 
-For power sensors not covered above (Renogy controllers, other chips), browse [all power-sensor modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=power_sensor).
+For power sensors not covered above (Renogy controllers, other chips), search for `power sensor` in the [Viam registry](https://app.viam.com/registry).
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-sensor.md
+++ b/docs/hardware/common-components/add-a-sensor.md
@@ -19,7 +19,7 @@ The sensor component provides a single method: `GetReadings`, which returns a
 map of key-value pairs. This simple interface works for any sensor that
 produces named measurements.
 
-Most physical sensors in Viam come from modules in the [Viam registry](https://app.viam.com/registry?type=component&subtype=sensor) rather than
+Most physical sensors in Viam come from modules in the [Viam registry](https://app.viam.com/registry) (search for `sensor`) rather than
 built-in models. This is because the sensor ecosystem is enormous. Thousands
 of different devices with different communication protocols exist, and modules cover
 specific hardware while keeping the same `GetReadings` API.
@@ -43,7 +43,7 @@ Viam-maintained sensor modules:
 | [`viam:viam-telegraf-sensor`](https://app.viam.com/module/viam/viam-telegraf-sensor) | Machine metrics through Telegraf                                |
 | [`viam:lorawan`](https://app.viam.com/module/viam/lorawan)                           | LoRaWAN gateway and node sensors (Milesight, Dragino, and more) |
 
-For sensors not covered above, browse [all sensor modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=sensor).
+For sensors not covered above, search for `sensor` in the [Viam registry](https://app.viam.com/registry).
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-servo.md
+++ b/docs/hardware/common-components/add-a-servo.md
@@ -18,7 +18,7 @@ A servo moves to a specific angle (typically 0-180 degrees) and holds that posit
 
 The built-in `gpio` servo model uses a single PWM-capable pin on a [board component](/hardware/common-components/add-a-board/). Other servo models in the registry support serial, I2C, or dedicated servo-driver boards.
 
-Browse all available servo models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=servo).
+Search for `servo` in the [Viam registry](https://app.viam.com/registry) to see available models.
 
 ### Built-in models
 
@@ -37,7 +37,7 @@ Viam-maintained servo modules:
 | -------------------------------------------------------------------- | ----------------------------------------------------------- |
 | [`viam:raspberry-pi`](https://app.viam.com/module/viam/raspberry-pi) | `rpi-servo` model for hobby servos on Raspberry Pi variants |
 
-For servos not covered above, browse [all servo modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=servo).
+For servos not covered above, search for `servo` in the [Viam registry](https://app.viam.com/registry).
 
 ## Steps
 

--- a/docs/hardware/common-components/add-a-switch.md
+++ b/docs/hardware/common-components/add-a-switch.md
@@ -26,7 +26,7 @@ Physical switch hardware typically comes from a **module in the registry** that
 reads GPIO pins or communicates with a switch controller.
 
 The `fake` built-in model simulates a switch with configurable positions and
-is useful for testing. Browse available switch models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=switch).
+is useful for testing. Search for `switch` in the [Viam registry](https://app.viam.com/registry) to see available models.
 
 ### Built-in models
 
@@ -34,7 +34,7 @@ is useful for testing. Browse available switch models in the [Viam registry](htt
 
 ### Registry modules
 
-For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=switch). Each module's configuration is documented on its registry page.
+For hardware the built-in models don't cover, search for `switch` in the [Viam registry](https://app.viam.com/registry). Each module's configuration is documented on its registry page.
 
 ## Steps
 

--- a/docs/hardware/common-components/add-an-arm.md
+++ b/docs/hardware/common-components/add-an-arm.md
@@ -45,7 +45,7 @@ Viam-maintained arm modules:
 | [`viam:universal-robots`](https://app.viam.com/module/viam/universal-robots) | UR3e, UR5e, UR7e, UR20       |
 | [`viam:yaskawa`](https://app.viam.com/module/viam/yaskawa)                   | GP12, GP180-120              |
 
-For arms not covered above, browse [all arm modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=arm). Each module's configuration is documented on its registry page.
+For arms not covered above, search for `arm` in the [Viam registry](https://app.viam.com/registry). Each module's configuration is documented on its registry page.
 
 ## Steps
 

--- a/docs/hardware/common-components/add-an-encoder.md
+++ b/docs/hardware/common-components/add-an-encoder.md
@@ -27,7 +27,7 @@ signal transitions ("ticks") that correspond to motor shaft rotation.
 
 Once you configure an encoder and reference it from a motor component, the
 motor gains accurate position control. `GoFor` and `GoTo` use actual encoder
-feedback instead of time-based estimates. Browse all available encoder models in the [Viam registry](https://app.viam.com/registry?type=component&subtype=encoder).
+feedback instead of time-based estimates. Search for `encoder` in the [Viam registry](https://app.viam.com/registry) to see available models.
 
 ### Built-in models
 
@@ -48,7 +48,7 @@ Viam-maintained encoder modules:
 | -------------------------------------------------- | ------------------------------------------- |
 | [`viam:ams`](https://app.viam.com/module/viam/ams) | AMS AS5048 magnetic rotary absolute encoder |
 
-For encoders not covered above, browse [all encoder modules in the Viam registry](https://app.viam.com/registry?type=component&subtype=encoder).
+For encoders not covered above, search for `encoder` in the [Viam registry](https://app.viam.com/registry).
 
 ## Steps
 

--- a/docs/hardware/common-components/add-an-input-controller.md
+++ b/docs/hardware/common-components/add-an-input-controller.md
@@ -29,7 +29,7 @@ callbacks for these events and translates them into machine actions.
 
 ### Registry modules
 
-For hardware the built-in models don't cover, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=input_controller). Each module's configuration is documented on its registry page.
+For hardware the built-in models don't cover, search for `input controller` in the [Viam registry](https://app.viam.com/registry). Each module's configuration is documented on its registry page.
 
 ## Steps
 

--- a/docs/navigation/how-to/set-up-gps.md
+++ b/docs/navigation/how-to/set-up-gps.md
@@ -14,9 +14,8 @@ enough to drive the robot.
 
 ## Choose a GPS module
 
-Browse GPS-capable movement sensor models in the
-[Viam registry](https://app.viam.com/registry?type=component&subtype=movement_sensor).
-Search for your GPS hardware by manufacturer or chip name.
+In the [Viam registry](https://app.viam.com/registry), search for `gps` to see GPS-capable
+movement sensor models. You can also search by manufacturer or chip name.
 
 ### GPS accuracy and what it means for navigation
 

--- a/docs/reference/components/arm/_index.md
+++ b/docs/reference/components/arm/_index.md
@@ -18,7 +18,7 @@ Use these pages when you are writing a JSON configuration, debugging a config va
 
 - For how to add and configure a arm component on your machine, see [Arm](/hardware/common-components/add-an-arm/).
 - For the methods you call on a arm in code, see the [Arm API reference](/reference/apis/components/arm/).
-- For arm models outside the built-in set, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=arm). Each registry module's configuration is documented in its own README on its registry page.
+- For arm models outside the built-in set, search for `arm` in the [Viam registry](https://app.viam.com/registry). Each registry module's configuration is documented in its own README on its registry page.
 
 ## Built-in models
 

--- a/docs/reference/components/base/_index.md
+++ b/docs/reference/components/base/_index.md
@@ -18,7 +18,7 @@ Use these pages when you are writing a JSON configuration, debugging a config va
 
 - For how to add and configure a base component on your machine, see [Base](/hardware/common-components/add-a-base/).
 - For the methods you call on a base in code, see the [Base API reference](/reference/apis/components/base/).
-- For base models outside the built-in set, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=base). Each registry module's configuration is documented in its own README on its registry page.
+- For base models outside the built-in set, search for `base` in the [Viam registry](https://app.viam.com/registry). Each registry module's configuration is documented in its own README on its registry page.
 
 ## Built-in models
 

--- a/docs/reference/components/board/_index.md
+++ b/docs/reference/components/board/_index.md
@@ -18,7 +18,7 @@ Use these pages when you are writing a JSON configuration, debugging a config va
 
 - For how to add and configure a board component on your machine, see [Board](/hardware/common-components/add-a-board/).
 - For the methods you call on a board in code, see the [Board API reference](/reference/apis/components/board/).
-- For board models outside the built-in set, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=board). Each registry module's configuration is documented in its own README on its registry page.
+- For board models outside the built-in set, search for `board` in the [Viam registry](https://app.viam.com/registry). Each registry module's configuration is documented in its own README on its registry page.
 
 ## Built-in models
 

--- a/docs/reference/components/button/_index.md
+++ b/docs/reference/components/button/_index.md
@@ -18,8 +18,8 @@ Use these pages when you are writing a JSON configuration, debugging a config va
 
 - For how to add and configure a button component on your machine, see [Button](/hardware/common-components/add-a-button/).
 - For the methods you call on a button in code, see the [Button API reference](/reference/apis/components/button/).
-- For button models outside the built-in set, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=button). Each registry module's configuration is documented in its own README on its registry page.
+- For button models outside the built-in set, search for `button` in the [Viam registry](https://app.viam.com/registry). Each registry module's configuration is documented in its own README on its registry page.
 
 ## Built-in models
 
-No built-in button models ship with `viam-server`. Find button hardware support through the [Viam registry](https://app.viam.com/registry?type=component&subtype=button).
+No built-in button models ship with `viam-server`. Find button hardware support by searching for `button` in the [Viam registry](https://app.viam.com/registry).

--- a/docs/reference/components/camera/_index.md
+++ b/docs/reference/components/camera/_index.md
@@ -19,7 +19,7 @@ Use these pages when you are writing a JSON configuration, debugging a config va
 
 - For how to add and configure a camera component on your machine, see [Add a camera](/hardware/common-components/add-a-camera/).
 - For the methods you call on a camera in code, see the [Camera API reference](/reference/apis/components/camera/).
-- For camera modules outside the built-in set (for example, `realsense` or `viamrtsp`), browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=camera). Each registry module's configuration is documented in its own README on its registry page.
+- For camera modules outside the built-in set (for example, `realsense` or `viamrtsp`), search for `camera` in the [Viam registry](https://app.viam.com/registry). Each registry module's configuration is documented in its own README on its registry page.
 
 ## Built-in models
 

--- a/docs/reference/components/encoder/_index.md
+++ b/docs/reference/components/encoder/_index.md
@@ -18,7 +18,7 @@ Use these pages when you are writing a JSON configuration, debugging a config va
 
 - For how to add and configure a encoder component on your machine, see [Encoder](/hardware/common-components/add-an-encoder/).
 - For the methods you call on a encoder in code, see the [Encoder API reference](/reference/apis/components/encoder/).
-- For encoder models outside the built-in set, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=encoder). Each registry module's configuration is documented in its own README on its registry page.
+- For encoder models outside the built-in set, search for `encoder` in the [Viam registry](https://app.viam.com/registry). Each registry module's configuration is documented in its own README on its registry page.
 
 ## Built-in models
 

--- a/docs/reference/components/gantry/_index.md
+++ b/docs/reference/components/gantry/_index.md
@@ -18,7 +18,7 @@ Use these pages when you are writing a JSON configuration, debugging a config va
 
 - For how to add and configure a gantry component on your machine, see [Gantry](/hardware/common-components/add-a-gantry/).
 - For the methods you call on a gantry in code, see the [Gantry API reference](/reference/apis/components/gantry/).
-- For gantry models outside the built-in set, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=gantry). Each registry module's configuration is documented in its own README on its registry page.
+- For gantry models outside the built-in set, search for `gantry` in the [Viam registry](https://app.viam.com/registry). Each registry module's configuration is documented in its own README on its registry page.
 
 ## Built-in models
 

--- a/docs/reference/components/generic/_index.md
+++ b/docs/reference/components/generic/_index.md
@@ -18,7 +18,7 @@ Use these pages when you are writing a JSON configuration, debugging a config va
 
 - For how to add and configure a generic component on your machine, see [Generic](/hardware/common-components/add-a-generic/).
 - For the methods you call on a generic in code, see the [Generic API reference](/reference/apis/components/generic/).
-- For generic models outside the built-in set, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=generic). Each registry module's configuration is documented in its own README on its registry page.
+- For generic models outside the built-in set, search for `generic` in the [Viam registry](https://app.viam.com/registry). Each registry module's configuration is documented in its own README on its registry page.
 
 ## Built-in models
 

--- a/docs/reference/components/gripper/_index.md
+++ b/docs/reference/components/gripper/_index.md
@@ -18,7 +18,7 @@ Use these pages when you are writing a JSON configuration, debugging a config va
 
 - For how to add and configure a gripper component on your machine, see [Gripper](/hardware/common-components/add-a-gripper/).
 - For the methods you call on a gripper in code, see the [Gripper API reference](/reference/apis/components/gripper/).
-- For gripper models outside the built-in set, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=gripper). Each registry module's configuration is documented in its own README on its registry page.
+- For gripper models outside the built-in set, search for `gripper` in the [Viam registry](https://app.viam.com/registry). Each registry module's configuration is documented in its own README on its registry page.
 
 ## Built-in models
 

--- a/docs/reference/components/input-controller/_index.md
+++ b/docs/reference/components/input-controller/_index.md
@@ -18,7 +18,7 @@ Use these pages when you are writing a JSON configuration, debugging a config va
 
 - For how to add and configure a input controller component on your machine, see [Input controller](/hardware/common-components/add-an-input-controller/).
 - For the methods you call on a input controller in code, see the [Input controller API reference](/reference/apis/components/input-controller/).
-- For input controller models outside the built-in set, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=input_controller). Each registry module's configuration is documented in its own README on its registry page.
+- For input controller models outside the built-in set, search for `input controller` in the [Viam registry](https://app.viam.com/registry). Each registry module's configuration is documented in its own README on its registry page.
 
 ## Built-in models
 

--- a/docs/reference/components/motor/_index.md
+++ b/docs/reference/components/motor/_index.md
@@ -18,7 +18,7 @@ Use these pages when you are writing a JSON configuration, debugging a config va
 
 - For how to add and configure a motor component on your machine, see [Motor](/hardware/common-components/add-a-motor/).
 - For the methods you call on a motor in code, see the [Motor API reference](/reference/apis/components/motor/).
-- For motor models outside the built-in set, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=motor). Each registry module's configuration is documented in its own README on its registry page.
+- For motor models outside the built-in set, search for `motor` in the [Viam registry](https://app.viam.com/registry). Each registry module's configuration is documented in its own README on its registry page.
 
 ## Built-in models
 

--- a/docs/reference/components/movement-sensor/_index.md
+++ b/docs/reference/components/movement-sensor/_index.md
@@ -18,7 +18,7 @@ Use these pages when you are writing a JSON configuration, debugging a config va
 
 - For how to add and configure a movement sensor component on your machine, see [Movement sensor](/hardware/common-components/add-a-movement-sensor/).
 - For the methods you call on a movement sensor in code, see the [Movement sensor API reference](/reference/apis/components/movement-sensor/).
-- For movement sensor models outside the built-in set, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=movement_sensor). Each registry module's configuration is documented in its own README on its registry page.
+- For movement sensor models outside the built-in set, search for `movement sensor` in the [Viam registry](https://app.viam.com/registry). Each registry module's configuration is documented in its own README on its registry page.
 
 ## Built-in models
 

--- a/docs/reference/components/power-sensor/_index.md
+++ b/docs/reference/components/power-sensor/_index.md
@@ -18,7 +18,7 @@ Use these pages when you are writing a JSON configuration, debugging a config va
 
 - For how to add and configure a power sensor component on your machine, see [Power sensor](/hardware/common-components/add-a-power-sensor/).
 - For the methods you call on a power sensor in code, see the [Power sensor API reference](/reference/apis/components/power-sensor/).
-- For power sensor models outside the built-in set, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=power_sensor). Each registry module's configuration is documented in its own README on its registry page.
+- For power sensor models outside the built-in set, search for `power sensor` in the [Viam registry](https://app.viam.com/registry). Each registry module's configuration is documented in its own README on its registry page.
 
 ## Built-in models
 

--- a/docs/reference/components/sensor/_index.md
+++ b/docs/reference/components/sensor/_index.md
@@ -18,7 +18,7 @@ Use these pages when you are writing a JSON configuration, debugging a config va
 
 - For how to add and configure a sensor component on your machine, see [Sensor](/hardware/common-components/add-a-sensor/).
 - For the methods you call on a sensor in code, see the [Sensor API reference](/reference/apis/components/sensor/).
-- For sensor models outside the built-in set, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=sensor). Each registry module's configuration is documented in its own README on its registry page.
+- For sensor models outside the built-in set, search for `sensor` in the [Viam registry](https://app.viam.com/registry). Each registry module's configuration is documented in its own README on its registry page.
 
 ## Built-in models
 

--- a/docs/reference/components/servo/_index.md
+++ b/docs/reference/components/servo/_index.md
@@ -20,7 +20,7 @@ Use these pages when you are writing a JSON configuration, debugging a config va
 
 - For how to add and configure a servo component on your machine, see [Servo](/hardware/common-components/add-a-servo/).
 - For the methods you call on a servo in code, see the [Servo API reference](/reference/apis/components/servo/).
-- For servo models outside the built-in set, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=servo). Each registry module's configuration is documented in its own README on its registry page.
+- For servo models outside the built-in set, search for `servo` in the [Viam registry](https://app.viam.com/registry). Each registry module's configuration is documented in its own README on its registry page.
 
 ## Built-in models
 

--- a/docs/reference/components/switch/_index.md
+++ b/docs/reference/components/switch/_index.md
@@ -18,7 +18,7 @@ Use these pages when you are writing a JSON configuration, debugging a config va
 
 - For how to add and configure a switch component on your machine, see [Switch](/hardware/common-components/add-a-switch/).
 - For the methods you call on a switch in code, see the [Switch API reference](/reference/apis/components/switch/).
-- For switch models outside the built-in set, browse the [Viam registry](https://app.viam.com/registry?type=component&subtype=switch). Each registry module's configuration is documented in its own README on its registry page.
+- For switch models outside the built-in set, search for `switch` in the [Viam registry](https://app.viam.com/registry). Each registry module's configuration is documented in its own README on its registry page.
 
 ## Built-in models
 

--- a/docs/vision/3d-vision/measure-depth.md
+++ b/docs/vision/3d-vision/measure-depth.md
@@ -81,7 +81,7 @@ Common depth-capable cameras and the modules that wrap them:
 - Orbbec cameras, through the [Orbbec module](https://github.com/viam-modules/orbbec)
 - The `fake` camera model, for development without hardware (returns synthetic but structurally correct point clouds)
 
-For other depth cameras, search the [registry](https://app.viam.com/registry?type=component&subtype=camera) for a matching module.
+For other depth cameras, search for `camera` in the [Viam registry](https://app.viam.com/registry).
 
 Check that the depth stream is enabled in the camera's configuration, and confirm the camera reports `supports_pcd: true` through [`GetProperties`](/reference/apis/components/camera/#getproperties). Without depth support, none of the steps below will work.
 


### PR DESCRIPTION
## Summary

Slack thread ([team-modules-registry](https://viaminc.slack.com/archives/C08RLQ7TEV8/p1775574411135329) on Apr 7; Jalen again today) flagged that `https://app.viam.com/registry?type=component&subtype=<X>` URLs in the docs don't actually filter the registry.

Confirmed in `app/ui/src/routes/registry/+page.svelte` and `app/ui/src/lib/registry-item.ts`:

- The registry page reads `?type=` but only accepts exact values `All`, `Module`, `ML Model`, `Training Script` — `type=component` silently falls back to `All`.
- `?subtype=` is not read anywhere on the page.

So every `?type=component&subtype=<X>` link was dumping users onto the unfiltered registry. Fixes 45 such links across 34 pages by linking to `https://app.viam.com/registry` directly and telling the reader what to search for in the search box. Sentence shapes vary, so the rewrite was adapted case-by-case (action, fallback, and mid-sentence declarative forms).

Left alone on purpose: the six `?type=ML+Model` and `?type=Training+Script` links in `docs/cli/reference.md`, `docs/train/custom-training-scripts.md`, and `docs/data/filter-at-the-edge.md` — those values still match the `TypeFilter` enum and filter correctly.

## Test plan

- [x] prettier, markdownlint, vale clean on all 34 files
- [x] `make build-prod` — 947 pages built, no errors
- [x] `make htmltest-fast` — only pre-existing external-link failures (pkg.go.dev 429s, unrelated third-party 404s); nothing in the changed files
- [x] `curl https://app.viam.com/registry` → 200
- [ ] Spot-check a few deploy-preview pages (for example `/hardware/common-components/add-a-motor/` and `/reference/components/switch/`) to confirm the prose reads naturally