### PR TITLE
cli/reference: restructure per-subcommand and add missing commands

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -17,6 +17,19 @@ All commands use this format:
 viam [global options] command [command options] [arguments...]
 ```
 
+## Global options
+
+You can pass global options after the `viam` CLI keyword with any command.
+
+<!-- prettier-ignore -->
+| Global option | Description |
+| ------------- | ----------- |
+| `--debug` | Enable debug logging. Default: `false`. |
+| `--disable-profiles`, `disable-profile` | Disable usage of [profiles](#profiles), falling back to default (false) behavior. Default: `false`. |
+| `--help`, `-h` | Show help. Default: `false`. |
+| `--profile` | Specify a particular [profile](#profiles) for the current command. |
+| `--quiet`, `-q` | Suppress warnings. Default: `false` |
+
 ## `data`
 
 The `data` command allows you to manage machine data.
@@ -2746,16 +2759,3 @@ Convert a xacro file to URDF.
 | `--collapse-fixed-joints` | Collapse fixed-joint chains to ensure only one end effector exists. | Optional |
 | `--install-packages` | Install `ros-<distro>-xacro` in the container (required for the default image). Disable only if your custom image already includes xacro. | Optional |
 | `--dry-run` | Show the docker command without executing it. | Optional |
-
-## Global options
-
-You can pass global options after the `viam` CLI keyword with any command.
-
-<!-- prettier-ignore -->
-| Global option | Description |
-| ------------- | ----------- |
-| `--debug` | Enable debug logging. Default: `false`. |
-| `--disable-profiles`, `disable-profile` | Disable usage of [profiles](#profiles), falling back to default (false) behavior. Default: `false`. |
-| `--help`, `-h` | Show help. Default: `false`. |
-| `--profile` | Specify a particular [profile](#profiles) for the current command. |
-| `--quiet`, `-q` | Suppress warnings. Default: `false` |

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -17,9 +17,7 @@ All commands use this format:
 viam [global options] command [command options] [arguments...]
 ```
 
-## Commands
-
-### `data`
+## `data`
 
 The `data` command allows you to manage machine data.
 With it, you can export data in a variety of formats, delete data, add or remove tags from all data that matches a given filter, or configure a database user to enable querying synced data directly in the cloud.
@@ -41,7 +39,7 @@ viam data index delete --collection-type=<type> --index-name=<name> [--org-id=<o
 viam data index list --collection-type=<type> [--org-id=<org-id>]
 ```
 
-#### `data export tabular`
+### `data export tabular`
 
 Export tabular or sensor data to a specified location in the <file>.ndjson</file> output format. You can copy this from the UI with a filter. See [Copy `export` command](#copy-export-command).
 
@@ -61,7 +59,7 @@ viam data export tabular --part-id=e1234f0c-912c-1234-a123-5ac1234612345 --resou
 | `--start` | ISO-8601 timestamp indicating the start of the interval. | Optional |
 | `--end` | ISO-8601 timestamp indicating the end of the interval. | Optional |
 
-#### `data export binary filter`
+### `data export binary filter`
 
 Export binary or image data matching a filter to a specified location. Binary data will be downloaded in the original output it was specified as. You can copy this from the UI with a filter. See [Copy `export` command](#copy-export-command).
 
@@ -91,7 +89,7 @@ viam data export binary filter --mime-types=image/jpeg,image/png --org-ids=12345
 | `--tags` | Filter by specified tag (accepts comma-separated list). | Optional |
 | `--timeout` | Number of seconds to wait for file downloads. Default: `30`. | Optional |
 
-#### `data export binary ids`
+### `data export binary ids`
 
 Export binary or image data by binary data ID to a specified location.
 
@@ -107,7 +105,7 @@ viam data export binary ids --destination=<output path> --binary-data-ids=<binar
 | `--parallel` | Number of download requests to make in parallel. Default: `100`. | Optional |
 | `--timeout` | Number of seconds to wait for file downloads. Default: `30`. | Optional |
 
-#### `data delete binary`
+### `data delete binary`
 
 Delete binary data from the Viam Cloud.
 
@@ -144,7 +142,7 @@ for i in {00..59}; do
 done
 ```
 
-#### `data delete tabular`
+### `data delete tabular`
 
 Delete tabular data from the Viam Cloud.
 
@@ -158,7 +156,7 @@ viam data delete tabular --org-id=<org-id> --delete-older-than-days=<N>
 | `--org-id` | The organization ID. | **Required** |
 | `--delete-older-than-days` | Number of days, 0 means all data will be deleted. | **Required** |
 
-#### `data database configure`
+### `data database configure`
 
 Create a new database user for the Viam organization's MongoDB Atlas Data Federation instance, or change the password of an existing user. See [Configure data query](/data/query-data/).
 
@@ -174,7 +172,7 @@ viam data database configure --org-id=abc --password=my_password123
 | `--org-id` | The organization ID. Uses default org if set. | Optional |
 | `--password` | Password for the database user being configured. | **Required** |
 
-#### `data database hostname`
+### `data database hostname`
 
 Get the MongoDB Atlas Data Federation instance hostname and connection URI. See [Configure data query](/data/query-data/).
 
@@ -188,7 +186,7 @@ viam data database hostname --org-id=abc
 | -------- | ----------- | --------- |
 | `--org-id` | The organization ID. Uses default org if set. | Optional |
 
-#### `data tag ids add`
+### `data tag ids add`
 
 Add tags to all data that matches the given binary data IDs.
 
@@ -205,7 +203,7 @@ See [Using the `ids` argument](#using-the-ids-argument) for details on retrievin
 | `--binary-data-ids` | Binary data IDs to add tags to. | **Required** |
 | `--tags` | Tags to add (accepts comma-separated list). | Optional |
 
-#### `data tag ids remove`
+### `data tag ids remove`
 
 Remove tags from all data that matches the given binary data IDs.
 
@@ -220,7 +218,7 @@ viam data tag ids remove --tags=new_tag_1,new_tag_2,new_tag_3 --binary-data-ids=
 | `--binary-data-ids` | Binary data IDs to remove tags from. | **Required** |
 | `--tags` | Tags to remove (accepts comma-separated list). | Optional |
 
-#### `data tag filter add`
+### `data tag filter add`
 
 Add tags to all data that matches a given filter. See [Using the `filter` argument](#using-the-filter-argument).
 
@@ -248,7 +246,7 @@ viam data tag filter add --tags=new_tag_1,new_tag_2 --location-ids=012 --machine
 | `--start` | ISO-8601 timestamp indicating the start of the interval. | Optional |
 | `--end` | ISO-8601 timestamp indicating the end of the interval. | Optional |
 
-#### `data tag filter remove`
+### `data tag filter remove`
 
 Remove tags from all data that matches a given filter. See [Using the `filter` argument](#using-the-filter-argument).
 
@@ -276,7 +274,7 @@ viam data tag filter remove --tags=new_tag_1 --location-ids=012 --machine-name=c
 | `--start` | ISO-8601 timestamp indicating the start of the interval. | Optional |
 | `--end` | ISO-8601 timestamp indicating the end of the interval. | Optional |
 
-#### `data index create`
+### `data index create`
 
 Create a custom index on a data collection.
 
@@ -292,7 +290,7 @@ viam data index create --collection-type=<type> --index-path=<file> [--org-id=<o
 | `--org-id` | The organization ID. Uses default org if set. | Optional |
 | `--pipeline-name` | Name of the data pipeline (required when `--collection-type` is `pipeline-sink`). | Conditional |
 
-#### `data index delete`
+### `data index delete`
 
 Delete a custom index from a data collection.
 
@@ -308,7 +306,7 @@ viam data index delete --collection-type=<type> --index-name=<name> [--org-id=<o
 | `--org-id` | The organization ID. Uses default org if set. | Optional |
 | `--pipeline-name` | Name of the data pipeline (required when `--collection-type` is `pipeline-sink`). | Conditional |
 
-#### `data index list`
+### `data index list`
 
 List all custom indexes for a data collection.
 
@@ -322,7 +320,7 @@ viam data index list --collection-type=<type> [--org-id=<org-id>]
 | `--collection-type` | Data collection type for index operations. Options: `hot-storage`, `pipeline-sink`. | **Required** |
 | `--org-id` | The organization ID. Uses default org if set. | Optional |
 
-### `datapipelines`
+## `datapipelines`
 
 The `datapipelines` command provides access to data pipelines for processing machine data with {{< glossary_tooltip term_id="mql" text="MQL" >}} queries.
 Data pipelines help you optimize query performance for frequently accessed complex data transformations.
@@ -337,7 +335,7 @@ viam datapipelines disable --id=<pipeline-id>
 viam datapipelines delete --id=<pipeline-id>
 ```
 
-#### `datapipelines create`
+### `datapipelines create`
 
 Create a new data pipeline.
 
@@ -360,7 +358,7 @@ viam datapipelines create --org-id=123 --name="Real-time Analytics" --schedule="
 | `--mql-path` | Path to a JSON file containing the MQL query for the data pipeline. You must specify either `--mql` or `--mql-path` when creating a pipeline. | Optional |
 | `--data-source-type` | Data source type for the pipeline. Options: `standard` (default), `hotstorage`. | Optional |
 
-#### `datapipelines rename`
+### `datapipelines rename`
 
 Rename a data pipeline.
 
@@ -374,7 +372,7 @@ viam datapipelines rename --id=<pipeline-id> --name=<new-name>
 | `--id` | ID of the data pipeline. | **Required** |
 | `--name` | New name for the data pipeline. | **Required** |
 
-#### `datapipelines list`
+### `datapipelines list`
 
 List all data pipelines in an organization.
 
@@ -387,7 +385,7 @@ viam datapipelines list --org-id=123
 | -------- | ----------- | --------- |
 | `--org-id` | ID of the organization that owns the data pipelines. Uses default org if set. | Optional |
 
-#### `datapipelines describe`
+### `datapipelines describe`
 
 Get detailed information about a specific data pipeline.
 
@@ -400,7 +398,7 @@ viam datapipelines describe --id=abc123
 | -------- | ----------- | --------- |
 | `--id` | ID of the data pipeline. | **Required** |
 
-#### `datapipelines enable`
+### `datapipelines enable`
 
 Resume executing a disabled data pipeline.
 
@@ -413,7 +411,7 @@ viam datapipelines enable --id=abc123
 | -------- | ----------- | --------- |
 | `--id` | ID of the data pipeline. | **Required** |
 
-#### `datapipelines disable`
+### `datapipelines disable`
 
 Stop executing a data pipeline without deleting it.
 
@@ -426,7 +424,7 @@ viam datapipelines disable --id=abc123
 | -------- | ----------- | --------- |
 | `--id` | ID of the data pipeline. | **Required** |
 
-#### `datapipelines delete`
+### `datapipelines delete`
 
 Delete a data pipeline.
 
@@ -439,7 +437,7 @@ viam datapipelines delete --id=abc123
 | -------- | ----------- | --------- |
 | `--id` | ID of the data pipeline. | **Required** |
 
-### `dataset`
+## `dataset`
 
 The `dataset` command allows you to manage machine data in datasets.
 With it, you can add or remove images from a dataset, export data from a dataset, or filter a dataset by tags.
@@ -458,7 +456,7 @@ viam dataset data add ids --dataset-id=<dataset-id>  --binary-data-ids=<binary-d
 viam dataset data remove ids --dataset-id=<dataset-id> --binary-data-ids=<binary-data-ids>
 ```
 
-#### `dataset create`
+### `dataset create`
 
 Create a new dataset.
 
@@ -472,7 +470,7 @@ viam dataset create --org-id=123 --name=MyDataset
 | `--org-id` | Organization ID of the organization the dataset belongs to. | **Required** |
 | `--name` | The name of the dataset to create. | **Required** |
 
-#### `dataset rename`
+### `dataset rename`
 
 Rename an existing dataset.
 
@@ -486,7 +484,7 @@ viam dataset rename --dataset-id=123 --name=MyCoolDataset
 | `--dataset-id` | Dataset to rename. To retrieve the ID, navigate to your dataset's page, click **…** in the left-hand menu, and click **Copy dataset ID**. | **Required** |
 | `--name` | The new name for the dataset. | **Required** |
 
-#### `dataset list`
+### `dataset list`
 
 List dataset information from specified IDs or for an org ID.
 
@@ -504,7 +502,7 @@ viam dataset list --dataset-ids=123,456
 | `--org-id` | Organization ID of the organization the dataset belongs to. | Optional |
 | `--dataset-ids` | Dataset IDs of datasets to be listed (comma-separated list). To retrieve these IDs, navigate to your dataset's page, click **…** in the left-hand menu, and click **Copy dataset ID**. | Optional |
 
-#### `dataset delete`
+### `dataset delete`
 
 Delete a dataset.
 
@@ -517,7 +515,7 @@ viam dataset delete --dataset-id=123
 | -------- | ----------- | --------- |
 | `--dataset-id` | Dataset to delete. | **Required** |
 
-#### `dataset export`
+### `dataset export`
 
 Download all the data from a dataset to a specified output directory in two folders called "data" and "metadata".
 
@@ -534,7 +532,7 @@ viam dataset export --destination=./dataset/example --dataset-id=abc
 | `--force-linux-path` | Force the use of Linux-style paths in the dataset.jsonl file. | Optional |
 | `--parallel` | Number of download requests to make in parallel, with a default value of 100. | Optional |
 
-#### `dataset merge`
+### `dataset merge`
 
 Merge multiple datasets into a new dataset.
 
@@ -549,7 +547,7 @@ viam dataset merge --name=CombinedDataset --dataset-ids=123,456 --org-id=789
 | `--dataset-ids` | Dataset IDs of datasets to merge (comma-separated list). | **Required** |
 | `--org-id` | Organization ID of the organization the dataset belongs to. | **Required** |
 
-#### `dataset data add ids`
+### `dataset data add ids`
 
 Add new images to an existing dataset by binary data ID. See [Using the `ids` argument](#using-the-ids-argument) for details on retrieving the IDs.
 
@@ -564,7 +562,7 @@ viam dataset data add ids --dataset-id=abc --binary-data-ids=aaa,bbb
 | `--binary-data-ids` | The binary data IDs of the images to add. | **Required** |
 | `--org-id` | Organization ID of the organization the dataset belongs to. | Optional |
 
-#### `dataset data add filter`
+### `dataset data add filter`
 
 Add to an existing dataset images that match a specified [filter](#using-the-filter-argument).
 
@@ -592,7 +590,7 @@ viam dataset data add filter --dataset-id=abc --location-ids=123 --org-ids=456 -
 | `--part-id` | Filter data on part ID. | Optional |
 | `--part-name` | Filter data on part name. | Optional |
 
-#### `dataset data remove ids`
+### `dataset data remove ids`
 
 Remove images from an existing dataset by binary data ID. See [Using the `ids` argument](#using-the-ids-argument) for details on retrieving the IDs.
 
@@ -606,7 +604,7 @@ viam dataset data remove ids --dataset-id=abc --binary-data-ids=aaa,bbb
 | `--dataset-id` | Dataset to remove images from. | **Required** |
 | `--binary-data-ids` | The binary data IDs of the images to remove. | **Required** |
 
-#### `dataset data remove filter`
+### `dataset data remove filter`
 
 Remove from an existing dataset images that match a specified [filter](#using-the-filter-argument).
 
@@ -633,7 +631,7 @@ viam dataset data remove filter --dataset-id=abc --location-ids=123 --org-ids=45
 | `--part-id` | Filter data on part ID. | Optional |
 | `--part-name` | Filter data on part name. | Optional |
 
-#### Using the `ids` argument
+### Using the `ids` argument
 
 When you use the `viam dataset data add` and `viam dataset data remove` commands, you specify images to add or remove using their binary data IDs as a comma-separated list.
 For example, the following command adds three images specified by their binary data IDs to the specified dataset:
@@ -661,7 +659,7 @@ The **Binary Data ID** is shown under the **DETAILS** subtab that appears on the
 
 You cannot use filter arguments such as `--start` or `--end` with the `ids` argument.
 
-#### Using the `filter` argument
+### Using the `filter` argument
 
 When you use the `viam dataset data add`, `viam dataset data remove` or `viam data tag` commands, you can optionally `filter` by common search criteria to `add` or `remove` a specific subset of images based on a search filter.
 For example, the following command adds all images captured between January 1 and October 1, 2023, that have the `example` tag applied, to the specified dataset:
@@ -681,7 +679,7 @@ Click **...** in the left-hand menu and click **Copy dataset ID**.
 
 To find a location ID, run `viam locations list` or visit your [fleet's page](https://app.viam.com/robots) and copy from **Location ID**.
 
-##### Copy `export` command
+#### Copy `export` command
 
 You can also have the filter parameters generated for you using the **Filters** pane of the **DATA** tab.
 Navigate to the [**DATA** tab](https://app.viam.com/data/view), make your selections from the search parameters under the **Filters** pane (such as robot name, start and end time, or tags), and click the **Copy export command** button.
@@ -692,7 +690,7 @@ You cannot use the `--binary-data-ids` argument when using `filter`.
 
 See [Create a dataset](/train/create-a-dataset/) for more information.
 
-### `defaults`
+## `defaults`
 
 The `defaults` command sets or clears default argument values so you do not have to pass the same `--org-id` or `--location-id` flag on every command. Once set, the value is read from your CLI config and used as the default for any command that accepts that argument.
 
@@ -703,7 +701,7 @@ viam defaults set-location --location-id=<location-id>
 viam defaults clear-location
 ```
 
-#### `defaults set-org`
+### `defaults set-org`
 
 Set the default organization argument.
 
@@ -712,11 +710,11 @@ Set the default organization argument.
 | -------- | ----------- | --------- |
 | `--org-id` | The organization ID to set as the default. | **Required** |
 
-#### `defaults clear-org`
+### `defaults clear-org`
 
 Clear the default organization argument.
 
-#### `defaults set-location`
+### `defaults set-location`
 
 Set the default location argument.
 
@@ -725,11 +723,11 @@ Set the default location argument.
 | -------- | ----------- | --------- |
 | `--location-id` | The location ID to set as the default. | **Required** |
 
-#### `defaults clear-location`
+### `defaults clear-location`
 
 Clear the default location argument.
 
-### `infer`
+## `infer`
 
 The `infer` command enables you to run [cloud inference](/vision/configure/) on data. Cloud inference runs in the cloud, instead of on a local machine.
 
@@ -763,7 +761,7 @@ Bounding Box Format: [x_min, y_min, x_max, y_max]
 | `--org-id` | The organization ID of the organization that will run the inference. | **Required** |
 | `--model-org-id` | The organization ID of the organization that owns the model. | **Required** |
 
-### `locations`
+## `locations`
 
 The `locations` command allows you to manage the [locations](/reference/) that you have access to.
 With it, you can list available locations, filter locations by organization, or create a new location API key.
@@ -773,7 +771,7 @@ viam locations list [<organization id>]
 viam locations api-key create --location-id=<location-id>
 ```
 
-#### `locations list`
+### `locations list`
 
 List all locations (name and id) that the authenticated session has access to, grouped by organization.
 
@@ -783,7 +781,7 @@ viam locations list [<organization id>]
 
 Pass an organization ID as a positional argument to return results for that organization only. Optional.
 
-#### `locations api-key create`
+### `locations api-key create`
 
 Create an API key for a specific location.
 
@@ -798,7 +796,7 @@ viam locations api-key create --location-id=<location-id>
 | `--name` | The name of the API key. | Optional |
 | `--org-id` | The organization ID to attach the key to. | Optional |
 
-### `login`
+## `login`
 
 The `login` command authorizes your device for CLI usage.
 By default, `viam login` opens a browser to authenticate using a personal access token.
@@ -817,7 +815,7 @@ viam login print-access-token
 | -------- | ----------- | --------- |
 | `--no-browser` | Authenticate in a headless environment by preventing the opening of the default browser during login. Default: `false`. | Optional |
 
-#### `login api-key`
+### `login api-key`
 
 Authenticate to Viam using an organization, location, or machine part API key.
 
@@ -831,7 +829,7 @@ viam login api-key --key-id=<api-key-uuid> --key=<api-key-secret-value>
 | `--key-id` | The `key id` (UUID) of the API key. | **Required** |
 | `--key` | The `key value` of the API key. | **Required** |
 
-#### `login print-access-token`
+### `login print-access-token`
 
 Print the access token used to authenticate the current CLI session.
 
@@ -839,7 +837,7 @@ Print the access token used to authenticate the current CLI session.
 viam login print-access-token
 ```
 
-### `logout`
+## `logout`
 
 The `logout` command ends an authenticated CLI session.
 
@@ -847,7 +845,7 @@ The `logout` command ends an authenticated CLI session.
 viam logout
 ```
 
-### `machines` (alias `robots` and `machine`)
+## `machines` (alias `robots` and `machine`)
 
 The `machines` command allows you to manage your machine fleet.
 This includes:
@@ -881,7 +879,7 @@ viam machines part cp --part=<part id> <file name> machine:/path/to/file
 
 To use `part shell` and `part cp`, add the [`ViamShellDanger` fragment](https://app.viam.com/fragment/b511adfa-80ab-4a70-9bd5-fbb14696b17e/json), which contains the latest version of the shell service.
 
-#### `machines create`
+### `machines create`
 
 Create a new machine in a specified location.
 
@@ -895,7 +893,7 @@ viam machines create --name="My Machine" --location=12345
 | `--name` | Name for the machine. | **Required** |
 | `--location` | ID of the location that the machine belongs to. | **Required** |
 
-#### `machines update`
+### `machines update`
 
 Move a machine from one location to another and/or rename the machine.
 
@@ -913,7 +911,7 @@ viam machines update --machine=123 --location=67890
 | `--organization` | ID of the organization that the machine belongs to. | Optional |
 | `--location` | ID of the current location of the machine. | Optional |
 
-#### `machines delete`
+### `machines delete`
 
 Delete a machine. Passing location and organization is optional but speeds up the process.
 
@@ -928,7 +926,7 @@ viam machines delete --machine=123
 | `--location` | ID of the location that the machine belongs to. | Optional |
 | `--organization` | ID of the organization that the machine belongs to. | Optional |
 
-#### `machines list`
+### `machines list`
 
 List all machines that the authenticated session has access to in a specified organization or location. Defaults to first organization and location alphabetically.
 
@@ -944,7 +942,7 @@ viam machines list --all --organization=12345
 | `--location` | ID of the location to list machines in. | Optional |
 | `--organization` | ID of the organization to list machines in. | Optional |
 
-#### `machines status`
+### `machines status`
 
 Retrieve machine status for a specified machine.
 
@@ -960,7 +958,7 @@ viam machines status --machine=123
 | `--location` | ID of the location that the machine belongs to. | Optional |
 | `--organization` | ID of the organization that the machine belongs to. | Optional |
 
-#### `machines logs`
+### `machines logs`
 
 Retrieve logs for a specified machine.
 
@@ -984,7 +982,7 @@ viam machines logs --machine=123
 | `--location` | ID of the location that the machine belongs to. | Optional |
 | `--organization` | ID of the organization that the machine belongs to. | Optional |
 
-#### `machines api-key create`
+### `machines api-key create`
 
 Create an API key for a specific machine.
 
@@ -999,7 +997,7 @@ viam machines api-key create --machine-id=123 --name=MyKey
 | `--machine-id` | The ID of the machine to create an API key for. | **Required** |
 | `--name` | The optional name of the API key. If omitted, a name will be auto-generated. | Optional |
 
-#### `machines part list`
+### `machines part list`
 
 List machine parts.
 
@@ -1015,7 +1013,7 @@ viam machines part list --machine=123
 | `--location` | ID of the location that the machine belongs to. | Optional |
 | `--organization` | ID of the organization that the machine belongs to. | Optional |
 
-#### `machines part status`
+### `machines part status`
 
 Retrieve machine status for a specified machine part.
 
@@ -1030,7 +1028,7 @@ viam machines part status --machine=<machine id>
 | `--location` | ID of the location that the machine belongs to. | Optional |
 | `--organization` | ID of the organization that the machine belongs to. | Optional |
 
-#### `machines part run`
+### `machines part run`
 
 Run a component or service command, optionally at a specified interval. For commands that return data in their response, you can use this to stream data. See [Using the `--stream` and `--data` arguments](#using-the---stream-and---data-arguments).
 
@@ -1048,7 +1046,7 @@ viam.service.vision.v1.VisionService.GetClassificationsFromCamera
 | `--data` | Command data for the command being request to run. See [Using the `--stream` and `--data` arguments](#using-the---stream-and---data-arguments). | **Required** |
 | `--stream` | If specified, the interval in which to stream the specified data, for example, 100ms or 1s. | Optional |
 
-#### `machines part logs`
+### `machines part logs`
 
 Get logs for the specified machine part.
 
@@ -1071,7 +1069,7 @@ viam machines part logs --part=myrover-main --tail=true
 | `--format` | The file format for the output file. Options: `text` or `json`. | Optional |
 | `--output` | The path to the output file to store logs in. | Optional |
 
-#### `machines part shell`
+### `machines part shell`
 
 Access a machine part securely using a secure shell to execute commands. To use this feature you must add the [`ViamShellDanger` fragment](https://app.viam.com/fragment/b511adfa-80ab-4a70-9bd5-fbb14696b17e/json). The `ViamShellDanger` fragment contains the latest version of the shell service, which you must add to your machine before copying files or using the shell.
 
@@ -1084,7 +1082,7 @@ viam machines part shell --machine=<machine id> --part=<part id>
 | -------- | ----------- | --------- |
 | `--part` | Part ID for which the command is being issued. | **Required** |
 
-#### `machines part restart`
+### `machines part restart`
 
 Restart a machine part.
 
@@ -1098,7 +1096,7 @@ viam machines part restart --part=123
 | -------- | ----------- | --------- |
 | `--part` | Part ID for which the command is being issued. | **Required** |
 
-#### `machines part cp`
+### `machines part cp`
 
 Copy files to and from a machine part. To use this feature you must add the [`ViamShellDanger` fragment](https://app.viam.com/fragment/b511adfa-80ab-4a70-9bd5-fbb14696b17e/json), which contains the shell service, to your machine. Once added you can use `cp` in a similar way to the Linux `scp` command to copy files to and from machines.
 
@@ -1129,7 +1127,7 @@ viam machines part cp --part=123 -r -p machine:my_dir machine:my_file ~/some/exi
 | `--recursive`, `-r` | Recursively copy files. Default: `false`. | Optional |
 | `--preserve`, `-p` | Preserve modification times and file mode bits from the source files. Default: `false`. | Optional |
 
-#### `machines part tunnel`
+### `machines part tunnel`
 
 Tunnel connections to a specified port on a machine part. You must explicitly enumerate ports to which you are allowed to tunnel in your machine's JSON config. See [Tunnel to a machine part](/fleet/system-settings/).
 
@@ -1145,7 +1143,7 @@ viam machines part tunnel --part=123 --destination-port=1111 --local-port 2222
 | `--destination-port` | The port on a machine part to tunnel to. | **Required** |
 | `--local-port` | The local port from which to tunnel. | **Required** |
 
-#### `machines part get-ftdc`
+### `machines part get-ftdc`
 
 Download FTDC data from a machine part. Requires the shell service.
 
@@ -1159,7 +1157,7 @@ viam machines part get-ftdc --part=123 ~/some/existing/dir/
 | -------- | ----------- | --------- |
 | `--part` | Part ID for which the command is being issued. | **Required** |
 
-#### `machines part create`
+### `machines part create`
 
 Create a new part on a machine.
 
@@ -1173,7 +1171,7 @@ viam machines part create --machine=<machine id> --part-name=<new part name>
 | `--machine` | Machine ID or name. | **Required** |
 | `--part-name` | Name for the new part. | **Required** |
 
-#### `machines part delete`
+### `machines part delete`
 
 Delete a part.
 
@@ -1186,7 +1184,7 @@ viam machines part delete --part=<part id>
 | -------- | ----------- | --------- |
 | `--part` | Part ID to delete. | **Required** |
 
-#### `machines part add-resource`
+### `machines part add-resource`
 
 Add a component or service to a part's configuration by specifying an API and model triplet.
 
@@ -1201,7 +1199,7 @@ viam machines part add-resource --part=<part id> --name=<resource name> --model-
 | `--name` | Name for the resource. | **Required** |
 | `--model-name` | Model triplet (`namespace:type:model`) for the resource to add. | **Required** |
 
-#### `machines part remove-resource`
+### `machines part remove-resource`
 
 Remove a resource from a part's configuration.
 
@@ -1215,7 +1213,7 @@ viam machines part remove-resource --part=<part id> --name=<resource name>
 | `--part` | Part ID for which the command is being issued. | **Required** |
 | `--name` | Name of the resource to remove. | **Required** |
 
-#### `machines part fragments add`
+### `machines part fragments add`
 
 Attach a configuration fragment to a part.
 
@@ -1229,7 +1227,7 @@ viam machines part fragments add --part=<part id> [--fragment=<fragment id>]
 | `--part` | Part ID for which the command is being issued. | **Required** |
 | `--fragment` | Fragment ID to add. If omitted, the CLI prompts interactively. | Optional |
 
-#### `machines part fragments remove`
+### `machines part fragments remove`
 
 Detach a configuration fragment from a part.
 
@@ -1243,7 +1241,7 @@ viam machines part fragments remove --part=<part id> [--fragment=<fragment id>]
 | `--part` | Part ID for which the command is being issued. | **Required** |
 | `--fragment` | Fragment ID to remove. | Optional |
 
-#### `machines part motion print-config`
+### `machines part motion print-config`
 
 Print the motion planning configuration for the part.
 
@@ -1256,7 +1254,7 @@ viam machines part motion print-config --part=<part id>
 | -------- | ----------- | --------- |
 | `--part` | Part ID for which the command is being issued. | **Required** |
 
-#### `machines part motion print-status`
+### `machines part motion print-status`
 
 Print current motion state for the part.
 
@@ -1269,7 +1267,7 @@ viam machines part motion print-status --part=<part id>
 | -------- | ----------- | --------- |
 | `--part` | Part ID for which the command is being issued. | **Required** |
 
-#### `machines part motion get-pose`
+### `machines part motion get-pose`
 
 Get the pose of a component in a reference frame.
 
@@ -1283,7 +1281,7 @@ viam machines part motion get-pose --part=<part id> --component=<component name>
 | `--part` | Part ID for which the command is being issued. | **Required** |
 | `--component` | Component name for the motion command. | **Required** |
 
-#### `machines part motion set-pose`
+### `machines part motion set-pose`
 
 Command a component to move to a specific pose.
 
@@ -1297,7 +1295,7 @@ viam machines part motion set-pose --part=<part id> --component=<component name>
 | `--part` | Part ID for which the command is being issued. | **Required** |
 | `--component` | Component name for the motion command. | **Required** |
 
-#### Using the `--stream` and `--data` arguments
+### Using the `--stream` and `--data` arguments
 
 Issuing the `part` command with the `run` positional argument allows you to run component and service (resource) commands for a selected machine part.
 
@@ -1323,7 +1321,7 @@ viam.service.vision.v1.VisionService.GetClassificationsFromCamera
 
 The `--stream` argument, when included in the CLI command prior to the `--data` command, will stream data back at the specified interval.
 
-### `metadata`
+## `metadata`
 
 The `metadata` command allows you to read organization, location, machine, and machine part metadata.
 
@@ -1331,7 +1329,7 @@ The `metadata` command allows you to read organization, location, machine, and m
 viam metadata read --part-id=<part-id>
 ```
 
-#### `metadata read`
+### `metadata read`
 
 Read organization, location, machine, and machine part metadata.
 
@@ -1343,7 +1341,7 @@ Read organization, location, machine, and machine part metadata.
 | `--org-id` | The ID of the org to read metadata from. | Optional |
 | `--part-id` | The ID of the part to read metadata from. | Optional |
 
-### `module`
+## `module`
 
 The `module` command allows to you to work with {{< glossary_tooltip term_id="module" text="modules" >}}.
 This includes:
@@ -1378,7 +1376,7 @@ viam module download [command options]
 viam module local-app-testing --app-url http://localhost:3000
 ```
 
-#### `module generate`
+### `module generate`
 
 Generate a new module with stub files and a <file>meta.json</file> file. Recommended when starting a new module.
 
@@ -1431,7 +1429,7 @@ Services:
 | `--resource-subtype` | The API to implement with the modular resource. For example, `motor`. We recommend _not_ using this option and instead following the prompts after running the command. | Optional |
 | `--resource-type` | Whether the new resource is a component or a service. For example, `component`. We recommend _not_ using this option and instead following the prompts. | Optional |
 
-#### `module create`
+### `module create`
 
 Generate a <file>meta.json</file> file and register the metadata with the Viam registry. Recommended when you already have working module code.
 
@@ -1451,7 +1449,7 @@ viam module create --name=my-module --org-id=abc
 | `--public-namespace` | The namespace to associate the module to. See [Using the `--org-id` and `--public-namespace` arguments](#using-the---org-id-and---public-namespace-arguments). | **Required** |
 | `--local-only` | Create a meta.json file for local use, but don't create the module on the backend. Default: `false`. | Optional |
 
-#### `module update`
+### `module update`
 
 Update your module's metadata and documentation in the Viam registry. Updates are based on changes to [<file>meta.json</file>](/build-modules/module-reference/), the module <file>README.md</file>, and the model readme <FILE>namespace_module_model.md</FILE>. Viam automatically runs `update` when you `upload` your module, as well as when you trigger a cloud build with Viam's default build action.
 
@@ -1465,7 +1463,7 @@ viam module update --module=./meta.json
 | -------- | ----------- | --------- |
 | `--module` | The path to the [`meta.json` file](/build-modules/module-reference/) for the module, if not in the current directory. | Optional |
 
-#### `module update-models`
+### `module update-models`
 
 Update the module's metadata file with the models it provides.
 
@@ -1480,7 +1478,7 @@ viam module update-models --binary=./packaged-module.tar.gz --module=./meta.json
 | `--binary` | The module executable to run (binary or script). Must work on the OS or processor of the device. If omitted, the CLI uses the entrypoint defined in <file>meta.json</file>. | Optional |
 | `--module` | The path to the [`meta.json` file](/build-modules/module-reference/) for the module, if not in the current directory. | Optional |
 
-#### `module upload`
+### `module upload`
 
 Validate and upload a new or existing custom module on your local filesystem to the Viam Registry. See [Upload validation](#upload-validation) for more information.
 
@@ -1503,7 +1501,7 @@ viam module upload --version=1.0.0 --platform=darwin/arm64 packaged-module.tar.g
 | `--tags` | Comma-separated list of platform tags that determine to which platforms this binary can be deployed. Examples: `distro:debian,distro:ubuntu, os_version:22.04,os_codename:jammy`. For a machine to use an uploaded binary, all tags must be satisfied as well as the `--platform` field. <ul><li>`distro`: Distribution. You can find this in `/etc/os-release`. `"debian"` or `"ubuntu"`.</li><li>`os_version`:  Operating System version. On Linux, you can find this in `/etc/os-release`. Example for linux: `22.04`. On Mac, run `sw_vers --productVersion` and use the major version only. Example for mac: `14`.</li><li>`codename`: The operating system codename. Find this in `/etc/os-release`. For example: `"bullseye"`, `"bookworm"`, or `"jammy"`.</li><li>`cuda`: Whether using CUDA compiler. Run `nvcc --version`. For example: `"true"`.</li><li>`cuda_version`: The CUDA compiler version. Run `nvcc --version`. For example: `"11"` or `"12"`.</li><li>`jetpack`: Version of the NVIDIA JetPack SDK. Run `apt-cache show nvidia-jetpack`. For example: `"5"`.</li><li>`pi`: Version of the Raspberry Pi: `"4"` or `"5"`.</li><li>`pifull`: Compute module or model number, for example `cm5p` or `5B`.</li></ul> | Optional |
 | `--force` | Skip local validation of the packaged module, which may result in an unusable module if the contents of the packaged module are not correct. | Optional |
 
-#### `module reload`
+### `module reload`
 
 Build a module in the cloud and configure the target machine to download it directly. Rebuild and restart if the module is already running.
 
@@ -1525,7 +1523,7 @@ viam module reload --part-id e1234f0c-912c-1234-a123-5ac1234612345
 | `--path` | The path to the root of the git repo to build. Default: `.`. | Optional |
 | `--workdir` | Use this to indicate that your <file>meta.json</file> is in a subdirectory of your repo. `--module` flag should be relative to this. Default: `.`. | Optional |
 
-#### `module reload-local`
+### `module reload-local`
 
 Build a module locally and run it on a target machine. Rebuild and restart if it is already running. The module is loaded to <FILE>~/.viam/packages-local/namespace_module-name_from_reload-module.tar.gz</FILE> on the target machine.
 
@@ -1550,7 +1548,7 @@ viam module reload-local --local
 | `--home` | Specify home directory for a remote machine where `$HOME` is not the default `/root`. | Optional |
 | `--name` | The name of the module. For example: `hello-world`. | Optional |
 
-#### `module restart`
+### `module restart`
 
 Restart a running module.
 
@@ -1567,7 +1565,7 @@ viam module restart --id viam:python-example-module
 | `--cloud-config` | The location of the <FILE>viam.json</FILE> file which contains the machine ID to lookup the part-id. Alternative to `--part-id`. Default: `/etc/viam.json`. | Optional |
 | `--name` | The name of the module. For example: `hello-world`. | Optional |
 
-#### `module build start`
+### `module build start`
 
 Start a module build in a cloud runner using the build step in your [`meta.json` file](/build-modules/module-reference/). See [Using the `build` subcommand](#using-the-build-subcommand).
 
@@ -1589,7 +1587,7 @@ viam module build start --version "0.1.2" --token ghp_1234567890abcdefghijklmnop
 | `--token` | GitHub token with repository **Contents** read access, and **Actions** read and write access. Required for private repos, not necessary for public repos. | Optional |
 | `--workdir` | Use this to indicate that your <file>meta.json</file> is in a subdirectory of your repo. `--module` flag should be relative to this. Default: `.`. | Optional |
 
-#### `module build local`
+### `module build local`
 
 Start a module build locally using the build step in your [`meta.json` file](/build-modules/module-reference/). See [Using the `build` subcommand](#using-the-build-subcommand).
 
@@ -1603,7 +1601,7 @@ viam module build local
 | -------- | ----------- | --------- |
 | `--module` | The path to the [`meta.json` file](/build-modules/module-reference/) for the module, if not in the current directory. | Optional |
 
-#### `module build list`
+### `module build list`
 
 List the status of your cloud module builds. See [Using the `build` subcommand](#using-the-build-subcommand).
 
@@ -1618,7 +1616,7 @@ viam module build list
 | `--id` | The build ID to list, as returned from `build start`. | Optional |
 | `--count` | Number of cloud builds to list. Defaults to displaying all builds. | Optional |
 
-#### `module build logs`
+### `module build logs`
 
 Show the logs from a specific cloud module build. See [Using the `build` subcommand](#using-the-build-subcommand).
 
@@ -1635,7 +1633,7 @@ viam module build logs --wait --id=$(viam module build start --version "0.1.2")
 | `--wait` | Wait for the build to finish before outputting any logs. | Optional |
 | `--group-logs` | Group log output by platform. | Optional |
 
-#### `module download`
+### `module download`
 
 Download a module package from the registry.
 
@@ -1658,7 +1656,7 @@ viam module download --id=acme:my-module --version=1.0.0 --platform=linux/amd64
 | `--platform` | The architecture of the module binary to download. See [Using the `--platform` argument](#using-the---platform-argument). | Optional |
 | `--destination` | Output directory for downloaded package. Default: `.`. | Optional |
 
-#### `module local-app-testing`
+### `module local-app-testing`
 
 Test your viam application locally. This will stand up a local proxy at `http://localhost:8012` to simulate the Viam application server.
 
@@ -1673,7 +1671,7 @@ viam module local-app-testing --app-url http://localhost:3000
 | `--app-url` | The url where local app is running, including port number. For example `http://localhost:5000`. | **Required** |
 | `--machine-id` | The machine ID of the machine you want to test with. You can get your machine ID on the [Fleet page](https://app.viam.com/fleet/machines). | Optional |
 
-#### Using the `--org-id` and `--public-namespace` arguments
+### Using the `--org-id` and `--public-namespace` arguments
 
 All of the `module` commands accept either the `--org-id` or `--public-namespace` argument.
 
@@ -1683,7 +1681,7 @@ All of the `module` commands accept either the `--org-id` or `--public-namespace
 
 You may use either argument for the `viam module create` command, but must use `--public-namespace` for the `update` and `upload` commands when uploading as a public module (`"visibility": "public"`) to the Viam Registry.
 
-#### Using the `--platform` argument
+### Using the `--platform` argument
 
 The `--platform` argument accepts one of the following architectures:
 
@@ -1718,7 +1716,7 @@ The Viam Registry page for your module displays the platforms your module suppor
 
 If you are using the `build logs` command, the `--platform` argument instead restricts the logs returned by the command to only those build jobs that match the specified platform.
 
-#### Using the `--version` argument
+### Using the `--version` argument
 
 The `--version` argument accepts a valid [semver 2.0](https://semver.org/) version (example: `1.0.0`).
 You set an initial version for your custom module with your first `viam module upload` command for that module, and can later increment the version with subsequent `viam module upload` commands.
@@ -1734,7 +1732,7 @@ Users can choose to pin to a specific patch version, permit upgrades within majo
 When you `update` a module configuration and then `upload` it, the `entrypoint` for that module defined in the [`meta.json` file](/build-modules/module-reference/) is associated with the specific `--version` for that `upload`.
 Therefore, you are able to change the `entrypoint` file from version to version, if desired.
 
-#### Upload validation
+### Upload validation
 
 When you `upload` a module, the command performs basic validation of your module to check for common errors.
 The following criteria are checked for every `upload`:
@@ -1746,7 +1744,7 @@ The following criteria are checked for every `upload`:
 
 See [Create a module](/build-modules/write-a-driver-module/) and [Update and manage modules you created](/build-modules/manage-modules/) for a detailed walkthrough of the `viam module` commands.
 
-#### Using the `build` subcommand
+### Using the `build` subcommand
 
 You can use the `module build start` or `module build local` commands to build your custom module according to the build steps in your <file>meta.json</file> file:
 
@@ -1919,7 +1917,7 @@ To list all in-progress builds and their build status, use the following command
 viam module build list
 ```
 
-### `organizations`
+## `organizations`
 
 The `organizations` command allows you to list the organizations your authenticated session has access to, and to create a new organization API key.
 
@@ -1943,7 +1941,7 @@ viam organization auth-service oauth-app [read | delete] --org-id=<org-id> --cli
 
 See [Manage API keys](/cli/administer-your-organization/#manage-api-keys) for more information.
 
-#### `organizations list`
+### `organizations list`
 
 List all organizations (name, ID, and [namespace](/build-modules/module-reference/)) that the authenticated session has access to.
 
@@ -1952,7 +1950,7 @@ List all organizations (name, ID, and [namespace](/build-modules/module-referenc
 viam organizations list
 ```
 
-#### `organizations api-key create`
+### `organizations api-key create`
 
 Create a new organization API key.
 
@@ -1967,7 +1965,7 @@ viam organizations api-key create --org-id=123 --name=my-key
 | `--org-id` | The organization to create the API key in. | **Required** |
 | `--name` | The optional name for the organization API key. If omitted, a name will be auto-generated based on your login info and the current time. | Optional |
 
-#### `organizations support-email get`
+### `organizations support-email get`
 
 Get the support email for an organization.
 
@@ -1980,7 +1978,7 @@ viam organizations support-email get --org-id=<org-id>
 | -------- | ----------- | --------- |
 | `--org-id` | The organization to perform the command on. | **Required** |
 
-#### `organizations support-email set`
+### `organizations support-email set`
 
 Set the support email for an organization.
 
@@ -1994,7 +1992,7 @@ viam organizations support-email set --org-id=<org-id> --support-email=<support-
 | `--org-id` | The organization to perform the command on. | **Required** |
 | `--support-email` | The support email to set for the organization. | **Required** |
 
-#### `organizations logo set`
+### `organizations logo set`
 
 Upload the logo for an organization from a local file.
 
@@ -2008,7 +2006,7 @@ viam organizations logo set --org-id=<org-id> --logo-path=<logo-path>
 | `--org-id` | The organization to perform the command on. | **Required** |
 | `--logo-path` | Path to the logo file to upload. | **Required** |
 
-#### `organizations billing-service get-config`
+### `organizations billing-service get-config`
 
 Get the billing service config for an organization.
 
@@ -2021,7 +2019,7 @@ viam organizations billing-service get-config --org-id=<org-id>
 | -------- | ----------- | --------- |
 | `--org-id` | The organization to perform the command on. | **Required** |
 
-#### `organizations billing-service enable`
+### `organizations billing-service enable`
 
 Enable the billing service for an organization.
 
@@ -2035,7 +2033,7 @@ viam organizations billing-service enable --org-id=<org-id> --address=<address>
 | `--org-id` | The organization to perform the command on. | **Required** |
 | `--address` | The stringified billing address that follows the pattern: line1, line2 (optional), city, state, zipcode. | **Required** |
 
-#### `organizations billing-service update`
+### `organizations billing-service update`
 
 Update the billing service for an organization.
 
@@ -2049,7 +2047,7 @@ viam organizations billing-service update --org-id=<org-id> --address=<address>
 | `--org-id` | The organization to perform the command on. | **Required** |
 | `--address` | The stringified billing address that follows the pattern: line1, line2 (optional), city, state, zipcode. | **Required** |
 
-#### `organizations billing-service disable`
+### `organizations billing-service disable`
 
 Disable the billing service for an organization.
 
@@ -2062,7 +2060,7 @@ viam organizations billing-service disable --org-id=<org-id>
 | -------- | ----------- | --------- |
 | `--org-id` | The organization to perform the command on. | **Required** |
 
-#### `organizations auth-service enable`
+### `organizations auth-service enable`
 
 Enable auth-service for OAuth applications.
 
@@ -2075,7 +2073,7 @@ viam organization auth-service enable --org-id=<org-id>
 | -------- | ----------- | --------- |
 | `--org-id` | The organization to perform the command on. | **Required** |
 
-#### `organizations auth-service disable`
+### `organizations auth-service disable`
 
 Disable auth-service for OAuth applications. Disabling the auth-service does not delete your OAuth token, it will just take off the custom branding.
 
@@ -2088,7 +2086,7 @@ viam organization auth-service disable --org-id=<org-id>
 | -------- | ----------- | --------- |
 | `--org-id` | The organization to perform the command on. | **Required** |
 
-#### `organizations auth-service oauth-app create`
+### `organizations auth-service oauth-app create`
 
 Create a new OAuth application.
 
@@ -2109,7 +2107,7 @@ viam organization auth-service oauth-app create --client-authentication=<policy>
 | `--redirect-uris` | Comma-separated redirect URIs for the OAuth application. | **Required** |
 | `--url-validation` | URL validation for the OAuth application. Options: `unspecified`, `exact_match`, `allow_wildcards`. Default: `unspecified`. | **Required** |
 
-#### `organizations auth-service oauth-app update`
+### `organizations auth-service oauth-app update`
 
 Update an existing OAuth application.
 
@@ -2131,7 +2129,7 @@ viam organization auth-service oauth-app update --org-id=<org-id> --client-id=<c
 | `--redirect-uris` | Comma-separated redirect URIs for the OAuth application. | **Required** |
 | `--url-validation` | URL validation for the OAuth application. Options: `unspecified`, `exact_match`, `allow_wildcards`. Default: `unspecified`. | **Required** |
 
-#### `organizations auth-service oauth-app list`
+### `organizations auth-service oauth-app list`
 
 List OAuth applications for an organization.
 
@@ -2144,7 +2142,7 @@ viam organization auth-service oauth-app list --org-id=<org-id>
 | -------- | ----------- | --------- |
 | `--org-id` | The organization to perform the command on. | **Required** |
 
-#### `organizations auth-service oauth-app read`
+### `organizations auth-service oauth-app read`
 
 Read an OAuth application.
 
@@ -2158,7 +2156,7 @@ viam organization auth-service oauth-app read --org-id=<org-id> --client-id=<cli
 | `--org-id` | The organization to perform the command on. | **Required** |
 | `--client-id` | The client ID of the OAuth application. | **Required** |
 
-#### `organizations auth-service oauth-app delete`
+### `organizations auth-service oauth-app delete`
 
 Delete an OAuth application.
 
@@ -2172,7 +2170,7 @@ viam organization auth-service oauth-app delete --org-id=<org-id> --client-id=<c
 | `--org-id` | The organization to perform the command on. | **Required** |
 | `--client-id` | The client ID of the OAuth application. | **Required** |
 
-### `packages`
+## `packages`
 
 The `packages` command allows you to upload packages to the Viam Cloud or export packages from the Viam Cloud.
 For example, you can use this command to download ML models or modules from the registry.
@@ -2182,7 +2180,7 @@ viam packages upload --org-id=<org-id> --name=<package-name> --version=<version>
 viam packages export --org-id=<org-id> --name=<package-name> --version=<version> --type=<type> --destination=<path-to-export-destination>
 ```
 
-#### `packages upload`
+### `packages upload`
 
 Upload a package to the Viam Cloud.
 
@@ -2201,7 +2199,7 @@ viam packages upload --org-id=123 --name=MyMLModel --version=1.0.0 --type=ml_mod
 | `--model-framework` | The framework for an uploaded `ml_model`. Valid options: `unspecified`, `tflite`, `tensorflow`, `pytorch`, or `onnx`. | **Required** |
 | `--model-type` | The type of the model. Valid options: `unspecified`, `single_label_classification`, `multi_label_classification`, `object_detection`. | **Required** |
 
-#### `packages export`
+### `packages export`
 
 Download a package from the Viam Cloud.
 
@@ -2218,7 +2216,7 @@ viam packages export --org-id=123 --name=MyMLModel --version=latest --type=ml_mo
 | `--type` | The type of the package: `ml_model`, `archive`, `module`, `slam_map`, or `unspecified`. | **Required** |
 | `--destination` | The output directory for downloaded package. | **Required** |
 
-### `parse-ftdc`
+## `parse-ftdc`
 
 The `parse-ftdc` command parses an FTDC (Full-Time Diagnostic Data Capture) file and opens an interactive REPL for inspecting performance metrics collected by `viam-server`.
 This is a diagnostic tool. Viam support may ask you to run it when troubleshooting performance issues.
@@ -2233,7 +2231,7 @@ viam parse-ftdc --path ftdc-tmp/<part-id>/viam-server-<date>-<time>.ftdc
 | -------- | ----------- | --------- |
 | `--path` | The absolute file path to the FTDC file. | **Required** |
 
-### `profiles`
+## `profiles`
 
 The `profiles` command allows you to manage different CLI authentication profiles, so you can easily switch between API key authentications (for example authentication to one organization versus another).
 
@@ -2269,7 +2267,7 @@ See [Manage API keys](/cli/administer-your-organization/#manage-api-keys) for mo
 You can set a default profile by using the `VIAM_CLI_PROFILE_NAME` environment variable.
 {{% /alert %}}
 
-#### `profiles add`
+### `profiles add`
 
 Add a new profile for authentication. Throws an error if the profile already exists.
 
@@ -2284,7 +2282,7 @@ viam profiles add --profile-name=<name-of-profile-to-add> --key-id=<API-key-ID> 
 | `--key-id` | The `key id` (UUID) of the API key. | **Required** |
 | `--key` | The `key value` of the API key. | **Required** |
 
-#### `profiles update`
+### `profiles update`
 
 Update an existing profile for authentication, or add it if it doesn't exist.
 
@@ -2299,7 +2297,7 @@ viam profiles update --profile-name=<name-of-profile-to-update> --key-id=<API-ke
 | `--key-id` | The `key id` (UUID) of the API key. | **Required** |
 | `--key` | The `key value` of the API key. | **Required** |
 
-#### `profiles list`
+### `profiles list`
 
 List all existing profiles by name.
 
@@ -2307,7 +2305,7 @@ List all existing profiles by name.
 viam profiles list
 ```
 
-#### `profiles remove`
+### `profiles remove`
 
 Remove a profile.
 
@@ -2320,7 +2318,7 @@ viam profiles remove --profile-name=<name-of-profile-to-remove>
 | -------- | ----------- | --------- |
 | `--profile-name` | Name of the profile to remove. | **Required** |
 
-### `resource`
+## `resource`
 
 The `resource` command enables, disables, or updates individual resources (components and services) on a machine part. Use it to temporarily disable a resource without removing it from the configuration, or to update attributes without using the Viam app.
 
@@ -2349,7 +2347,7 @@ viam resource update --part=abc123 --resource-name=my-sensor --config=/path/to/u
 viam resource update --part=abc123 --resource-name=my-sensor --config='{"pin": ""}'
 ```
 
-#### `resource enable`
+### `resource enable`
 
 Enable one or more resources on a machine part.
 
@@ -2366,7 +2364,7 @@ viam resource enable --part=<part> --resource-name=<resource-name> [--resource-n
 | `--location` | Location ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
 | `--machine` | Machine ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
 
-#### `resource disable`
+### `resource disable`
 
 Disable one or more resources on a machine part. Disabled resources are not started by viam-server.
 
@@ -2383,7 +2381,7 @@ viam resource disable --part=<part> --resource-name=<resource-name> [--resource-
 | `--location` | Location ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
 | `--machine` | Machine ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
 
-#### `resource update`
+### `resource update`
 
 Replace a resource's attributes with new values. The `--config` flag accepts inline JSON or a path to a JSON file. An empty JSON object deletes all attributes.
 
@@ -2401,7 +2399,7 @@ viam resource update --part=<part> --resource-name=<resource-name> --config=<jso
 | `--location` | Location ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
 | `--machine` | Machine ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
 
-### `train`
+## `train`
 
 Use a training script to train an ML model on data.
 
@@ -2416,7 +2414,7 @@ viam train list --org-id=<org-id> --job-status=<job-status>
 viam train containers list
 ```
 
-#### `train submit managed`
+### `train submit managed`
 
 Submit a training job on data in the Viam Cloud with a Viam-managed training script.
 
@@ -2436,7 +2434,7 @@ viam train submit managed --dataset-id=456 --model-org-id=123 --model-name=MyCoo
 | `--model-labels` | Labels to train on. These will either be classification or object detection labels. | **Required** |
 | `--model-version` | Set the version of the submitted model. Defaults to current timestamp if unspecified. | Optional |
 
-#### `train submit custom from-registry`
+### `train submit custom from-registry`
 
 Submit a custom training job with an existing training script in the registry on data in the Viam Cloud.
 
@@ -2457,7 +2455,7 @@ viam train submit custom from-registry --dataset-id=<INSERT DATASET ID> --org-id
 | `--model-version` | Set the version of the submitted model. Defaults to current timestamp if unspecified. | Optional |
 | `--args` | Pass custom comma-separated arguments to the training script. Example: `num_epochs=3,model_type=multi_label`. To include whitespace, enclose the value with whitespace in single and double quotes. Example: `num_epochs=3,labels="'green_square blue_star'"`. | Optional |
 
-#### `train submit custom with-upload`
+### `train submit custom with-upload`
 
 Upload a draft training script and submit a custom training job on data in the Viam Cloud.
 
@@ -2482,7 +2480,7 @@ viam train submit custom with-upload --dataset-id=<INSERT DATASET ID> --model-or
 | `--url` | URL of the GitHub repository associated with the training scripts. | Optional |
 | `--args` | Pass custom comma-separated arguments to the training script. Example: `num_epochs=3,model_type=multi_label`. To include whitespace, enclose the value with whitespace in single and double quotes. Example: `num_epochs=3,labels="'green_square blue_star'"`. | Optional |
 
-#### `train get`
+### `train get`
 
 Get a training job from the Viam Cloud based on training job ID.
 
@@ -2496,7 +2494,7 @@ viam train get --job-id=123
 | -------- | ----------- | --------- |
 | `--job-id` | The ID of the training job to get. You can retrieve this value with `train list`. | **Required** |
 
-#### `train logs`
+### `train logs`
 
 Get the logs of a training job from the Viam Cloud based on training job ID.
 
@@ -2510,7 +2508,7 @@ viam train logs --job-id=123
 | -------- | ----------- | --------- |
 | `--job-id` | The ID of the training job to get logs for. | **Required** |
 
-#### `train cancel`
+### `train cancel`
 
 Cancel a training job in the Viam Cloud based on training job ID.
 
@@ -2524,7 +2522,7 @@ viam train cancel --job-id=123
 | -------- | ----------- | --------- |
 | `--job-id` | The ID of the training job to cancel. | **Required** |
 
-#### `train list`
+### `train list`
 
 List training jobs in Viam Cloud based on organization ID and job status.
 
@@ -2539,7 +2537,7 @@ viam train list --org-id=123 --job-status=completed
 | `--org-id` | The organization ID to list training jobs from. | **Required** |
 | `--job-status` | Training status to filter for. Can be one of `canceled`, `canceling`, `completed`, `failed`, `in_progress`, `pending`, or `unspecified`. | Optional |
 
-#### `train containers list`
+### `train containers list`
 
 List supported Docker container images for custom training.
 
@@ -2547,7 +2545,7 @@ List supported Docker container images for custom training.
 viam train containers list
 ```
 
-### `training-script`
+## `training-script`
 
 Manage training scripts for [custom ML training](/train/custom-training-scripts/).
 
@@ -2556,7 +2554,7 @@ viam training-script upload --framework=<framework> --org-id=<org-id> --path=<pa
 viam training-script update --org-id=<org-id> --script-name=<script-name> --visibility=<visibility>
 ```
 
-#### `training-script upload`
+### `training-script upload`
 
 Upload an ML training script to the registry.
 
@@ -2577,7 +2575,7 @@ viam training-script upload --framework=tflite --org-id=123 --path=. --script-na
 | `--type` | Task type of the ML training script to upload, can be `single_label_classification`, `multi_label_classification`, or `object_detection`. | Optional |
 | `--draft` | Indicate draft mode, drafts are not viewable in the registry. | Optional |
 
-#### `training-script update`
+### `training-script update`
 
 Update the visibility of an ML training script in the registry.
 
@@ -2594,7 +2592,7 @@ viam training-script update --org-id=123 --script-name=MyCustomTrainingScript --
 | `--visibility` | Visibility of the registry item, can be `public`, `private`, or `draft`. | **Required** |
 | `--description` | Description of the ML training script. | Optional |
 
-### `traces`
+## `traces`
 
 The `traces` command imports viam-server trace files to an OTLP endpoint or prints them to the console. Use it to debug machine performance and request flow with a tracing backend such as Jaeger or Tempo.
 
@@ -2608,7 +2606,7 @@ viam traces print-remote --part=<part> [--organization=<org>] [--location=<locat
 viam traces get-remote --part=<part> [target] [--organization=<org>] [--location=<location>]
 ```
 
-#### `traces import-local`
+### `traces import-local`
 
 Import traces from a local viam-server trace file to an OTLP endpoint.
 
@@ -2623,7 +2621,7 @@ Pass the path to a local viam-server trace file as a positional argument.
 | -------- | ----------- | --------- |
 | `--endpoint` | OTLP endpoint in `host:port` format. Default: `localhost:4317`. | Optional |
 
-#### `traces import-remote`
+### `traces import-remote`
 
 Import traces from a remote machine to an OTLP endpoint.
 
@@ -2639,7 +2637,7 @@ viam traces import-remote --part=<part> [--endpoint=<host:port>] [--organization
 | `--organization` | Organization ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
 | `--location` | Location ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
 
-#### `traces print-local`
+### `traces print-local`
 
 Print traces from a local trace file to the console.
 
@@ -2649,7 +2647,7 @@ viam traces print-local <traces-file>
 
 Pass the path to a local viam-server trace file as a positional argument.
 
-#### `traces print-remote`
+### `traces print-remote`
 
 Print traces from a remote machine to the console.
 
@@ -2664,7 +2662,7 @@ viam traces print-remote --part=<part> [--organization=<org>] [--location=<locat
 | `--organization` | Organization ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
 | `--location` | Location ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
 
-#### `traces get-remote`
+### `traces get-remote`
 
 Download traces from a remote machine to a local file. If `[target]` is omitted, the file is saved to the current working directory.
 
@@ -2679,7 +2677,7 @@ viam traces get-remote --part=<part> [target] [--organization=<org>] [--location
 | `--organization` | Organization ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
 | `--location` | Location ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
 
-### `update`
+## `update`
 
 The `update` command updates the CLI to the latest version.
 If the CLI was installed with Homebrew, it updates through Homebrew.
@@ -2694,7 +2692,7 @@ viam update
 | -------- | ----------- | --------- |
 | `--no-progress` | Hide progress output during the update. Default: `false`. | Optional |
 
-### `version`
+## `version`
 
 The `version` command returns the version of the Viam CLI.
 To update to the latest version of the CLI, run [`viam update`](#update).
@@ -2703,7 +2701,7 @@ To update to the latest version of the CLI, run [`viam update`](#update).
 viam version
 ```
 
-### `whoami`
+## `whoami`
 
 The `whoami` command returns the Viam user for an authenticated CLI session, or "Not logged in" if there is no authenticated session.
 
@@ -2711,7 +2709,7 @@ The `whoami` command returns the Viam user for an authenticated CLI session, or 
 viam whoami
 ```
 
-### `xacro`
+## `xacro`
 
 The `xacro` command converts ROS xacro files to URDF using a Docker container. Use it to integrate ROS-based robot descriptions with Viam's frame system.
 
@@ -2732,7 +2730,7 @@ viam xacro convert --input-file=arm.xacro --output-file=arm.urdf --args=name:=ur
 viam xacro convert --input-file=robot.xacro --output-file=robot.urdf --collapse-fixed-joints
 ```
 
-#### `xacro convert`
+### `xacro convert`
 
 Convert a xacro file to URDF.
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -4,7 +4,7 @@ linkTitle: "CLI reference"
 weight: 90
 type: "docs"
 description: "Complete command reference for the Viam CLI: every command, subcommand, flag, and alias."
-date: "2024-08-23"
+date: "2026-04-25"
 # updated: ""  # When the content was last entirely checked
 ---
 
@@ -41,37 +41,98 @@ viam data index delete --collection-type=<type> --index-name=<name> [--org-id=<o
 viam data index list --collection-type=<type> [--org-id=<org-id>]
 ```
 
-Examples:
+#### `data export tabular`
+
+Export tabular or sensor data to a specified location in the <file>.ndjson</file> output format. You can copy this from the UI with a filter. See [Copy `export` command](#copy-export-command).
+
+```sh {class="command-line" data-prompt="$"}
+# export tabular data to /home/robot/data for specified part id with resource name my_movement_sensor, subtype movement_sensor and method Readings
+viam data export tabular --part-id=e1234f0c-912c-1234-a123-5ac1234612345 --resource-name=my_movement_sensor --resource-subtype=rdk:component:movement_sensor --method=Readings --destination=/home/robot/data
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--destination` | Output directory for downloaded data. | **Required** |
+| `--part-id` | Filter by specified part ID. | **Required** |
+| `--resource-name` | Resource name. Sometimes called "component name". | **Required** |
+| `--resource-subtype` | Resource {{< glossary_tooltip term_id="api-namespace-triplet" text="API namespace triplet" >}}. | **Required** |
+| `--method` | Filter by specified method. | **Required** |
+| `--start` | ISO-8601 timestamp indicating the start of the interval. | Optional |
+| `--end` | ISO-8601 timestamp indicating the end of the interval. | Optional |
+
+#### `data export binary filter`
+
+Export binary or image data matching a filter to a specified location. Binary data will be downloaded in the original output it was specified as. You can copy this from the UI with a filter. See [Copy `export` command](#copy-export-command).
 
 ```sh {class="command-line" data-prompt="$"}
 # export binary data from the specified org with mime types image/jpeg and image/png to /home/robot/data
 viam data export binary filter --mime-types=image/jpeg,image/png --org-ids=12345678-eb33-123a-88ec-12a345b123a1 --destination=/home/robot/data
+```
 
-# export tabular data to /home/robot/data for specified part id with resource name my_movement_sensor, subtype movement_sensor and method Readings
-viam data export tabular --part-id=e1234f0c-912c-1234-a123-5ac1234612345 --resource-name=my_movement_sensor --resource-subtype=rdk:component:movement_sensor --method=Readings --destination=/home/robot/data
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--destination` | Output directory for downloaded data. | **Required** |
+| `--bbox-labels` | String labels corresponding to bounding boxes within images. | Optional |
+| `--component-name` | Filter by specified component name. | Optional |
+| `--component-type` | Filter by specified component type. | Optional |
+| `--location-ids` | Filter by specified location ID (accepts comma-separated list). See [Using the `ids` argument](#using-the-ids-argument) for instructions on retrieving these values. | Optional |
+| `--machine-id` | Filter by specified machine ID. | Optional |
+| `--machine-name` | Filter by specified machine name. | Optional |
+| `--method` | Filter by specified method. | Optional |
+| `--mime-types` | Filter by specified MIME type (accepts comma-separated list). | Optional |
+| `--org-ids` | Filter by specified organizations ID (accepts comma-separated list). See [Using the `ids` argument](#using-the-ids-argument) for instructions on retrieving these values. | Optional |
+| `--parallel` | Number of download requests to make in parallel. Default: `100`. | Optional |
+| `--part-id` | Filter by specified part ID. | Optional |
+| `--part-name` | Filter by specified part name. | Optional |
+| `--start` | ISO-8601 timestamp indicating the start of the interval. | Optional |
+| `--end` | ISO-8601 timestamp indicating the end of the interval. | Optional |
+| `--tags` | Filter by specified tag (accepts comma-separated list). | Optional |
+| `--timeout` | Number of seconds to wait for file downloads. Default: `30`. | Optional |
 
+#### `data export binary ids`
+
+Export binary or image data by binary data ID to a specified location.
+
+```sh {class="command-line" data-prompt="$"}
+viam data export binary ids --destination=<output path> --binary-data-ids=<binary-data-ids>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--destination` | Output directory for downloaded data. | **Required** |
+| `--binary-data-ids` | Binary data IDs to download. | **Required** |
+| `--parallel` | Number of download requests to make in parallel. Default: `100`. | Optional |
+| `--timeout` | Number of seconds to wait for file downloads. Default: `30`. | Optional |
+
+#### `data delete binary`
+
+Delete binary data from the Viam Cloud.
+
+```sh {class="command-line" data-prompt="$"}
 # delete binary data of mime type image/jpeg in an organization between a specified timestamp
 viam data delete binary --org-ids=123 --mime-types=image/jpeg --start 2024-08-20T14:10:34-04:00 --end 2024-08-20T14:16:34-04:00
-
-# configure a database user for the Viam organization's MongoDB Atlas Data
-# Federation instance, in order to query tabular data
-viam data database configure --org-id=abc --password=my_password123
-
-# get the hostname to access a MongoDB Atlas Data Federation instance
-viam data database hostname --org-id=abc
-
-# add tags to all data that matches the given ids in the current organization
-viam data tag ids add --tags=new_tag_1,new_tag_2,new_tag_3 --binary-data-ids=123,456
-
-# remove tags from all data that matches the given ids in the current organization
-viam data tag ids remove --tags=new_tag_1,new_tag_2,new_tag_3 --binary-data-ids=123,456
-
-# add tags to all data that matches a given filter
-viam data tag filter add --tags=new_tag_1,new_tag_2 --location-ids=012 --machine-name=cool-machine --org-ids=84842  --mime-types=image/jpeg,image/png
-
-# remove tags from all data that matches a given filter
-viam data tag filter remove --tags=new_tag_1 --location-ids=012 --machine-name=cool-machine --org-ids=84842  --mime-types=image/jpeg,image/png
 ```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-ids` | Filter by specified organizations ID (accepts comma-separated list). | Optional |
+| `--start` | ISO-8601 timestamp indicating the start of the interval. | Optional |
+| `--end` | ISO-8601 timestamp indicating the end of the interval. | Optional |
+| `--component-name` | Filter by specified component name. | Optional |
+| `--component-type` | Filter by specified component type. | Optional |
+| `--location-ids` | Filter by specified location ID (accepts comma-separated list). | Optional |
+| `--machine-id` | Filter by specified machine ID. | Optional |
+| `--machine-name` | Filter by specified machine name. | Optional |
+| `--method` | Filter by specified method. | Optional |
+| `--mime-types` | Filter by specified MIME type (accepts comma-separated list). | Optional |
+| `--parallel` | Number of download requests to make in parallel. Default: `100`. | Optional |
+| `--part-id` | Filter by specified part ID. | Optional |
+| `--part-name` | Filter by specified part name. | Optional |
+| `--tags` | Filter by specified tag (accepts comma-separated list). | Optional |
 
 Viam currently only supports deleting approximately 500 files at a time.
 To delete more data iterate over the data with a shell script:
@@ -83,65 +144,183 @@ for i in {00..59}; do
 done
 ```
 
-#### Command options
+#### `data delete tabular`
+
+Delete tabular data from the Viam Cloud.
+
+```sh {class="command-line" data-prompt="$"}
+viam data delete tabular --org-id=<org-id> --delete-older-than-days=<N>
+```
 
 <!-- prettier-ignore -->
-| Command option | Description | Positional arguments |
-| -------------- | ----------- | -------------------- |
-| `export tabular` | Export tabular or sensor data to a specified location in the <file>.ndjson</file> output format. You can copy this from the UI with a filter. See [Copy `export` command](#copy-export-command). | - |
-| `export binary` | Export binary or image data to a specified location. Binary data will be downloaded in the original output it was specified as. You can copy this from the UI with a filter. See [Copy `export` command](#copy-export-command). | `ids`, `filter` |
-| `tag` | Add or remove tags from data matching the IDs or filter. | `ids`, `filter` |
-| `database configure` | Create a new database user for the Viam organization's MongoDB Atlas Data Federation instance, or change the password of an existing user. See [Configure data query](/data/query-data/). | - |
-| `database hostname` | Get the MongoDB Atlas Data Federation instance hostname and connection URI. See [Configure data query](/data/query-data/). | - |
-| `delete binary` | Delete binary data from the Viam Cloud. | - |
-| `delete tabular` | Delete tabular data from the Viam Cloud. | - |
-| `index create` | Create a custom index on a data collection. | - |
-| `index delete` | Delete a custom index from a data collection. | - |
-| `index list` | List all custom indexes for a data collection. | - |
-| `--help` | Return help | - |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization ID. | **Required** |
+| `--delete-older-than-days` | Number of days, 0 means all data will be deleted. | **Required** |
 
-##### Positional arguments: `tag`
+#### `data database configure`
 
-<!-- prettier-ignore -->
-| Argument | Description |
-| -------- | ----------- |
-| `filter` | `add` or `remove` images or tags from a dataset using a filter. See [Using the `filter` argument](#using-the-filter-argument). |
-| `ids` | `add` or `remove` images or tags from a dataset by specifying one or more binary data IDs as a comma-separated list. See [Using the `ids` argument](#using-the-ids-argument). |
-| `--help` | Return help |
+Create a new database user for the Viam organization's MongoDB Atlas Data Federation instance, or change the password of an existing user. See [Configure data query](/data/query-data/).
 
-##### Named arguments
+```sh {class="command-line" data-prompt="$"}
+# configure a database user for the Viam organization's MongoDB Atlas Data
+# Federation instance, in order to query tabular data
+viam data database configure --org-id=abc --password=my_password123
+```
 
 <!-- prettier-ignore -->
-| Argument | Description | Applicable commands | Required? |
-| -------- | ----------- | ------------------- | --------- |
-| `--destination` | Output directory for downloaded data. | `export tabular`, `export binary` | **Required** |
-| `--component-name` | Filter by specified component name. | `export binary`, `delete`, `tag filter` | Optional |
-| `--component-type` | Filter by specified component type. | `export binary`, `delete`, `tag filter` | Optional |
-| `--delete-older-than-days` | Number of days, 0 means all data will be deleted. | `delete tabular` | **Required** |
-| `--timeout` | Number of seconds to wait for file downloads. Default: `30`. | `export binary` | Optional |
-| `--start` | ISO-8601 timestamp indicating the start of the interval. | `export binary`, `export tabular`, `delete`, `dataset`, `tag filter` | Optional |
-| `--end` | ISO-8601 timestamp indicating the end of the interval. | `export binary`, `export tabular`, `delete`, `dataset`, `tag filter` | Optional |
-| `--binary-data-ids` | Binary data IDs to add or remove tags from. | `export binary ids`, `tag ids` | **Required** |
-| `--location-ids` | Filter by specified location ID (accepts comma-separated list). See [Using the `ids` argument](#using-the-ids-argument) for instructions on retrieving these values. | `export binary`, `delete`, `tag filter` | Optional |
-| `--method` | Filter by specified method. | `export binary`, `export tabular`, `delete`, `tag filter` | Optional, **Required** for `export tabular` |
-| `--mime-types` | Filter by specified MIME type (accepts comma-separated list). | `export binary`, `delete`, `tag filter` | Optional |
-| `--org-ids` | Filter by specified organizations ID (accepts comma-separated list). See [Using the `ids` argument](#using-the-ids-argument) for instructions on retrieving these values. | `export binary`, `delete`, `tag filter` | Optional |
-| `--parallel` | Number of download requests to make in parallel. Default: `100`. | `export binary`, `delete`, `dataset export` | Optional |
-| `--part-id` | Filter by specified part ID. | `export binary`, `export tabular`, `delete`, `tag filter` | Optional, **Required** for `export tabular` |
-| `--part-name` | Filter by specified part name. | `export binary`, `delete`, `tag filter` | Optional |
-| `--machine-id` | Filter by specified machine ID. | `export binary`, `delete`, `tag filter` | Optional |
-| `--machine-name` | Filter by specified machine name. | `export binary`, `delete`, `tag filter` | Optional |
-| `--tags` | Filter by (`export`, `delete`) or add (`tag`) specified tag (accepts comma-separated list). | `export binary`, `delete`, `tag ids`, `tag filter` | Optional |
-| `--filter-tags` | Filter tags. Options: `'tagged'`, `'untagged'`, or a comma-separated list of tags for all data matching any of the tags. | `tag filter` | Optional |
-| `--bbox-labels` | String labels corresponding to bounding boxes within images. | `tag filter`, `export binary` | Optional |
-| `--org-id` | The organization ID. Required for `delete tabular`. Uses default org if set for other commands. | `delete tabular`, `database configure`, `database hostname`, `index create`, `index delete`, `index list` | Optional, **Required** for `delete tabular` |
-| `--password` | Password for the database user being configured. | `database configure` | **Required** |
-| `--resource-name` | Resource name. Sometimes called "component name". | `export tabular` | **Required** |
-| `--resource-subtype` | Resource {{< glossary_tooltip term_id="api-namespace-triplet" text="API namespace triplet" >}}. | `export tabular` | **Required** |
-| `--collection-type` | Data collection type for index operations. Options: `hot-storage`, `pipeline-sink`. | `index create`, `index delete`, `index list` | **Required** |
-| `--index-path` | Path to a JSON file defining the index using MongoDB index specification format. | `index create` | **Required** |
-| `--index-name` | Name of the index to delete. | `index delete` | **Required** |
-| `--pipeline-name` | Name of the data pipeline (required when `--collection-type` is `pipeline-sink`). | `index create`, `index delete` | Conditional |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization ID. Uses default org if set. | Optional |
+| `--password` | Password for the database user being configured. | **Required** |
+
+#### `data database hostname`
+
+Get the MongoDB Atlas Data Federation instance hostname and connection URI. See [Configure data query](/data/query-data/).
+
+```sh {class="command-line" data-prompt="$"}
+# get the hostname to access a MongoDB Atlas Data Federation instance
+viam data database hostname --org-id=abc
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization ID. Uses default org if set. | Optional |
+
+#### `data tag ids add`
+
+Add tags to all data that matches the given binary data IDs.
+
+```sh {class="command-line" data-prompt="$"}
+# add tags to all data that matches the given ids in the current organization
+viam data tag ids add --tags=new_tag_1,new_tag_2,new_tag_3 --binary-data-ids=123,456
+```
+
+See [Using the `ids` argument](#using-the-ids-argument) for details on retrieving the IDs.
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--binary-data-ids` | Binary data IDs to add tags to. | **Required** |
+| `--tags` | Tags to add (accepts comma-separated list). | Optional |
+
+#### `data tag ids remove`
+
+Remove tags from all data that matches the given binary data IDs.
+
+```sh {class="command-line" data-prompt="$"}
+# remove tags from all data that matches the given ids in the current organization
+viam data tag ids remove --tags=new_tag_1,new_tag_2,new_tag_3 --binary-data-ids=123,456
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--binary-data-ids` | Binary data IDs to remove tags from. | **Required** |
+| `--tags` | Tags to remove (accepts comma-separated list). | Optional |
+
+#### `data tag filter add`
+
+Add tags to all data that matches a given filter. See [Using the `filter` argument](#using-the-filter-argument).
+
+```sh {class="command-line" data-prompt="$"}
+# add tags to all data that matches a given filter
+viam data tag filter add --tags=new_tag_1,new_tag_2 --location-ids=012 --machine-name=cool-machine --org-ids=84842  --mime-types=image/jpeg,image/png
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--tags` | Tags to add (accepts comma-separated list). | Optional |
+| `--filter-tags` | Filter tags. Options: `'tagged'`, `'untagged'`, or a comma-separated list of tags for all data matching any of the tags. | Optional |
+| `--bbox-labels` | String labels corresponding to bounding boxes within images. | Optional |
+| `--component-name` | Filter by specified component name. | Optional |
+| `--component-type` | Filter by specified component type. | Optional |
+| `--location-ids` | Filter by specified location ID (accepts comma-separated list). | Optional |
+| `--machine-id` | Filter by specified machine ID. | Optional |
+| `--machine-name` | Filter by specified machine name. | Optional |
+| `--method` | Filter by specified method. | Optional |
+| `--mime-types` | Filter by specified MIME type (accepts comma-separated list). | Optional |
+| `--org-ids` | Filter by specified organizations ID (accepts comma-separated list). | Optional |
+| `--part-id` | Filter by specified part ID. | Optional |
+| `--part-name` | Filter by specified part name. | Optional |
+| `--start` | ISO-8601 timestamp indicating the start of the interval. | Optional |
+| `--end` | ISO-8601 timestamp indicating the end of the interval. | Optional |
+
+#### `data tag filter remove`
+
+Remove tags from all data that matches a given filter. See [Using the `filter` argument](#using-the-filter-argument).
+
+```sh {class="command-line" data-prompt="$"}
+# remove tags from all data that matches a given filter
+viam data tag filter remove --tags=new_tag_1 --location-ids=012 --machine-name=cool-machine --org-ids=84842  --mime-types=image/jpeg,image/png
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--tags` | Tags to remove (accepts comma-separated list). | Optional |
+| `--filter-tags` | Filter tags. Options: `'tagged'`, `'untagged'`, or a comma-separated list of tags for all data matching any of the tags. | Optional |
+| `--bbox-labels` | String labels corresponding to bounding boxes within images. | Optional |
+| `--component-name` | Filter by specified component name. | Optional |
+| `--component-type` | Filter by specified component type. | Optional |
+| `--location-ids` | Filter by specified location ID (accepts comma-separated list). | Optional |
+| `--machine-id` | Filter by specified machine ID. | Optional |
+| `--machine-name` | Filter by specified machine name. | Optional |
+| `--method` | Filter by specified method. | Optional |
+| `--mime-types` | Filter by specified MIME type (accepts comma-separated list). | Optional |
+| `--org-ids` | Filter by specified organizations ID (accepts comma-separated list). | Optional |
+| `--part-id` | Filter by specified part ID. | Optional |
+| `--part-name` | Filter by specified part name. | Optional |
+| `--start` | ISO-8601 timestamp indicating the start of the interval. | Optional |
+| `--end` | ISO-8601 timestamp indicating the end of the interval. | Optional |
+
+#### `data index create`
+
+Create a custom index on a data collection.
+
+```sh {class="command-line" data-prompt="$"}
+viam data index create --collection-type=<type> --index-path=<file> [--org-id=<org-id>] [--pipeline-name=<name>]
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--collection-type` | Data collection type for index operations. Options: `hot-storage`, `pipeline-sink`. | **Required** |
+| `--index-path` | Path to a JSON file defining the index using MongoDB index specification format. | **Required** |
+| `--org-id` | The organization ID. Uses default org if set. | Optional |
+| `--pipeline-name` | Name of the data pipeline (required when `--collection-type` is `pipeline-sink`). | Conditional |
+
+#### `data index delete`
+
+Delete a custom index from a data collection.
+
+```sh {class="command-line" data-prompt="$"}
+viam data index delete --collection-type=<type> --index-name=<name> [--org-id=<org-id>] [--pipeline-name=<name>]
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--collection-type` | Data collection type for index operations. Options: `hot-storage`, `pipeline-sink`. | **Required** |
+| `--index-name` | Name of the index to delete. | **Required** |
+| `--org-id` | The organization ID. Uses default org if set. | Optional |
+| `--pipeline-name` | Name of the data pipeline (required when `--collection-type` is `pipeline-sink`). | Conditional |
+
+#### `data index list`
+
+List all custom indexes for a data collection.
+
+```sh {class="command-line" data-prompt="$"}
+viam data index list --collection-type=<type> [--org-id=<org-id>]
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--collection-type` | Data collection type for index operations. Options: `hot-storage`, `pipeline-sink`. | **Required** |
+| `--org-id` | The organization ID. Uses default org if set. | Optional |
 
 ### `datapipelines`
 
@@ -153,9 +332,14 @@ viam datapipelines create --org-id=<org-id> --name=<name> --schedule=<schedule> 
 viam datapipelines rename --id=<pipeline-id> --name=<new-name>
 viam datapipelines list --org-id=<org-id>
 viam datapipelines describe --id=<pipeline-id>
+viam datapipelines enable --id=<pipeline-id>
+viam datapipelines disable --id=<pipeline-id>
+viam datapipelines delete --id=<pipeline-id>
 ```
 
-Examples:
+#### `datapipelines create`
+
+Create a new data pipeline.
 
 ```sh {class="command-line" data-prompt="$"}
 # create a new data pipeline with standard data source type (default)
@@ -163,50 +347,97 @@ viam datapipelines create --org-id=123 --name="Daily Sensor Summary" --schedule=
 
 # create a data pipeline with hot storage data source type for faster access
 viam datapipelines create --org-id=123 --name="Real-time Analytics" --schedule="*/5 * * * *" --data-source-type=hotstorage --mql='[{"$match": {"component_name": "camera-1"}}]' --enable-backfill=False
+```
 
-# disable a pipeline
-viam datapipelines disable --id=abc123
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--name` | Name of the data pipeline. | **Required** |
+| `--schedule` | Cron schedule that expresses when the pipeline should run, for example `0 9 * * *` for daily at 9 AM. | **Required** |
+| `--enable-backfill` | Enable the data pipeline to run over organization's historical data. Default: `false`. | **Required** |
+| `--org-id` | ID of the organization that owns the data pipeline. Uses default org if set. | Optional |
+| `--mql` | MQL (MongoDB Query Language) query as a JSON string for data processing. You must specify either `--mql` or `--mql-path` when creating a pipeline. | Optional |
+| `--mql-path` | Path to a JSON file containing the MQL query for the data pipeline. You must specify either `--mql` or `--mql-path` when creating a pipeline. | Optional |
+| `--data-source-type` | Data source type for the pipeline. Options: `standard` (default), `hotstorage`. | Optional |
 
-# enable a pipeline
-viam datapipelines enable --id=abc123
+#### `datapipelines rename`
 
-# list all data pipelines in an organization
+Rename a data pipeline.
+
+```sh {class="command-line" data-prompt="$"}
+viam datapipelines rename --id=<pipeline-id> --name=<new-name>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--id` | ID of the data pipeline. | **Required** |
+| `--name` | New name for the data pipeline. | **Required** |
+
+#### `datapipelines list`
+
+List all data pipelines in an organization.
+
+```sh {class="command-line" data-prompt="$"}
 viam datapipelines list --org-id=123
+```
 
-# get detailed information about a specific data pipeline
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | ID of the organization that owns the data pipelines. Uses default org if set. | Optional |
+
+#### `datapipelines describe`
+
+Get detailed information about a specific data pipeline.
+
+```sh {class="command-line" data-prompt="$"}
 viam datapipelines describe --id=abc123
+```
 
-# delete a data pipeline
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--id` | ID of the data pipeline. | **Required** |
+
+#### `datapipelines enable`
+
+Resume executing a disabled data pipeline.
+
+```sh {class="command-line" data-prompt="$"}
+viam datapipelines enable --id=abc123
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--id` | ID of the data pipeline. | **Required** |
+
+#### `datapipelines disable`
+
+Stop executing a data pipeline without deleting it.
+
+```sh {class="command-line" data-prompt="$"}
+viam datapipelines disable --id=abc123
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--id` | ID of the data pipeline. | **Required** |
+
+#### `datapipelines delete`
+
+Delete a data pipeline.
+
+```sh {class="command-line" data-prompt="$"}
 viam datapipelines delete --id=abc123
 ```
 
-#### Command options
-
 <!-- prettier-ignore -->
-| Command option | Description | Positional arguments |
-| -------------- | ----------- | -------------------- |
-| `create` | Create a new data pipeline. | - |
-| `describe` | Get detailed information about a specific data pipeline. | - |
-| `delete` | Delete a data pipeline. | - |
-| `enable` | Resume executing a disabled data pipeline. | - |
-| `disable` | Stop executing a data pipeline without deleting it. | - |
-| `list` | List all data pipelines in an organization. | - |
-| `rename` | Rename a data pipeline. | - |
-| `--help` | Return help. | - |
-
-##### Named arguments
-
-<!-- prettier-ignore -->
-| Argument | Description | Applicable commands | Required? |
-| -------- | ----------- | ------------------- | --------- |
-| `--org-id` | ID of the organization that owns the data pipeline. Uses default org if set. | `create`, `list` | Optional |
-| `--name` | Name of the data pipeline. | `create`, `rename` | **Required** |
-| `--schedule` | Cron schedule that expresses when the pipeline should run, for example `0 9 * * *` for daily at 9 AM. | `create` | **Required** for `create` |
-| `--mql` | MQL (MongoDB Query Language) query as a JSON string for data processing. You must specify either `--mql` or `--mql-path` when creating a pipeline. | `create` | Optional |
-| `--mql-path` | Path to a JSON file containing the MQL query for the data pipeline. You must specify either `--mql` or `--mql-path` when creating a pipeline. | `create` | Optional |
-| `--data-source-type` | Data source type for the pipeline. Options: `standard` (default), `hotstorage`. | `create` | Optional |
-| `--id` | ID of the data pipeline. | `enable`, `delete`, `describe`, `disable`, `rename` | **Required** |
-| `--enable-backfill` | Enable the data pipeline to run over organization's historical data. Default: `false`. | `create` | **Required** |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--id` | ID of the data pipeline. | **Required** |
 
 ### `dataset`
 
@@ -227,97 +458,182 @@ viam dataset data add ids --dataset-id=<dataset-id>  --binary-data-ids=<binary-d
 viam dataset data remove ids --dataset-id=<dataset-id> --binary-data-ids=<binary-data-ids>
 ```
 
-Examples:
+#### `dataset create`
+
+Create a new dataset.
 
 ```sh {class="command-line" data-prompt="$"}
-# create a new dataset
 viam dataset create --org-id=123 --name=MyDataset
+```
 
-# rename dataset 123 from MyDataset to MyCoolDataset
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | Organization ID of the organization the dataset belongs to. | **Required** |
+| `--name` | The name of the dataset to create. | **Required** |
+
+#### `dataset rename`
+
+Rename an existing dataset.
+
+```sh {class="command-line" data-prompt="$"}
 viam dataset rename --dataset-id=123 --name=MyCoolDataset
+```
 
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--dataset-id` | Dataset to rename. To retrieve the ID, navigate to your dataset's page, click **…** in the left-hand menu, and click **Copy dataset ID**. | **Required** |
+| `--name` | The new name for the dataset. | **Required** |
+
+#### `dataset list`
+
+List dataset information from specified IDs or for an org ID.
+
+```sh {class="command-line" data-prompt="$"}
 # show dataset information for all datasets within a specified org
 viam dataset list --org-id=123
 
 # show dataset information for the specified dataset IDs
 viam dataset list --dataset-ids=123,456
+```
 
-# delete the specified dataset
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | Organization ID of the organization the dataset belongs to. | Optional |
+| `--dataset-ids` | Dataset IDs of datasets to be listed (comma-separated list). To retrieve these IDs, navigate to your dataset's page, click **…** in the left-hand menu, and click **Copy dataset ID**. | Optional |
+
+#### `dataset delete`
+
+Delete a dataset.
+
+```sh {class="command-line" data-prompt="$"}
 viam dataset delete --dataset-id=123
+```
 
-# export dataset abc to output directory ./dataset/example in two folders called "data" and "metadata"
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--dataset-id` | Dataset to delete. | **Required** |
+
+#### `dataset export`
+
+Download all the data from a dataset to a specified output directory in two folders called "data" and "metadata".
+
+```sh {class="command-line" data-prompt="$"}
 viam dataset export --destination=./dataset/example --dataset-id=abc
+```
 
-# merge datasets 123 and 456 into a new dataset named CombinedDataset
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--dataset-id` | Dataset to export. | **Required** |
+| `--destination` | Output directory for downloaded data. | **Required** |
+| `--only-jsonl` | Include only the JSON Lines files for local testing. No binary data is downloaded. | Optional |
+| `--force-linux-path` | Force the use of Linux-style paths in the dataset.jsonl file. | Optional |
+| `--parallel` | Number of download requests to make in parallel, with a default value of 100. | Optional |
+
+#### `dataset merge`
+
+Merge multiple datasets into a new dataset.
+
+```sh {class="command-line" data-prompt="$"}
 viam dataset merge --name=CombinedDataset --dataset-ids=123,456 --org-id=789
+```
 
-# add images tagged with the "example" tag between January and October of 2023 to dataset abc
-viam dataset data add filter --dataset-id=abc --location-ids=123 --org-ids=456 --start=2023-01-01T05:00:00.000Z --end=2023-10-01T04:00:00.000Z --tags=example
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--name` | The name of the new merged dataset. | **Required** |
+| `--dataset-ids` | Dataset IDs of datasets to merge (comma-separated list). | **Required** |
+| `--org-id` | Organization ID of the organization the dataset belongs to. | **Required** |
 
-# remove images tagged with the "example" tag between January and October of 2023 to dataset abc
-viam dataset data remove filter --dataset-id=abc --location-ids=123 --org-ids=456 --start=2023-01-01T05:00:00.000Z --end=2023-10-01T04:00:00.000Z --tags=example
+#### `dataset data add ids`
 
-# add images with binary data IDs aaa and bbb in the org 123 and location 456 to dataset abc
+Add new images to an existing dataset by binary data ID. See [Using the `ids` argument](#using-the-ids-argument) for details on retrieving the IDs.
+
+```sh {class="command-line" data-prompt="$"}
 viam dataset data add ids --dataset-id=abc --binary-data-ids=aaa,bbb
+```
 
-# remove images with binary data IDs aaa and bbb in the org 123 and location 456 from dataset abc
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--dataset-id` | Dataset to add images to. To retrieve the ID, navigate to your dataset's page, click **…** in the left-hand menu, and click **Copy dataset ID**. | **Required** |
+| `--binary-data-ids` | The binary data IDs of the images to add. | **Required** |
+| `--org-id` | Organization ID of the organization the dataset belongs to. | Optional |
+
+#### `dataset data add filter`
+
+Add to an existing dataset images that match a specified [filter](#using-the-filter-argument).
+
+```sh {class="command-line" data-prompt="$"}
+viam dataset data add filter --dataset-id=abc --location-ids=123 --org-ids=456 --start=2023-01-01T05:00:00.000Z --end=2023-10-01T04:00:00.000Z --tags=example
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--dataset-id` | Dataset to add images to. | **Required** |
+| `--org-id` | Organization ID of the organization the dataset belongs to. | Optional |
+| `--org-ids` | Organization IDs of the organizations to filter data on. | Optional |
+| `--start` | ISO-8601 timestamp indicating the start of the interval. | Optional |
+| `--end` | ISO-8601 timestamp indicating the end of the interval. | Optional |
+| `--tags` | Filter by specified tag (accepts comma-separated list). | Optional |
+| `--bbox-labels` | Filter data on bounding box labels. Accepts comma-separated list. | Optional |
+| `--component-name` | Filter data on component name. | Optional |
+| `--component-type` | Filter data on component type. | Optional |
+| `--location-ids` | Filter data on location IDs. Accepts comma-separated list. | Optional |
+| `--machine-id` | Filter data on machine ID. | Optional |
+| `--machine-name` | Filter data on machine name. | Optional |
+| `--method` | Filter data on capture method. | Optional |
+| `--mime-types` | Filter data on MIME types. Accepts comma-separated list. | Optional |
+| `--part-id` | Filter data on part ID. | Optional |
+| `--part-name` | Filter data on part name. | Optional |
+
+#### `dataset data remove ids`
+
+Remove images from an existing dataset by binary data ID. See [Using the `ids` argument](#using-the-ids-argument) for details on retrieving the IDs.
+
+```sh {class="command-line" data-prompt="$"}
 viam dataset data remove ids --dataset-id=abc --binary-data-ids=aaa,bbb
 ```
 
-#### Command options
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--dataset-id` | Dataset to remove images from. | **Required** |
+| `--binary-data-ids` | The binary data IDs of the images to remove. | **Required** |
+
+#### `dataset data remove filter`
+
+Remove from an existing dataset images that match a specified [filter](#using-the-filter-argument).
+
+```sh {class="command-line" data-prompt="$"}
+viam dataset data remove filter --dataset-id=abc --location-ids=123 --org-ids=456 --start=2023-01-01T05:00:00.000Z --end=2023-10-01T04:00:00.000Z --tags=example
+```
 
 <!-- prettier-ignore -->
-| Command option | Description | Positional arguments |
-| -------------- | ----------- | -------------------- |
-| `create` | Create a new dataset. | - |
-| `rename` | Rename an existing dataset. | - |
-| `list` | List dataset information from specified IDs or for an org ID. | - |
-| `delete` | Delete a dataset. | - |
-| `data add` | Add new images to an existing dataset by binary data ID or add images that match a specified [filter](#using-the-filter-argument). | `ids`, `filter` |
-| `data remove` | Remove images from an existing dataset by binary data ID or remove images that match a specified [filter](#using-the-filter-argument). | `ids`, `filter` |
-| `export` | Download all the data from a dataset. | - |
-| `merge` | Merge multiple datasets into a new dataset. | - |
-| `--help` | Return help. | - |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--dataset-id` | Dataset to remove images from. | **Required** |
+| `--org-ids` | Organization IDs of the organizations to filter data on. | Optional |
+| `--start` | ISO-8601 timestamp indicating the start of the interval. | Optional |
+| `--end` | ISO-8601 timestamp indicating the end of the interval. | Optional |
+| `--tags` | Filter by specified tag (accepts comma-separated list). | Optional |
+| `--bbox-labels` | Filter data on bounding box labels. Accepts comma-separated list. | Optional |
+| `--component-name` | Filter data on component name. | Optional |
+| `--component-type` | Filter data on component type. | Optional |
+| `--location-ids` | Filter data on location IDs. Accepts comma-separated list. | Optional |
+| `--machine-id` | Filter data on machine ID. | Optional |
+| `--machine-name` | Filter data on machine name. | Optional |
+| `--method` | Filter data on capture method. | Optional |
+| `--mime-types` | Filter data on MIME types. Accepts comma-separated list. | Optional |
+| `--part-id` | Filter data on part ID. | Optional |
+| `--part-name` | Filter data on part name. | Optional |
 
-##### Positional arguments
-
-<!-- prettier-ignore -->
-| Argument | Description |
-| -------- | ----------- |
-| `filter` | `add` or `remove` images from a dataset using a filter. See [Using the `filter` argument)](#using-the-filter-argument). |
-| `ids` | `add` or `remove` images from a dataset by specifying one or more binary data IDs as a comma-separated list. See [Using the `ids` argument)](#using-the-ids-argument). |
-| `--help` | Return help. |
-
-##### Named arguments
-
-<!-- prettier-ignore -->
-| Argument | Description | Applicable commands | Required? |
-| -------- | ----------- | ------------------- | --------- |
-| `--dataset-id` | Dataset to perform an operation on. To retrieve the ID, navigate to your dataset's page, click **…** in the left-hand menu, and click **Copy dataset ID** | `rename`, `delete`, `data add`, `data remove`, `export` | **Required** |
-| `--dataset-ids` | Dataset IDs of datasets to be listed or merged (comma-separated list). To retrieve these IDs, navigate to your dataset's page, click **…** in the left-hand menu, and click **Copy dataset ID** | `list`, `merge` | Optional for `list`; **Required** for `merge` |
-| `--destination` | Output directory for downloaded data. | `export` | **Required** |
-| `--end` | ISO-8601 timestamp indicating the end of the interval. | `data add`, `data remove` | Optional |
-| `--binary-data-ids` | The binary data IDs of the files to perform an operation on. | `data add ids`, `data remove ids` | **Required** |
-| `--only-jsonl` | Include only the JSON Lines files for local testing. No binary data is downloaded. | `export` | Optional |
-| `--force-linux-path` | Force the use of Linux-style paths in the dataset.jsonl file. | `export` | Optional |
-| `--name` | The name of the dataset to create, rename, or merge into. | `create`, `rename`, `merge` | **Required** |
-| `--org-id` | Organization ID of the organization the dataset belongs to. | `create`, `data add`, `list`, `merge` | **Required** for `create` and `merge`; Optional otherwise |
-| `--org-ids` | Organization IDs of the organizations to filter data on. | `data add filter`, `data remove filter` | Optional |
-| `--parallel` | Number of download requests to make in parallel, with a default value of 100. | `export` | Optional |
-| `--start` | ISO-8601 timestamp indicating the start of the interval. | `data add`, `data remove` | Optional |
-| `--tags` | Filter by specified tag (accepts comma-separated list). | `data add`, `data remove` | Optional |
-| `--bbox-labels` | Filter data on bounding box labels. Accepts comma-separated list. | `data add filter`, `data remove filter` | Optional |
-| `--component-name` | Filter data on component name. | `data add filter`, `data remove filter` | Optional |
-| `--component-type` | Filter data on component type. | `data add filter`, `data remove filter` | Optional |
-| `--location-ids` | Filter data on location IDs. Accepts comma-separated list. | `data add filter`, `data remove filter` | Optional |
-| `--machine-id` | Filter data on machine ID. | `data add filter`, `data remove filter` | Optional |
-| `--machine-name` | Filter data on machine name. | `data add filter`, `data remove filter` | Optional |
-| `--method` | Filter data on capture method. | `data add filter`, `data remove filter` | Optional |
-| `--mime-types` | Filter data on MIME types. Accepts comma-separated list. | `data add filter`, `data remove filter` | Optional |
-| `--part-id` | Filter data on part ID. | `data add filter`, `data remove filter` | Optional |
-| `--part-name` | Filter data on part name. | `data add filter`, `data remove filter` | Optional |
-
-##### Using the `ids` argument
+#### Using the `ids` argument
 
 When you use the `viam dataset data add` and `viam dataset data remove` commands, you specify images to add or remove using their binary data IDs as a comma-separated list.
 For example, the following command adds three images specified by their binary data IDs to the specified dataset:
@@ -345,7 +661,7 @@ The **Binary Data ID** is shown under the **DETAILS** subtab that appears on the
 
 You cannot use filter arguments such as `--start` or `--end` with the `ids` argument.
 
-##### Using the `filter` argument
+#### Using the `filter` argument
 
 When you use the `viam dataset data add`, `viam dataset data remove` or `viam data tag` commands, you can optionally `filter` by common search criteria to `add` or `remove` a specific subset of images based on a search filter.
 For example, the following command adds all images captured between January 1 and October 1, 2023, that have the `example` tag applied, to the specified dataset:
@@ -365,7 +681,7 @@ Click **...** in the left-hand menu and click **Copy dataset ID**.
 
 To find a location ID, run `viam locations list` or visit your [fleet's page](https://app.viam.com/robots) and copy from **Location ID**.
 
-###### Copy `export` command
+##### Copy `export` command
 
 You can also have the filter parameters generated for you using the **Filters** pane of the **DATA** tab.
 Navigate to the [**DATA** tab](https://app.viam.com/data/view), make your selections from the search parameters under the **Filters** pane (such as robot name, start and end time, or tags), and click the **Copy export command** button.
@@ -387,24 +703,31 @@ viam defaults set-location --location-id=<location-id>
 viam defaults clear-location
 ```
 
-#### Command options
+#### `defaults set-org`
+
+Set the default organization argument.
 
 <!-- prettier-ignore -->
-| Command option | Description |
-| -------------- | ----------- |
-| `set-org` | Set the default organization argument. |
-| `clear-org` | Clear the default organization argument. |
-| `set-location` | Set the default location argument. |
-| `clear-location` | Clear the default location argument. |
-| `--help` | Return help. |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization ID to set as the default. | **Required** |
 
-##### Named arguments
+#### `defaults clear-org`
+
+Clear the default organization argument.
+
+#### `defaults set-location`
+
+Set the default location argument.
 
 <!-- prettier-ignore -->
-| Argument | Description | Applicable commands | Required? |
-| -------- | ----------- | ------------------- | --------- |
-| `--org-id` | The organization ID to set as the default. | `set-org` | **Required** |
-| `--location-id` | The location ID to set as the default. | `set-location` | **Required** |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--location-id` | The location ID to set as the default. | **Required** |
+
+#### `defaults clear-location`
+
+Clear the default location argument.
 
 ### `infer`
 
@@ -431,8 +754,6 @@ Bounding Box Format: [x_min, y_min, x_max, y_max]
   No annotations.
 ```
 
-#### Named arguments
-
 <!-- prettier-ignore -->
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
@@ -452,62 +773,71 @@ viam locations list [<organization id>]
 viam locations api-key create --location-id=<location-id>
 ```
 
-#### Command options
+#### `locations list`
+
+List all locations (name and id) that the authenticated session has access to, grouped by organization.
+
+```sh {class="command-line" data-prompt="$"}
+viam locations list [<organization id>]
+```
+
+Pass an organization ID as a positional argument to return results for that organization only. Optional.
+
+#### `locations api-key create`
+
+Create an API key for a specific location.
+
+```sh {class="command-line" data-prompt="$"}
+viam locations api-key create --location-id=<location-id>
+```
 
 <!-- prettier-ignore -->
-| Command option | Description | Positional arguments |
-| -------------- | ----------- | -------------------- |
-| `list` | List all locations (name and id) that the authenticated session has access to, grouped by organization | **organization id** : (_optional_) return results for specified organization only. |
-| `api-key` | Work with an API key for your location. | `create` |
-| `--help` | Return help. | - |
-
-##### Positional arguments: `api-key`
-
-<!-- prettier-ignore -->
-| Argument | Description |
-| -------- | ----------- |
-| `create` | Create an API key for a specific location. |
-| `--help` | Return help. |
-
-##### Named arguments
-
-<!-- prettier-ignore -->
-| Argument | Description | Applicable commands | Required? |
-| -------- | ----------- | ------------------- | --------- |
-| `--location-id` | The location to create an API key for. | `api-key` | **Required** |
-| `--name` | The name of the API key. | `api-key` | Optional |
-| `--org-id` | The organization ID to attach the key to. | `api-key` | Optional |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--location-id` | The location to create an API key for. | **Required** |
+| `--name` | The name of the API key. | Optional |
+| `--org-id` | The organization ID to attach the key to. | Optional |
 
 ### `login`
 
-The `login` command allows you to authorize your device for CLI usage.
+The `login` command authorizes your device for CLI usage.
+By default, `viam login` opens a browser to authenticate using a personal access token.
+Pass `--no-browser` to authenticate in a headless environment without opening a browser.
+Use `viam login api-key` to authenticate using an API key, or `viam login print-access-token` to print the access token used by the current session.
+See [Authenticate](/cli/overview/#authenticate).
 
 ```sh {class="command-line" data-prompt="$"}
-viam login
+viam login [--no-browser]
 viam login api-key --key-id=<api-key-uuid> --key=<api-key-secret-value>
 viam login print-access-token
 ```
 
-Use `viam login` to authenticate using a personal access token, or `viam login api-key` to authenticate using an API key.
-See [Authenticate](/cli/overview/#authenticate).
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--no-browser` | Authenticate in a headless environment by preventing the opening of the default browser during login. Default: `false`. | Optional |
 
-#### Command options
+#### `login api-key`
+
+Authenticate to Viam using an organization, location, or machine part API key.
+
+```sh {class="command-line" data-prompt="$"}
+viam login api-key --key-id=<api-key-uuid> --key=<api-key-secret-value>
+```
 
 <!-- prettier-ignore -->
-| Command option | Description | Positional arguments |
-| -------------- | ----------- | -------------------- |
-| `api-key` | Authenticate to Viam using an organization, location, or machine part API key. | - |
-| `print-access-token` | Prints the access token used to authenticate the current CLI session. | - |
-| `--no-browser` | Authenticate in a headless environment by preventing the opening of the default browser during login (default: `false`). | - |
-| `--help` | Return help. | - |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--key-id` | The `key id` (UUID) of the API key. | **Required** |
+| `--key` | The `key value` of the API key. | **Required** |
 
-##### Named arguments
+#### `login print-access-token`
 
-<!-- prettier-ignore -->
-| Argument | Description | Applicable commands | Required? |
-| -------- | ----------- | ------------------- | --------- |
-| `--key-id` | The `key id` (UUID) of the API key. | `api-key` | **Required** |
-| `--key` | The `key value` of the API key. | `api-key` | **Required** |
+Print the access token used to authenticate the current CLI session.
+
+```sh {class="command-line" data-prompt="$"}
+viam login print-access-token
+```
 
 ### `logout`
 
@@ -549,48 +879,230 @@ viam machines part restart --machine=<machine id> --part=<part id>
 viam machines part cp --part=<part id> <file name> machine:/path/to/file
 ```
 
-Examples:
+To use `part shell` and `part cp`, add the [`ViamShellDanger` fragment](https://app.viam.com/fragment/b511adfa-80ab-4a70-9bd5-fbb14696b17e/json), which contains the latest version of the shell service.
+
+#### `machines create`
+
+Create a new machine in a specified location.
 
 ```sh {class="command-line" data-prompt="$"}
-# create a new machine
 viam machines create --name="My Machine" --location=12345
+```
 
-# update machine name or location
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--name` | Name for the machine. | **Required** |
+| `--location` | ID of the location that the machine belongs to. | **Required** |
+
+#### `machines update`
+
+Move a machine from one location to another and/or rename the machine.
+
+```sh {class="command-line" data-prompt="$"}
 viam machines update --machine=123 --name="New Name"
 viam machines update --machine=123 --location=67890
+```
 
-# delete a machine
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--machine` | Machine ID or name for which the command is being issued. If machine name is used instead of ID, `--organization` and `--location` are required. | **Required** |
+| `--new-name` | New name for the machine when renaming. | Optional |
+| `--new-location` | ID of the location to move the machine to. | Optional |
+| `--organization` | ID of the organization that the machine belongs to. | Optional |
+| `--location` | ID of the current location of the machine. | Optional |
+
+#### `machines delete`
+
+Delete a machine. Passing location and organization is optional but speeds up the process.
+
+```sh {class="command-line" data-prompt="$"}
 viam machines delete --machine=123
+```
 
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--machine` | Machine ID or name. | **Required** |
+| `--location` | ID of the location that the machine belongs to. | Optional |
+| `--organization` | ID of the organization that the machine belongs to. | Optional |
+
+#### `machines list`
+
+List all machines that the authenticated session has access to in a specified organization or location. Defaults to first organization and location alphabetically.
+
+```sh {class="command-line" data-prompt="$"}
 # list all machines in an organization, in all locations
 viam machines list --all --organization=12345
+```
 
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--all` | List all machines in the organization. Overrides `--location` flag. Default: `false`. | Optional |
+| `--location` | ID of the location to list machines in. | Optional |
+| `--organization` | ID of the organization to list machines in. | Optional |
+
+#### `machines status`
+
+Retrieve machine status for a specified machine.
+
+```sh {class="command-line" data-prompt="$"}
 # get machine status
-viam machines status  --machine=123
+viam machines status --machine=123
+```
 
-# create an API key for a machine
-viam machines api-key create --machine-id=123 --name=MyKey
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--machine` | Machine ID or name. | **Required** |
+| `--location` | ID of the location that the machine belongs to. | Optional |
+| `--organization` | ID of the organization that the machine belongs to. | Optional |
 
+#### `machines logs`
+
+Retrieve logs for a specified machine.
+
+```sh {class="command-line" data-prompt="$"}
 # stream logs from a machine
 viam machines logs --machine=123
+```
 
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--machine` | Machine ID or name. | **Required** |
+| `--errors` | Boolean, return only errors. Default: `false`. | Optional |
+| `--levels` | Filter logs by levels (debug, info, warn, error). Accepts multiple inputs in comma-separated list. | Optional |
+| `--keyword` | Filter logs by keyword. | Optional |
+| `--start` | Filter logs to include only those after the start time. Time format example: `2025-01-13T21:30:00Z` (ISO-8601 timestamp in RFC3339). | Optional |
+| `--end` | Filter logs to include only those before the end time. Time format example: `2025-01-13T21:35:00Z` (ISO-8601 timestamp in RFC3339). | Optional |
+| `--count` | The number of logs to fetch. | Optional |
+| `--format` | The file format for the output file. Options: `text` or `json`. | Optional |
+| `--output` | The path to the output file to store logs in. | Optional |
+| `--location` | ID of the location that the machine belongs to. | Optional |
+| `--organization` | ID of the organization that the machine belongs to. | Optional |
+
+#### `machines api-key create`
+
+Create an API key for a specific machine.
+
+```sh {class="command-line" data-prompt="$"}
+# create an API key for a machine
+viam machines api-key create --machine-id=123 --name=MyKey
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--machine-id` | The ID of the machine to create an API key for. | **Required** |
+| `--name` | The optional name of the API key. If omitted, a name will be auto-generated. | Optional |
+
+#### `machines part list`
+
+List machine parts.
+
+```sh {class="command-line" data-prompt="$"}
 # list machine parts
 viam machines part list --machine=123
+```
 
-# stream logs from a machine part
-viam machines part logs --part=myrover-main --tail=true
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--machine` | Machine ID or name. | **Required** |
+| `--location` | ID of the location that the machine belongs to. | Optional |
+| `--organization` | ID of the organization that the machine belongs to. | Optional |
 
+#### `machines part status`
+
+Retrieve machine status for a specified machine part.
+
+```sh {class="command-line" data-prompt="$"}
+viam machines part status --machine=<machine id>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+| `--location` | ID of the location that the machine belongs to. | Optional |
+| `--organization` | ID of the organization that the machine belongs to. | Optional |
+
+#### `machines part run`
+
+Run a component or service command, optionally at a specified interval. For commands that return data in their response, you can use this to stream data. See [Using the `--stream` and `--data` arguments](#using-the---stream-and---data-arguments).
+
+```sh {class="command-line" data-prompt="$"}
 # stream classifications from a machine part every 500 milliseconds from the Viam Vision Service with classifier "stuff_detector"
 viam machines part run --part=myrover-main --stream=500ms \
 --data='{"name": "vision", "camera_name": "cam", "classifier_name": "stuff_classifier", "n":1}' \
 viam.service.vision.v1.VisionService.GetClassificationsFromCamera
+```
 
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+| `--data` | Command data for the command being request to run. See [Using the `--stream` and `--data` arguments](#using-the---stream-and---data-arguments). | **Required** |
+| `--stream` | If specified, the interval in which to stream the specified data, for example, 100ms or 1s. | Optional |
+
+#### `machines part logs`
+
+Get logs for the specified machine part.
+
+```sh {class="command-line" data-prompt="$"}
+# stream logs from a machine part
+viam machines part logs --part=myrover-main --tail=true
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+| `--tail` | Tail (stream) logs. Default: `false`. | Optional |
+| `--errors` | Return only errors. Default: `false`. | Optional |
+| `--levels` | Filter logs by levels (debug, info, warn, error). Accepts multiple inputs in comma-separated list. | Optional |
+| `--keyword` | Filter logs by keyword. | Optional |
+| `--start` | Filter logs to include only those after the start time. | Optional |
+| `--end` | Filter logs to include only those before the end time. | Optional |
+| `--count` | The number of logs to fetch. | Optional |
+| `--format` | The file format for the output file. Options: `text` or `json`. | Optional |
+| `--output` | The path to the output file to store logs in. | Optional |
+
+#### `machines part shell`
+
+Access a machine part securely using a secure shell to execute commands. To use this feature you must add the [`ViamShellDanger` fragment](https://app.viam.com/fragment/b511adfa-80ab-4a70-9bd5-fbb14696b17e/json). The `ViamShellDanger` fragment contains the latest version of the shell service, which you must add to your machine before copying files or using the shell.
+
+```sh {class="command-line" data-prompt="$"}
+viam machines part shell --machine=<machine id> --part=<part id>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+
+#### `machines part restart`
+
+Restart a machine part.
+
+```sh {class="command-line" data-prompt="$"}
 # restart a part of a specified machine
 viam machines part restart --part=123
+```
 
-# tunnel connections to the specified port on a machine part
-viam machines part tunnel --part=123 --destination-port=1111 --local-port 2222
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
 
+#### `machines part cp`
+
+Copy files to and from a machine part. To use this feature you must add the [`ViamShellDanger` fragment](https://app.viam.com/fragment/b511adfa-80ab-4a70-9bd5-fbb14696b17e/json), which contains the shell service, to your machine. Once added you can use `cp` in a similar way to the Linux `scp` command to copy files to and from machines.
+
+```sh {class="command-line" data-prompt="$"}
 # Copy a single file to a machine:
 viam machines part cp --part=123 my_file machine:/home/user/
 
@@ -608,96 +1120,184 @@ viam machines part cp --part=123 -r machine:my_dir ~/Downloads/
 
 # Copy multiple files from the machine to a local destination with recursion and keep original permissions and metadata for the files:
 viam machines part cp --part=123 -r -p machine:my_dir machine:my_file ~/some/existing/dir/
+```
 
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+| `--recursive`, `-r` | Recursively copy files. Default: `false`. | Optional |
+| `--preserve`, `-p` | Preserve modification times and file mode bits from the source files. Default: `false`. | Optional |
+
+#### `machines part tunnel`
+
+Tunnel connections to a specified port on a machine part. You must explicitly enumerate ports to which you are allowed to tunnel in your machine's JSON config. See [Tunnel to a machine part](/fleet/system-settings/).
+
+```sh {class="command-line" data-prompt="$"}
+# tunnel connections to the specified port on a machine part
+viam machines part tunnel --part=123 --destination-port=1111 --local-port 2222
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+| `--destination-port` | The port on a machine part to tunnel to. | **Required** |
+| `--local-port` | The local port from which to tunnel. | **Required** |
+
+#### `machines part get-ftdc`
+
+Download FTDC data from a machine part. Requires the shell service.
+
+```sh {class="command-line" data-prompt="$"}
 # Download FTDC data from a part to a local directory:
 viam machines part get-ftdc --part=123 ~/some/existing/dir/
 ```
 
-#### Command options
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+
+#### `machines part create`
+
+Create a new part on a machine.
+
+```sh {class="command-line" data-prompt="$"}
+viam machines part create --machine=<machine id> --part-name=<new part name>
+```
 
 <!-- prettier-ignore -->
-| Command option | Description | Positional arguments |
-| -------------- | ----------- | -------------------- |
-| `create` | Create a new machine in a specified location. | - |
-| `update` | Move a machine from one location to another and/or rename the machine. | - |
-| `delete` | Delete a machine. Passing location and organization is optional but speeds up the process. | - |
-| `list` | List all machines that the authenticated session has access to in a specified organzation or location. Defaults to first organization and location alphabetically. | - |
-| `api-key` | Work with an API key for your machine. | `create` (see [positional arguments: api-key](#positional-arguments-api-key)) |
-| `status` | Retrieve machine status for a specified machine. | - |
-| `logs` | Retrieve logs for a specified machine. | - |
-| `part` | Manage a specified machine part. | `list`, `status`, `run`, `logs`, `shell`, `restart`, `tunnel`, `get-ftdc`, `cp`, `create`, `delete`, `add-resource`, `remove-resource`, `fragments`, `motion` (see [positional arguments: part](#positional-arguments-part)). To use `part shell` and `part cp`, add the [ViamShellDanger fragment](https://app.viam.com/fragment/b511adfa-80ab-4a70-9bd5-fbb14696b17e/json). |
-| `--help` | Return help. | - |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--machine` | Machine ID or name. | **Required** |
+| `--part-name` | Name for the new part. | **Required** |
 
-##### Positional arguments: `api-key`
+#### `machines part delete`
 
-<!-- prettier-ignore -->
-| Argument | Description |
-| -------- | ----------- |
-| `create` | Create an API key for a specific machine. |
-| `--help` | Return help. |
+Delete a part.
 
-##### Positional arguments: `part`
+```sh {class="command-line" data-prompt="$"}
+viam machines part delete --part=<part id>
+```
 
 <!-- prettier-ignore -->
-| Argument | Description |
-| -------- | ----------- |
-| `list` | List machine parts. |
-| `status` | Retrieve machine status for a specified machine part. |
-| `run` | Run a component or service command, optionally at a specified interval. For commands that return data in their response, you can use this to stream data. |
-| `logs` | Get logs for the specified machine or machine part. |
-| `shell` | Access a machine part securely using a secure shell to execute commands. To use this feature you must add the [`ViamShellDanger` fragment](https://app.viam.com/fragment/b511adfa-80ab-4a70-9bd5-fbb14696b17e/json). The `ViamShellDanger` fragment contains the latest version of the shell service, which you must add to your machine before copying files or using the shell. |
-| `restart` | Restart a machine part. |
-| `cp` | Copy files to and from a machine part. To use this feature you must add the [`ViamShellDanger` fragment](https://app.viam.com/fragment/b511adfa-80ab-4a70-9bd5-fbb14696b17e/json), which contains the shell service, to your machine. Once added you can use `cp` in a similar way to the Linux `scp` command to copy files to and from machines. |
-| `tunnel` | Tunnel connections to a specified port on a machine part. You must explicitly enumerate ports to which you are allowed to tunnel in your machine's JSON config. See [Tunnel to a machine part](/fleet/system-settings/). |
-| `get-ftdc` | Download FTDC data from a machine part. Requires the shell service. |
-| `create` | Create a new part on a machine. |
-| `delete` | Delete a part. |
-| `add-resource` | Add a component or service to a part's configuration by specifying an API and model triplet. |
-| `remove-resource` | Remove a resource from a part's configuration. |
-| `fragments add` | Attach a configuration fragment to a part. |
-| `fragments remove` | Detach a configuration fragment from a part. |
-| `motion print-config` | Print the motion planning configuration for the part. |
-| `motion print-status` | Print current motion state for the part. |
-| `motion get-pose` | Get the pose of a component in a reference frame. |
-| `motion set-pose` | Command a component to move to a specific pose. |
-| `--help` | Return help. |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID to delete. | **Required** |
 
-##### Named arguments
+#### `machines part add-resource`
+
+Add a component or service to a part's configuration by specifying an API and model triplet.
+
+```sh {class="command-line" data-prompt="$"}
+viam machines part add-resource --part=<part id> --name=<resource name> --model-name=<namespace:type:model>
+```
 
 <!-- prettier-ignore -->
-| Argument | Description | Applicable commands | Required? |
-| -------- | ----------- | ------------------- | --------- |
-| `--part` | Part ID for which the command is being issued. | `part` | **Required** |
-| `--machine` | Machine ID or name for which the command is being issued. If machine name is used instead of ID, `--organization` and `--location` are required. | `update`, `delete`, `status`, `logs` | **Required** |
-| `--name` | Name for the machine. | `create`, `part add-resource`, `part remove-resource` | **Required** for `create`, `part add-resource`, `part remove-resource` |
-| `--new-name` | New name for the machine when renaming. | `update` | Optional |
-| `--location` | ID of the location that the machine belongs to or to list machines in. | `create`, `delete`, `list`, `status`, `logs`, `part` | **Required** for `create`, Optional for others |
-| `--new-location` | ID of the location to move the machine to. | `update` | Optional |
-| `--organization` | ID of the organization that the machine belongs to or to list machines in. | `delete`, `list`, `status`, `logs`, `part` | Optional |
-| `--all` | List all machines in the organization. Overrides `--location` flag. Default: `false` | `list` | Optional |
-| `--errors` | Boolean, return only errors (default: false). | `logs` | Optional |
-| `--levels` | Filter logs by levels (debug, info, warn, error). Accepts multiple inputs in comma-separated list. | `logs` | Optional |
-| `--tail` | Tail (stream) logs, boolean(default false). | `part logs` | Optional |
-| `--keyword` | Filter logs by keyword. | `logs` | Optional |
-| `--start` | Filter logs to include only those after the start time. Time format example: `2025-01-13T21:30:00Z` (ISO-8601 timestamp in RFC3339). | `logs` | Optional |
-| `--end` | Filter logs to include only those before the end time. Time format example: `2025-01-13T21:35:00Z` (ISO-8601 timestamp in RFC3339). | `logs` | Optional |
-| `--count` | The number of logs to fetch. | `logs` | Optional |
-| `--format` | THe file format for the output file. Options: `text` or `json`. | `logs` | Optional |
-| `--output` | The path to the output file to store logs in. | `logs` | Optional |
-| `--stream` | If specified, the interval in which to stream the specified data, for example, 100ms or 1s. | `part run` | Optional |
-| `--data` | Command data for the command being request to run (see [data argument](#using-the---stream-and---data-arguments)). | `part run` | **Required** |
-| `--machine-id` | The ID of the machine to create an API key for. | `api-key` | **Required** |
-| `--name` | The optional name of the API key. | `api-key` | Optional |
-| `--recursive`, `-r` | Recursively copy files. Default: `false`. | `part cp` | Optional |
-| `--preserve`, `-p` | Preserve modification times and file mode bits from the source files. Default: `false`. | `part cp` | Optional |
-| `--destination-port` | The port on a machine part to tunnel to. | `part tunnel` | **Required** |
-| `--local-port` | The local port from which to tunnel. | `part tunnel` | **Required** |
-| `--part-name` | Name for the new part. | `part create` | **Required** |
-| `--model-name` | Model triplet (`namespace:type:model`) for the resource to add. | `part add-resource` | **Required** |
-| `--fragment` | Fragment ID to add or remove. If omitted for `add`, the CLI prompts interactively. | `part fragments add`, `part fragments remove` | Optional |
-| `--component` | Component name for motion commands. | `part motion get-pose`, `part motion set-pose` | **Required** |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+| `--name` | Name for the resource. | **Required** |
+| `--model-name` | Model triplet (`namespace:type:model`) for the resource to add. | **Required** |
 
-##### Using the `--stream` and `--data` arguments
+#### `machines part remove-resource`
+
+Remove a resource from a part's configuration.
+
+```sh {class="command-line" data-prompt="$"}
+viam machines part remove-resource --part=<part id> --name=<resource name>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+| `--name` | Name of the resource to remove. | **Required** |
+
+#### `machines part fragments add`
+
+Attach a configuration fragment to a part.
+
+```sh {class="command-line" data-prompt="$"}
+viam machines part fragments add --part=<part id> [--fragment=<fragment id>]
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+| `--fragment` | Fragment ID to add. If omitted, the CLI prompts interactively. | Optional |
+
+#### `machines part fragments remove`
+
+Detach a configuration fragment from a part.
+
+```sh {class="command-line" data-prompt="$"}
+viam machines part fragments remove --part=<part id> [--fragment=<fragment id>]
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+| `--fragment` | Fragment ID to remove. | Optional |
+
+#### `machines part motion print-config`
+
+Print the motion planning configuration for the part.
+
+```sh {class="command-line" data-prompt="$"}
+viam machines part motion print-config --part=<part id>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+
+#### `machines part motion print-status`
+
+Print current motion state for the part.
+
+```sh {class="command-line" data-prompt="$"}
+viam machines part motion print-status --part=<part id>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+
+#### `machines part motion get-pose`
+
+Get the pose of a component in a reference frame.
+
+```sh {class="command-line" data-prompt="$"}
+viam machines part motion get-pose --part=<part id> --component=<component name>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+| `--component` | Component name for the motion command. | **Required** |
+
+#### `machines part motion set-pose`
+
+Command a component to move to a specific pose.
+
+```sh {class="command-line" data-prompt="$"}
+viam machines part motion set-pose --part=<part id> --component=<component name>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+| `--component` | Component name for the motion command. | **Required** |
+
+#### Using the `--stream` and `--data` arguments
 
 Issuing the `part` command with the `run` positional argument allows you to run component and service (resource) commands for a selected machine part.
 
@@ -731,22 +1331,17 @@ The `metadata` command allows you to read organization, location, machine, and m
 viam metadata read --part-id=<part-id>
 ```
 
-#### Command options
+#### `metadata read`
+
+Read organization, location, machine, and machine part metadata.
 
 <!-- prettier-ignore -->
-| Command option | Description | Positional arguments |
-| -------------- | ----------- | -------------------- |
-| `read` | Read organization, location, machine, and machine part metadata. | - |
-
-##### Named arguments
-
-<!-- prettier-ignore -->
-| Argument | Description | Applicable commands | Required? |
-| -------- | ----------- | ------------------- | --------- |
-| `--location-id` | The ID of the location to read metadata from. | `read` | Optional |
-| `--machine-id` | The ID of the machine to read metadata from. | `read` | Optional |
-| `--org-id` | The ID of the org to read metadata from. | `read` | Optional |
-| `--part-id` | The ID of the part to read metadata from. | `read` | Optional |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--location-id` | The ID of the location to read metadata from. | Optional |
+| `--machine-id` | The ID of the machine to read metadata from. | Optional |
+| `--org-id` | The ID of the org to read metadata from. | Optional |
+| `--part-id` | The ID of the part to read metadata from. | Optional |
 
 ### `module`
 
@@ -781,6 +1376,15 @@ viam module reload [...named args]
 viam module upload --version=<version> --platform=<platform> [--org-id=<org-id> | --public-namespace=<namespace>] [--module=<path to meta.json>] <module-path> --tags=<tags>
 viam module download [command options]
 viam module local-app-testing --app-url http://localhost:3000
+```
+
+#### `module generate`
+
+Generate a new module with stub files and a <file>meta.json</file> file. Recommended when starting a new module.
+
+```sh {class="command-line" data-prompt="$"}
+# auto-generate stub files for a new modular resource by following prompts
+viam module generate
 ```
 
 {{% alert title="Note" color="note" %}}
@@ -821,51 +1425,221 @@ Services:
 
 {{% /hiddencontent %}}
 
-Examples:
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--resource-subtype` | The API to implement with the modular resource. For example, `motor`. We recommend _not_ using this option and instead following the prompts after running the command. | Optional |
+| `--resource-type` | Whether the new resource is a component or a service. For example, `component`. We recommend _not_ using this option and instead following the prompts. | Optional |
+
+#### `module create`
+
+Generate a <file>meta.json</file> file and register the metadata with the Viam registry. Recommended when you already have working module code.
 
 ```sh {class="command-line" data-prompt="$"}
-# auto-generate stub files for a new modular resource by following prompts
-viam module generate
-
 # generate metadata for and register a module named 'my-module' using your organization's public namespace:
 viam module create --name=my-module --public-namespace=my-namespace
 
 # generate metadata for and register a module named "my-module" using your organization's organization ID:
 viam module create --name=my-module --org-id=abc
+```
 
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--name` | The name of the module. For example: `hello-world`. | **Required** |
+| `--org-id` | The organization ID to associate the module to. See [Using the `--org-id` and `--public-namespace` arguments](#using-the---org-id-and---public-namespace-arguments). | **Required** |
+| `--public-namespace` | The namespace to associate the module to. See [Using the `--org-id` and `--public-namespace` arguments](#using-the---org-id-and---public-namespace-arguments). | **Required** |
+| `--local-only` | Create a meta.json file for local use, but don't create the module on the backend. Default: `false`. | Optional |
+
+#### `module update`
+
+Update your module's metadata and documentation in the Viam registry. Updates are based on changes to [<file>meta.json</file>](/build-modules/module-reference/), the module <file>README.md</file>, and the model readme <FILE>namespace_module_model.md</FILE>. Viam automatically runs `update` when you `upload` your module, as well as when you trigger a cloud build with Viam's default build action.
+
+```sh {class="command-line" data-prompt="$"}
 # update an existing module
 viam module update --module=./meta.json
+```
 
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--module` | The path to the [`meta.json` file](/build-modules/module-reference/) for the module, if not in the current directory. | Optional |
+
+#### `module update-models`
+
+Update the module's metadata file with the models it provides.
+
+```sh {class="command-line" data-prompt="$"}
 # update a module's metadata file based on models it provides
 viam module update-models --binary=./packaged-module.tar.gz --module=./meta.json
+```
 
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--binary` | The module executable to run (binary or script). Must work on the OS or processor of the device. If omitted, the CLI uses the entrypoint defined in <file>meta.json</file>. | Optional |
+| `--module` | The path to the [`meta.json` file](/build-modules/module-reference/) for the module, if not in the current directory. | Optional |
+
+#### `module upload`
+
+Validate and upload a new or existing custom module on your local filesystem to the Viam Registry. See [Upload validation](#upload-validation) for more information.
+
+Pass the path to the file, directory, or compressed archive (with `.tar.gz` or `.tgz` extension) that contains your custom module code as a positional argument.
+
+```sh {class="command-line" data-prompt="$"}
+# upload a new or updated custom module to the Viam Registry:
+viam module upload --version=1.0.0 --platform=darwin/arm64 packaged-module.tar.gz --tags=distro:ubuntu,os_version:20.04,codename:focal,cuda:true,cuda_version:11,jetpack:5
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--version` | The version of your module to set for this upload. See [Using the `--version` argument](#using-the---version-argument). | **Required** |
+| `--platform` | The architecture of your module binary. See [Using the `--platform` argument](#using-the---platform-argument). | **Required** |
+| `--org-id` | The organization ID to associate the module to. See [Using the `--org-id` and `--public-namespace` arguments](#using-the---org-id-and---public-namespace-arguments). | **Required** |
+| `--public-namespace` | The namespace to associate the module to. See [Using the `--org-id` and `--public-namespace` arguments](#using-the---org-id-and---public-namespace-arguments). | **Required** |
+| `--module` | The path to the [`meta.json` file](/build-modules/module-reference/) for the module, if not in the current directory. | Optional |
+| `--upload` | The path to the upload. | Optional |
+| `--tags` | Comma-separated list of platform tags that determine to which platforms this binary can be deployed. Examples: `distro:debian,distro:ubuntu, os_version:22.04,os_codename:jammy`. For a machine to use an uploaded binary, all tags must be satisfied as well as the `--platform` field. <ul><li>`distro`: Distribution. You can find this in `/etc/os-release`. `"debian"` or `"ubuntu"`.</li><li>`os_version`:  Operating System version. On Linux, you can find this in `/etc/os-release`. Example for linux: `22.04`. On Mac, run `sw_vers --productVersion` and use the major version only. Example for mac: `14`.</li><li>`codename`: The operating system codename. Find this in `/etc/os-release`. For example: `"bullseye"`, `"bookworm"`, or `"jammy"`.</li><li>`cuda`: Whether using CUDA compiler. Run `nvcc --version`. For example: `"true"`.</li><li>`cuda_version`: The CUDA compiler version. Run `nvcc --version`. For example: `"11"` or `"12"`.</li><li>`jetpack`: Version of the NVIDIA JetPack SDK. Run `apt-cache show nvidia-jetpack`. For example: `"5"`.</li><li>`pi`: Version of the Raspberry Pi: `"4"` or `"5"`.</li><li>`pifull`: Compute module or model number, for example `cm5p` or `5B`.</li></ul> | Optional |
+| `--force` | Skip local validation of the packaged module, which may result in an unusable module if the contents of the packaged module are not correct. | Optional |
+
+#### `module reload`
+
+Build a module in the cloud and configure the target machine to download it directly. Rebuild and restart if the module is already running.
+
+```sh {class="command-line" data-prompt="$"}
+# build a module and run it on target machine
+viam module reload --part-id e1234f0c-912c-1234-a123-5ac1234612345
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--id` | The module ID (`namespace:module-name` or `org-id:module-name`). | Optional |
+| `--part-id` | Part ID of the machine part. Required if running on a remote device. | Optional |
+| `--cloud-config` | The location of the <FILE>viam.json</FILE> file which contains the machine ID to lookup the part-id. Alternative to `--part-id`. Default: `/etc/viam.json`. | Optional |
+| `--module` | The path to the [`meta.json` file](/build-modules/module-reference/) for the module, if not in the current directory. | Optional |
+| `--model-name` | If passed, creates a resource in the part config with the given model triple. Use with `--resource-name`. Default: Creates no new resource. | Optional |
+| `--resource-name` | If passed, creates a new resource with the given resource name. Use with `--model-name`. Default: Creates no new resource. | Optional |
+| `--local` | Use if the target machine is localhost, to run the entrypoint directly rather than transferring a bundle. Default: `false`. | Optional |
+| `--path` | The path to the root of the git repo to build. Default: `.`. | Optional |
+| `--workdir` | Use this to indicate that your <file>meta.json</file> is in a subdirectory of your repo. `--module` flag should be relative to this. Default: `.`. | Optional |
+
+#### `module reload-local`
+
+Build a module locally and run it on a target machine. Rebuild and restart if it is already running. The module is loaded to <FILE>~/.viam/packages-local/namespace_module-name_from_reload-module.tar.gz</FILE> on the target machine.
+
+```sh {class="command-line" data-prompt="$"}
+# build and configure a module running on your local machine without shipping a tarball.
+viam module reload-local --local
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--id` | The module ID (`namespace:module-name` or `org-id:module-name`). | Optional |
+| `--part-id` | Part ID of the machine part. Required if running on a remote device. | Optional |
+| `--cloud-config` | The location of the <FILE>viam.json</FILE> file which contains the machine ID to lookup the part-id. Alternative to `--part-id`. Default: `/etc/viam.json`. | Optional |
+| `--module` | The path to the [`meta.json` file](/build-modules/module-reference/) for the module, if not in the current directory. | Optional |
+| `--model-name` | If passed, creates a resource in the part config with the given model triple. Use with `--resource-name`. Default: Creates no new resource. | Optional |
+| `--resource-name` | If passed, creates a new resource with the given resource name. Use with `--model-name`. Default: Creates no new resource. | Optional |
+| `--local` | Use if the target machine is localhost, to run the entrypoint directly rather than transferring a bundle. Default: `false`. | Optional |
+| `--workdir` | Use this to indicate that your <file>meta.json</file> is in a subdirectory of your repo. `--module` flag should be relative to this. Default: `.`. | Optional |
+| `--no-build` | Skip build step. Default: `false`. | Optional |
+| `--no-progress` | Hide progress of the file transfer. Default: `false`. | Optional |
+| `--home` | Specify home directory for a remote machine where `$HOME` is not the default `/root`. | Optional |
+| `--name` | The name of the module. For example: `hello-world`. | Optional |
+
+#### `module restart`
+
+Restart a running module.
+
+```sh {class="command-line" data-prompt="$"}
+# restart a running module
+viam module restart --id viam:python-example-module
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--id` | The module ID (`namespace:module-name` or `org-id:module-name`). | Optional |
+| `--part-id` | Part ID of the machine part. Required if running on a remote device. | Optional |
+| `--cloud-config` | The location of the <FILE>viam.json</FILE> file which contains the machine ID to lookup the part-id. Alternative to `--part-id`. Default: `/etc/viam.json`. | Optional |
+| `--name` | The name of the module. For example: `hello-world`. | Optional |
+
+#### `module build start`
+
+Start a module build in a cloud runner using the build step in your [`meta.json` file](/build-modules/module-reference/). See [Using the `build` subcommand](#using-the-build-subcommand).
+
+```sh {class="command-line" data-prompt="$"}
 # initiate a cloud build for a public GitHub repo
 viam module build start --version "0.1.2"
 
 # initiate a cloud build for a private GitHub repo
 viam module build start --version "0.1.2" --token ghp_1234567890abcdefghijklmnopqrstuvwxyzABCD
+```
 
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--version` | The version of your module to set for this build. See [Using the `--version` argument](#using-the---version-argument). | **Required** |
+| `--module` | The path to the [`meta.json` file](/build-modules/module-reference/) for the module, if not in the current directory. | Optional |
+| `--platforms` | List of platforms to cloud build for. Default: `build.arch` in <file>meta.json</file>. | Optional |
+| `--ref` | Git reference to clone when building your module. This can be a branch name or a commit hash. Default: `main`. | Optional |
+| `--token` | GitHub token with repository **Contents** read access, and **Actions** read and write access. Required for private repos, not necessary for public repos. | Optional |
+| `--workdir` | Use this to indicate that your <file>meta.json</file> is in a subdirectory of your repo. `--module` flag should be relative to this. Default: `.`. | Optional |
+
+#### `module build local`
+
+Start a module build locally using the build step in your [`meta.json` file](/build-modules/module-reference/). See [Using the `build` subcommand](#using-the-build-subcommand).
+
+```sh {class="command-line" data-prompt="$"}
 # initiate a build locally without running a cloud build job
 viam module build local
+```
 
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--module` | The path to the [`meta.json` file](/build-modules/module-reference/) for the module, if not in the current directory. | Optional |
+
+#### `module build list`
+
+List the status of your cloud module builds. See [Using the `build` subcommand](#using-the-build-subcommand).
+
+```sh {class="command-line" data-prompt="$"}
 # list all in-progress builds and their build status
 viam module build list
+```
 
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--id` | The build ID to list, as returned from `build start`. | Optional |
+| `--count` | Number of cloud builds to list. Defaults to displaying all builds. | Optional |
+
+#### `module build logs`
+
+Show the logs from a specific cloud module build. See [Using the `build` subcommand](#using-the-build-subcommand).
+
+```sh {class="command-line" data-prompt="$"}
 # initiate a build and return the build logs as soon as completed
 viam module build logs --wait --id=$(viam module build start --version "0.1.2")
+```
 
-# build a module and run it on target machine
-viam module reload --part-id e1234f0c-912c-1234-a123-5ac1234612345
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--id` | The build ID to show logs for, as returned from `build start`. | Optional |
+| `--platform` | Restricts the logs returned by the command to only those build jobs that match the specified platform. See [Using the `--platform` argument](#using-the---platform-argument). | Optional |
+| `--wait` | Wait for the build to finish before outputting any logs. | Optional |
+| `--group-logs` | Group log output by platform. | Optional |
 
-# build and configure a module running on your local machine without shipping a tarball.
-viam module reload-local --local
+#### `module download`
 
-# restart a running module
-viam module restart --id viam:python-example-module
+Download a module package from the registry.
 
-# upload a new or updated custom module to the Viam Registry:
-viam module upload --version=1.0.0 --platform=darwin/arm64 packaged-module.tar.gz --tags=distro:ubuntu,os_version:20.04,codename:focal,cuda:true,cuda_version:11,jetpack:5
-
+```sh {class="command-line" data-prompt="$"}
 # download a module package from the registry to the current directory
 viam module download --id=acme:my-module
 
@@ -874,72 +1648,32 @@ viam module download --id=acme:my-module --destination=/path/to/download/directo
 
 # download a specific version of a module package for a specific platform
 viam module download --id=acme:my-module --version=1.0.0 --platform=linux/amd64
+```
 
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--id` | The module ID (`namespace:module-name` or `org-id:module-name`). | Optional |
+| `--version` | The version of the module to download. Defaults to `latest`. | Optional |
+| `--platform` | The architecture of the module binary to download. See [Using the `--platform` argument](#using-the---platform-argument). | Optional |
+| `--destination` | Output directory for downloaded package. Default: `.`. | Optional |
+
+#### `module local-app-testing`
+
+Test your viam application locally. This will stand up a local proxy at `http://localhost:8012` to simulate the Viam application server.
+
+```sh {class="command-line" data-prompt="$"}
 # proxy your local Viam application and open a browser window and navigate to `http://localhost:8012/
 viam module local-app-testing --app-url http://localhost:3000
 ```
 
-#### Command options
-
 <!-- prettier-ignore -->
-| Command option | Description | Positional arguments |
-| -------------- | ----------- | -------------------- |
-| `generate` | Generate a new module with stub files and a <file>meta.json</file> file. Recommended when starting a new module. | - |
-| `create` | Generate a <file>meta.json</file> file and register the metadata with the Viam registry. Recommended when you already have working module code. | - |
-| `update` | Update your module's metadata and documentation in the Viam registry. Updates are based on changes to [<file>meta.json</file>](/build-modules/module-reference/), the module <file>README.md</file>, and the model readme <FILE>namespace_module_model.md</FILE>. Viam automatically runs `update` when you `upload` your module, as well as when you trigger a cloud build with Viam's default build action. | - |
-| `update-models` | Update the module's metadata file with the models it provides. | - |
-| `upload` | Validate and upload a new or existing custom module on your local filesystem to the Viam Registry. See [Upload validation](#upload-validation) for more information. | **module-path** : specify the path to the file, directory, or compressed archive (with `.tar.gz` or `.tgz` extension) that contains your custom module code. |
-| `reload` | Build a module in the cloud and configure the target machine to download it directly. Rebuild and restart if the module is already running. | - |
-| `reload-local` | Build a module locally and run it on a target machine. Rebuild and restart if it is already running. The module is loaded to <FILE>~/.viam/packages-local/namespace_module-name_from_reload-module.tar.gz</FILE> on the target machine. | - |
-| `restart` | Restart a running module. | - |
-| `build start` | Start a module build in a cloud runner using the build step in your [`meta.json` file](/build-modules/module-reference/). See [Using the `build` subcommand](#using-the-build-subcommand). | - |
-| `build local` | Start a module build locally using the build step in your [`meta.json` file](/build-modules/module-reference/). See [Using the `build` subcommand](#using-the-build-subcommand). | - |
-| `build list` | List the status of your cloud module builds. See [Using the `build` subcommand](#using-the-build-subcommand). | - |
-| `build logs` | Show the logs from a specific cloud module build. See [Using the `build` subcommand](#using-the-build-subcommand). | - |
-| `download` | Download a module package from the registry. | - |
-| `local-app-testing` | Test your viam application locally. This will stand up a local proxy at `http://localhost:8012` to simulate the Viam application server. | - |
-| `--help` | Return help. | - |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--app-url` | The url where local app is running, including port number. For example `http://localhost:5000`. | **Required** |
+| `--machine-id` | The machine ID of the machine you want to test with. You can get your machine ID on the [Fleet page](https://app.viam.com/fleet/machines). | Optional |
 
-##### Named arguments
-
-<!-- prettier-ignore -->
-| Argument | Description | Applicable commands | Required? |
-| -------- | ----------- | ------------------- | --------- |
-| `--binary` | The module executable to run (binary or script). Must work on the OS or processor of the device. If omitted, the CLI uses the entrypoint defined in <file>meta.json</file>. | `update-models` | Optional |
-| `--count` | Number of cloud builds to list, defaults to displaying all builds | `build list` | Optional |
-| `--cloud-config` | The location of the <FILE>viam.json</FILE> file which contains the machine ID to lookup the part-id. Alternative to `--part-id`. Default: `/etc/viam.json` | `reload`, `reload-local`, `restart` | Optional |
-| `--destination` | Output directory for downloaded package (default: `.`) | `download` | Optional |
-| `--force` | Skip local validation of the packaged module, which may result in an unusable module if the contents of the packaged module are not correct. | `upload` | Optional |
-| `--home` | Specify home directory for a remote machine where `$HOME` is not the default `/root`. | `reload-local` | Optional |
-| `--id` | For `build`, the build ID to list or show logs for, as returned from `build start`. For `reload`, `reload-local`, `restart`, and `download`, the module ID (`namespace:module-name` or `org-id:module-name`). | `build list`, `build logs`, `reload`, `reload`, `reload-local`, `restart`, `download` | Optional |
-| `--local` | Use if the target machine is localhost, to run the entrypoint directly rather than transferring a bundle. Default: `false`. | `reload`, `reload-local` | Optional |
-| `--module` | The path to the [`meta.json` file](/build-modules/module-reference/) for the module, if not in the current directory. | `update`, `upload`, `build`, `reload`, `reload-local` | Optional |
-| `--model-name` | If passed, creates a resource in the part config with the given model triple. Use with `--resource-name`. Default: Creates no new resource. | `reload`, `reload-local` | Optional |
-| `--no-build` | Skip build step. Default: `false`. | `reload-local` | Optional |
-| `--no-progress` | Hide progress of the file transfer. Default: `false`. | `reload-local` | Optional |
-| `--part-id` | Part ID of the machine part. Required if running on a remote device. | `reload`, `reload-local`, `restart` | Optional |
-| `--path` | The path to the root of the git repo to build. Default: `.` | `reload` | Optional |
-| `--resource-name` | If passed, creates a new resource with the given resource name. Use with `--model-name`. Default: Creates no new resource. | `reload`, `reload-local` | Optional |
-| `--resource-subtype` | The API to implement with the modular resource. For example, `motor`. We recommend _not_ using this option and instead following the prompts after running the command. | `generate` | Optional |
-| `--resource-type` | Whether the new resource is a component or a service. For example, `component`. We recommend _not_ using this option and instead following the prompts. | `generate` | Optional |
-| `--local-only` | Create a meta.json file for local use, but don't create the module on the backend (default: `false`). | `create` | Optional |
-| `--name` | The name of the module. For example: `hello-world`. | `create`, `reload-local`, `restart` | Optional |
-| `--org-id` | The organization ID to associate the module to. See [Using the `--org-id` argument](#using-the---org-id-and---public-namespace-arguments). | `create`, `upload` | **Required** |
-| `--public-namespace` | The namespace to associate the module to. See [Using the `--public-namespace` argument](#using-the---org-id-and---public-namespace-arguments). | `create`, `upload` | **Required** |
-| `--platform` | The architecture of your module binary. See [Using the `--platform` argument](#using-the---platform-argument). | `upload`, `build logs`, `download` | **Required** for `upload` |
-| `--platforms` | List of platforms to cloud build for. Default: `build.arch` in <file>meta.json</file>. | `build start` | Optional |
-| `--ref` | Git reference to clone when building your module. This can be a branch name or a commit hash. Default: `main`. | `build start` | Optional |
-| `--tags` | Comma-separated list of platform tags that determine to which platforms this binary can be deployed. Examples: `distro:debian,distro:ubuntu, os_version:22.04,os_codename:jammy`. For a machine to use an uploaded binary, all tags must be satisfied as well as the `--platform` field. <ul><li>`distro`: Distribution. You can find this in `/etc/os-release`. `"debian"` or `"ubuntu"`.</li><li>`os_version`:  Operating System version. On Linux, you can find this in `/etc/os-release`. Example for linux: `22.04`. On Mac, run `sw_vers --productVersion` and use the major version only. Example for mac: `14`.</li><li>`codename`: The operating system codename. Find this in `/etc/os-release`. For example: `"bullseye"`, `"bookworm"`, or `"jammy"`.</li><li>`cuda`: Whether using CUDA compiler. Run `nvcc --version`. For example: `"true"`.</li><li>`cuda_version`: The CUDA compiler version. Run `nvcc --version`. For example: `"11"` or `"12"`.</li><li>`jetpack`: Version of the NVIDIA JetPack SDK. Run `apt-cache show nvidia-jetpack`. For example: `"5"`.</li><li>`pi`: Version of the Raspberry Pi: `"4"` or `"5"`.</li><li>`pifull`: Compute module or model number, for example `cm5p` or `5B`.</li></ul> | `upload` | Optional |
-| `--token` | GitHub token with repository **Contents** read access, and **Actions** read and write access. Required for private repos, not necessary for public repos. | `build start` | Optional |
-| `--upload` | The path to the upload. | `upload` | Optional |
-| `--version` | The version of your module to set for this upload or download. For `download`, defaults to `latest`. See [Using the `--version` argument](#using-the---version-argument). | `upload`, `download` | **Required** for `upload` |
-| `--workdir` | Use this to indicate that your <file>meta.json</file> is in a subdirectory of your repo. `--module` flag should be relative to this. Default: `.` | `build start`, `reload`, `reload-local` | Optional |
-| `--wait` | Wait for the build to finish before outputting any logs. | `build logs` | Optional |
-| `--group-logs` | Group log output by platform. | `build logs` | Optional |
-| `--app-url` | The url where local app is running, including port number. For example `http://localhost:5000`. | `local-app-testing` | **Required** |
-| `--machine-id` | The machine ID of the machine you want to test with. You can get your machine ID on the [Fleet page](https://app.viam.com/fleet/machines). | `local-app-testing` | Optional |
-
-##### Using the `--org-id` and `--public-namespace` arguments
+#### Using the `--org-id` and `--public-namespace` arguments
 
 All of the `module` commands accept either the `--org-id` or `--public-namespace` argument.
 
@@ -949,7 +1683,7 @@ All of the `module` commands accept either the `--org-id` or `--public-namespace
 
 You may use either argument for the `viam module create` command, but must use `--public-namespace` for the `update` and `upload` commands when uploading as a public module (`"visibility": "public"`) to the Viam Registry.
 
-##### Using the `--platform` argument
+#### Using the `--platform` argument
 
 The `--platform` argument accepts one of the following architectures:
 
@@ -984,7 +1718,7 @@ The Viam Registry page for your module displays the platforms your module suppor
 
 If you are using the `build logs` command, the `--platform` argument instead restricts the logs returned by the command to only those build jobs that match the specified platform.
 
-##### Using the `--version` argument
+#### Using the `--version` argument
 
 The `--version` argument accepts a valid [semver 2.0](https://semver.org/) version (example: `1.0.0`).
 You set an initial version for your custom module with your first `viam module upload` command for that module, and can later increment the version with subsequent `viam module upload` commands.
@@ -1000,7 +1734,7 @@ Users can choose to pin to a specific patch version, permit upgrades within majo
 When you `update` a module configuration and then `upload` it, the `entrypoint` for that module defined in the [`meta.json` file](/build-modules/module-reference/) is associated with the specific `--version` for that `upload`.
 Therefore, you are able to change the `entrypoint` file from version to version, if desired.
 
-##### Upload validation
+#### Upload validation
 
 When you `upload` a module, the command performs basic validation of your module to check for common errors.
 The following criteria are checked for every `upload`:
@@ -1012,7 +1746,7 @@ The following criteria are checked for every `upload`:
 
 See [Create a module](/build-modules/write-a-driver-module/) and [Update and manage modules you created](/build-modules/manage-modules/) for a detailed walkthrough of the `viam module` commands.
 
-##### Using the `build` subcommand
+#### Using the `build` subcommand
 
 You can use the `module build start` or `module build local` commands to build your custom module according to the build steps in your <file>meta.json</file> file:
 
@@ -1194,6 +1928,9 @@ viam organizations list
 viam organizations api-key create --org-id=<org-id> [--name=<key-name>]
 viam organizations support-email [get | set] --org-id=<org-id> --support-email=<support-email>
 viam organizations logo set --org-id=<org-id> --logo-path=<logo-path>
+viam organizations billing-service get-config --org-id=<org-id>
+viam organizations billing-service [enable | update] --org-id=<org-id> --address=<address>
+viam organizations billing-service disable --org-id=<org-id>
 viam organization auth-service [enable | disable] --org-id=<org-id>
 viam organization auth-service oauth-app [create | update] --client-authentication [required | unspecified | not_required | not_required_when_using_pkce] \
     --client-name <client-name> --enabled-grants [password | unspecified | refresh_token | implicit | device_code | authorization_code] \
@@ -1204,54 +1941,236 @@ viam organization auth-service oauth-app [list] --org-id=<org-id>
 viam organization auth-service oauth-app [read | delete] --org-id=<org-id> --client-id=<client-id>
 ```
 
-Examples:
+See [Manage API keys](/cli/administer-your-organization/#manage-api-keys) for more information.
+
+#### `organizations list`
+
+List all organizations (name, ID, and [namespace](/build-modules/module-reference/)) that the authenticated session has access to.
 
 ```sh {class="command-line" data-prompt="$"}
 # list all the organizations that you are currently authenticated to
 viam organizations list
+```
 
+#### `organizations api-key create`
+
+Create a new organization API key.
+
+```sh {class="command-line" data-prompt="$"}
 # create a new organization API key in org 123
 viam organizations api-key create --org-id=123 --name=my-key
 ```
 
-See [Manage API keys](/cli/administer-your-organization/#manage-api-keys) for more information.
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization to create the API key in. | **Required** |
+| `--name` | The optional name for the organization API key. If omitted, a name will be auto-generated based on your login info and the current time. | Optional |
 
-#### Command options
+#### `organizations support-email get`
+
+Get the support email for an organization.
+
+```sh {class="command-line" data-prompt="$"}
+viam organizations support-email get --org-id=<org-id>
+```
 
 <!-- prettier-ignore -->
-| Command option | Description | Positional arguments |
-| -------------- | ----------- | -------------------- |
-| `list` | List all organizations (name, ID, and [namespace](/build-modules/module-reference/)) that the authenticated session has access to. | - |
-| `api-key create` | Create a new organization API key. | - |
-| `support-email get` | Get the support email for an organization. | - |
-| `support-email set` | Set the support email for an organization. | - |
-| `logo set` | Upload the logo for an organization from a local file. | - |
-| `billing-service get-config` | Get the billing service config for an organization. | - |
-| `billing-service` | Enable, update, or disable the billing service for an organization. | `enable`, `update`, `disable` |
-| `auth-service` | Enable or disable auth-service for OAuth applications. Disabling the auth-service does not delete your OAuth token, it will just take off the custom branding. | `enable`, `disable` |
-| `auth-service oauth-app` | List, create, update, read, or delete OAuth applications. | `create`, `update`, `list`, `read`, `delete` |
-| `--help` | Return help. | - |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization to perform the command on. | **Required** |
 
-##### Named arguments
+#### `organizations support-email set`
+
+Set the support email for an organization.
+
+```sh {class="command-line" data-prompt="$"}
+viam organizations support-email set --org-id=<org-id> --support-email=<support-email>
+```
 
 <!-- prettier-ignore -->
-| Argument | Description | Applicable commands | Required? |
-| -------- | ----------- | ------------------- | --------- |
-| `--org-id` | The organization to perform the command on. | `api-key`, `support-email get`, `support-email set`, `logo set`, `billing-service get-config`, `billing-service enable`, `billing-service update`, `billing-service disable`, `auth-service enable`, `auth-service disable`, `auth-service oauth-app create`, `auth-service oauth-app update` `auth-service oauth-app list`, `auth-service oauth-app read`, `auth-service oauth-app delete`. | **Required** |
-| `--name` | The optional name for the organization API key. If omitted, a name will be auto-generated based on your login info and the current time. | `api-key` | Optional |
-| `--support-email` | The support email to set for the organization. | `support-email get`, `support-email set` | **Required** |
-| `--logo-path` | The support email to set for the organization. | `logo set` | **Required** |
-| `--address` | The stringified billing address that follows the pattern: line1, line2 (optional), city, state, zipcode. | `billing-service enable`, `billing-service update` | **Required** |
-| `--client-id` | The client ID of the OAuth application. | `auth-service oauth-app read`, `auth-service oauth-app delete`, `auth-service oauth-app update` | **Required** |
-| `--client-authentication` | The client authentication policy for the OAuth application. Options: `unspecified`, `required`, `not_required`, `not_required_when_using_pkce`. Default: `unspecified`. | `auth-service oauth-app create`, `auth-service oauth-app update` | **Required** |
-| `--client-name` | The name for the OAuth application. | `auth-service oauth-app create`, `auth-service oauth-app update` | **Required** |
-| `--enabled-grants` | Comma-separated enabled grants for the OAuth application. Options: `unspecified`, `refresh_token`, `password`, `implicit`, `device_code`, `authorization_code`. | `auth-service oauth-app create`, `auth-service oauth-app update` | **Required** |
-| `--logout-uri` | The logout uri for the OAuth application. | `auth-service oauth-app create`, `auth-service oauth-app update` | **Required** |
-| `--org-id` | The organization ID that is tied to the OAuth application. | `auth-service oauth-app create`, `auth-service oauth-app update` | **Required** |
-| `--origin-uris` | Comma-separated origin URIs for the OAuth application. | `auth-service oauth-app create`, `auth-service oauth-app update` | **Required** |
-| `--pkce` | Proof Key for Code Exchange (PKCE) for the OAuth application. Options: `unspecified`, `required`, `not_required`, `not_required_when_using_client_authentication`. Default: `unspecified`. | `auth-service oauth-app create`, `auth-service oauth-app update` | **Required** |
-| `--redirect-uris` | Comma-separated redirect URIs for the OAuth application. | `auth-service oauth-app create`, `auth-service oauth-app update` | **Required** |
-| `--url-validation` | URL validation for the OAuth application. Options: `unspecified`, `exact_match`, `allow_wildcards`. Default: `unspecified`. | `auth-service oauth-app create`, `auth-service oauth-app update` | **Required** |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization to perform the command on. | **Required** |
+| `--support-email` | The support email to set for the organization. | **Required** |
+
+#### `organizations logo set`
+
+Upload the logo for an organization from a local file.
+
+```sh {class="command-line" data-prompt="$"}
+viam organizations logo set --org-id=<org-id> --logo-path=<logo-path>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization to perform the command on. | **Required** |
+| `--logo-path` | Path to the logo file to upload. | **Required** |
+
+#### `organizations billing-service get-config`
+
+Get the billing service config for an organization.
+
+```sh {class="command-line" data-prompt="$"}
+viam organizations billing-service get-config --org-id=<org-id>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization to perform the command on. | **Required** |
+
+#### `organizations billing-service enable`
+
+Enable the billing service for an organization.
+
+```sh {class="command-line" data-prompt="$"}
+viam organizations billing-service enable --org-id=<org-id> --address=<address>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization to perform the command on. | **Required** |
+| `--address` | The stringified billing address that follows the pattern: line1, line2 (optional), city, state, zipcode. | **Required** |
+
+#### `organizations billing-service update`
+
+Update the billing service for an organization.
+
+```sh {class="command-line" data-prompt="$"}
+viam organizations billing-service update --org-id=<org-id> --address=<address>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization to perform the command on. | **Required** |
+| `--address` | The stringified billing address that follows the pattern: line1, line2 (optional), city, state, zipcode. | **Required** |
+
+#### `organizations billing-service disable`
+
+Disable the billing service for an organization.
+
+```sh {class="command-line" data-prompt="$"}
+viam organizations billing-service disable --org-id=<org-id>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization to perform the command on. | **Required** |
+
+#### `organizations auth-service enable`
+
+Enable auth-service for OAuth applications.
+
+```sh {class="command-line" data-prompt="$"}
+viam organization auth-service enable --org-id=<org-id>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization to perform the command on. | **Required** |
+
+#### `organizations auth-service disable`
+
+Disable auth-service for OAuth applications. Disabling the auth-service does not delete your OAuth token, it will just take off the custom branding.
+
+```sh {class="command-line" data-prompt="$"}
+viam organization auth-service disable --org-id=<org-id>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization to perform the command on. | **Required** |
+
+#### `organizations auth-service oauth-app create`
+
+Create a new OAuth application.
+
+```sh {class="command-line" data-prompt="$"}
+viam organization auth-service oauth-app create --client-authentication=<policy> --client-name=<name> --enabled-grants=<grants> --logout-uri=<uri> --origin-uris=<uris> --pkce=<pkce> --redirect-uris=<uris> --url-validation=<validation> --org-id=<org-id>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization ID that is tied to the OAuth application. | **Required** |
+| `--client-authentication` | The client authentication policy for the OAuth application. Options: `unspecified`, `required`, `not_required`, `not_required_when_using_pkce`. Default: `unspecified`. | **Required** |
+| `--client-name` | The name for the OAuth application. | **Required** |
+| `--enabled-grants` | Comma-separated enabled grants for the OAuth application. Options: `unspecified`, `refresh_token`, `password`, `implicit`, `device_code`, `authorization_code`. | **Required** |
+| `--logout-uri` | The logout uri for the OAuth application. | **Required** |
+| `--origin-uris` | Comma-separated origin URIs for the OAuth application. | **Required** |
+| `--pkce` | Proof Key for Code Exchange (PKCE) for the OAuth application. Options: `unspecified`, `required`, `not_required`, `not_required_when_using_client_authentication`. Default: `unspecified`. | **Required** |
+| `--redirect-uris` | Comma-separated redirect URIs for the OAuth application. | **Required** |
+| `--url-validation` | URL validation for the OAuth application. Options: `unspecified`, `exact_match`, `allow_wildcards`. Default: `unspecified`. | **Required** |
+
+#### `organizations auth-service oauth-app update`
+
+Update an existing OAuth application.
+
+```sh {class="command-line" data-prompt="$"}
+viam organization auth-service oauth-app update --org-id=<org-id> --client-id=<client-id> [other options]
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization ID that is tied to the OAuth application. | **Required** |
+| `--client-id` | The client ID of the OAuth application. | **Required** |
+| `--client-authentication` | The client authentication policy for the OAuth application. Options: `unspecified`, `required`, `not_required`, `not_required_when_using_pkce`. Default: `unspecified`. | **Required** |
+| `--client-name` | The name for the OAuth application. | **Required** |
+| `--enabled-grants` | Comma-separated enabled grants for the OAuth application. Options: `unspecified`, `refresh_token`, `password`, `implicit`, `device_code`, `authorization_code`. | **Required** |
+| `--logout-uri` | The logout uri for the OAuth application. | **Required** |
+| `--origin-uris` | Comma-separated origin URIs for the OAuth application. | **Required** |
+| `--pkce` | Proof Key for Code Exchange (PKCE) for the OAuth application. Options: `unspecified`, `required`, `not_required`, `not_required_when_using_client_authentication`. Default: `unspecified`. | **Required** |
+| `--redirect-uris` | Comma-separated redirect URIs for the OAuth application. | **Required** |
+| `--url-validation` | URL validation for the OAuth application. Options: `unspecified`, `exact_match`, `allow_wildcards`. Default: `unspecified`. | **Required** |
+
+#### `organizations auth-service oauth-app list`
+
+List OAuth applications for an organization.
+
+```sh {class="command-line" data-prompt="$"}
+viam organization auth-service oauth-app list --org-id=<org-id>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization to perform the command on. | **Required** |
+
+#### `organizations auth-service oauth-app read`
+
+Read an OAuth application.
+
+```sh {class="command-line" data-prompt="$"}
+viam organization auth-service oauth-app read --org-id=<org-id> --client-id=<client-id>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization to perform the command on. | **Required** |
+| `--client-id` | The client ID of the OAuth application. | **Required** |
+
+#### `organizations auth-service oauth-app delete`
+
+Delete an OAuth application.
+
+```sh {class="command-line" data-prompt="$"}
+viam organization auth-service oauth-app delete --org-id=<org-id> --client-id=<client-id>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization to perform the command on. | **Required** |
+| `--client-id` | The client ID of the OAuth application. | **Required** |
 
 ### `packages`
 
@@ -1263,34 +2182,41 @@ viam packages upload --org-id=<org-id> --name=<package-name> --version=<version>
 viam packages export --org-id=<org-id> --name=<package-name> --version=<version> --type=<type> --destination=<path-to-export-destination>
 ```
 
-Examples:
+#### `packages upload`
+
+Upload a package to the Viam Cloud.
 
 ```sh {class="command-line" data-prompt="$"}
 viam packages upload --org-id=123 --name=MyMLModel --version=1.0.0 --type=ml_model --upload=./the_package.tar.gz --model-framework=tensorflow
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization ID of the package. | **Required** |
+| `--name` | The name of the package. | **Required** |
+| `--version` | The version of the package or `latest`. | **Required** |
+| `--type` | The type of the package: `ml_model`, `archive`, `module`, `slam_map`, or `unspecified`. | **Required** |
+| `--upload` | The path to the package for upload. Executable or zipped tar with the `.tar.gz` extension. | **Required** |
+| `--model-framework` | The framework for an uploaded `ml_model`. Valid options: `unspecified`, `tflite`, `tensorflow`, `pytorch`, or `onnx`. | **Required** |
+| `--model-type` | The type of the model. Valid options: `unspecified`, `single_label_classification`, `multi_label_classification`, `object_detection`. | **Required** |
+
+#### `packages export`
+
+Download a package from the Viam Cloud.
+
+```sh {class="command-line" data-prompt="$"}
 viam packages export --org-id=123 --name=MyMLModel --version=latest --type=ml_model --destination=.
 ```
 
-#### Command options
-
 <!-- prettier-ignore -->
-| Command option | Description | Positional arguments |
-| -------------- | ----------- | -------------------- |
-| `upload` | Upload a package to the Viam Cloud. | - |
-| `export` | Download a package from the Viam Cloud. | - |
-
-##### Named arguments
-
-<!-- prettier-ignore -->
-| Argument | Description | Applicable commands | Required? |
-| -------- | ----------- | ------------------- | -------- |
-| `--org-id` | The organization ID of the package. | `upload`, `export` | **Required** |
-| `--name` | The name of the package. | `upload`, `export` | **Required** |
-| `--version` | The version of the package or `latest` | `upload`, `export` | **Required** |
-| `--type` | The type of the package: `ml_model`, `archive`, `module`, `slam_map`, or `unspecified`. | `upload`, `export` | **Required** |
-| `--upload` | The path to the package for upload. Executable or zipped tar with the `.tar.gz` extension. | `upload` | **Required** |
-| `--model-framework` | The framework for an uploaded `ml_model`. Valid options: `unspecified`, `tflite`, `tensorflow`, `pytorch`, or `onnx`. | `upload` | **Required** |
-| `--model-type` | The type of the model. Valid options: `unspecified`, `single_label_classification`, `multi_label_classification`, `object_detection`. | `upload` | **Required** |
-| `--destination` | The output directory for downloaded package. | `export` | **Required** |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization ID of the package. | **Required** |
+| `--name` | The name of the package. | **Required** |
+| `--version` | The version of the package or `latest`. | **Required** |
+| `--type` | The type of the package: `ml_model`, `archive`, `module`, `slam_map`, or `unspecified`. | **Required** |
+| `--destination` | The output directory for downloaded package. | **Required** |
 
 ### `parse-ftdc`
 
@@ -1301,15 +2227,6 @@ This is a diagnostic tool. Viam support may ask you to run it when troubleshooti
 viam machines part get-ftdc --part=<part-id> ftdc-data
 viam parse-ftdc --path ftdc-tmp/<part-id>/viam-server-<date>-<time>.ftdc
 ```
-
-#### Command options
-
-<!-- prettier-ignore -->
-| Command option | Description | Positional arguments |
-| -------------- | ----------- | -------------------- |
-| `--help` | Return help. | - |
-
-##### Named arguments
 
 <!-- prettier-ignore -->
 | Argument | Description | Required? |
@@ -1352,25 +2269,56 @@ See [Manage API keys](/cli/administer-your-organization/#manage-api-keys) for mo
 You can set a default profile by using the `VIAM_CLI_PROFILE_NAME` environment variable.
 {{% /alert %}}
 
-#### Command options
+#### `profiles add`
+
+Add a new profile for authentication. Throws an error if the profile already exists.
+
+```sh {class="command-line" data-prompt="$"}
+viam profiles add --profile-name=<name-of-profile-to-add> --key-id=<API-key-ID> --key=<API-key>
+```
 
 <!-- prettier-ignore -->
-| Command option | Description | Positional arguments |
-| -------------- | ----------- | -------------------- |
-| `add` | List all existing profiles by name. | - |
-| `update` | Update an existing profile for authentication, or add it if it doesn't exist. | - |
-| `list` | List all existing profiles by name. | - |
-| `remove` | Remove a profile. | - |
-| `--help` | Return help. | - |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--profile-name` | Name of the profile to add. | **Required** |
+| `--key-id` | The `key id` (UUID) of the API key. | **Required** |
+| `--key` | The `key value` of the API key. | **Required** |
 
-##### Named arguments
+#### `profiles update`
+
+Update an existing profile for authentication, or add it if it doesn't exist.
+
+```sh {class="command-line" data-prompt="$"}
+viam profiles update --profile-name=<name-of-profile-to-update> --key-id=<API-key-ID> --key=<API-key>
+```
 
 <!-- prettier-ignore -->
-| Argument | Description | Applicable commands | Required? |
-| -------- | ----------- | ------------------- | --------- |
-| `--profile-name` | Name of the profile to add, update, or remove. | `add`, `update`, `remove` | **Required** |
-| `--key-id` | The `key id` (UUID) of the API key. | `add`, `update` | **Required** |
-| `--key` | The `key value` of the API key. | `api-key`, `update` | **Required** |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--profile-name` | Name of the profile to update. | **Required** |
+| `--key-id` | The `key id` (UUID) of the API key. | **Required** |
+| `--key` | The `key value` of the API key. | **Required** |
+
+#### `profiles list`
+
+List all existing profiles by name.
+
+```sh {class="command-line" data-prompt="$"}
+viam profiles list
+```
+
+#### `profiles remove`
+
+Remove a profile.
+
+```sh {class="command-line" data-prompt="$"}
+viam profiles remove --profile-name=<name-of-profile-to-remove>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--profile-name` | Name of the profile to remove. | **Required** |
 
 ### `resource`
 
@@ -1401,70 +2349,57 @@ viam resource update --part=abc123 --resource-name=my-sensor --config=/path/to/u
 viam resource update --part=abc123 --resource-name=my-sensor --config='{"pin": ""}'
 ```
 
-#### Command options
+#### `resource enable`
 
-<!-- prettier-ignore -->
-| Command option | Description |
-| -------------- | ----------- |
-| `enable` | Enable one or more resources on a machine part. |
-| `disable` | Disable one or more resources on a machine part. Disabled resources are not started by viam-server. |
-| `update` | Replace a resource's attributes with new values. The `--config` flag accepts inline JSON or a path to a JSON file. An empty JSON object deletes all attributes. |
-| `--help` | Return help. |
-
-##### Named arguments
-
-<!-- prettier-ignore -->
-| Argument | Description | Applicable commands | Required? |
-| -------- | ----------- | ------------------- | --------- |
-| `--part` | Machine part ID or name. | `enable`, `disable`, `update` | **Required** |
-| `--resource-name` | Name of the resource. Repeat the flag to apply `enable` or `disable` to multiple resources at once. | `enable`, `disable`, `update` | **Required** |
-| `--config` | Inline JSON or path to a JSON file containing the new attributes. | `update` | **Required** |
-| `--organization` | Organization ID or name. Required when using a name (rather than ID) to identify the part. | `enable`, `disable`, `update` | Optional |
-| `--location` | Location ID or name. Required when using a name (rather than ID) to identify the part. | `enable`, `disable`, `update` | Optional |
-| `--machine` | Machine ID or name. Required when using a name (rather than ID) to identify the part. | `enable`, `disable`, `update` | Optional |
-
-### `training-script`
-
-Manage training scripts for [custom ML training](/train/custom-training-scripts/).
+Enable one or more resources on a machine part.
 
 ```sh {class="command-line" data-prompt="$"}
-viam training-script upload --framework=<framework> --org-id=<org-id> --path=<path-to-script> --script-name=<script-name> --type=<type>
-viam training-script update --org-id=<org-id> --script-name=<script-name> --visibility=<visibility>
+viam resource enable --part=<part> --resource-name=<resource-name> [--resource-name=<resource-name> ...]
 ```
 
-Examples:
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Machine part ID or name. | **Required** |
+| `--resource-name` | Name of the resource. Repeat the flag to apply `enable` to multiple resources at once. | **Required** |
+| `--organization` | Organization ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
+| `--location` | Location ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
+| `--machine` | Machine ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
+
+#### `resource disable`
+
+Disable one or more resources on a machine part. Disabled resources are not started by viam-server.
 
 ```sh {class="command-line" data-prompt="$"}
-# upload a single label classification script in the tflite framework to organization 123
-viam training-script upload --framework=tflite --org-id=123 --path=. --script-name=MyCustomTrainingScript --type=single_label_classification
-
-# update MyCustomTrainingScript with public visibility
-viam training-script update --org-id=123 --script-name=MyCustomTrainingScript --visibility=public --description="A single label classification training script"
+viam resource disable --part=<part> --resource-name=<resource-name> [--resource-name=<resource-name> ...]
 ```
 
-#### Command options
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Machine part ID or name. | **Required** |
+| `--resource-name` | Name of the resource. Repeat the flag to apply `disable` to multiple resources at once. | **Required** |
+| `--organization` | Organization ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
+| `--location` | Location ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
+| `--machine` | Machine ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
+
+#### `resource update`
+
+Replace a resource's attributes with new values. The `--config` flag accepts inline JSON or a path to a JSON file. An empty JSON object deletes all attributes.
+
+```sh {class="command-line" data-prompt="$"}
+viam resource update --part=<part> --resource-name=<resource-name> --config=<json-or-path>
+```
 
 <!-- prettier-ignore -->
-| Command option | Description | Positional arguments |
-| -------------- | ----------- | -------------------- |
-| `upload` | Upload ML training script to the registry | - |
-| `update` | Update visibility of ML training script in registry | - |
-
-##### Named arguments
-
-<!-- prettier-ignore -->
-| Argument | Description | Applicable commands | Required? |
-| -------- | ----------- | ------------------- | --------- |
-| `--path` | The path to ML training scripts for upload. | `upload` | **Required** |
-| `--org-id` | The organization ID to host the scripts in. You can find your organization ID by running `viam organizations list` or by visiting your organization's **Settings** page in the [Viam app](https://app.viam.com/). | `upload`, `update` | **Required** |
-| `--script-name` | Name of the ML training script to update or upload. | `upload`, `update` | **Required** |
-| `--visibility` | Visibility of the registry item, can be `public`, `private`, or `draft`. | `update` | **Required** |
-| `--version` | Version of the ML training script to upload. | `upload` | Optional |
-| `--description` | Description of the ML training script. | `update` | Optional |
-| `--framework` | Framework of the ML training script to upload, can be `tflite`, `tensorflow`, `pytorch`, or `onnx`. | `upload` | Optional |
-| `--url` | URL of GitHub repository associated with the training script. | `upload` | Optional |
-| `--type` | Task type of the ML training script to upload, can be `single_label_classification`, `multi_label_classification`, or `object_detection`. | `upload` | Optional |
-| `--draft` | Indicate draft mode, drafts are not viewable in the registry. | `upload` | Optional |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Machine part ID or name. | **Required** |
+| `--resource-name` | Name of the resource. | **Required** |
+| `--config` | Inline JSON or path to a JSON file containing the new attributes. | **Required** |
+| `--organization` | Organization ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
+| `--location` | Location ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
+| `--machine` | Machine ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
 
 ### `train`
 
@@ -1481,81 +2416,183 @@ viam train list --org-id=<org-id> --job-status=<job-status>
 viam train containers list
 ```
 
-Examples:
+#### `train submit managed`
+
+Submit a training job on data in the Viam Cloud with a Viam-managed training script.
 
 ```sh {class="command-line" data-prompt="$"}
 # submit training job on data in Viam Cloud with a Viam-managed training script
 viam train submit managed --dataset-id=456 --model-org-id=123 --model-name=MyCoolClassifier --model-type=single_label_classification --model-labels=1,2,3
+```
 
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--dataset-id` | The ID of the dataset to train on. To find the dataset ID of a given dataset, go to the [**DATASETS** subtab](https://app.viam.com/data/datasets) of the **DATA** tab and select a dataset. Click **...** in the left-hand menu and click **Copy dataset ID**. | **Required** |
+| `--model-org-id` | The organization ID to train and save the ML model in. You can find your organization ID by running `viam organizations list` or by visiting your organization's **Settings** page in the [Viam app](https://app.viam.com/). | **Required** |
+| `--model-name` | The name of the ML model. | **Required** |
+| `--model-type` | Type of model to train. Must be one of `single_label_classification`, `multi_label_classification`, or `object_detection`. | **Required** |
+| `--model-framework` | The framework of model to train. Must be one of `tflite` or `tensorflow`. | **Required** |
+| `--model-labels` | Labels to train on. These will either be classification or object detection labels. | **Required** |
+| `--model-version` | Set the version of the submitted model. Defaults to current timestamp if unspecified. | Optional |
+
+#### `train submit custom from-registry`
+
+Submit a custom training job with an existing training script in the registry on data in the Viam Cloud.
+
+```sh {class="command-line" data-prompt="$"}
 # submit custom training job with an existing training script in the Registry on data in Viam Cloud
 viam train submit custom from-registry --dataset-id=<INSERT DATASET ID> --org-id=<INSERT ORG ID> --model-name=MyRegistryModel --model-version=2 --version=1 --script-name=mycompany:MyCustomTrainingScript  --args=num_epochs=3,model_type=multi_label
+```
 
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--dataset-id` | The ID of the dataset to train on. | **Required** |
+| `--org-id` | The organization ID to train and save the ML model in. | **Required** |
+| `--model-name` | The name of the ML model. | **Required** |
+| `--script-name` | The registry name of the ML training script to use for training. | **Required** |
+| `--version` | The version of the ML training script to use for training. | **Required** |
+| `--container-version` | Docker container version for training. Use `viam train containers list` to see available versions. | **Required** |
+| `--model-version` | Set the version of the submitted model. Defaults to current timestamp if unspecified. | Optional |
+| `--args` | Pass custom comma-separated arguments to the training script. Example: `num_epochs=3,model_type=multi_label`. To include whitespace, enclose the value with whitespace in single and double quotes. Example: `num_epochs=3,labels="'green_square blue_star'"`. | Optional |
+
+#### `train submit custom with-upload`
+
+Upload a draft training script and submit a custom training job on data in the Viam Cloud.
+
+```sh {class="command-line" data-prompt="$"}
 # submit custom training job with an uploaded training script on data in Viam Cloud
 viam train submit custom with-upload --dataset-id=<INSERT DATASET ID> --model-org-id=<INSERT ORG ID> --model-name=MyRegistryModel --model-type=single_label_classification --model-version=2 --version=1 --path=<path-to-tar.gz> --script-name=mycompany:MyCustomTrainingScript --args=num_epochs=3,labels="'green_square blue_star'"
+```
 
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--dataset-id` | The ID of the dataset to train on. | **Required** |
+| `--model-org-id` | The organization ID to train and save the ML model in. | **Required** |
+| `--model-name` | The name of the ML model. | **Required** |
+| `--script-name` | The registry name of the ML training script to use for training. This sets the name on upload. | **Required** |
+| `--version` | The version of the ML training script to use for training. | **Required** |
+| `--path` | The path to the ML training script to upload. | **Required** |
+| `--framework` | Framework of the ML training script to upload, can be `tflite`, `tensorflow`, `pytorch`, or `onnx`. | **Required** |
+| `--container-version` | Docker container version for training. Use `viam train containers list` to see available versions. | **Required** |
+| `--model-type` | Type of model to train. Must be one of `single_label_classification`, `multi_label_classification`, `object_detection`, or `unspecified`. | Optional |
+| `--model-version` | Set the version of the submitted model. Defaults to current timestamp if unspecified. | Optional |
+| `--url` | URL of the GitHub repository associated with the training scripts. | Optional |
+| `--args` | Pass custom comma-separated arguments to the training script. Example: `num_epochs=3,model_type=multi_label`. To include whitespace, enclose the value with whitespace in single and double quotes. Example: `num_epochs=3,labels="'green_square blue_star'"`. | Optional |
+
+#### `train get`
+
+Get a training job from the Viam Cloud based on training job ID.
+
+```sh {class="command-line" data-prompt="$"}
 # get a training job from Viam Cloud based on training job ID
 viam train get --job-id=123
+```
 
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--job-id` | The ID of the training job to get. You can retrieve this value with `train list`. | **Required** |
+
+#### `train logs`
+
+Get the logs of a training job from the Viam Cloud based on training job ID.
+
+```sh {class="command-line" data-prompt="$"}
 # get training job logs from Viam Cloud based on training job ID
 viam train logs --job-id=123
+```
 
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--job-id` | The ID of the training job to get logs for. | **Required** |
+
+#### `train cancel`
+
+Cancel a training job in the Viam Cloud based on training job ID.
+
+```sh {class="command-line" data-prompt="$"}
 # cancel training job in Viam Cloud based on training job ID
 viam train cancel --job-id=123
+```
 
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--job-id` | The ID of the training job to cancel. | **Required** |
+
+#### `train list`
+
+List training jobs in Viam Cloud based on organization ID and job status.
+
+```sh {class="command-line" data-prompt="$"}
 # list training jobs in Viam Cloud based on organization ID and job status
 viam train list --org-id=123 --job-status=completed
 ```
 
-#### Command options
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization ID to list training jobs from. | **Required** |
+| `--job-status` | Training status to filter for. Can be one of `canceled`, `canceling`, `completed`, `failed`, `in_progress`, `pending`, or `unspecified`. | Optional |
+
+#### `train containers list`
+
+List supported Docker container images for custom training.
+
+```sh {class="command-line" data-prompt="$"}
+viam train containers list
+```
+
+### `training-script`
+
+Manage training scripts for [custom ML training](/train/custom-training-scripts/).
+
+```sh {class="command-line" data-prompt="$"}
+viam training-script upload --framework=<framework> --org-id=<org-id> --path=<path-to-script> --script-name=<script-name> --type=<type>
+viam training-script update --org-id=<org-id> --script-name=<script-name> --visibility=<visibility>
+```
+
+#### `training-script upload`
+
+Upload an ML training script to the registry.
+
+```sh {class="command-line" data-prompt="$"}
+# upload a single label classification script in the tflite framework to organization 123
+viam training-script upload --framework=tflite --org-id=123 --path=. --script-name=MyCustomTrainingScript --type=single_label_classification
+```
 
 <!-- prettier-ignore -->
-| Command option | Description | Positional arguments |
-| -------------- | ----------- | -------------------- |
-| `submit` | Submits training job on data in the Viam Cloud. | `managed`, `custom` |
-| `get` | Gets a training job from the Viam Cloud based on training job ID. | - |
-| `logs` | Gets the logs of a training job from the Viam Cloud based on training job ID. | - |
-| `cancel` | Cancels training job in the Viam Cloud based on training job ID. | - |
-| `list` | Lists training jobs in Viam Cloud based on organization ID and job status. | - |
-| `containers list` | Lists supported Docker container images for custom training. | - |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--path` | The path to ML training scripts for upload. | **Required** |
+| `--org-id` | The organization ID to host the scripts in. You can find your organization ID by running `viam organizations list` or by visiting your organization's **Settings** page in the [Viam app](https://app.viam.com/). | **Required** |
+| `--script-name` | Name of the ML training script to upload. | **Required** |
+| `--version` | Version of the ML training script to upload. | Optional |
+| `--framework` | Framework of the ML training script to upload, can be `tflite`, `tensorflow`, `pytorch`, or `onnx`. | Optional |
+| `--url` | URL of GitHub repository associated with the training script. | Optional |
+| `--type` | Task type of the ML training script to upload, can be `single_label_classification`, `multi_label_classification`, or `object_detection`. | Optional |
+| `--draft` | Indicate draft mode, drafts are not viewable in the registry. | Optional |
 
-##### Positional arguments: `submit`
+#### `training-script update`
 
-<!-- prettier-ignore -->
-| Argument | Description | Positional Arguments |
-| -------- | ----------- | -------------------- |
-| `managed` | Submits training job on data in the Viam Cloud with a Viam-managed training script. | - |
-| `custom` | Submits custom training job on data in the Viam Cloud. | `from-registry`, `with-upload` |
+Update the visibility of an ML training script in the registry.
 
-##### Positional arguments: `submit custom`
-
-<!-- prettier-ignore -->
-| Argument | Description |
-| -------- | ----------- |
-| `from-registry` | Submit custom training job with an existing training script in the registry on data in the Viam Cloud. |
-| `with-upload` | Upload a draft training script and submit a custom training job on data in the Viam Cloud. |
-
-##### Named arguments
+```sh {class="command-line" data-prompt="$"}
+# update MyCustomTrainingScript with public visibility
+viam training-script update --org-id=123 --script-name=MyCustomTrainingScript --visibility=public --description="A single label classification training script"
+```
 
 <!-- prettier-ignore -->
-| Argument | Description | Applicable commands | Required? |
-| -------- | ----------- | ------------------- | --------- |
-| `--dataset-id` | The ID of the dataset to train on. To find the dataset ID of a given dataset, go to the [**DATASETS** subtab](https://app.viam.com/data/datasets) of the **DATA** tab and select a dataset. Click **...** in the left-hand menu and click **Copy dataset ID**. | `submit managed`, `submit custom from-registry`, `submit custom with-upload` | **Required** |
-| `--model-org-id` | The organization ID to train and save the ML model in. You can find your organization ID by running `viam organizations list` or by visiting your organization's **Settings** page in the [Viam app](https://app.viam.com/). | `submit managed`, `submit custom with-upload` | **Required** |
-| `--org-id` | The organization ID to train and save the ML model in or list training jobs from. You can find your organization ID by running `viam organizations list` or by visiting your organization's **Settings** page in the [Viam app](https://app.viam.com/). | `submit custom from-registry`, `list` | **Required** |
-| `--model-name` | The name of the ML model. | `submit managed`, `submit custom from-registry`, `submit custom with-upload` | **Required** |
-| `--model-type` | Type of model to train. For `submit managed`, must be one of `single_label_classification`, `multi_label_classification`, or `object_detection`. For `submit custom with-upload`, also accepts `unspecified`. | `submit managed`, `submit custom with-upload` | **Required**, Optional |
-| `--model-framework` | The framework of model to train. Must be one of `tflite` or `tensorflow`. | `submit managed` | **Required** |
-| `--model-labels` | Labels to train on. These will either be classification or object detection labels. | `submit managed` | **Required** |
-| `--model-version` | Set the version of the submitted model. Defaults to current timestamp if unspecified. | `submit managed`, `submit custom from-registry`, `submit custom with-upload` | Optional |
-| `--script-name` | The registry name of the ML training script to use for training. If uploading, this sets the name. | `submit custom from-registry`, `submit custom with-upload` | **Required** |
-| `--version` | The version of the ML training script to use for training. | `submit custom from-registry`, `submit custom with-upload` | **Required** |
-| `--path` | The path to the ML training script to upload. | `submit custom with-upload` | **Required** |
-| `--job-id` | The ID of the training job to get or cancel. You can retrieve this value with `train list`. | `get`, `logs`, `cancel` | **Required** |
-| `--job-status` | Training status to filter for. Can be one of `canceled`, `canceling`, `completed`, `failed`, `in_progress`, `pending`, or `unspecified`. | `list` | Optional |
-| `--framework` | Framework of the ML training script to upload, can be `tflite`, `tensorflow`, `pytorch`, or `onnx`. | `submit custom with-upload` | **Required** |
-| `--container-version` | Docker container version for training. Use `viam train containers list` to see available versions. | `submit custom from-registry`, `submit custom with-upload` | **Required** |
-| `--url` | URL of the GitHub repository associated with the training scripts. | `submit custom with-upload` | Optional |
-| `--args` | Pass custom comma-separated arguments to the training script. Example: `num_epochs=3,model_type=multi_label`. To include whitespace, enclose the value with whitespace in single and double quotes. Example: `num_epochs=3,labels="'green_square blue_star'"`. | `submit custom from-registry`, `submit custom with-upload` | Optional |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization ID hosting the script. You can find your organization ID by running `viam organizations list` or by visiting your organization's **Settings** page in the [Viam app](https://app.viam.com/). | **Required** |
+| `--script-name` | Name of the ML training script to update. | **Required** |
+| `--visibility` | Visibility of the registry item, can be `public`, `private`, or `draft`. | **Required** |
+| `--description` | Description of the ML training script. | Optional |
 
 ### `traces`
 
@@ -1571,27 +2608,76 @@ viam traces print-remote --part=<part> [--organization=<org>] [--location=<locat
 viam traces get-remote --part=<part> [target] [--organization=<org>] [--location=<location>]
 ```
 
-#### Command options
+#### `traces import-local`
+
+Import traces from a local viam-server trace file to an OTLP endpoint.
+
+```sh {class="command-line" data-prompt="$"}
+viam traces import-local <traces-file> [--endpoint=<host:port>]
+```
+
+Pass the path to a local viam-server trace file as a positional argument.
 
 <!-- prettier-ignore -->
-| Command option | Description |
-| -------------- | ----------- |
-| `import-local` | Import traces from a local viam-server trace file to an OTLP endpoint. |
-| `import-remote` | Import traces from a remote machine to an OTLP endpoint. |
-| `print-local` | Print traces from a local trace file to the console. |
-| `print-remote` | Print traces from a remote machine to the console. |
-| `get-remote` | Download traces from a remote machine to a local file. If `[target]` is omitted, the file is saved to the current working directory. |
-| `--help` | Return help. |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--endpoint` | OTLP endpoint in `host:port` format. Default: `localhost:4317`. | Optional |
 
-##### Named arguments
+#### `traces import-remote`
+
+Import traces from a remote machine to an OTLP endpoint.
+
+```sh {class="command-line" data-prompt="$"}
+viam traces import-remote --part=<part> [--endpoint=<host:port>] [--organization=<org>] [--location=<location>]
+```
 
 <!-- prettier-ignore -->
-| Argument | Description | Applicable commands | Required? |
-| -------- | ----------- | ------------------- | --------- |
-| `--endpoint` | OTLP endpoint in `host:port` format. Default: `localhost:4317`. | `import-local`, `import-remote` | Optional |
-| `--part` | Machine part ID or name. | `import-remote`, `print-remote`, `get-remote` | **Required** |
-| `--organization` | Organization ID or name. Required when using a name (rather than ID) to identify the part. | `import-remote`, `print-remote`, `get-remote` | Optional |
-| `--location` | Location ID or name. Required when using a name (rather than ID) to identify the part. | `import-remote`, `print-remote`, `get-remote` | Optional |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Machine part ID or name. | **Required** |
+| `--endpoint` | OTLP endpoint in `host:port` format. Default: `localhost:4317`. | Optional |
+| `--organization` | Organization ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
+| `--location` | Location ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
+
+#### `traces print-local`
+
+Print traces from a local trace file to the console.
+
+```sh {class="command-line" data-prompt="$"}
+viam traces print-local <traces-file>
+```
+
+Pass the path to a local viam-server trace file as a positional argument.
+
+#### `traces print-remote`
+
+Print traces from a remote machine to the console.
+
+```sh {class="command-line" data-prompt="$"}
+viam traces print-remote --part=<part> [--organization=<org>] [--location=<location>]
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Machine part ID or name. | **Required** |
+| `--organization` | Organization ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
+| `--location` | Location ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
+
+#### `traces get-remote`
+
+Download traces from a remote machine to a local file. If `[target]` is omitted, the file is saved to the current working directory.
+
+```sh {class="command-line" data-prompt="$"}
+viam traces get-remote --part=<part> [target] [--organization=<org>] [--location=<location>]
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Machine part ID or name. | **Required** |
+| `--organization` | Organization ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
+| `--location` | Location ID or name. Required when using a name (rather than ID) to identify the part. | Optional |
 
 ### `update`
 
@@ -1602,8 +2688,6 @@ Otherwise, it downloads and replaces the binary directly.
 ```sh {class="command-line" data-prompt="$"}
 viam update
 ```
-
-#### Named arguments
 
 <!-- prettier-ignore -->
 | Argument | Description | Required? |
@@ -1648,28 +2732,22 @@ viam xacro convert --input-file=arm.xacro --output-file=arm.urdf --args=name:=ur
 viam xacro convert --input-file=robot.xacro --output-file=robot.urdf --collapse-fixed-joints
 ```
 
-#### Command options
+#### `xacro convert`
+
+Convert a xacro file to URDF.
 
 <!-- prettier-ignore -->
-| Command option | Description |
-| -------------- | ----------- |
-| `convert` | Convert a xacro file to URDF. |
-| `--help` | Return help. |
-
-##### Named arguments
-
-<!-- prettier-ignore -->
-| Argument | Description | Applicable commands | Required? |
-| -------- | ----------- | ------------------- | --------- |
-| `--input-file` | Path to the xacro file to expand. | `convert` | **Required** |
-| `--output-file` | Path where the URDF file will be written. | `convert` | **Required** |
-| `--args` | xacro arguments to pass through, in the form `name:=value`. Repeat the flag for multiple arguments. Required if the xacro file uses `<xacro:arg>` tags. | `convert` | Optional |
-| `--ros-distro` | ROS distribution to use. Auto-detected from the docker image if not specified. | `convert` | Optional |
-| `--docker-image` | Docker image to use for xacro processing. Default: `osrf/ros:humble-desktop`. | `convert` | Optional |
-| `--package-xml` | Path to `package.xml` if not in the current directory. | `convert` | Optional |
-| `--collapse-fixed-joints` | Collapse fixed-joint chains to ensure only one end effector exists. | `convert` | Optional |
-| `--install-packages` | Install `ros-<distro>-xacro` in the container (required for the default image). Disable only if your custom image already includes xacro. | `convert` | Optional |
-| `--dry-run` | Show the docker command without executing it. | `convert` | Optional |
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--input-file` | Path to the xacro file to expand. | **Required** |
+| `--output-file` | Path where the URDF file will be written. | **Required** |
+| `--args` | xacro arguments to pass through, in the form `name:=value`. Repeat the flag for multiple arguments. Required if the xacro file uses `<xacro:arg>` tags. | Optional |
+| `--ros-distro` | ROS distribution to use. Auto-detected from the docker image if not specified. | Optional |
+| `--docker-image` | Docker image to use for xacro processing. Default: `osrf/ros:humble-desktop`. | Optional |
+| `--package-xml` | Path to `package.xml` if not in the current directory. | Optional |
+| `--collapse-fixed-joints` | Collapse fixed-joint chains to ensure only one end effector exists. | Optional |
+| `--install-packages` | Install `ros-<distro>-xacro` in the container (required for the default image). Disable only if your custom image already includes xacro. | Optional |
+| `--dry-run` | Show the docker command without executing it. | Optional |
 
 ## Global options
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -778,8 +778,8 @@ The `locations` command allows you to manage the [locations](/reference/) that y
 With it, you can list available locations, filter locations by organization, or create a new location API key.
 
 ```sh {class="command-line" data-prompt="$"}
-viam locations list [<organization id>]
-viam locations api-key create --location-id=<location-id>
+viam locations list [--organization=<organization>]
+viam locations api-key create [--location-id=<location-id>] [--name=<name>] [--org-id=<org-id>]
 ```
 
 ### `locations list`
@@ -787,10 +787,13 @@ viam locations api-key create --location-id=<location-id>
 List all locations (name and id) that the authenticated session has access to, grouped by organization.
 
 ```sh {class="command-line" data-prompt="$"}
-viam locations list [<organization id>]
+viam locations list [--organization=<organization>]
 ```
 
-Pass an organization ID as a positional argument to return results for that organization only. Optional.
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--organization` | Restrict results to this organization. Default: the org set by `viam defaults set-org` if it exists, else the first one alphabetically. | Optional |
 
 ### `locations api-key create`
 
@@ -803,9 +806,9 @@ viam locations api-key create --location-id=<location-id>
 <!-- prettier-ignore -->
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
-| `--location-id` | The location to create an API key for. | **Required** |
-| `--name` | The name of the API key. | Optional |
-| `--org-id` | The organization ID to attach the key to. | Optional |
+| `--location-id` | The location to create an API key for. Default: the default location set with `viam defaults set-location`. | Optional |
+| `--name` | The name of the API key. Default: your login info with the current time. | Optional |
+| `--org-id` | The organization ID to attach the key to. Default: attempts to attach the key to the org of the location if only one org is attached to the location. | Optional |
 
 ## `login`
 
@@ -885,7 +888,13 @@ viam machines part status --machine=<machine id>
 viam machines part run --machine=<machine id> [--stream] --data <method>
 viam machines part shell --machine=<machine id> --part=<part id>
 viam machines part restart --machine=<machine id> --part=<part id>
+viam machines part history --part=<part id>
 viam machines part cp --part=<part id> <file name> machine:/path/to/file
+viam machines part add-job --part=<part id> [--config=<json or path>]
+viam machines part update-job --part=<part id> --name=<job name> --config=<json or path>
+viam machines part delete-job --part=<part id> --name=<job name>
+viam machines part add-trigger --part=<part id> [--config=<json or path>]
+viam machines part delete-trigger --part=<part id> --name=<trigger name>
 ```
 
 To use `part shell` and `part cp`, add the [`ViamShellDanger` fragment](https://app.viam.com/fragment/b511adfa-80ab-4a70-9bd5-fbb14696b17e/json), which contains the latest version of the shell service.
@@ -1107,6 +1116,23 @@ viam machines part restart --part=123
 | -------- | ----------- | --------- |
 | `--part` | Part ID for which the command is being issued. | **Required** |
 
+### `machines part history`
+
+Display the configuration history for a machine part.
+
+```sh {class="command-line" data-prompt="$"}
+viam machines part history --part=<part id>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+| `--organization` | Organization name. | Optional |
+| `--location` | Location name. | Optional |
+| `--machine` | Machine ID or name. | Optional |
+| `--filter-by-email` | Show only history entries saved by this email address. | Optional |
+
 ### `machines part cp`
 
 Copy files to and from a machine part. To use this feature you must add the [`ViamShellDanger` fragment](https://app.viam.com/fragment/b511adfa-80ab-4a70-9bd5-fbb14696b17e/json), which contains the shell service, to your machine. Once added you can use `cp` in a similar way to the Linux `scp` command to copy files to and from machines.
@@ -1306,6 +1332,131 @@ viam machines part motion set-pose --part=<part id> --component=<component name>
 | `--part` | Part ID for which the command is being issued. | **Required** |
 | `--component` | Component name for the motion command. | **Required** |
 
+### `machines part add-job`
+
+Add a scheduled job that runs a method on a resource at a given interval. Run without `--config` to launch an interactive builder, or pass `--config` with inline JSON or a path to a JSON file.
+
+A job config object accepts the following fields:
+
+- `name` (required): unique name for this job.
+- `schedule` (required): one of `continuous`, a Go duration (for example, `5s`, `1h30m`, `500ms`), or a cron expression (for example, `0 0 * * *`, or `*/5 * * * * *` with seconds).
+- `resource` (required): name of the component or service to run the method on.
+- `method` (required): gRPC method name. For example, `DoCommand` or `GetReadings`.
+- `command` (optional): JSON object passed as the argument to `DoCommand`.
+- `log_configuration` (optional): for example, `{"level":"debug"}`. Level must be one of `debug`, `info`, `warn`, or `error`.
+
+```sh {class="command-line" data-prompt="$"}
+# launch the interactive job builder
+viam machines part add-job --part=<part id>
+
+# add a job from inline JSON
+viam machines part add-job --part=<part id> \
+    --config '{"name":"my-job","schedule":"1h","resource":"my-sensor","method":"GetReadings"}'
+
+# add a job from a JSON file
+viam machines part add-job --part=<part id> --config ./job.json
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+| `--config` | JSON job config or path to JSON file. Omit to use the interactive form. | Optional |
+| `--organization` | Organization name. | Optional |
+| `--location` | Location name. | Optional |
+| `--machine` | Machine ID or name. | Optional |
+
+### `machines part update-job`
+
+Update an existing job's configuration by name. The `--config` flag accepts a single JSON object (inline or a path to a JSON file) with the fields to change. Only the fields provided will be updated; all other fields remain unchanged. The job name cannot be changed.
+
+```sh {class="command-line" data-prompt="$"}
+# change the schedule
+viam machines part update-job --part=<part id> --name=my-job --config '{"schedule":"30m"}'
+
+# change multiple fields
+viam machines part update-job --part=<part id> --name=my-job \
+    --config '{"schedule":"0 0 * * *","method":"DoCommand","command":{"action":"reset"}}'
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+| `--name` | Name of the job to update. | **Required** |
+| `--config` | JSON job config or path to JSON file with fields to update. | **Required** |
+| `--organization` | Organization name. | Optional |
+| `--location` | Location name. | Optional |
+| `--machine` | Machine ID or name. | Optional |
+
+### `machines part delete-job`
+
+Delete an existing scheduled job by name.
+
+```sh {class="command-line" data-prompt="$"}
+viam machines part delete-job --part=<part id> --name=my-job
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+| `--name` | Name of the job to delete. | **Required** |
+| `--organization` | Organization name. | Optional |
+| `--location` | Location name. | Optional |
+| `--machine` | Machine ID or name. | Optional |
+
+### `machines part add-trigger`
+
+Add a trigger to a machine part. Run without `--config` to use an interactive form, or provide `--config` with inline JSON or a path to a JSON file.
+
+Trigger configs support the following event types:
+
+- `part_online`: liveness check.
+- `part_data_ingested`: fires when data of the specified types is ingested.
+- `conditional_data_ingested`: fires when data ingested by a specific data capture method matches a condition.
+- `conditional_logs_ingested`: fires when logs at the specified levels are ingested.
+
+Each trigger requires `notifications`, an array of objects with `type` (`email` or `webhook`), `value`, and `seconds_between_notifications`.
+
+```sh {class="command-line" data-prompt="$"}
+# launch the interactive trigger builder
+viam machines part add-trigger --part=<part id>
+
+# add a trigger from inline JSON
+viam machines part add-trigger --part=<part id> \
+    --config '{"name":"my-online-trigger","event":{"type":"part_online"},"notifications":[{"type":"email","value":"user@example.com","seconds_between_notifications":60}]}'
+
+# add a trigger from a JSON file
+viam machines part add-trigger --part=<part id> --config ./trigger.json
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+| `--config` | JSON trigger config or path to JSON file. Omit to use the interactive form. | Optional |
+| `--organization` | Organization name. | Optional |
+| `--location` | Location name. | Optional |
+| `--machine` | Machine ID or name. | Optional |
+
+### `machines part delete-trigger`
+
+Delete a trigger from a machine part by name.
+
+```sh {class="command-line" data-prompt="$"}
+viam machines part delete-trigger --part=<part id> --name=<trigger name>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--part` | Part ID for which the command is being issued. | **Required** |
+| `--name` | Name of the trigger to delete. | **Required** |
+| `--organization` | Organization name. | Optional |
+| `--location` | Location name. | Optional |
+| `--machine` | Machine ID or name. | Optional |
+
 ### Using the `--stream` and `--data` arguments
 
 Issuing the `part` command with the `run` positional argument allows you to run component and service (resource) commands for a selected machine part.
@@ -1380,7 +1531,7 @@ viam module update-models [--binary=<binary>] [...named args]
 viam module build start --version=<version> [...named args]
 viam module build local --module=<path to meta.json> [arguments...]
 viam module build list [command options] [arguments...]
-viam module build logs --id=<id> [...named args]
+viam module build logs --build-id=<build-id> [...named args]
 viam module reload [...named args]
 viam module upload --version=<version> --platform=<platform> [--org-id=<org-id> | --public-namespace=<namespace>] [--module=<path to meta.json>] <module-path> --tags=<tags>
 viam module download [command options]
@@ -1437,8 +1588,13 @@ Services:
 <!-- prettier-ignore -->
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
+| `--name` | Name to use for the module. For example, a module that contains sensor implementations might be named `sensors`. We recommend _not_ using this option and instead following the prompts. | Optional |
+| `--language` | Language to use for the module. Options: `python`, `go`. We recommend _not_ using this option and instead following the prompts. | Optional |
+| `--visibility` | Module visibility. Options: `private`, `public`, `public_unlisted`. We recommend _not_ using this option and instead following the prompts. | Optional |
+| `--public-namespace` | Namespace or organization ID of the module. Must be either a valid organization ID, or a namespace that exists within a user organization. We recommend _not_ using this option and instead following the prompts. | Optional |
 | `--resource-subtype` | The API to implement with the modular resource. For example, `motor`. We recommend _not_ using this option and instead following the prompts after running the command. | Optional |
-| `--resource-type` | Whether the new resource is a component or a service. For example, `component`. We recommend _not_ using this option and instead following the prompts. | Optional |
+| `--model-name` | Name for the particular resource subtype implementation. For example, a sensor model that detects moisture might be named `moisture`. We recommend _not_ using this option and instead following the prompts. | Optional |
+| `--register` | Register the module with Viam to associate it with your organization. Default: `false`. | Optional |
 
 ### `module create`
 
@@ -1507,7 +1663,8 @@ viam module upload --version=1.0.0 --platform=darwin/arm64 packaged-module.tar.g
 | `--platform` | The architecture of your module binary. See [Using the `--platform` argument](#using-the---platform-argument). | **Required** |
 | `--org-id` | The organization ID to associate the module to. See [Using the `--org-id` and `--public-namespace` arguments](#using-the---org-id-and---public-namespace-arguments). | **Required** |
 | `--public-namespace` | The namespace to associate the module to. See [Using the `--org-id` and `--public-namespace` arguments](#using-the---org-id-and---public-namespace-arguments). | **Required** |
-| `--module` | The path to the [`meta.json` file](/build-modules/module-reference/) for the module, if not in the current directory. | Optional |
+| `--module` | The path to the [`meta.json` file](/build-modules/module-reference/) for the module, if not in the current directory. Default: `./meta.json`. | Optional |
+| `--name` | Name of the module. Used if you don't have a <file>meta.json</file>. | Optional |
 | `--upload` | The path to the upload. | Optional |
 | `--tags` | Comma-separated list of platform tags that determine to which platforms this binary can be deployed. Examples: `distro:debian,distro:ubuntu, os_version:22.04,os_codename:jammy`. For a machine to use an uploaded binary, all tags must be satisfied as well as the `--platform` field. <ul><li>`distro`: Distribution. You can find this in `/etc/os-release`. `"debian"` or `"ubuntu"`.</li><li>`os_version`:  Operating System version. On Linux, you can find this in `/etc/os-release`. Example for linux: `22.04`. On Mac, run `sw_vers --productVersion` and use the major version only. Example for mac: `14`.</li><li>`codename`: The operating system codename. Find this in `/etc/os-release`. For example: `"bullseye"`, `"bookworm"`, or `"jammy"`.</li><li>`cuda`: Whether using CUDA compiler. Run `nvcc --version`. For example: `"true"`.</li><li>`cuda_version`: The CUDA compiler version. Run `nvcc --version`. For example: `"11"` or `"12"`.</li><li>`jetpack`: Version of the NVIDIA JetPack SDK. Run `apt-cache show nvidia-jetpack`. For example: `"5"`.</li><li>`pi`: Version of the Raspberry Pi: `"4"` or `"5"`.</li><li>`pifull`: Compute module or model number, for example `cm5p` or `5B`.</li></ul> | Optional |
 | `--force` | Skip local validation of the packaged module, which may result in an unusable module if the contents of the packaged module are not correct. | Optional |
@@ -1524,14 +1681,12 @@ viam module reload --part-id e1234f0c-912c-1234-a123-5ac1234612345
 <!-- prettier-ignore -->
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
-| `--id` | The module ID (`namespace:module-name` or `org-id:module-name`). | Optional |
-| `--part-id` | Part ID of the machine part. Required if running on a remote device. | Optional |
+| `--part-id` | Part ID of the machine part. Get from the **Live**/**Offline** dropdown in the web app. Default: the part ID present in the cloud credentials at <file>/etc/viam.json</file>. | Optional |
 | `--cloud-config` | The location of the <FILE>viam.json</FILE> file which contains the machine ID to lookup the part-id. Alternative to `--part-id`. Default: `/etc/viam.json`. | Optional |
-| `--module` | The path to the [`meta.json` file](/build-modules/module-reference/) for the module, if not in the current directory. | Optional |
+| `--module` | The path to the [`meta.json` file](/build-modules/module-reference/) for the module, if not in the current directory. Default: `meta.json`. | Optional |
 | `--model-name` | If passed, creates a resource in the part config with the given model triple. Use with `--resource-name`. Default: Creates no new resource. | Optional |
-| `--resource-name` | If passed, creates a new resource with the given resource name. Use with `--model-name`. Default: Creates no new resource. | Optional |
-| `--local` | Use if the target machine is localhost, to run the entrypoint directly rather than transferring a bundle. Default: `false`. | Optional |
-| `--path` | The path to the root of the git repo to build. Default: `.`. | Optional |
+| `--resource-name` | If passed, creates a new resource with the given resource name. Use with `--model-name`. Default: resource type with a unique numerical suffix. | Optional |
+| `--path` | The path to the root of the module's git repo to build. Default: `.`. | Optional |
 | `--workdir` | Use this to indicate that your <file>meta.json</file> is in a subdirectory of your repo. `--module` flag should be relative to this. Default: `.`. | Optional |
 
 ### `module reload-local`
@@ -1571,10 +1726,11 @@ viam module restart --id viam:python-example-module
 <!-- prettier-ignore -->
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
-| `--id` | The module ID (`namespace:module-name` or `org-id:module-name`). | Optional |
-| `--part-id` | Part ID of the machine part. Required if running on a remote device. | Optional |
+| `--id` | ID of the module to restart, for example `viam:wifi-sensor`. Pass at most one of `--name`, `--id`. | Optional |
+| `--name` | Name of the module to restart. Pass at most one of `--name`, `--id`. | Optional |
+| `--part-id` | Part ID of the machine part. Required if running on a remote device. Default: the part ID present in <file>/etc/viam.json</file>. | Optional |
 | `--cloud-config` | The location of the <FILE>viam.json</FILE> file which contains the machine ID to lookup the part-id. Alternative to `--part-id`. Default: `/etc/viam.json`. | Optional |
-| `--name` | The name of the module. For example: `hello-world`. | Optional |
+| `--module` | The path to the <file>meta.json</file> file. Used for module ID. Can be overridden with `--id` or `--name`. Default: `meta.json`. | Optional |
 
 ### `module build start`
 
@@ -1624,7 +1780,8 @@ viam module build list
 <!-- prettier-ignore -->
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
-| `--id` | The build ID to list, as returned from `build start`. | Optional |
+| `--module` | Path to <file>meta.json</file>. Default: `./meta.json`. | Optional |
+| `--id` | Restrict output to just return builds that match this build ID. | Optional |
 | `--count` | Number of cloud builds to list. Defaults to displaying all builds. | Optional |
 
 ### `module build logs`
@@ -1633,16 +1790,16 @@ Show the logs from a specific cloud module build. See [Using the `build` subcomm
 
 ```sh {class="command-line" data-prompt="$"}
 # initiate a build and return the build logs as soon as completed
-viam module build logs --wait --id=$(viam module build start --version "0.1.2")
+viam module build logs --wait --build-id=$(viam module build start --version "0.1.2")
 ```
 
 <!-- prettier-ignore -->
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
-| `--id` | The build ID to show logs for, as returned from `build start`. | Optional |
-| `--platform` | Restricts the logs returned by the command to only those build jobs that match the specified platform. See [Using the `--platform` argument](#using-the---platform-argument). | Optional |
-| `--wait` | Wait for the build to finish before outputting any logs. | Optional |
-| `--group-logs` | Group log output by platform. | Optional |
+| `--build-id` | The build ID to show logs for, as returned from `build start`. | **Required** |
+| `--platform` | Restricts the logs returned by the command to only those build jobs that match the specified platform. See [Using the `--platform` argument](#using-the---platform-argument). Default: all platforms. | Optional |
+| `--wait` | Wait for the build to finish before outputting any logs. Default: `false`. | Optional |
+| `--group-logs` | Write `::group::` commands so GitHub Actions logs collapse. Default: `false`. | Optional |
 
 ### `module download`
 
@@ -1919,7 +2076,7 @@ Provide that build ID to the `module build logs` command to show the relevant bu
 For example, use the following to initiate a build, and return the build logs as soon as it completes:
 
 ```sh {class="command-line" data-prompt="$"}
-viam module build logs --wait --id=$(viam module build start --version "0.1.2")
+viam module build logs --wait --build-id=$(viam module build start --version "0.1.2")
 ```
 
 To list all in-progress builds and their build status, use the following command:
@@ -1936,7 +2093,8 @@ The `organizations` command allows you to list the organizations your authentica
 viam organizations list
 viam organizations api-key create --org-id=<org-id> [--name=<key-name>]
 viam organizations support-email [get | set] --org-id=<org-id> --support-email=<support-email>
-viam organizations logo set --org-id=<org-id> --logo-path=<logo-path>
+viam organizations logo [get | set] --org-id=<org-id> [--logo-path=<logo-path>]
+viam organizations firebase-config [set | read | delete] --org-id=<org-id> [--app-id=<app-id>] [--firebase-config-path=<path>]
 viam organizations billing-service get-config --org-id=<org-id>
 viam organizations billing-service [enable | update] --org-id=<org-id> --address=<address>
 viam organizations billing-service disable --org-id=<org-id>
@@ -2015,7 +2173,62 @@ viam organizations logo set --org-id=<org-id> --logo-path=<logo-path>
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
 | `--org-id` | The organization to perform the command on. | **Required** |
-| `--logo-path` | Path to the logo file to upload. | **Required** |
+| `--logo-path` | Path to the logo file to upload. Must be a PNG file. | **Required** |
+
+### `organizations logo get`
+
+Get the logo for an organization.
+
+```sh {class="command-line" data-prompt="$"}
+viam organizations logo get --org-id=<org-id>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | The organization to get the logo for. | **Required** |
+
+### `organizations firebase-config set`
+
+Upload a Firebase config JSON for a specific app ID. Organization owner only.
+
+```sh {class="command-line" data-prompt="$"}
+viam organizations firebase-config set --org-id=<org-id> --app-id=com.example.myapp --firebase-config-path=./firebase-config.json
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | Organization ID. | **Required** |
+| `--app-id` | App ID. For example, `com.example.myapp`. | **Required** |
+| `--firebase-config-path` | Path to the Firebase config JSON file. | **Required** |
+
+### `organizations firebase-config read`
+
+Read Firebase config metadata for an organization. Organization owner only.
+
+```sh {class="command-line" data-prompt="$"}
+viam organizations firebase-config read --org-id=<org-id>
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | Organization ID. | **Required** |
+
+### `organizations firebase-config delete`
+
+Delete a Firebase config for a specific app ID. Organization owner only.
+
+```sh {class="command-line" data-prompt="$"}
+viam organizations firebase-config delete --org-id=<org-id> --app-id=com.example.myapp
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--org-id` | Organization ID. | **Required** |
+| `--app-id` | App ID. For example, `com.example.myapp`. | **Required** |
 
 ### `organizations billing-service get-config`
 
@@ -2109,14 +2322,15 @@ viam organization auth-service oauth-app create --client-authentication=<policy>
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
 | `--org-id` | The organization ID that is tied to the OAuth application. | **Required** |
-| `--client-authentication` | The client authentication policy for the OAuth application. Options: `unspecified`, `required`, `not_required`, `not_required_when_using_pkce`. Default: `unspecified`. | **Required** |
-| `--client-name` | The name for the OAuth application. | **Required** |
+| `--client-authentication` | The client authentication policy for the OAuth application. Options: `unspecified`, `required`, `not_required`, `not_required_when_using_pkce`. | **Required** |
 | `--enabled-grants` | Comma-separated enabled grants for the OAuth application. Options: `unspecified`, `refresh_token`, `password`, `implicit`, `device_code`, `authorization_code`. | **Required** |
-| `--logout-uri` | The logout uri for the OAuth application. | **Required** |
-| `--origin-uris` | Comma-separated origin URIs for the OAuth application. | **Required** |
-| `--pkce` | Proof Key for Code Exchange (PKCE) for the OAuth application. Options: `unspecified`, `required`, `not_required`, `not_required_when_using_client_authentication`. Default: `unspecified`. | **Required** |
-| `--redirect-uris` | Comma-separated redirect URIs for the OAuth application. | **Required** |
-| `--url-validation` | URL validation for the OAuth application. Options: `unspecified`, `exact_match`, `allow_wildcards`. Default: `unspecified`. | **Required** |
+| `--logout-uri` | The logout URI for the OAuth application. | **Required** |
+| `--pkce` | Proof Key for Code Exchange (PKCE) for the OAuth application. Options: `unspecified`, `required`, `not_required`, `not_required_when_using_client_authentication`. | **Required** |
+| `--redirect-uris` | Comma-separated redirect URIs for the OAuth application. Requires at least one. | **Required** |
+| `--url-validation` | URL validation for the OAuth application. Options: `unspecified`, `exact_match`, `allow_wildcards`. | **Required** |
+| `--client-name` | The name for the OAuth application. | Optional |
+| `--origin-uris` | Comma-separated origin URIs for the OAuth application. | Optional |
+| `--invite-redirect-uri` | Redirect URI to send users after they accept an org invite. | Optional |
 
 ### `organizations auth-service oauth-app update`
 
@@ -2130,15 +2344,16 @@ viam organization auth-service oauth-app update --org-id=<org-id> --client-id=<c
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
 | `--org-id` | The organization ID that is tied to the OAuth application. | **Required** |
-| `--client-id` | The client ID of the OAuth application. | **Required** |
-| `--client-authentication` | The client authentication policy for the OAuth application. Options: `unspecified`, `required`, `not_required`, `not_required_when_using_pkce`. Default: `unspecified`. | **Required** |
-| `--client-name` | The name for the OAuth application. | **Required** |
-| `--enabled-grants` | Comma-separated enabled grants for the OAuth application. Options: `unspecified`, `refresh_token`, `password`, `implicit`, `device_code`, `authorization_code`. | **Required** |
-| `--logout-uri` | The logout uri for the OAuth application. | **Required** |
-| `--origin-uris` | Comma-separated origin URIs for the OAuth application. | **Required** |
-| `--pkce` | Proof Key for Code Exchange (PKCE) for the OAuth application. Options: `unspecified`, `required`, `not_required`, `not_required_when_using_client_authentication`. Default: `unspecified`. | **Required** |
-| `--redirect-uris` | Comma-separated redirect URIs for the OAuth application. | **Required** |
-| `--url-validation` | URL validation for the OAuth application. Options: `unspecified`, `exact_match`, `allow_wildcards`. Default: `unspecified`. | **Required** |
+| `--client-id` | The client ID of the OAuth application to be updated. | **Required** |
+| `--client-name` | Updated name for the OAuth application. | Optional |
+| `--client-authentication` | Updated client authentication policy. Options: `unspecified`, `required`, `not_required`, `not_required_when_using_pkce`. Default: `unspecified`. | Optional |
+| `--enabled-grants` | Updated comma-separated enabled grants. Options: `unspecified`, `refresh_token`, `password`, `implicit`, `device_code`, `authorization_code`. | Optional |
+| `--logout-uri` | Updated logout URI for the OAuth application. | Optional |
+| `--origin-uris` | Updated comma-separated origin URIs for the OAuth application. | Optional |
+| `--pkce` | Updated PKCE policy. Options: `unspecified`, `required`, `not_required`, `not_required_when_using_client_authentication`. Default: `unspecified`. | Optional |
+| `--redirect-uris` | Updated comma-separated redirect URIs for the OAuth application. | Optional |
+| `--url-validation` | Updated URL validation. Options: `unspecified`, `exact_match`, `allow_wildcards`. Default: `unspecified`. | Optional |
+| `--invite-redirect-uri` | Redirect URI to send users after they accept an org invite. | Optional |
 
 ### `organizations auth-service oauth-app list`
 
@@ -2187,8 +2402,8 @@ The `packages` command allows you to upload packages to the Viam Cloud or export
 For example, you can use this command to download ML models or modules from the registry.
 
 ```sh {class="command-line" data-prompt="$"}
-viam packages upload --org-id=<org-id> --name=<package-name> --version=<version> --type=<type> --upload=<path-to-package.tar.gz> --model-framework=<framework>
-viam packages export --org-id=<org-id> --name=<package-name> --version=<version> --type=<type> --destination=<path-to-export-destination>
+viam packages upload --path=<path-to-package.tar.gz> --org-id=<org-id> --name=<package-name> --version=<version> --type=<type>
+viam packages export --type=<type> [--org-id=<org-id>] [--name=<package-name>] [--version=<version>] [--destination=<path-to-export-destination>]
 ```
 
 ### `packages upload`
@@ -2196,36 +2411,36 @@ viam packages export --org-id=<org-id> --name=<package-name> --version=<version>
 Upload a package to the Viam Cloud.
 
 ```sh {class="command-line" data-prompt="$"}
-viam packages upload --org-id=123 --name=MyMLModel --version=1.0.0 --type=ml_model --upload=./the_package.tar.gz --model-framework=tensorflow
+viam packages upload --path=./the_package.tar.gz --org-id=123 --name=MyMLModel --version=1.0.0 --type=ml_model --model-framework=tensorflow
 ```
 
 <!-- prettier-ignore -->
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
+| `--path` | The path to the package for upload. Executable or zipped tar with the `.tar.gz` extension. | **Required** |
 | `--org-id` | The organization ID of the package. | **Required** |
 | `--name` | The name of the package. | **Required** |
 | `--version` | The version of the package or `latest`. | **Required** |
 | `--type` | The type of the package: `ml_model`, `archive`, `module`, `slam_map`, or `unspecified`. | **Required** |
-| `--upload` | The path to the package for upload. Executable or zipped tar with the `.tar.gz` extension. | **Required** |
-| `--model-framework` | The framework for an uploaded `ml_model`. Valid options: `unspecified`, `tflite`, `tensorflow`, `pytorch`, or `onnx`. | **Required** |
-| `--model-type` | The type of the model. Valid options: `unspecified`, `single_label_classification`, `multi_label_classification`, `object_detection`. | **Required** |
+| `--model-framework` | The framework for an uploaded `ml_model`. Valid options: `unspecified`, `tflite`, `tensorflow`, `pytorch`, or `onnx`. | Required if `--type=ml_model` |
+| `--model-type` | The type of the model. Valid options: `unspecified`, `single_label_classification`, `multi_label_classification`, `object_detection`. | Required if `--type=ml_model` |
 
 ### `packages export`
 
 Download a package from the Viam Cloud.
 
 ```sh {class="command-line" data-prompt="$"}
-viam packages export --org-id=123 --name=MyMLModel --version=latest --type=ml_model --destination=.
+viam packages export --type=ml_model --org-id=123 --name=MyMLModel --version=latest --destination=.
 ```
 
 <!-- prettier-ignore -->
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
-| `--org-id` | The organization ID of the package. | **Required** |
-| `--name` | The name of the package. | **Required** |
-| `--version` | The version of the package or `latest`. | **Required** |
 | `--type` | The type of the package: `ml_model`, `archive`, `module`, `slam_map`, or `unspecified`. | **Required** |
-| `--destination` | The output directory for downloaded package. | **Required** |
+| `--org-id` | The organization ID or namespace of the package. Default: `default-org` value if set, else attempts to read from <file>meta.json</file>. | Optional |
+| `--name` | The name of the package. Default: attempts to read from <file>meta.json</file>. | Optional |
+| `--version` | The version of the package or `latest`. Default: `latest`. | Optional |
+| `--destination` | The output directory for downloaded package. Default: `.`. | Optional |
 
 ## `parse-ftdc`
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -134,7 +134,6 @@ done
 | `--tags` | Filter by (`export`, `delete`) or add (`tag`) specified tag (accepts comma-separated list). | `export binary`, `delete`, `tag ids`, `tag filter` | Optional |
 | `--filter-tags` | Filter tags. Options: `'tagged'`, `'untagged'`, or a comma-separated list of tags for all data matching any of the tags. | `tag filter` | Optional |
 | `--bbox-labels` | String labels corresponding to bounding boxes within images. | `tag filter`, `export binary` | Optional |
-| `--chunk-limit` | Maximum number of results per download request (tabular data only). | `tag filter` | Optional |
 | `--org-id` | The organization ID. Required for `delete tabular`. Uses default org if set for other commands. | `delete tabular`, `database configure`, `database hostname`, `index create`, `index delete`, `index list` | Optional, **Required** for `delete tabular` |
 | `--password` | Password for the database user being configured. | `database configure` | **Required** |
 | `--resource-name` | Resource name. Sometimes called "component name". | `export tabular` | **Required** |
@@ -221,6 +220,7 @@ viam dataset list --org-id=<org-id>
 viam dataset list --dataset-ids=<dataset-ids>
 viam dataset delete --dataset-id=<dataset-id>
 viam dataset export --destination=<output-directory> --dataset-id=<dataset-id>
+viam dataset merge --name=<new-dataset-name> --dataset-ids=<dataset-id-1>,<dataset-id-2> [--org-id=<org-id>]
 viam dataset data add filter --dataset-id=<dataset-id> [...named args]
 viam dataset data remove filter --dataset-id=<dataset-id> [...named args]
 viam dataset data add ids --dataset-id=<dataset-id>  --binary-data-ids=<binary-data-ids>
@@ -248,6 +248,9 @@ viam dataset delete --dataset-id=123
 # export dataset abc to output directory ./dataset/example in two folders called "data" and "metadata"
 viam dataset export --destination=./dataset/example --dataset-id=abc
 
+# merge datasets 123 and 456 into a new dataset named CombinedDataset
+viam dataset merge --name=CombinedDataset --dataset-ids=123,456 --org-id=789
+
 # add images tagged with the "example" tag between January and October of 2023 to dataset abc
 viam dataset data add filter --dataset-id=abc --location-ids=123 --org-ids=456 --start=2023-01-01T05:00:00.000Z --end=2023-10-01T04:00:00.000Z --tags=example
 
@@ -273,6 +276,7 @@ viam dataset data remove ids --dataset-id=abc --binary-data-ids=aaa,bbb
 | `data add` | Add new images to an existing dataset by binary data ID or add images that match a specified [filter](#using-the-filter-argument). | `ids`, `filter` |
 | `data remove` | Remove images from an existing dataset by binary data ID or remove images that match a specified [filter](#using-the-filter-argument). | `ids`, `filter` |
 | `export` | Download all the data from a dataset. | - |
+| `merge` | Merge multiple datasets into a new dataset. | - |
 | `--help` | Return help. | - |
 
 ##### Positional arguments
@@ -290,13 +294,14 @@ viam dataset data remove ids --dataset-id=abc --binary-data-ids=aaa,bbb
 | Argument | Description | Applicable commands | Required? |
 | -------- | ----------- | ------------------- | --------- |
 | `--dataset-id` | Dataset to perform an operation on. To retrieve the ID, navigate to your dataset's page, click **…** in the left-hand menu, and click **Copy dataset ID** | `rename`, `delete`, `data add`, `data remove`, `export` | **Required** |
-| `--dataset-ids` | Dataset IDs of datasets to be listed. To retrieve these IDs, navigate to your dataset's page, click **…** in the left-hand menu, and click **Copy dataset ID** | `list` | Optional |
+| `--dataset-ids` | Dataset IDs of datasets to be listed or merged (comma-separated list). To retrieve these IDs, navigate to your dataset's page, click **…** in the left-hand menu, and click **Copy dataset ID** | `list`, `merge` | Optional for `list`; **Required** for `merge` |
 | `--destination` | Output directory for downloaded data. | `export` | **Required** |
 | `--end` | ISO-8601 timestamp indicating the end of the interval. | `data add`, `data remove` | Optional |
 | `--binary-data-ids` | The binary data IDs of the files to perform an operation on. | `data add ids`, `data remove ids` | **Required** |
-| `--include-jsonl` | Set to `true` to include JSON Lines files for local testing. | `export` | Optional |
-| `--name` | The name of the dataset to create or rename. | `create`, `rename` | **Required** |
-| `--org-id` | Organization ID of the organization the dataset belongs to. | `create`, `data add`, `list` | **Required** |
+| `--only-jsonl` | Include only the JSON Lines files for local testing. No binary data is downloaded. | `export` | Optional |
+| `--force-linux-path` | Force the use of Linux-style paths in the dataset.jsonl file. | `export` | Optional |
+| `--name` | The name of the dataset to create, rename, or merge into. | `create`, `rename`, `merge` | **Required** |
+| `--org-id` | Organization ID of the organization the dataset belongs to. | `create`, `data add`, `list`, `merge` | **Required** for `create` and `merge`; Optional otherwise |
 | `--org-ids` | Organization IDs of the organizations to filter data on. | `data add filter`, `data remove filter` | Optional |
 | `--parallel` | Number of download requests to make in parallel, with a default value of 100. | `export` | Optional |
 | `--start` | ISO-8601 timestamp indicating the start of the interval. | `data add`, `data remove` | Optional |
@@ -370,6 +375,36 @@ Removing the `viam data export` string, you can use the same filter parameters (
 You cannot use the `--binary-data-ids` argument when using `filter`.
 
 See [Create a dataset](/train/create-a-dataset/) for more information.
+
+### `defaults`
+
+The `defaults` command sets or clears default argument values so you do not have to pass the same `--org-id` or `--location-id` flag on every command. Once set, the value is read from your CLI config and used as the default for any command that accepts that argument.
+
+```sh {class="command-line" data-prompt="$"}
+viam defaults set-org --org-id=<org-id>
+viam defaults clear-org
+viam defaults set-location --location-id=<location-id>
+viam defaults clear-location
+```
+
+#### Command options
+
+<!-- prettier-ignore -->
+| Command option | Description |
+| -------------- | ----------- |
+| `set-org` | Set the default organization argument. |
+| `clear-org` | Clear the default organization argument. |
+| `set-location` | Set the default location argument. |
+| `clear-location` | Clear the default location argument. |
+| `--help` | Return help. |
+
+##### Named arguments
+
+<!-- prettier-ignore -->
+| Argument | Description | Applicable commands | Required? |
+| -------- | ----------- | ------------------- | --------- |
+| `--org-id` | The organization ID to set as the default. | `set-org` | **Required** |
+| `--location-id` | The location ID to set as the default. | `set-location` | **Required** |
 
 ### `infer`
 
@@ -1337,6 +1372,57 @@ You can set a default profile by using the `VIAM_CLI_PROFILE_NAME` environment v
 | `--key-id` | The `key id` (UUID) of the API key. | `add`, `update` | **Required** |
 | `--key` | The `key value` of the API key. | `api-key`, `update` | **Required** |
 
+### `resource`
+
+The `resource` command enables, disables, or updates individual resources (components and services) on a machine part. Use it to temporarily disable a resource without removing it from the configuration, or to update attributes without using the Viam app.
+
+```sh {class="command-line" data-prompt="$"}
+viam resource enable --part=<part> --resource-name=<resource-name> [--resource-name=<resource-name> ...]
+viam resource disable --part=<part> --resource-name=<resource-name> [--resource-name=<resource-name> ...]
+viam resource update --part=<part> --resource-name=<resource-name> --config=<json-or-path>
+```
+
+Examples:
+
+```sh {class="command-line" data-prompt="$"}
+# enable a single resource
+viam resource enable --part=abc123 --resource-name=my-sensor
+
+# enable multiple resources at once
+viam resource enable --part=abc123 --resource-name=my-sensor --resource-name=arm-1
+
+# update a resource attribute inline
+viam resource update --part=abc123 --resource-name=my-sensor --config='{"pin": "38"}'
+
+# update from a JSON file
+viam resource update --part=abc123 --resource-name=my-sensor --config=/path/to/updates.json
+
+# delete an attribute by passing an empty value
+viam resource update --part=abc123 --resource-name=my-sensor --config='{"pin": ""}'
+```
+
+#### Command options
+
+<!-- prettier-ignore -->
+| Command option | Description |
+| -------------- | ----------- |
+| `enable` | Enable one or more resources on a machine part. |
+| `disable` | Disable one or more resources on a machine part. Disabled resources are not started by viam-server. |
+| `update` | Replace a resource's attributes with new values. The `--config` flag accepts inline JSON or a path to a JSON file. An empty JSON object deletes all attributes. |
+| `--help` | Return help. |
+
+##### Named arguments
+
+<!-- prettier-ignore -->
+| Argument | Description | Applicable commands | Required? |
+| -------- | ----------- | ------------------- | --------- |
+| `--part` | Machine part ID or name. | `enable`, `disable`, `update` | **Required** |
+| `--resource-name` | Name of the resource. Repeat the flag to apply `enable` or `disable` to multiple resources at once. | `enable`, `disable`, `update` | **Required** |
+| `--config` | Inline JSON or path to a JSON file containing the new attributes. | `update` | **Required** |
+| `--organization` | Organization ID or name. Required when using a name (rather than ID) to identify the part. | `enable`, `disable`, `update` | Optional |
+| `--location` | Location ID or name. Required when using a name (rather than ID) to identify the part. | `enable`, `disable`, `update` | Optional |
+| `--machine` | Machine ID or name. Required when using a name (rather than ID) to identify the part. | `enable`, `disable`, `update` | Optional |
+
 ### `training-script`
 
 Manage training scripts for [custom ML training](/train/custom-training-scripts/).
@@ -1440,7 +1526,7 @@ viam train list --org-id=123 --job-status=completed
 | `managed` | Submits training job on data in the Viam Cloud with a Viam-managed training script. | - |
 | `custom` | Submits custom training job on data in the Viam Cloud. | `from-registry`, `with-upload` |
 
-##### Position arguments: `submit custom`
+##### Positional arguments: `submit custom`
 
 <!-- prettier-ignore -->
 | Argument | Description |
@@ -1457,8 +1543,8 @@ viam train list --org-id=123 --job-status=completed
 | `--model-org-id` | The organization ID to train and save the ML model in. You can find your organization ID by running `viam organizations list` or by visiting your organization's **Settings** page in the [Viam app](https://app.viam.com/). | `submit managed`, `submit custom with-upload` | **Required** |
 | `--org-id` | The organization ID to train and save the ML model in or list training jobs from. You can find your organization ID by running `viam organizations list` or by visiting your organization's **Settings** page in the [Viam app](https://app.viam.com/). | `submit custom from-registry`, `list` | **Required** |
 | `--model-name` | The name of the ML model. | `submit managed`, `submit custom from-registry`, `submit custom with-upload` | **Required** |
-| `--model-type` | Type of model to train. Can be one of `single_label_classification`, `multi_label_classification`, `object_detection`, or `unspecified`. | `submit managed`, `submit custom with-upload` | **Required**, Optional |
-| `--model-framework` | The framework of model to train. Options: `tflite`, `tensorflow`, `pytorch`, `onnx`. | `submit managed` | **Required** |
+| `--model-type` | Type of model to train. For `submit managed`, must be one of `single_label_classification`, `multi_label_classification`, or `object_detection`. For `submit custom with-upload`, also accepts `unspecified`. | `submit managed`, `submit custom with-upload` | **Required**, Optional |
+| `--model-framework` | The framework of model to train. Must be one of `tflite` or `tensorflow`. | `submit managed` | **Required** |
 | `--model-labels` | Labels to train on. These will either be classification or object detection labels. | `submit managed` | **Required** |
 | `--model-version` | Set the version of the submitted model. Defaults to current timestamp if unspecified. | `submit managed`, `submit custom from-registry`, `submit custom with-upload` | Optional |
 | `--script-name` | The registry name of the ML training script to use for training. If uploading, this sets the name. | `submit custom from-registry`, `submit custom with-upload` | **Required** |
@@ -1468,7 +1554,44 @@ viam train list --org-id=123 --job-status=completed
 | `--job-status` | Training status to filter for. Can be one of `canceled`, `canceling`, `completed`, `failed`, `in_progress`, `pending`, or `unspecified`. | `list` | Optional |
 | `--framework` | Framework of the ML training script to upload, can be `tflite`, `tensorflow`, `pytorch`, or `onnx`. | `submit custom with-upload` | **Required** |
 | `--container-version` | Docker container version for training. Use `viam train containers list` to see available versions. | `submit custom from-registry`, `submit custom with-upload` | **Required** |
+| `--url` | URL of the GitHub repository associated with the training scripts. | `submit custom with-upload` | Optional |
 | `--args` | Pass custom comma-separated arguments to the training script. Example: `num_epochs=3,model_type=multi_label`. To include whitespace, enclose the value with whitespace in single and double quotes. Example: `num_epochs=3,labels="'green_square blue_star'"`. | `submit custom from-registry`, `submit custom with-upload` | Optional |
+
+### `traces`
+
+The `traces` command imports viam-server trace files to an OTLP endpoint or prints them to the console. Use it to debug machine performance and request flow with a tracing backend such as Jaeger or Tempo.
+
+The `import-remote`, `print-remote`, and `get-remote` subcommands require the machine to have a valid shell-type service. Organization and location are required if you are identifying the part by name rather than ID.
+
+```sh {class="command-line" data-prompt="$"}
+viam traces import-local <traces-file> [--endpoint=<host:port>]
+viam traces import-remote --part=<part> [--endpoint=<host:port>] [--organization=<org>] [--location=<location>]
+viam traces print-local <traces-file>
+viam traces print-remote --part=<part> [--organization=<org>] [--location=<location>]
+viam traces get-remote --part=<part> [target] [--organization=<org>] [--location=<location>]
+```
+
+#### Command options
+
+<!-- prettier-ignore -->
+| Command option | Description |
+| -------------- | ----------- |
+| `import-local` | Import traces from a local viam-server trace file to an OTLP endpoint. |
+| `import-remote` | Import traces from a remote machine to an OTLP endpoint. |
+| `print-local` | Print traces from a local trace file to the console. |
+| `print-remote` | Print traces from a remote machine to the console. |
+| `get-remote` | Download traces from a remote machine to a local file. If `[target]` is omitted, the file is saved to the current working directory. |
+| `--help` | Return help. |
+
+##### Named arguments
+
+<!-- prettier-ignore -->
+| Argument | Description | Applicable commands | Required? |
+| -------- | ----------- | ------------------- | --------- |
+| `--endpoint` | OTLP endpoint in `host:port` format. Default: `localhost:4317`. | `import-local`, `import-remote` | Optional |
+| `--part` | Machine part ID or name. | `import-remote`, `print-remote`, `get-remote` | **Required** |
+| `--organization` | Organization ID or name. Required when using a name (rather than ID) to identify the part. | `import-remote`, `print-remote`, `get-remote` | Optional |
+| `--location` | Location ID or name. Required when using a name (rather than ID) to identify the part. | `import-remote`, `print-remote`, `get-remote` | Optional |
 
 ### `update`
 
@@ -1503,6 +1626,50 @@ The `whoami` command returns the Viam user for an authenticated CLI session, or 
 ```sh {class="command-line" data-prompt="$"}
 viam whoami
 ```
+
+### `xacro`
+
+The `xacro` command converts ROS xacro files to URDF using a Docker container. Use it to integrate ROS-based robot descriptions with Viam's frame system.
+
+```sh {class="command-line" data-prompt="$"}
+viam xacro convert --input-file=<file> --output-file=<file> [other options]
+```
+
+Examples:
+
+```sh {class="command-line" data-prompt="$"}
+# basic conversion
+viam xacro convert --input-file=robot.xacro --output-file=robot.urdf
+
+# pass xacro arguments
+viam xacro convert --input-file=arm.xacro --output-file=arm.urdf --args=name:=ur20
+
+# collapse fixed-joint chains so only one end effector exists
+viam xacro convert --input-file=robot.xacro --output-file=robot.urdf --collapse-fixed-joints
+```
+
+#### Command options
+
+<!-- prettier-ignore -->
+| Command option | Description |
+| -------------- | ----------- |
+| `convert` | Convert a xacro file to URDF. |
+| `--help` | Return help. |
+
+##### Named arguments
+
+<!-- prettier-ignore -->
+| Argument | Description | Applicable commands | Required? |
+| -------- | ----------- | ------------------- | --------- |
+| `--input-file` | Path to the xacro file to expand. | `convert` | **Required** |
+| `--output-file` | Path where the URDF file will be written. | `convert` | **Required** |
+| `--args` | xacro arguments to pass through, in the form `name:=value`. Repeat the flag for multiple arguments. Required if the xacro file uses `<xacro:arg>` tags. | `convert` | Optional |
+| `--ros-distro` | ROS distribution to use. Auto-detected from the docker image if not specified. | `convert` | Optional |
+| `--docker-image` | Docker image to use for xacro processing. Default: `osrf/ros:humble-desktop`. | `convert` | Optional |
+| `--package-xml` | Path to `package.xml` if not in the current directory. | `convert` | Optional |
+| `--collapse-fixed-joints` | Collapse fixed-joint chains to ensure only one end effector exists. | `convert` | Optional |
+| `--install-packages` | Install `ros-<distro>-xacro` in the container (required for the default image). Disable only if your custom image already includes xacro. | `convert` | Optional |
+| `--dry-run` | Show the docker command without executing it. | `convert` | Optional |
 
 ## Global options
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -17,8 +17,6 @@ All commands use this format:
 viam [global options] command [command options] [arguments...]
 ```
 
-## Global options
-
 You can pass global options after the `viam` CLI keyword with any command.
 
 <!-- prettier-ignore -->

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -22,11 +22,12 @@ You can pass global options after the `viam` CLI keyword with any command.
 <!-- prettier-ignore -->
 | Global option | Description |
 | ------------- | ----------- |
-| `--debug` | Enable debug logging. Default: `false`. |
-| `--disable-profiles`, `disable-profile` | Disable usage of [profiles](#profiles), falling back to default (false) behavior. Default: `false`. |
+| `--config`, `-c` | Load configuration from `FILE`. |
+| `--debug`, `--vvv` | Enable debug logging. Default: `false`. |
+| `--disable-profiles`, `--disable-profile` | Disable usage of [profiles](#profiles), falling back to default behavior. Default: `false`. |
 | `--help`, `-h` | Show help. Default: `false`. |
 | `--profile` | Specify a particular [profile](#profiles) for the current command. |
-| `--quiet`, `-q` | Suppress warnings. Default: `false` |
+| `--quiet`, `-q` | Suppress warnings. Default: `false`. |
 
 ## `data`
 
@@ -69,6 +70,7 @@ viam data export tabular --part-id=e1234f0c-912c-1234-a123-5ac1234612345 --resou
 | `--method` | Filter by specified method. | **Required** |
 | `--start` | ISO-8601 timestamp indicating the start of the interval. | Optional |
 | `--end` | ISO-8601 timestamp indicating the end of the interval. | Optional |
+| `--additional-params` | Additional parameters to pass to the tabular data export query. Accepts a JSON string of key-value pairs. | Optional |
 
 ### `data export binary filter`
 
@@ -112,8 +114,7 @@ viam data export binary ids --destination=<output path> --binary-data-ids=<binar
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
 | `--destination` | Output directory for downloaded data. | **Required** |
-| `--binary-data-ids` | Binary data IDs to download. | **Required** |
-| `--parallel` | Number of download requests to make in parallel. Default: `100`. | Optional |
+| `--binary-data-ids` | Binary data IDs to download. Accepts a single ID or a comma-separated list. | **Required** |
 | `--timeout` | Number of seconds to wait for file downloads. Default: `30`. | Optional |
 
 ### `data delete binary`
@@ -128,9 +129,10 @@ viam data delete binary --org-ids=123 --mime-types=image/jpeg --start 2024-08-20
 <!-- prettier-ignore -->
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
-| `--org-ids` | Filter by specified organizations ID (accepts comma-separated list). | Optional |
-| `--start` | ISO-8601 timestamp indicating the start of the interval. | Optional |
-| `--end` | ISO-8601 timestamp indicating the end of the interval. | Optional |
+| `--org-ids` | Filter by specified organizations ID (accepts comma-separated list). | **Required** |
+| `--start` | ISO-8601 timestamp indicating the start of the interval. | **Required** |
+| `--end` | ISO-8601 timestamp indicating the end of the interval. | **Required** |
+| `--bbox-labels` | String labels corresponding to bounding boxes within images. | Optional |
 | `--component-name` | Filter by specified component name. | Optional |
 | `--component-type` | Filter by specified component type. | Optional |
 | `--location-ids` | Filter by specified location ID (accepts comma-separated list). | Optional |
@@ -138,10 +140,9 @@ viam data delete binary --org-ids=123 --mime-types=image/jpeg --start 2024-08-20
 | `--machine-name` | Filter by specified machine name. | Optional |
 | `--method` | Filter by specified method. | Optional |
 | `--mime-types` | Filter by specified MIME type (accepts comma-separated list). | Optional |
-| `--parallel` | Number of download requests to make in parallel. Default: `100`. | Optional |
 | `--part-id` | Filter by specified part ID. | Optional |
 | `--part-name` | Filter by specified part name. | Optional |
-| `--tags` | Filter by specified tag (accepts comma-separated list). | Optional |
+| `--tags` | Filter by specified tag. Accepts `tagged` for all tagged data, `untagged` for all untagged data, or a comma-separated list of tags. | Optional |
 
 Viam currently only supports deleting approximately 500 files at a time.
 To delete more data iterate over the data with a shell script:
@@ -212,7 +213,7 @@ See [Using the `ids` argument](#using-the-ids-argument) for details on retrievin
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
 | `--binary-data-ids` | Binary data IDs to add tags to. | **Required** |
-| `--tags` | Tags to add (accepts comma-separated list). | Optional |
+| `--tags` | Tags to add (accepts comma-separated list). | **Required** |
 
 ### `data tag ids remove`
 
@@ -227,7 +228,7 @@ viam data tag ids remove --tags=new_tag_1,new_tag_2,new_tag_3 --binary-data-ids=
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
 | `--binary-data-ids` | Binary data IDs to remove tags from. | **Required** |
-| `--tags` | Tags to remove (accepts comma-separated list). | Optional |
+| `--tags` | Tags to remove (accepts comma-separated list). | **Required** |
 
 ### `data tag filter add`
 
@@ -241,7 +242,7 @@ viam data tag filter add --tags=new_tag_1,new_tag_2 --location-ids=012 --machine
 <!-- prettier-ignore -->
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
-| `--tags` | Tags to add (accepts comma-separated list). | Optional |
+| `--tags` | Tags to add (accepts comma-separated list). | **Required** |
 | `--filter-tags` | Filter tags. Options: `'tagged'`, `'untagged'`, or a comma-separated list of tags for all data matching any of the tags. | Optional |
 | `--bbox-labels` | String labels corresponding to bounding boxes within images. | Optional |
 | `--component-name` | Filter by specified component name. | Optional |
@@ -269,7 +270,7 @@ viam data tag filter remove --tags=new_tag_1 --location-ids=012 --machine-name=c
 <!-- prettier-ignore -->
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
-| `--tags` | Tags to remove (accepts comma-separated list). | Optional |
+| `--tags` | Tags to remove (accepts comma-separated list). | **Required** |
 | `--filter-tags` | Filter tags. Options: `'tagged'`, `'untagged'`, or a comma-separated list of tags for all data matching any of the tags. | Optional |
 | `--bbox-labels` | String labels corresponding to bounding boxes within images. | Optional |
 | `--component-name` | Filter by specified component name. | Optional |
@@ -541,7 +542,8 @@ viam dataset export --destination=./dataset/example --dataset-id=abc
 | `--destination` | Output directory for downloaded data. | **Required** |
 | `--only-jsonl` | Include only the JSON Lines files for local testing. No binary data is downloaded. | Optional |
 | `--force-linux-path` | Force the use of Linux-style paths in the dataset.jsonl file. | Optional |
-| `--parallel` | Number of download requests to make in parallel, with a default value of 100. | Optional |
+| `--parallel` | Number of download requests to make in parallel. Default: `100`. | Optional |
+| `--timeout` | Number of seconds to wait for large file downloads. Default: `30`. | Optional |
 
 ### `dataset merge`
 
@@ -571,7 +573,6 @@ viam dataset data add ids --dataset-id=abc --binary-data-ids=aaa,bbb
 | -------- | ----------- | --------- |
 | `--dataset-id` | Dataset to add images to. To retrieve the ID, navigate to your dataset's page, click **…** in the left-hand menu, and click **Copy dataset ID**. | **Required** |
 | `--binary-data-ids` | The binary data IDs of the images to add. | **Required** |
-| `--org-id` | Organization ID of the organization the dataset belongs to. | Optional |
 
 ### `dataset data add filter`
 
@@ -859,7 +860,7 @@ The `logout` command ends an authenticated CLI session.
 viam logout
 ```
 
-## `machines` (alias `robots` and `machine`)
+## `machines` (aliases `robots`, `robot`, `machine`)
 
 The `machines` command allows you to manage your machine fleet.
 This includes:
@@ -876,16 +877,16 @@ This includes:
 
 ```sh {class="command-line" data-prompt="$"}
 viam machines create --name=<machine name> --location=<location id>
-viam machines update --machine=<machine id> [--name=<new name>] [--location=<new location id>]
+viam machines update --machine=<machine id> [--new-name=<new name>] [--new-location=<new location id>]
 viam machines delete --machine=<machine id>
 viam machines list
 viam machines status --machine=<machine id>
 viam machines logs --machine=<machine id> [...named args]
 viam machines api-key create --machine-id=<machine id> --org-id=<org id> --name=<key name>
 viam machines part list --machine=<machine id>
-viam machines part logs --machine=<machine id> --part=<part id> [...named args]
-viam machines part status --machine=<machine id>
-viam machines part run --machine=<machine id> [--stream] --data <method>
+viam machines part logs --part=<part id> [...named args]
+viam machines part status --part=<part id>
+viam machines part run --part=<part id> --method=<method> [--data=<data>] [--stream=<interval>]
 viam machines part shell --machine=<machine id> --part=<part id>
 viam machines part restart --machine=<machine id> --part=<part id>
 viam machines part history --part=<part id>
@@ -918,8 +919,8 @@ viam machines create --name="My Machine" --location=12345
 Move a machine from one location to another and/or rename the machine.
 
 ```sh {class="command-line" data-prompt="$"}
-viam machines update --machine=123 --name="New Name"
-viam machines update --machine=123 --location=67890
+viam machines update --machine=123 --new-name="New Name"
+viam machines update --machine=123 --new-location=67890
 ```
 
 <!-- prettier-ignore -->
@@ -1055,16 +1056,21 @@ Run a component or service command, optionally at a specified interval. For comm
 ```sh {class="command-line" data-prompt="$"}
 # stream classifications from a machine part every 500 milliseconds from the Viam Vision Service with classifier "stuff_detector"
 viam machines part run --part=myrover-main --stream=500ms \
---data='{"name": "vision", "camera_name": "cam", "classifier_name": "stuff_classifier", "n":1}' \
-viam.service.vision.v1.VisionService.GetClassificationsFromCamera
+--method=viam.service.vision.v1.VisionService.GetClassificationsFromCamera \
+--data='{"name": "vision", "camera_name": "cam", "classifier_name": "stuff_classifier", "n":1}'
 ```
 
 <!-- prettier-ignore -->
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
 | `--part` | Part ID for which the command is being issued. | **Required** |
-| `--data` | Command data for the command being request to run. See [Using the `--stream` and `--data` arguments](#using-the---stream-and---data-arguments). | **Required** |
-| `--stream` | If specified, the interval in which to stream the specified data, for example, 100ms or 1s. | Optional |
+| `--method` | Method name (for example, `DoCommand`) or full service method (for example, `viam.component.camera.v1.CameraService.DoCommand`). | **Required** |
+| `--data`, `-d` | Command data for the command being requested to run. See [Using the `--stream` and `--data` arguments](#using-the---stream-and---data-arguments). | Optional |
+| `--component`, `-c` | Component name. Automatically sets `name` in `--data` and resolves short method names. | Optional |
+| `--stream`, `-s` | If specified, the interval at which to stream the specified data, for example, `100ms` or `1s`. Default: `0s`. | Optional |
+| `--organization` | Organization ID or name. | Optional |
+| `--location` | Location ID or name. | Optional |
+| `--machine` | Machine ID or name. | Optional |
 
 ### `machines part logs`
 
@@ -1459,29 +1465,21 @@ viam machines part delete-trigger --part=<part id> --name=<trigger name>
 
 ### Using the `--stream` and `--data` arguments
 
-Issuing the `part` command with the `run` positional argument allows you to run component and service (resource) commands for a selected machine part.
+Issuing the `machines part run` command allows you to run component and service (resource) commands for a selected machine part.
 
-The `--data` parameter is required and you must specify both:
+You specify the resource method with `--method`. Use either the short name (for example, `DoCommand` or `GetReadings`) together with `--component=<name>`, or the full {{< glossary_tooltip term_id="protobuf" text="protobuf" >}} package and method path (for example, `viam.service.vision.v1.VisionService.GetClassificationsFromCamera`).
 
-- Method arguments in JSON format
-- A resource method (in the form of the {{< glossary_tooltip term_id="protobuf" text="protobuf" >}} package and method path)
-
-The format of what is passed to the `--data` argument is:
+The `--data` parameter accepts method arguments as a JSON object. For example:
 
 ```sh {class="command-line" data-prompt="$"}
-'{"arg1": "val1"}' <protobuf path>
+viam machines part run --part=<part-id> \
+    --method=viam.service.vision.v1.VisionService.GetClassificationsFromCamera \
+    --data='{"name": "vision", "camera_name": "cam", "classifier_name": "my_classifier", "n":1}'
 ```
 
-You can find the protobuf path for the Viam package and method in the [Viam API package](https://github.com/viamrobotics/api/tree/main/proto/viam) by navigating to the component or service directory and then clicking on the resource file. The protobuf path is the package name.
+You can find the protobuf path for any Viam package and method in the [Viam API package](https://github.com/viamrobotics/api/tree/main/proto/viam) by navigating to the component or service directory and then clicking on the resource file. The protobuf path is the package name.
 
-For example:
-
-```sh {class="command-line" data-prompt="$"}
-'{"name": "vision", "camera_name": "cam", "classifier_name": "my_classifier", "n":1}' \
-viam.service.vision.v1.VisionService.GetClassificationsFromCamera
-```
-
-The `--stream` argument, when included in the CLI command prior to the `--data` command, will stream data back at the specified interval.
+The `--stream` argument streams data back at the specified interval, for example `100ms` or `1s`.
 
 ## `metadata`
 
@@ -2656,8 +2654,8 @@ viam train submit managed --dataset-id=456 --model-org-id=123 --model-name=MyCoo
 | `--model-org-id` | The organization ID to train and save the ML model in. You can find your organization ID by running `viam organizations list` or by visiting your organization's **Settings** page in the [Viam app](https://app.viam.com/). | **Required** |
 | `--model-name` | The name of the ML model. | **Required** |
 | `--model-type` | Type of model to train. Must be one of `single_label_classification`, `multi_label_classification`, or `object_detection`. | **Required** |
-| `--model-framework` | The framework of model to train. Must be one of `tflite` or `tensorflow`. | **Required** |
 | `--model-labels` | Labels to train on. These will either be classification or object detection labels. | **Required** |
+| `--model-framework` | The framework of model to train. Must be one of `tflite` or `tensorflow`. | Optional |
 | `--model-version` | Set the version of the submitted model. Defaults to current timestamp if unspecified. | Optional |
 
 ### `train submit custom from-registry`
@@ -2694,14 +2692,15 @@ viam train submit custom with-upload --dataset-id=<INSERT DATASET ID> --model-or
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
 | `--dataset-id` | The ID of the dataset to train on. | **Required** |
-| `--model-org-id` | The organization ID to train and save the ML model in. | **Required** |
+| `--org-id` | The organization ID to save the custom training script in. | **Required** |
+| `--model-org-id` | The organization ID to upload and run the training job in. | **Required** |
 | `--model-name` | The name of the ML model. | **Required** |
-| `--script-name` | The registry name of the ML training script to use for training. This sets the name on upload. | **Required** |
-| `--version` | The version of the ML training script to use for training. | **Required** |
 | `--path` | The path to the ML training script to upload. | **Required** |
-| `--framework` | Framework of the ML training script to upload, can be `tflite`, `tensorflow`, `pytorch`, or `onnx`. | **Required** |
+| `--script-name` | The registry name of the ML training script to use for training. This sets the name on upload. | **Required** |
 | `--container-version` | Docker container version for training. Use `viam train containers list` to see available versions. | **Required** |
+| `--framework` | Framework of the ML training script to upload. Options: `unspecified`, `tflite`, `tensorflow`, `pytorch`, `onnx`. | Optional |
 | `--model-type` | Type of model to train. Must be one of `single_label_classification`, `multi_label_classification`, `object_detection`, or `unspecified`. | Optional |
+| `--version` | The version of the ML training script to upload. Default: current timestamp. | Optional |
 | `--model-version` | Set the version of the submitted model. Defaults to current timestamp if unspecified. | Optional |
 | `--url` | URL of the GitHub repository associated with the training scripts. | Optional |
 | `--args` | Pass custom comma-separated arguments to the training script. Example: `num_epochs=3,model_type=multi_label`. To include whitespace, enclose the value with whitespace in single and double quotes. Example: `num_epochs=3,labels="'green_square blue_star'"`. | Optional |
@@ -2800,6 +2799,7 @@ viam training-script upload --framework=tflite --org-id=123 --path=. --script-na
 | `--url` | URL of GitHub repository associated with the training script. | Optional |
 | `--type` | Task type of the ML training script to upload, can be `single_label_classification`, `multi_label_classification`, or `object_detection`. | Optional |
 | `--draft` | Indicate draft mode, drafts are not viewable in the registry. | Optional |
+| `--visibility` | Visibility of the training script. Options: `public`, `private`. | Optional |
 
 ### `training-script update`
 
@@ -2815,8 +2815,9 @@ viam training-script update --org-id=123 --script-name=MyCustomTrainingScript --
 | -------- | ----------- | --------- |
 | `--org-id` | The organization ID hosting the script. You can find your organization ID by running `viam organizations list` or by visiting your organization's **Settings** page in the [Viam app](https://app.viam.com/). | **Required** |
 | `--script-name` | Name of the ML training script to update. | **Required** |
-| `--visibility` | Visibility of the registry item, can be `public`, `private`, or `draft`. | **Required** |
+| `--visibility` | Visibility of the registry item. Options: `public`, `private`. | **Required** |
 | `--description` | Description of the ML training script. | Optional |
+| `--url` | URL of the GitHub repository associated with the training scripts. | Optional |
 
 ## `traces`
 


### PR DESCRIPTION
## Summary

Restructures the CLI reference page so each subcommand becomes its own H4 section with a scoped flag table, instead of cramming every subcommand into one consolidated "Command options" table with an "Applicable commands" cross-reference column. Bundles the correctness fixes from the closed #5018 plus a full coverage sweep where every command on the page was verified against `viam <cmd> --help` from the v0.123.0 binary.

This also reorders `train` before `training-script` (alphabetical), promotes Global options to the top of the page, bumps each command from H3 to H2 so they're easier to scan, and refreshes the frontmatter date.

## Why

The single-table-per-command pattern got progressively worse as commands grew. `module` had three different views of the same surface (synopsis + Command options table + Named arguments table), `module build` was a 170-line H5 buried under another H5, and the "Applicable commands" column was the only thing scoping a flat flag table to its subcommands. Promoting subcommands to H3s with their own flag tables solves all of that with no link-redirect cost (the page stays at `/cli/reference/`).

## Correctness fixes (originally from #5018)

- Removed `--chunk-limit` row from `data` (didn't exist in the binary).
- Renamed `--include-jsonl` to `--only-jsonl` for `dataset export`.
- Added `--force-linux-path` row for `dataset export`.
- Added `viam dataset merge` (was missing entirely).
- Tightened `train submit managed` enums: `--model-type` to 3 values; `--model-framework` to `tflite | tensorflow`.
- Added `--url` row for `train submit custom with-upload`.
- Fixed "Position arguments" → "Positional arguments" typo.
- Added 4 previously undocumented commands: `defaults`, `resource`, `traces`, `xacro`.

## Correctness fixes (first sweep)

Renamed flags
- `module build logs`: `--id` → `--build-id` (also marked Required).
- `packages upload`: `--upload` → `--path`.

Removed flags not in binary
- `module reload`: `--id`, `--local`.
- `module generate`: `--resource-type`.

Added missing flags
- `module generate`: `--name`, `--language`, `--visibility`, `--public-namespace`, `--model-name`, `--register`.
- `module build list`: `--module`.
- `module restart`: `--module`.
- `module upload`: `--name`.
- `oauth-app create | update`: `--invite-redirect-uri`.

Required → Optional / Conditional
- `packages upload`: `--model-framework` / `--model-type` are conditional on `--type=ml_model`.
- `packages export`: only `--type` is required.
- `locations api-key create`: `--location-id` has a default.
- `oauth-app create`: `--client-name` / `--origin-uris` optional.
- `oauth-app update`: only `--org-id` / `--client-id` required.

Synopsis fix
- `locations list`: `--organization` is named, not positional.

Added missing subcommands
- `organizations logo get`
- `organizations firebase-config set | read | delete`
- `machines part history`
- `machines part add-job | update-job | delete-job`
- `machines part add-trigger | delete-trigger`

## Correctness fixes (full coverage sweep)

Verified every remaining command on the page against the v0.123.0 binary's `--help`:

- **Global options:** added `--config FILE` / `-c`, `--vvv` alias; fixed `--disable-profile` alias.
- **data export tabular:** added missing `--additional-params`.
- **data export binary ids:** removed phantom `--parallel`.
- **data delete binary:** removed phantom `--parallel`; added `--bbox-labels`; marked `--org-ids` / `--start` / `--end` as Required (per USAGE).
- **data tag ids add | remove, data tag filter add | remove:** marked `--tags` as Required.
- **dataset export:** added missing `--timeout`.
- **dataset data add ids:** removed phantom `--org-id`.
- **machines part run:** added `--method` (Required) and `--component`; corrected `--data` to Optional; added `--organization` / `--location` / `--machine`; rewrote example to pass the method as a flag (was a trailing positional).
- **train submit managed:** `--model-framework` Required → Optional.
- **train submit custom with-upload:** added missing `--org-id` (Required); `--framework` Required → Optional; reordered table.
- **training-script upload:** added missing `--visibility`.
- **training-script update:** removed nonexistent `draft` value from `--visibility`; added missing `--url`.
- **machines update:** fixed example (`--name` → `--new-name`, `--location` → `--new-location`).
- **machines header:** aliases now lists `robots`, `robot`, `machine` (was missing `robot`).
- **machines synopsis:** updated for `update`, `part run`, `part status`, `part logs`.

## Structural changes

- Each leaf subcommand → its own H3 section (originally H4 in the first restructure pass; H3 after the heading-bump commit): heading, one-line description, syntax block (with a worked example where useful), scoped flag table.
- Dropped the "Command options" subcommand-list table.
- Dropped the "Applicable commands" column.
- Dropped the "Positional arguments: api-key" / "Positional arguments: part" / "Positional arguments: tag" tables (absorbed into the relevant subcommand sections).
- Promoted cross-cutting flag how-tos (Using `--platform`, Using `--version`, Using `--org-id` and `--public-namespace`, Upload validation, Using the `build` subcommand, Using `--stream` and `--data`, Using `ids`, Using `filter`).
- Reordered `train` before `training-script`.
- Moved Global options to the top of the page (under the synopsis), without a section heading.

## What was preserved (verified by diff)

- All 133 unique flag names from the original.
- All 12 Hugo shortcodes (alerts, expand blocks, glossary tooltips, hiddencontent).
- All 11 internal anchor refs still resolve to existing headings.
- Specific prose blocks: Python 3.11 alert (now under `module generate`), supported-resources hiddencontent (under `module generate`), 500-file deletion shell script (under `data delete binary`), setup.sh / build.sh expand blocks under "Using the build subcommand", platform-specific HTML-commented build content, ViamShellDanger references on `part shell` / `part cp`.

## Test plan

- [x] `prettier --write`: unchanged after each commit
- [x] `vale docs/cli/reference.md`: 0 errors, 0 warnings
- [x] `markdownlint-cli2`: 0 errors
- [x] `make build-prod`: clean (the "Last update more than 6 months ago" warning for cli/reference is resolved)
- [ ] Spot-check a few subcommand sections in the Netlify deploy preview