### PR TITLE
cli/configure-machines: fix broken add-resource example, model triplets, and CLI ref link

### DIFF
--- a/docs/cli/configure-machines.md
+++ b/docs/cli/configure-machines.md
@@ -79,31 +79,55 @@ viam machines list --organization=<org-id> --all
 
 ## Add a component or service
 
-Add a resource to a machine part using its model triplet:
+Add a resource to a machine part by specifying its model and the resource subtype it implements.
+For built-in resources (such as a webcam camera or GPIO motor), pass the subtype with `--resource-subtype`:
 
 ```sh {class="command-line" data-prompt="$"}
 viam machines part add-resource \
   --part=<part-id> \
   --name=my-camera \
-  --model-name=viam:camera:webcam
+  --model-name=webcam \
+  --resource-subtype=camera
 ```
+
+For resources from a registry module, pass the model triplet with `--model-name` and use the same `--resource-subtype`:
+
+```sh {class="command-line" data-prompt="$"}
+viam machines part add-resource \
+  --part=<part-id> \
+  --name=my-board \
+  --model-name=viam:raspberry-pi:rpi5 \
+  --resource-subtype=board
+```
+
+The `--resource-subtype` value is the third segment of the model's API.
+The webcam camera's API is `rdk:component:camera`, so the subtype is `camera`.
+The vision service's API is `rdk:service:vision`, so the subtype is `vision`.
+See [Components](/reference/components/) and [Services](/reference/services/) for all standard subtypes.
+
+Use `--api` instead of `--resource-subtype` only for a [custom resource API](/build-modules/advanced-patterns/#define-a-new-resource-api).
+Pass the full triplet, for example `--api=acme:component:gizmo`.
+Most third-party modules implement a standard subtype or use [generic component](/reference/components/generic/) or [generic service](/reference/services/generic/), both of which take `--resource-subtype`.
 
 This creates a bare resource entry with no additional attributes.
 Most components need attributes like pin numbers or device paths to function.
 See [Update resource attributes](#update-resource-attributes) to set them from the CLI, or configure them in the [Viam app](https://app.viam.com).
 
-The model triplet follows the format `namespace:module-name:model-name`.
-You can browse available models in the [Viam registry](https://app.viam.com/registry).
-Common model triplets:
+Model names take one of two forms:
 
-| Component            | Model triplet            |
-| -------------------- | ------------------------ |
-| Webcam camera        | `viam:camera:webcam`     |
-| GPIO motor           | `viam:motor:gpio`        |
-| Raspberry Pi 5 board | `viam:raspberry-pi:rpi5` |
-| Ultrasonic sensor    | `viam:ultrasonic:sensor` |
-| Fake arm (testing)   | `viam:arm:fake`          |
-| Fake motor (testing) | `viam:motor:fake`        |
+- **Built-in models** ship with `viam-server` and use a single name (such as `webcam`, `gpio`, `fake`). Internally they expand to `rdk:builtin:<name>`.
+- **Module models** come from the registry and use a three-part triplet `<namespace>:<module>:<model>` (such as `viam:raspberry-pi:rpi5`). Browse available models in the [Viam registry](https://app.viam.com/registry).
+
+Common model names:
+
+| Component            | Model                    | Subtype  |
+| -------------------- | ------------------------ | -------- |
+| Webcam camera        | `webcam`                 | `camera` |
+| GPIO motor           | `gpio`                   | `motor`  |
+| Fake arm (testing)   | `fake`                   | `arm`    |
+| Fake motor (testing) | `fake`                   | `motor`  |
+| Raspberry Pi 5 board | `viam:raspberry-pi:rpi5` | `board`  |
+| Ultrasonic sensor    | `viam:ultrasonic:sensor` | `sensor` |
 
 ## Remove a component or service
 
@@ -211,9 +235,24 @@ viam machines delete --machine=<machine-id>
 viam machines part restart --part=<part-id>
 ```
 
+## Add or delete a part
+
+Most machines have only a main part, which is created when you create the machine.
+For [multi-part machines](/hardware/multi-machine/), add additional parts to an existing machine:
+
+```sh {class="command-line" data-prompt="$"}
+viam machines part create --machine=<machine-id> --part-name=<new-part-name>
+```
+
+Delete a part from a machine:
+
+```sh {class="command-line" data-prompt="$"}
+viam machines part delete --part=<part-id>
+```
+
 ## Related pages
 
 - [Get started](/set-up-a-machine/) for setting up your first machine
 - [Configure hardware](/hardware/) for component configuration with the Viam app
 - [Manage your fleet with the CLI](/cli/manage-your-fleet/) for monitoring and remote access
-- [CLI reference](/cli/) for the complete `machines` command reference
+- [CLI reference](/cli/reference/#machines-aliases-robots-robot-machine) for the complete `machines` command reference


### PR DESCRIPTION
## Summary

Playbook 1 correctness assessment of `docs/cli/configure-machines.md`. Every CLI invocation on the page was verified against the v0.123.0 binary's `--help` and the rdk source at `upstream/main` (`bb5e7153`). Three breaking issues, one broken link, and one coverage gap fixed.

## Breaking issues fixed

1. **`add-resource` example would error out as written.** The page showed:
   ```
   viam machines part add-resource --part=<part-id> --name=my-camera --model-name=viam:camera:webcam
   ```
   The action requires `--api` *or* `--resource-subtype` and returns `cannot add a resource of unknown subtype` without one (`rdk/cli/client.go:1386`). Added `--resource-subtype` to the example, plus a second example for module-provided resources, plus a note about `--api` for custom subtypes.

2. **Four of six model triplets in the "Common model triplets" table do not exist in the registry.** Verified via Typesense search of the registry index:
   - `viam:camera:webcam` — built-in is `webcam` (`rdk:builtin:webcam`)
   - `viam:motor:gpio` — built-in is `gpio`
   - `viam:arm:fake` — built-in is `fake`
   - `viam:motor:fake` — built-in is `fake`

   Replaced the table with correct model names and added a **Subtype** column so each example pairs `--model-name` with `--resource-subtype` correctly. Kept the two real module triplets (`viam:raspberry-pi:rpi5`, `viam:ultrasonic:sensor`).

3. **Triplet format description was wrong for built-ins.** The page said the format is `namespace:module-name:model-name` and applied that framing to built-ins. Built-ins use a single name (which `viam-server` expands to `rdk:builtin:<name>`); the three-part triplet is the registry-module form. Fixed (cite: `rdk/resource/model.go:16-22`).

## Broken link

- "CLI reference" in Related pages pointed to `/cli/` (the section landing page that redirects to `/cli/overview/`) instead of `/cli/reference/`. Updated to `/cli/reference/#machines-aliases-robots-robot-machine`, anchor verified in built HTML.

## Coverage gap

- Page introduces multi-part machines in §1 but never showed how to create or delete a part. Added a short "Add or delete a part" section using the verified `machines part create` / `machines part delete` commands, linked to `/hardware/multi-machine/`.

## What was verified and is correct (no change)

- `machines list` output format `(id: X) (main part id: Y)` matches `rdk/cli/client.go:747`.
- `machines create` output (`created new machine with id <id>`) matches `rdk/cli/client.go:875`.
- "Connected machines pick up configuration changes automatically" — 10s default config refresh (`rdk/config/config.go:696`).
- `machines update --machine --new-name --new-location` flags match the v0.123.0 binary.
- `resource update`, `resource enable`, `resource disable`, `machines part fragments add | remove`, `machines delete`, `machines part restart` — all flags and behaviors match the binary.
- All 10 links resolve (9 internal, 2 external returning 200/307).
- Vale, prettier, markdownlint, `make build-prod`: clean.

## Test plan

- [x] `prettier --write`: clean
- [x] `vale docs/cli/configure-machines.md`: 0 errors, 0 warnings
- [x] `markdownlint-cli2`: 0 errors
- [x] `make build-prod`: clean
- [ ] Spot-check the rendered page in the Netlify deploy preview (anchor link to `/cli/reference/#machines-aliases-robots-robot-machine`)