### PR TITLE
set-up-a-machine: add CLI-led setup path for repeat operators

### DIFF
--- a/docs/reference/device-setup/beaglebone-setup.md
+++ b/docs/reference/device-setup/beaglebone-setup.md
@@ -83,7 +83,7 @@ After SSH'ing into your BeagleBone, verify all packages are up to date:
 ## Next steps
 
 You have now installed an operating system on your BeagleBone.
-To use your BeagleBone, follow the [setup guide](/set-up-a-machine/overview/):
+To use your BeagleBone, follow the [setup guide](/set-up-a-machine/first-machine/):
 
 {{< cards >}}
 {{% card link="/set-up-a-machine/first-machine/" %}}

--- a/docs/reference/device-setup/beaglebone-setup.md
+++ b/docs/reference/device-setup/beaglebone-setup.md
@@ -86,7 +86,7 @@ You have now installed an operating system on your BeagleBone.
 To use your BeagleBone, follow the [setup guide](/set-up-a-machine/overview/):
 
 {{< cards >}}
-{{% card link="/set-up-a-machine/overview/" %}}
+{{% card link="/set-up-a-machine/first-machine/" %}}
 {{< /cards >}}
 
 ## Troubleshooting

--- a/docs/reference/device-setup/board1-setup.md
+++ b/docs/reference/device-setup/board1-setup.md
@@ -64,7 +64,7 @@ You have now installed an operating system on your BOARD.
 To use your BOARD, follow the [setup guide](/set-up-a-machine/overview/):
 
 {{< cards >}}
-{{% card link="/set-up-a-machine/overview/" %}}
+{{% card link="/set-up-a-machine/first-machine/" %}}
 {{< /cards >}}
 
 ## Troubleshooting

--- a/docs/reference/device-setup/board1-setup.md
+++ b/docs/reference/device-setup/board1-setup.md
@@ -61,7 +61,7 @@ Once you're connected to your board, you can verify all packages are up to date 
 ## Next steps
 
 You have now installed an operating system on your BOARD.
-To use your BOARD, follow the [setup guide](/set-up-a-machine/overview/):
+To use your BOARD, follow the [setup guide](/set-up-a-machine/first-machine/):
 
 {{< cards >}}
 {{% card link="/set-up-a-machine/first-machine/" %}}

--- a/docs/reference/device-setup/jetson-agx-orin-setup.md
+++ b/docs/reference/device-setup/jetson-agx-orin-setup.md
@@ -122,7 +122,7 @@ You have now installed an operating system on your Jetson board.
 To use your Jetson board, follow the [setup guide](/set-up-a-machine/overview/):
 
 {{< cards >}}
-{{% card link="/set-up-a-machine/overview/" %}}
+{{% card link="/set-up-a-machine/first-machine/" %}}
 {{< /cards >}}
 
 ## Troubleshooting

--- a/docs/reference/device-setup/jetson-agx-orin-setup.md
+++ b/docs/reference/device-setup/jetson-agx-orin-setup.md
@@ -119,7 +119,7 @@ See NVIDIA's documentation on [Configuring the Jetson Expansion Headers](https:/
 ## Next steps
 
 You have now installed an operating system on your Jetson board.
-To use your Jetson board, follow the [setup guide](/set-up-a-machine/overview/):
+To use your Jetson board, follow the [setup guide](/set-up-a-machine/first-machine/):
 
 {{< cards >}}
 {{% card link="/set-up-a-machine/first-machine/" %}}

--- a/docs/reference/device-setup/jetson-nano-setup.md
+++ b/docs/reference/device-setup/jetson-nano-setup.md
@@ -99,7 +99,7 @@ See NVIDIA's documentation on [Configuring the Jetson Expansion Headers](https:/
 ## Next steps
 
 You have now installed an operating system on your Jetson board.
-To use your Jetson board, follow the [setup guide](/set-up-a-machine/overview/):
+To use your Jetson board, follow the [setup guide](/set-up-a-machine/first-machine/):
 
 {{< cards >}}
 {{% card link="/set-up-a-machine/first-machine/" %}}

--- a/docs/reference/device-setup/jetson-nano-setup.md
+++ b/docs/reference/device-setup/jetson-nano-setup.md
@@ -102,7 +102,7 @@ You have now installed an operating system on your Jetson board.
 To use your Jetson board, follow the [setup guide](/set-up-a-machine/overview/):
 
 {{< cards >}}
-{{% card link="/set-up-a-machine/overview/" %}}
+{{% card link="/set-up-a-machine/first-machine/" %}}
 {{< /cards >}}
 
 ## Troubleshooting

--- a/docs/reference/device-setup/orange-pi-3-lts.md
+++ b/docs/reference/device-setup/orange-pi-3-lts.md
@@ -88,7 +88,7 @@ You have now installed an operating system on your Orange Pi.
 To use your Orange Pi, follow the [setup guide](/set-up-a-machine/overview/):
 
 {{< cards >}}
-{{% card link="/set-up-a-machine/overview/" %}}
+{{% card link="/set-up-a-machine/first-machine/" %}}
 {{< /cards >}}
 
 If you want to use the GPIO pins on the board, add a [`orangepi` board as a component](https://github.com/viam-modules/orange-pi/) after installing `viam-server`.

--- a/docs/reference/device-setup/orange-pi-3-lts.md
+++ b/docs/reference/device-setup/orange-pi-3-lts.md
@@ -48,7 +48,7 @@ Before you power the board, you need to install an operating system.
 1. Follow the [Orange Pi guide to prepare your microSD card](https://sbc-community.org/docs/general_guides/prepare_sd_card/) to flash the OS to your micro-SD card using [balenaEtcher](https://etcher.balena.io/).
 
    {{< alert title="Tip: How to think about building a machine" color="tip" >}}
-   While flashing your microSD card, we recommend reading [How to think about building a machine](/set-up-a-machine/overview/).
+   While flashing your microSD card, we recommend reading [How to think about building a machine](/set-up-a-machine/first-machine/).
    {{< /alert >}}
 
 1. Insert the micro-SD into the Orange Pi.
@@ -85,7 +85,7 @@ For more information, consult the [official user manual](https://drive.google.co
 ## Next steps
 
 You have now installed an operating system on your Orange Pi.
-To use your Orange Pi, follow the [setup guide](/set-up-a-machine/overview/):
+To use your Orange Pi, follow the [setup guide](/set-up-a-machine/first-machine/):
 
 {{< cards >}}
 {{% card link="/set-up-a-machine/first-machine/" %}}

--- a/docs/reference/device-setup/orange-pi-zero2.md
+++ b/docs/reference/device-setup/orange-pi-zero2.md
@@ -81,7 +81,7 @@ You have now installed an operating system on your Orange Pi.
 To use your Orange Pi, follow the [setup guide](/set-up-a-machine/overview/):
 
 {{< cards >}}
-{{% card link="/set-up-a-machine/overview/" %}}
+{{% card link="/set-up-a-machine/first-machine/" %}}
 {{< /cards >}}
 
 If you want to use the GPIO pins on the board, add a [`orangepi` board as a component](https://github.com/viam-modules/orange-pi/) after installing `viam-server`.

--- a/docs/reference/device-setup/orange-pi-zero2.md
+++ b/docs/reference/device-setup/orange-pi-zero2.md
@@ -47,7 +47,7 @@ Before you power the board, you need to install an operating system.
 1. Insert the micro-SD card into the SD card reader and connect the reader to your development machine.
 1. Follow [this guide](https://sbc-community.org/docs/general_guides/prepare_sd_card/) to flash the OS to your micro-SD card using [balenaEtcher](https://etcher.balena.io/).
    {{< alert title="Tip: How to think about building a machine" color="tip" >}}
-   While flashing your microSD card, we recommend reading [How to think about building a machine](/set-up-a-machine/overview/).
+   While flashing your microSD card, we recommend reading [How to think about building a machine](/set-up-a-machine/first-machine/).
    {{< /alert >}}
 1. Insert the micro-SD into the Orange Pi.
 
@@ -78,7 +78,7 @@ For more information, consult the [official user manual](https://drive.google.co
 ## Next steps
 
 You have now installed an operating system on your Orange Pi.
-To use your Orange Pi, follow the [setup guide](/set-up-a-machine/overview/):
+To use your Orange Pi, follow the [setup guide](/set-up-a-machine/first-machine/):
 
 {{< cards >}}
 {{% card link="/set-up-a-machine/first-machine/" %}}

--- a/docs/reference/device-setup/pumpkin.md
+++ b/docs/reference/device-setup/pumpkin.md
@@ -18,7 +18,7 @@ date: "2022-01-01"
 
 To use a [Mediatek Genio 500 Pumpkin single-board computer](https://ologicinc.com/portfolio/mediateki500/) with Viam:
 
-1. [Install `viam-server`](/set-up-a-machine/overview/) on your machine.
+1. [Install `viam-server`](/set-up-a-machine/first-machine/) on your machine.
 1. [Create a board definitions file](#create-a-board-definitions-file), specifying the mapping between your board's GPIO pins and connected hardware.
 1. [Configure a `customlinux` board](#configure-a-customlinux-board) on your machine, specifying the path to the definitions file in the board configuration.
 

--- a/docs/reference/device-setup/rpi-setup.md
+++ b/docs/reference/device-setup/rpi-setup.md
@@ -220,5 +220,5 @@ The Pi reads and removes `wpa_supplicant.conf` on boot, updating the stored WiFi
 Continue setting up `viam-server` on your Raspberry Pi in [the Viam app](https://app.viam.com/):
 
 {{< cards >}}
-{{% card link="/set-up-a-machine/overview/" %}}
+{{% card link="/set-up-a-machine/first-machine/" %}}
 {{< /cards >}}

--- a/docs/reference/device-setup/rpi-setup.md
+++ b/docs/reference/device-setup/rpi-setup.md
@@ -25,7 +25,7 @@ date: "2022-01-01"
 We recommend using Viam on a 64-bit Linux distribution.
 Support for older Raspberry Pis running on 32-bit ARM v7 is in beta.
 
-If you already have a Linux distribution installed on your {{< glossary_tooltip term_id="pi" text="Pi" >}}, you can skip ahead to [install `viam-server`](/set-up-a-machine/overview/).
+If you already have a Linux distribution installed on your {{< glossary_tooltip term_id="pi" text="Pi" >}}, you can skip ahead to [install `viam-server`](/set-up-a-machine/first-machine/).
 
 {{% expand "Click to check whether the Linux installation on your Raspberry Pi is 64-bit or 32-bit" %}}
 
@@ -35,7 +35,7 @@ Example output:
 
 {{< imgproc alt="Screenshot of a terminal running the 'lscpu' command. The output lists of this command on a Raspberry Pi. A red box highlights the command and the top of the output which reads 'Architecture: aarch64.'" src="/installation/rpi-setup/lscpu-output.png" resize="800x" declaredimensions=true class="shadow" >}}
 
-If the value of "Architecture: _'xxxxxx'_" ends in "64", you can skip ahead to [install `viam-server`](/set-up-a-machine/overview/).
+If the value of "Architecture: _'xxxxxx'_" ends in "64", you can skip ahead to [install `viam-server`](/set-up-a-machine/first-machine/).
 
 {{% /expand%}}
 
@@ -177,7 +177,7 @@ Be sure that you remember the `hostname` and `username` you set, as you will nee
 
     {{< alert title="Tip: How to think about building a machine" color="tip" >}}
 
-While the Imager is flashing your microSD card, we recommend reading [How to think about building a machine](/set-up-a-machine/overview/).
+While the Imager is flashing your microSD card, we recommend reading [How to think about building a machine](/set-up-a-machine/first-machine/).
 
     {{< /alert >}}
 

--- a/docs/reference/device-setup/sk-tda4vm.md
+++ b/docs/reference/device-setup/sk-tda4vm.md
@@ -114,7 +114,7 @@ You have now installed an operating system on your board.
 To use your board, follow the [setup guide](/set-up-a-machine/overview/):
 
 {{< cards >}}
-{{% card link="/set-up-a-machine/overview/" %}}
+{{% card link="/set-up-a-machine/first-machine/" %}}
 {{< /cards >}}
 
 ## Need assistance?

--- a/docs/reference/device-setup/sk-tda4vm.md
+++ b/docs/reference/device-setup/sk-tda4vm.md
@@ -63,7 +63,7 @@ You must extract the image from the zip file before flashing the microSD card.
    The flashing and verification process may take 10-20 minutes, depending on your system.
 
    {{< alert title="Tip: How to think about building a machine" color="tip" >}}
-   While the Etcher is flashing your microSD card, we recommend reading [How to think about building a machine](/set-up-a-machine/overview/).
+   While the Etcher is flashing your microSD card, we recommend reading [How to think about building a machine](/set-up-a-machine/first-machine/).
    {{< /alert >}}
 
 8. On completion of the flashing and validation process, remove the microSD card from your computer and insert it into the TDA4VM.
@@ -111,7 +111,7 @@ From the SSH session on the TDA4VM board:
 ## Next steps
 
 You have now installed an operating system on your board.
-To use your board, follow the [setup guide](/set-up-a-machine/overview/):
+To use your board, follow the [setup guide](/set-up-a-machine/first-machine/):
 
 {{< cards >}}
 {{% card link="/set-up-a-machine/first-machine/" %}}

--- a/docs/set-up-a-machine/_index.md
+++ b/docs/set-up-a-machine/_index.md
@@ -5,7 +5,7 @@ weight: 30
 layout: "docs"
 type: "docs"
 no_list: true
-manualLink: "/set-up-a-machine/overview/"
+manualLink: "/set-up-a-machine/first-machine/"
 description: "Create a machine in the Viam app and install Viam on your compute machine."
 date: "2025-01-30"
 ---

--- a/docs/set-up-a-machine/as-code.md
+++ b/docs/set-up-a-machine/as-code.md
@@ -1,0 +1,90 @@
+---
+linkTitle: "Set up machines as code"
+title: "Set up machines as code"
+weight: 2
+layout: "docs"
+type: "docs"
+description: "Create and connect machines from the command line. Repeatable, version-controllable, and ready to scale."
+---
+
+When you set up machines from the command line, every step lives in a command you can re-run, share with your team, and check into git.
+
+You'll need:
+
+- An organization and a location in the Viam app. New to Viam? Use [Set up your first machine](/set-up-a-machine/first-machine/) to create them, then come back.
+- An API key for the CLI. See [Manage API keys](/cli/administer-your-organization/#manage-api-keys).
+- A Linux or macOS device to run `viam-agent`. For Windows or ESP32, use [Set up your first machine](/set-up-a-machine/first-machine/).
+
+## 1. Install and authenticate the CLI
+
+{{< readfile "/static/include/how-to/install-cli.md" >}}
+
+In a script, authenticate with an API key:
+
+```sh {class="command-line" data-prompt="$"}
+viam login api-key --key-id=<key-id> --key=<key>
+```
+
+## 2. Create the machine
+
+```sh {class="command-line" data-prompt="$"}
+viam machines create --name=my-first-machine --location=<location-id>
+```
+
+The CLI prints the new machine's ID:
+
+```sh {class="command-line" data-prompt="$" data-output="1"}
+created new machine with id abc12345-1234-abcd-5678-ef1234567890
+```
+
+To find your location ID:
+
+```sh {class="command-line" data-prompt="$"}
+viam locations list
+```
+
+## 3. Get the part ID
+
+Every machine has at least one part. To install `viam-agent` on the device, you need the part ID:
+
+```sh {class="command-line" data-prompt="$"}
+viam machines part list --machine=<machine-id>
+```
+
+## 4. Install viam-agent on the device
+
+On the compute device that will run the machine, run:
+
+```sh {class="command-line" data-prompt="$"}
+sudo /bin/sh -c "VIAM_API_KEY_ID=<key-id> VIAM_API_KEY=<key> VIAM_PART_ID=<part-id>; $(curl -fsSL https://storage.googleapis.com/packages.viam.com/apps/viam-agent/install.sh)"
+```
+
+The install script downloads `viam-agent`, fetches the machine's cloud config to `/etc/viam.json` using the credentials above, and starts the agent service.
+
+## 5. Verify the machine is online
+
+```sh {class="command-line" data-prompt="$"}
+viam machines status --machine=<machine-id>
+```
+
+If the machine is connected, the CLI prints its part list and status. If not, see the troubleshooting tips on [Set up your first machine](/set-up-a-machine/first-machine/#troubleshooting).
+
+## 6. Apply a baseline configuration (optional)
+
+If you have a fragment defining your standard component setup, attach it to the machine's main part:
+
+```sh {class="command-line" data-prompt="$"}
+viam machines part fragments add --part=<part-id> --fragment=<fragment-id>
+```
+
+See [Reuse machine configuration](/fleet/reuse-configuration/) for the fragment authoring workflow.
+
+## Set up multiple machines
+
+The pattern above handles one machine. To do this for many machines, wrap steps 2-6 in a script. See [Automate with scripts](/cli/automate-with-scripts/#provisioning-create-and-configure-a-machine) for a complete provisioning script.
+
+## What's next
+
+- [Configure hardware](/hardware/configure-hardware/) to add components and services.
+- [Reuse machine configuration](/fleet/reuse-configuration/) to author the fragments your machines apply.
+- [Automate with scripts](/cli/automate-with-scripts/) for bulk operations and CI/CD.

--- a/docs/set-up-a-machine/first-machine.md
+++ b/docs/set-up-a-machine/first-machine.md
@@ -130,4 +130,4 @@ If the connection succeeds, the script prints your machine's available resources
 ## What's next
 
 - [Configure hardware](/hardware/configure-hardware/) to add cameras, motors, sensors, and other components to your machine.
-- [Set up machines as code](/set-up-a-machine/as-code/) to provision additional machines from the command line, scripted and reproducible.
+- [Set up machines with the CLI](/set-up-a-machine/with-cli/) to provision additional machines from the command line.

--- a/docs/set-up-a-machine/first-machine.md
+++ b/docs/set-up-a-machine/first-machine.md
@@ -1,12 +1,13 @@
 ---
-linkTitle: "Set up a machine"
-title: "Set up a machine"
+linkTitle: "Set up your first machine"
+title: "Set up your first machine"
 weight: 1
 layout: "docs"
 type: "docs"
 description: "Create a machine in the Viam app and install Viam on your compute machine."
 date: "2025-01-30"
 aliases:
+  - /set-up-a-machine/overview/
   - /foundation/
   - /build/foundation/
   - /foundation/initialize-a-viam-machine/
@@ -31,8 +32,8 @@ aliases:
   - /operate/install/setup/
 ---
 
-Connect a machine to the Viam platform so you can configure, control, and monitor it from anywhere.
-You'll create a machine in the Viam app, install Viam on your machine, and confirm it's online.
+Connect your first machine to the Viam platform so you can configure, control, and monitor it from anywhere.
+You'll create a machine in the Viam app, install Viam on your compute device, and confirm it's online.
 
 ## 1. Create a machine in the Viam app
 
@@ -128,4 +129,5 @@ If the connection succeeds, the script prints your machine's available resources
 
 ## What's next
 
-- [Configure hardware](/hardware/configure-hardware/) — Add cameras, motors, sensors, and other components to your machine.
+- [Configure hardware](/hardware/configure-hardware/) to add cameras, motors, sensors, and other components to your machine.
+- [Set up machines as code](/set-up-a-machine/as-code/) to provision additional machines from the command line, scripted and reproducible.

--- a/docs/set-up-a-machine/with-cli.md
+++ b/docs/set-up-a-machine/with-cli.md
@@ -1,13 +1,15 @@
 ---
-linkTitle: "Set up machines as code"
-title: "Set up machines as code"
+linkTitle: "Set up machines with the CLI"
+title: "Set up machines with the CLI"
 weight: 2
 layout: "docs"
 type: "docs"
-description: "Create and connect machines from the command line. Repeatable, version-controllable, and ready to scale."
+description: "Create and connect machines from the command line."
+aliases:
+  - /set-up-a-machine/as-code/
 ---
 
-When you set up machines from the command line, every step lives in a command you can re-run, share with your team, and check into git.
+Create and connect a machine to the Viam platform from the command line, instead of clicking through the Viam app.
 
 You'll need:
 

--- a/docs/tutorials/configure/configure-rover.md
+++ b/docs/tutorials/configure/configure-rover.md
@@ -34,7 +34,7 @@ If you are using a Viam Rover, use the [Viam Rover tutorial fragment](/try/) ins
 ## Requirements
 
 - A running an instance of `viam-server`.
-  See our [Installation Guide](/set-up-a-machine/overview/) for instructions.
+  See our [Installation Guide](/set-up-a-machine/first-machine/) for instructions.
 - A rover like the [SCUTTLE robot](https://www.scuttlerobot.org/shop/) or the Yahboom 4WD Smart Robot.
 
 Make sure your rover is assembled before starting this tutorial.

--- a/docs/tutorials/control/air-quality-fleet.md
+++ b/docs/tutorials/control/air-quality-fleet.md
@@ -49,7 +49,7 @@ For each machine, you need the following hardware:
 
 - A [SDS011 Nova PM sensor](https://www.amazon.com/SDS011-Quality-Detection-Conditioning-Monitor/dp/B07FSDMRR5)
   - If you choose to use a different air quality sensor, you may need to [create your own module](/build-modules/write-a-driver-module/) implementing the [sensor API](/reference/components/sensor/) for your specific hardware.
-- A single-board computer (SBC) [capable of running `viam-server`](/set-up-a-machine/overview/)
+- A single-board computer (SBC) [capable of running `viam-server`](/set-up-a-machine/first-machine/)
 - An appropriate power supply
 
 ## Set up one device for development
@@ -88,7 +88,7 @@ Use the **...** menu next to edit the location name to `Development`, then click
 Connect a PM sensor to a USB port on the machine's SBC.
 Then connect your device to power.
 
-If the computer does not already have a Viam-compatible operating system installed, follow the [prerequisite section of the setup guide](/set-up-a-machine/overview/) to install a compatible operating system.
+If the computer does not already have a Viam-compatible operating system installed, follow the [prerequisite section of the setup guide](/set-up-a-machine/first-machine/) to install a compatible operating system.
 You _do not_ need to follow the "Install `viam-server`" section; you will do that in the next step!
 
 Enable serial communication so that the SBC can communicate with the air quality sensor.

--- a/docs/tutorials/control/drive-rover.md
+++ b/docs/tutorials/control/drive-rover.md
@@ -71,7 +71,7 @@ If you are running out of time during your session, you can [extend your rover s
 {{% tab name="Other Rover" %}}
 
 {{% alert title="Important" color="note" %}}
-If you are using your own robot for this tutorial instead of [borrowing one](https://app.viam.com/try), be sure to [follow the setup instructions and install `viam-server`](/set-up-a-machine/overview/) on it, and connect and [configure](/tutorials/configure/configure-rover/) its hardware before proceeding with this tutorial.
+If you are using your own robot for this tutorial instead of [borrowing one](https://app.viam.com/try), be sure to [follow the setup instructions and install `viam-server`](/set-up-a-machine/first-machine/) on it, and connect and [configure](/tutorials/configure/configure-rover/) its hardware before proceeding with this tutorial.
 {{% /alert %}}
 
 {{% /tab %}}

--- a/docs/tutorials/control/flutter-app.md
+++ b/docs/tutorials/control/flutter-app.md
@@ -41,9 +41,9 @@ As you work through this project you will learn the following:
 
 ## Requirements
 
-You do not need any hardware for this tutorial other than a computer capable of running [`viam-server`](/set-up-a-machine/overview/).
+You do not need any hardware for this tutorial other than a computer capable of running [`viam-server`](/set-up-a-machine/first-machine/).
 
-This tutorial assumes you already have a machine [configured](/set-up-a-machine/overview/).
+This tutorial assumes you already have a machine [configured](/set-up-a-machine/first-machine/).
 
 ## Set up your Flutter development environment
 

--- a/docs/tutorials/custom/controlling-an-intermode-rover-canbus.md
+++ b/docs/tutorials/custom/controlling-an-intermode-rover-canbus.md
@@ -76,7 +76,7 @@ The tutorial uses the following hardware:
 ### Machine setup
 
 Before you can use Viam on your device, you must ensure it has a supported operating system.
-See [Start a new machine](/set-up-a-machine/overview/) for platform requirements and instructions.
+See [Start a new machine](/set-up-a-machine/first-machine/) for platform requirements and instructions.
 
 {{% snippet "setup.md" %}}
 

--- a/docs/tutorials/get-started/servo-mousemover.md
+++ b/docs/tutorials/get-started/servo-mousemover.md
@@ -52,7 +52,7 @@ This project is a good place to begin if you're new to robotics and would like t
 
 ### Hardware
 
-- [Raspberry Pi with microSD card](https://a.co/d/bxEdcAT), with `viam-server` installed per our [installation guide](/set-up-a-machine/overview/)
+- [Raspberry Pi with microSD card](https://a.co/d/bxEdcAT), with `viam-server` installed per our [installation guide](/set-up-a-machine/first-machine/)
 - microSD card reader
 - [Continuous rotation servo](https://a.co/d/2w0u6rK) (we used the FS90R servo)
 - Wheel or arm for the servo (this comes in some of the FS90R packages)

--- a/docs/tutorials/projects/claw-game.md
+++ b/docs/tutorials/projects/claw-game.md
@@ -57,7 +57,7 @@ To build your own claw game machine, you need the following hardware:
 
 To build your own claw game machine, you need the following software:
 
-- [`viam-server`](/set-up-a-machine/overview/)
+- [`viam-server`](/set-up-a-machine/first-machine/)
 - [Python 3](https://www.python.org/download/releases/3.0/)
 - [pip](https://pip.pypa.io/en/stable/#)
 - [Viam Python SDK](https://python.viam.dev/)

--- a/docs/tutorials/projects/helmet.md
+++ b/docs/tutorials/projects/helmet.md
@@ -48,7 +48,7 @@ After completing this tutorial, you will:
 
 - A camera such as a standard USB webcam.
   You can also test the hard hat detection system using the webcam built into your laptop.
-- A computer capable of running [`viam-server`](/set-up-a-machine/overview/).
+- A computer capable of running [`viam-server`](/set-up-a-machine/first-machine/).
 
 ### Optional hardware
 
@@ -60,7 +60,7 @@ Note that your machine must be connected to the internet for data sync and email
 
 ### Required software
 
-- [`viam-server`](/set-up-a-machine/overview/)
+- [`viam-server`](/set-up-a-machine/first-machine/)
 - [Ultralytics YOLOv8](https://docs.ultralytics.com/), integrated with Viam using the [YOLOv8 modular service](https://github.com/viam-labs/YOLOv8)
 - [YOLOv8 Hard Hat Detection model](https://huggingface.co/keremberke/yolov8s-hard-hat-detection)
 - [`objectfilter-camera`](https://app.viam.com/module/felixr/object-filter) {{< glossary_tooltip term_id="modular-resource" text="modular resource" >}}

--- a/docs/tutorials/projects/send-security-photo.md
+++ b/docs/tutorials/projects/send-security-photo.md
@@ -40,7 +40,7 @@ You need the following hardware for this tutorial:
 You will use the following software in this tutorial:
 
 - [Python 3.8 or newer](https://www.python.org/downloads/)
-- [`viam-server`](/set-up-a-machine/overview/)
+- [`viam-server`](/set-up-a-machine/first-machine/)
 - [Viam Python SDK](https://python.viam.dev/)
   - The Viam Python SDK (software development kit) lets you control your Viam-powered machine by writing custom scripts in the Python programming language.
     Install the Viam Python SDK by following [these instructions](https://python.viam.dev/).

--- a/docs/tutorials/services/color-detection-scuttle.md
+++ b/docs/tutorials/services/color-detection-scuttle.md
@@ -163,7 +163,7 @@ Next, create a file named <file>main.py</file> with the sample code from the **C
 Then, save your file.
 
 Run the code to verify that the Viam SDK is properly installed and that the `viam-server` instance on your robot is live.
-If you haven't yet installed `viam-server`, follow the [installation guide](/set-up-a-machine/overview/) to install `viam-server` on your robot before proceeding with this tutorial.
+If you haven't yet installed `viam-server`, follow the [installation guide](/set-up-a-machine/first-machine/) to install `viam-server` on your robot before proceeding with this tutorial.
 
 You can run your code by typing the following into your terminal from the same directory as your `main.py` file:
 

--- a/docs/tutorials/services/navigate-with-rover-base.md
+++ b/docs/tutorials/services/navigate-with-rover-base.md
@@ -80,7 +80,7 @@ If you are using different hardware, the navigation setup process will be mostly
 
 {{% /alert %}}
 
-Before you start, make sure to create a machine on [Viam](https://app.viam.com) and [install `viam-server`](/set-up-a-machine/overview/) on your robot.
+Before you start, make sure to create a machine on [Viam](https://app.viam.com) and [install `viam-server`](/set-up-a-machine/first-machine/) on your robot.
 Also, make sure to physically connect your components together to your machine's computer and power it on.
 
 ## Configure the components you need

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -9,7 +9,7 @@
         <div class="row-no-margin">
             {{ partial "card.html" (dict "link" "/" "class" "" "customTitle" "" "customDescription" "Get an overview of the Viam platform and how you can configure, program, operate, manage, and collect data from your machines." "customCanonicalLink" "" ) }}
             {{ partial "card.html" (dict "link" "/tutorials/control/drive-rover/" "class" "" "customTitle" "" "customDescription" "" "customCanonicalLink" "" ) }}
-            {{ partial "card.html" (dict "link" "/set-up-a-machine/overview/" "class" "" "customTitle" "" "customDescription" "" "customCanonicalLink" "" ) }}
+            {{ partial "card.html" (dict "link" "/set-up-a-machine/first-machine/" "class" "" "customTitle" "" "customDescription" "" "customCanonicalLink" "" ) }}
             {{ partial "card.html" (dict "link" "/reference/" "class" "" "customTitle" "" "customDescription" "" "customCanonicalLink" "" ) }}
             {{ partial "card.html" (dict "link" "/reference/sdks/" "class" "" "customTitle" "" "customDescription" "" "customCanonicalLink" "" ) }}
         </div>


### PR DESCRIPTION
## Summary

- Adds a new **Set up machines as code** page with a CLI-led walkthrough so operators provisioning multiple machines find the workflow without digging through the CLI section.
- Renames `overview.md` to `first-machine.md` to differentiate the two paths. The first-time UI walkthrough stays the default at the section index (via `manualLink`); the alias preserves `/set-up-a-machine/overview/`.
- Updates inbound card links in eight device-setup pages and the 404 template (regular markdown links continue to work via the alias).

The CLI path requires an existing org, location, and API key, and supports Linux/macOS only. Prerequisites are stated up front and the page links back to **Set up your first machine** for users who don't have those.

## Test plan

- [ ] Confirm `/set-up-a-machine/` redirects to `/set-up-a-machine/first-machine/`
- [ ] Confirm `/set-up-a-machine/overview/` redirects to `/set-up-a-machine/first-machine/` (alias)
- [ ] Confirm `/set-up-a-machine/as-code/` renders correctly
- [ ] Confirm device-setup card links resolve to the new URL
- [ ] Confirm sidebar shows both **Set up your first machine** and **Set up machines as code** under **Set up a machine**

🤖 Generated with [Claude Code](https://claude.com/claude-code)