### PR TITLE
write-an-inline-module: Playbook 1 review — correctness, scaffold orientation, worked-example framing

### DIFF
--- a/docs/build-modules/write-an-inline-module.md
+++ b/docs/build-modules/write-an-inline-module.md
@@ -21,6 +21,12 @@ directly in the Viam app's browser-based editor -- no IDE, terminal, or GitHub
 account required. When you click **Save & Deploy**, Viam builds your module in
 the cloud and deploys it to your machine automatically.
 
+Inline modules implement the Generic service API -- a single `DoCommand`
+method for arbitrary control logic. To write a hardware driver or use a more
+specific API, see
+[Write a driver module](/build-modules/write-a-driver-module/) or
+[Write a logic module](/build-modules/write-a-logic-module/).
+
 {{< alert title="Availability" color="tip" >}}
 Inline modules are currently available to organizations that have the feature
 enabled. If you do not see the **Viam-hosted** option when adding code, contact
@@ -30,6 +36,11 @@ Viam support to request access.
 For background on inline modules, how they compare to externally managed
 modules, and the Generic service API, see the
 [overview](/build-modules/overview/#inline-and-externally-managed-modules).
+
+To illustrate each step, this page uses a distance-responsive servo controller
+as a worked example -- a service that reads an ultrasonic sensor and adjusts a
+servo angle based on distance. The same patterns apply to any control logic;
+substitute your own attributes, dependencies, and command behavior.
 
 ## Steps
 
@@ -43,6 +54,10 @@ modules, and the Generic service API, see the
 4. Name your module (for example, `servo-distance-control`) and choose a language
    (**Python** or **Go**).
 5. Click **Create module**.
+
+You can also reach this dialog from your machine's **CONNECT** tab by selecting
+**Control code sample** from the sidebar and clicking **Create inline module**.
+Both paths open the same dialog and land you in the same editor.
 
 The browser opens the code editor with a working template that includes all
 necessary imports and method stubs.
@@ -61,7 +76,7 @@ extends `GenericService` and `EasyResource`:
 ```python
 class MyGenericService(GenericService, EasyResource):
     MODEL: ClassVar[Model] = Model(
-        ModelFamily("my-org", "my-module"), "generic-service"
+        ModelFamily("my-org", "servo-distance-control"), "generic-service"
     )
 ```
 
@@ -85,8 +100,9 @@ The editable file is `module.go`. It contains a struct, a config type, and
 registration logic:
 
 ```go
-var GenericService = resource.NewModel(
-    "my-org", "my-module", "generic-service",
+var (
+    GenericService   = resource.NewModel("my-org", "servo-distance-control", "generic-service")
+    errUnimplemented = errors.New("unimplemented")
 )
 
 func init() {
@@ -98,12 +114,20 @@ func init() {
 }
 ```
 
-The three areas to implement:
+`errUnimplemented` is a pre-declared error value you can return from method
+branches you have not implemented yet (for example,
+`return nil, errUnimplemented`).
 
+The areas you'll edit:
+
+- **`Config` struct** -- add JSON-tagged fields for each attribute your
+  service accepts.
 - **`Validate`** on the `Config` struct -- check attributes, return
   dependencies.
-- **`NewGenericService`** -- initialize the service with attributes and
-  dependencies.
+- **`genericService` struct** -- add fields to hold runtime state
+  (resolved dependencies, parsed config values).
+- **`NewGenericService`** -- populate the struct fields from attributes
+  and dependencies.
 - **`DoCommand`** -- your control logic.
 
 {{< alert title="Important" color="caution" >}}
@@ -123,7 +147,17 @@ on other components or services.
 
 This example validates attributes for a distance-responsive servo controller --
 a service that reads an ultrasonic sensor and adjusts a servo angle based on
-distance:
+distance.
+
+For this example, we use:
+
+- `sensor_range_start` -- lowest expected sensor reading, in meters. Required.
+- `sensor_range_end` -- highest expected sensor reading, in meters. Required.
+- `servo_angle_min` -- servo angle at the low end of the sensor range, in degrees. Optional; defaults to 0.
+- `servo_angle_max` -- servo angle at the high end of the sensor range, in degrees. Optional; defaults to 180.
+- `reversed` -- if true, map the low sensor reading to the high servo angle. Optional; defaults to false.
+- `servo` -- name of the servo component the service controls. Required.
+- `sensor` -- name of the distance sensor the service reads. Required.
 
 {{< tabs >}}
 {{% tab name="Python" %}}
@@ -248,7 +282,7 @@ def new(
     cls, config: ComponentConfig,
     dependencies: Mapping[ResourceName, ResourceBase]
 ) -> Self:
-    self = await super().new(config, dependencies)
+    self = super().new(config, dependencies)
     attrs = struct_to_dict(config.attributes)
 
     # Required attributes
@@ -319,6 +353,12 @@ func NewGenericService(
     }, nil
 }
 ```
+
+The scaffold contains both a private constructor, `newGenericService`, and a
+public constructor, `NewGenericService`. The private constructor converts the
+raw `resource.Config` into a typed `*Config` and delegates to the public
+constructor. Leave the private constructor alone -- put your logic in
+`NewGenericService`.
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -415,8 +455,12 @@ added.
 #### Configure the service
 
 1. In the module section, click **Add** to add a model of your generic service.
-2. Click **+** to add each dependency your service requires (for example, a servo and
-   a sensor). Configure each dependency with the appropriate attributes.
+2. If your service depends on any hardware that isn't already configured on the
+   machine, add those components now. Click the **+** icon next to your machine
+   part's name in the left sidebar and follow
+   [Configure hardware components](/hardware/configure-hardware/) to pick a
+   model and set attributes. The service references components by the names
+   you give them.
 3. Configure the attributes for your generic service:
 
 ```json


### PR DESCRIPTION
## Summary

Playbook 1 review of `write-an-inline-module.md`, verified against the inline editor's source code (`app/ui/src/lib/module-templates/template-py.ts`, `template-go.ts`) and the live editor's emitted scaffold.

- **Correctness fix:** remove `await` from `super().new(...)` in the Python constructor — `EasyResource.new` is a non-async classmethod, so the `await` is a hard SyntaxError. Verified via `python3 compile()` and against the editor's actual output.
- **Scaffold preview alignment:** the Section 2 Go snippet now shows the real `var (...)` block including `errUnimplemented`, matching what the editor emits.
- **"Areas you'll edit" expanded** for Go to include the `Config` struct and `genericService` struct edits a reader actually has to make.
- **Two-constructor split explained** so readers know `newGenericService` (private) is a stable adapter and `NewGenericService` (public) is where their logic goes.
- **Up-front worked-example framing** added (matches the sibling driver/logic module pages), plus an attribute list with units and required/optional status.
- **Generic service API constraint** stated explicitly, with cross-links to the driver and logic module pages for readers who need a different API.
- **Second entry point** documented: CONNECT tab → Control code sample → Create inline module. Both paths land in the same dialog and editor.
- **Dependency step reframed** around realistic state (most readers already have hardware) with a link to Configure hardware components.
- **Worked-example consistency**: Section 2 model triplet now uses `servo-distance-control` instead of generic `my-module`.

## Test plan

- [ ] Vale: 0 errors / 0 warnings (verified locally)
- [ ] Prettier: no changes (verified locally)
- [ ] Hugo `make build-prod`: succeeds (verified locally)
- [ ] Spot-check the Netlify deploy preview for the page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)