### PR TITLE
go.mod/go.sum cleanup, docsy → v0.6.0, pin Netlify Hugo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/viamrobotics/tutorials-and-docs
 
-go 1.12
+go 1.23
 
 require (
-	github.com/google/docsy v0.2.0 // indirect
-	github.com/google/docsy/dependencies v0.5.0 // indirect
+	github.com/google/docsy v0.5.0
+	github.com/google/docsy/dependencies v0.5.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/viamrobotics/tutorials-and-docs
 go 1.23
 
 require (
-	github.com/google/docsy v0.5.0
-	github.com/google/docsy/dependencies v0.5.0
+	github.com/google/docsy v0.6.0
+	github.com/google/docsy/dependencies v0.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,8 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac h1:AjwgwoaDsNEA1Wtc8pgw/BqG7SEk9bKxXPjEPQQ42vY=
 github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.2.0 h1:DN6wfyyp2rXsjdV1K3wioxOBTRvG6Gg48wLPDso2lc4=
-github.com/google/docsy v0.2.0/go.mod h1:shlabwAQakGX6qpXU6Iv/b/SilpHRd7d+xqtZQd3v+8=
-github.com/google/docsy v0.5.0 h1:ND+6sYJD1VYEEM8olBdJLPIyQrPDeDkC0PhzuZTVZMs=
-github.com/google/docsy v0.5.0/go.mod h1:RKikAcSUR3b/40oqYfweD9uiNYTUirEKaCgLiEXMbQo=
-github.com/google/docsy/dependencies v0.2.0/go.mod h1:2zZxHF+2qvkyXhLZtsbnqMotxMukJXLaf8fAZER48oo=
+github.com/google/docsy v0.5.0 h1:zJ1uWERLsqKXXEoGdTXPgYaRi4/VZfIDkwWiFuxlX70=
+github.com/google/docsy v0.5.0/go.mod h1:AUmO6qp2hViSTx9z+60qtHPz/zQNkZfmbtypiogKCIU=
 github.com/google/docsy/dependencies v0.5.0 h1:Qy8aLsuFHHfUyOfp3i2CDZRCgIKFSvt1M2oEBmh4eZo=
 github.com/google/docsy/dependencies v0.5.0/go.mod h1:2zZxHF+2qvkyXhLZtsbnqMotxMukJXLaf8fAZER48oo=
+github.com/twbs/bootstrap v4.6.1+incompatible h1:75PsBfPU1SS65ag0Z3Cq6JNXVAfUNfB0oCLHh9k9Fu8=
 github.com/twbs/bootstrap v4.6.1+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac h1:AjwgwoaDsNEA1Wtc8pgw/BqG7SEk9bKxXPjEPQQ42vY=
-github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.5.0 h1:zJ1uWERLsqKXXEoGdTXPgYaRi4/VZfIDkwWiFuxlX70=
-github.com/google/docsy v0.5.0/go.mod h1:AUmO6qp2hViSTx9z+60qtHPz/zQNkZfmbtypiogKCIU=
-github.com/google/docsy/dependencies v0.5.0 h1:Qy8aLsuFHHfUyOfp3i2CDZRCgIKFSvt1M2oEBmh4eZo=
-github.com/google/docsy/dependencies v0.5.0/go.mod h1:2zZxHF+2qvkyXhLZtsbnqMotxMukJXLaf8fAZER48oo=
-github.com/twbs/bootstrap v4.6.1+incompatible h1:75PsBfPU1SS65ag0Z3Cq6JNXVAfUNfB0oCLHh9k9Fu8=
-github.com/twbs/bootstrap v4.6.1+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f h1:bvkUptSRPZBr3Kxuk+bnWCEmQ5MtEJX5fjezyV0bC3g=
+github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.6.0 h1:43bVF18t2JihAamelQjjGzx1vO2ljCilVrBgetCA8oI=
+github.com/google/docsy v0.6.0/go.mod h1:VKKLqD8PQ7AglJc98yBorATfW7GrNVsn0kGXVYF6G+M=
+github.com/google/docsy/dependencies v0.6.0 h1:BFXDCINbp8ZuUGl/mrHjMfhCg+b1YX+hVLAA5fGW7Pc=
+github.com/google/docsy/dependencies v0.6.0/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
+github.com/twbs/bootstrap v4.6.2+incompatible h1:TDa+R51BTiy1wEHSYjmqDb8LxNl/zaEjAOpRE9Hwh/o=
+github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,9 @@
 [build]
   publish = "public"
 
+[build.environment]
+  HUGO_VERSION = "0.152.2"
+
 [[redirects]]
   from = "/data/"
   to = "/data/overview/"


### PR DESCRIPTION
## Summary

The `go.sum` file contained incorrect hashes for `github.com/google/docsy` (both `v0.2.0` and `v0.5.0`) that did not match the canonical hashes published by `sum.golang.org`, causing checksum verification failures on `go mod download`. This PR regenerates `go.sum` with verified hashes, tidies `go.mod`, bumps docsy from `v0.5.0` to `v0.6.0` so `go mod verify` passes, and pins Netlify's Hugo version to match CI so deploys reproduce the build environment that GitHub Actions already validates against.

This is phase 1 of a planned three-phase dependency cleanup. Phase 2 (Hugo bump) and phase 3 (larger docsy upgrade toward `v0.14.x`) will follow in separate PRs.

## Why bump docsy to v0.6.0?

`docsy v0.5.0`'s `go.mod` requires `dependencies@v0.5.0-0.20220905171817-ae8b8117ed16` — a malformed pseudo-version (a `-0.` prefix on the same base version implies a negative patch number). Modern Go toolchains reject it, so `go mod verify` fails on the resolved module graph. `v0.6.0` uses a properly-tagged `dependencies@v0.6.0` require, which restores verification. `v0.6.0` is the smallest possible step that fixes this — Bootstrap stays on 4.x (v5 first arrives in `docsy v0.7.0`), and the theme templates we render with are unchanged.

## Why pin HUGO_VERSION on Netlify?

`netlify.toml` did not pin a Hugo version, so Netlify used whatever default its build image shipped with. Recent Netlify builds drifted onto a Hugo version that errors hard on `.Site.Author.email` access (a long-deprecated field still referenced by docsy's `list.rss.xml`). GitHub Actions already pins `hugo-version: "0.152.2"` (the version recorded as "successfully tested" in `config.toml`'s `module.hugoVersion.min`), so this commit pins Netlify to the same value. Eliminates drift between CI and Netlify and unblocks the deploy preview. Will be revisited when Hugo itself is bumped in phase 2.

## Changes

- **go.sum**: Replaced all incorrect hashes (h1: + /go.mod for both `docsy v0.2.0` and `docsy v0.5.0` did not match `sum.golang.org`); regenerated for the new `v0.6.0` graph. Now contains full `h1:` + `/go.mod` hashes for all four modules (`docsy`, `docsy/dependencies`, `Font-Awesome`, `bootstrap`), each cross-verified against `sum.golang.org`.
- **go.mod**: Bumped `docsy` and `docsy/dependencies` from `v0.5.0` → `v0.6.0`. Removed stale `docsy v0.2.0` require, dropped `// indirect` markers (both modules are direct Hugo imports per `config.toml`), and bumped the `go` directive from `1.12` → `1.23`.
- **netlify.toml**: Added `[build.environment] HUGO_VERSION = "0.152.2"` to match CI's pinned Hugo version.
- **Transitive bumps via docsy v0.6.0**: Bootstrap `v4.6.1` → `v4.6.2`; Font-Awesome pin advanced to a 2022-08 commit.

## Testing

- `go mod verify` → `all modules verified` ✓
- `go mod download -json` confirms `Sum`/`GoModSum` match for all four modules in the graph.
- All hashes cross-verified against `https://sum.golang.org/lookup/...`.
- `hugo mod tidy` is a no-op against the new `go.mod`/`go.sum` (the module graph is canonical).
- GitHub Actions checks (htmltest, prettier, vale, codespell, etc.) — all green on the docsy bump alone.
- Local Hugo v0.160.1 reproduces the `.Site.Author.email` error that the Netlify pin works around — confirming the pin is the right fix for the deploy failure rather than a docsy regression.
- [x] Verified the [deploy preview](https://deploy-preview-5021--viam-docs.netlify.app)https://deploy-preview-5021--viam-docs.netlify.app/ looks normal

## Tickets

None.

## Claude Code Prompts Used

- "Hi Claude, this repo seems to have an issue with its go.sum file. We may also want to consider upgrading the docsy dependency or even the hugo dependency. Can you take a look and provide a recommendation?"
- "Let's proceed with phase 1"
- "Let's create a draft PR"
- "What upgrade do we need to make to get `go mod verify` passing?"
- "Let's make the change to v0.6.0 in this PR"
- "how do I install hugo?"
- "I have installed hugo. Can you check if things seem fine"
- "let's do option 1"

🤖 Generated with [Claude Code](https://claude.com/claude-code)