### PR TITLE
Remove inline module feature flag caveats

### DIFF
--- a/docs/build-modules/write-an-inline-module.md
+++ b/docs/build-modules/write-an-inline-module.md
@@ -27,12 +27,6 @@ specific API, see
 [Write a driver module](/build-modules/write-a-driver-module/) or
 [Write a logic module](/build-modules/write-a-logic-module/).
 
-{{< alert title="Availability" color="tip" >}}
-Inline modules are currently available to organizations that have the feature
-enabled. If you do not see the **Viam-hosted** option when adding code, contact
-Viam support to request access.
-{{< /alert >}}
-
 For background on inline modules, how they compare to externally managed
 modules, and the Generic service API, see the
 [overview](/build-modules/overview/#inline-and-externally-managed-modules).
@@ -518,14 +512,6 @@ it run automatically:
 6. Set up a scheduled job to run the logic continuously.
 
 ## Troubleshooting
-
-{{< expand "\"Viam-hosted\" option not visible" >}}
-
-The inline module feature is gated by a feature flag. If you do not see the
-"Viam-hosted" option when clicking **+** → **Control code**, your organization
-may not have the feature enabled. Contact Viam support to request access.
-
-{{< /expand >}}
 
 {{< expand "Build fails after saving" >}}
 


### PR DESCRIPTION
## Source changes

- app#11849: Removed ENABLE_INLINE_MODULES, ENABLE_MODULE_ASSISTANT, and ENABLE_MODULE_LSP feature flags. Inline modules, the AI assistant panel, and LSP syntax checking are now available to all organizations without a feature flag gate.

## Docs changes

- `docs/build-modules/write-an-inline-module.md`: Removed the "Availability" alert (lines 30-34) that told users the feature is gated and to contact support for access. Removed the troubleshooting entry "'Viam-hosted' option not visible" (lines 522-527) that repeated the same guidance. Both are now incorrect since the feature is GA.

## How I found these

- Grep for `ENABLE_INLINE_MODULES` in app feature_models.go diff showed the flag was removed
- Grep for "feature flag", "feature enabled", "request access" in docs found both affected sections

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2JbXAWg8N7NYCG46Y4KnD)_