### PR TITLE
frame system: document configuring physical properties through frame

### DIFF
--- a/docs/hardware/common-components/add-a-gripper.md
+++ b/docs/hardware/common-components/add-a-gripper.md
@@ -66,23 +66,46 @@ For a physical gripper, you'll typically configure the connection to the
 gripper controller. Check your module's documentation for the full list of
 attributes.
 
-### 3. Configure a frame (recommended)
+### 3. Configure a frame
 
-If you're using the gripper with an arm and motion planning, add a frame to
-define the gripper's position relative to the arm:
+For motion planning, the gripper must declare two things through its frame:
+the offset from the arm's tool flange to the gripper tip (the tool center
+point), and the collision volume of the gripper body. The motion service reads
+these from `frame.translation` and `frame.geometry`, not from `attributes`.
+
+For a typical parallel-jaw gripper that bolts directly to the arm flange and
+projects 120 mm forward, with an 80 × 80 × 120 mm body:
 
 ```json
 {
   "frame": {
     "parent": "my-arm",
-    "translation": { "x": 0, "y": 0, "z": 0 },
+    "translation": { "x": 0, "y": 0, "z": 120 },
     "orientation": {
       "type": "ov_degrees",
       "value": { "x": 0, "y": 0, "z": 1, "th": 0 }
+    },
+    "geometry": {
+      "type": "box",
+      "x": 80,
+      "y": 80,
+      "z": 120,
+      "translation": { "x": 0, "y": 0, "z": 60 }
     }
   }
 }
 ```
+
+Measure `translation.z` to the point you want the planner to drive to: jaw tip
+for a finger gripper, suction cup face for a vacuum tool. If the gripper
+module ships its own kinematics (call `GetKinematics` to check), you can omit
+`geometry` because the kinematic model already carries the collision shape.
+
+Symptoms of a wrong offset: motion plans validate, then the gripper tip lands
+short or long of the target, or the planner returns "outside workspace" for
+poses the arm can clearly reach. See
+[When the model has no physical-extent attribute](/motion-planning/frame-system/overview/#when-the-model-has-no-physical-extent-attribute)
+for the broader pattern.
 
 ### 4. Save and test
 

--- a/docs/hardware/common-components/add-a-gripper.md
+++ b/docs/hardware/common-components/add-a-gripper.md
@@ -69,9 +69,10 @@ attributes.
 ### 3. Configure a frame
 
 For motion planning, the gripper must declare two things through its frame:
-the offset from the arm's tool flange to the gripper tip (the tool center
-point), and the collision volume of the gripper body. The motion service reads
-these from `frame.translation` and `frame.geometry`, not from `attributes`.
+the position of the tool center point (TCP) relative to the arm's tool flange,
+and the collision volume of the gripper body. The TCP is the point you want
+the planner to drive to. The motion service reads both from
+`frame.translation` and `frame.geometry`, not from `attributes`.
 
 For a typical parallel-jaw gripper that bolts directly to the arm flange and
 projects 120 mm forward, with an 80 × 80 × 120 mm body:
@@ -90,16 +91,20 @@ projects 120 mm forward, with an 80 × 80 × 120 mm body:
       "x": 80,
       "y": 80,
       "z": 120,
-      "translation": { "x": 0, "y": 0, "z": 60 }
+      "translation": { "x": 0, "y": 0, "z": -60 }
     }
   }
 }
 ```
 
-Measure `translation.z` to the point you want the planner to drive to: jaw tip
-for a finger gripper, suction cup face for a vacuum tool. If the gripper
-module ships its own kinematics (call `GetKinematics` to check), you can omit
-`geometry` because the kinematic model already carries the collision shape.
+Two things to notice in the JSON. `frame.translation.z: 120` puts the frame
+origin at the TCP, 120 mm out from the arm flange. `geometry.translation.z: -60`
+sits the box's center halfway back toward the flange, so the box covers the
+gripper body from the flange to the TCP. Measure `translation.z` to the point
+you want the planner to drive to: jaw tip for a finger gripper, suction cup
+face for a vacuum tool. If the gripper module ships its own kinematics (call
+`GetKinematics` to check), you can omit `geometry` because the kinematic model
+already carries the collision shape.
 
 Symptoms of a wrong offset: motion plans validate, then the gripper tip lands
 short or long of the target, or the planner returns "outside workspace" for

--- a/docs/motion-planning/frame-system/arm-gripper-camera.md
+++ b/docs/motion-planning/frame-system/arm-gripper-camera.md
@@ -101,23 +101,24 @@ In the sidebar, click your gripper component to open its card. On the card, clic
 #### Pick where the gripper frame origin sits
 
 A point near the center of the gripper jaws is usually the most
-convenient frame origin. When you later call the motion service to move
-the gripper to a target pose, whatever point you pick here is what gets
-moved to that pose.
+convenient frame origin. The point you pick here is what `translation`
+measures _to_, and what gets moved to a target pose when you later call
+the motion service.
 
 #### Configure the frame
 
 In the JSON, set `parent` to your arm's component name, `translation` to
-the gripper frame origin's offset in mm from the arm's end effector, and
-`orientation` to the gripper's rotation relative to the arm.
+the offset in mm from the arm's end effector to the gripper frame
+origin, and `orientation` to the gripper's rotation relative to the arm.
 
-If the gripper attaches directly to the arm's end effector with no
-adapter plate and no rotation, use a zero offset:
+For a parallel-jaw gripper that bolts directly to the arm's end effector
+with the frame origin at the jaw tip, the offset is the gripper's body
+length. 120 mm is typical:
 
 ```json
 {
   "parent": "my-arm",
-  "translation": { "x": 0, "y": 0, "z": 0 },
+  "translation": { "x": 0, "y": 0, "z": 120 },
   "orientation": {
     "type": "ov_degrees",
     "value": { "x": 0, "y": 0, "z": 1, "th": 0 }
@@ -125,20 +126,13 @@ adapter plate and no rotation, use a zero offset:
 }
 ```
 
-If the gripper is mounted through an adapter plate or flange that adds
-height, set the z translation to the adapter height in millimeters. For
-example, with a 50 mm adapter plate:
+If the gripper is mounted through an adapter plate or flange, add the
+plate height to `translation.z`. For a 50 mm plate plus the 120 mm
+gripper above, use `z: 170`.
 
-```json
-{
-  "parent": "my-arm",
-  "translation": { "x": 0, "y": 0, "z": 50 },
-  "orientation": {
-    "type": "ov_degrees",
-    "value": { "x": 0, "y": 0, "z": 1, "th": 0 }
-  }
-}
-```
+A wrong `translation.z` produces silent failures: motion plans validate,
+then the physical gripper tip lands short or long of the target, or the
+planner returns "outside workspace" for poses the arm can clearly reach.
 
 Click **Save**.
 

--- a/docs/motion-planning/frame-system/overview.md
+++ b/docs/motion-planning/frame-system/overview.md
@@ -141,6 +141,27 @@ it relative to the frame.
 For detailed information about obstacle geometry, see
 [Define obstacles](/motion-planning/obstacles/).
 
+### When the model has no physical-extent attribute
+
+Many component models, including every `fake` model and some real ones, have an
+empty or near-empty `attributes` block. Their physical extent is not configured
+through attributes; it is configured through the frame.
+
+- For a gripper that has no length attribute, set `frame.translation.z` to the
+  arm-flange-to-tip offset and `frame.geometry` to the collision shape.
+- For a camera that has no mount-offset attribute, set `frame.translation` to
+  the camera's position relative to its parent.
+- For an IMU that has no mounted-orientation attribute, set `frame.orientation`
+  to its physical mounting rotation.
+
+If you skip this step, the planner treats the component as a zero-volume point
+at the parent's origin. Motion plans validate, then the physical robot misses
+its target by the unconfigured offset, or reachability checks fail for poses
+the robot can clearly reach.
+
+For a worked example with a gripper, see
+[Configure a frame for an arm, gripper, and camera](/motion-planning/frame-system/arm-gripper-camera/).
+
 ## Edit a frame in the Viam app
 
 To configure a frame, open the **CONFIGURE** tab in the Viam app, click

--- a/docs/motion-planning/frame-system/overview.md
+++ b/docs/motion-planning/frame-system/overview.md
@@ -148,7 +148,8 @@ empty or near-empty `attributes` block. Their physical extent is not configured
 through attributes; it is configured through the frame.
 
 - For a gripper that has no length attribute, set `frame.translation.z` to the
-  arm-flange-to-tip offset and `frame.geometry` to the collision shape.
+  offset from the arm's tool flange to the tool center point (TCP), and
+  `frame.geometry` to the collision shape.
 - For a camera that has no mount-offset attribute, set `frame.translation` to
   the camera's position relative to its parent.
 - For an IMU that has no mounted-orientation attribute, set `frame.orientation`

--- a/docs/reference/components/gripper/fake.md
+++ b/docs/reference/components/gripper/fake.md
@@ -35,4 +35,49 @@ Configure a `fake` gripper to test implementing a gripper on your machine withou
 No attributes are available for fake grippers.
 See [GitHub](https://github.com/viamrobotics/rdk/blob/main/components/gripper/fake/gripper.go) for API call return specifications.
 
+## Configure physical properties through the frame
+
+The `fake` gripper has no attribute for length or collision volume. The motion
+planner reads both from the component's `frame` field. Set `frame.translation.z`
+to the distance from the arm's tool flange to the gripper tip, and
+`frame.geometry` to the collision shape.
+
+For a typical 120 mm parallel-jaw gripper bolted directly to the arm flange:
+
+```json
+{
+  "name": "my-fake-gripper",
+  "model": "fake",
+  "api": "rdk:component:gripper",
+  "attributes": {},
+  "frame": {
+    "parent": "my-arm",
+    "translation": { "x": 0, "y": 0, "z": 120 },
+    "orientation": {
+      "type": "ov_degrees",
+      "value": { "x": 0, "y": 0, "z": 1, "th": 0 }
+    },
+    "geometry": {
+      "type": "box",
+      "x": 80,
+      "y": 80,
+      "z": 120,
+      "translation": { "x": 0, "y": 0, "z": 60 }
+    }
+  }
+}
+```
+
+Why this matters: motion planning, reachability checks, and approach and
+retract poses all use the gripper tip as the tool center point. With no
+`frame`, the planner treats the tool flange as the tip and the gripper as a
+zero-volume point.
+
+Symptoms if wrong: motion plans validate, then the physical gripper tip lands
+short or long of the target, or the planner returns "outside workspace" for
+poses the arm can clearly reach.
+
+For the broader pattern and worked examples for cameras and IMUs, see
+[When the model has no physical-extent attribute](/motion-planning/frame-system/overview/#when-the-model-has-no-physical-extent-attribute).
+
 {{< readfile "/static/include/components/test-control/gripper-control.md" >}}

--- a/docs/reference/components/gripper/fake.md
+++ b/docs/reference/components/gripper/fake.md
@@ -39,8 +39,8 @@ See [GitHub](https://github.com/viamrobotics/rdk/blob/main/components/gripper/fa
 
 The `fake` gripper has no attribute for length or collision volume. The motion
 planner reads both from the component's `frame` field. Set `frame.translation.z`
-to the distance from the arm's tool flange to the gripper tip, and
-`frame.geometry` to the collision shape.
+to the offset from the arm's tool flange to the tool center point (TCP) you
+want the planner to drive to, and `frame.geometry` to the collision shape.
 
 For a typical 120 mm parallel-jaw gripper bolted directly to the arm flange:
 
@@ -62,16 +62,21 @@ For a typical 120 mm parallel-jaw gripper bolted directly to the arm flange:
       "x": 80,
       "y": 80,
       "z": 120,
-      "translation": { "x": 0, "y": 0, "z": 60 }
+      "translation": { "x": 0, "y": 0, "z": -60 }
     }
   }
 }
 ```
 
+`frame.translation.z: 120` puts the frame origin at the TCP, 120 mm out from
+the arm flange. `geometry.translation.z: -60` sits the box's center halfway
+back toward the flange, so the box covers the gripper body from the flange to
+the TCP.
+
 Why this matters: motion planning, reachability checks, and approach and
-retract poses all use the gripper tip as the tool center point. With no
-`frame`, the planner treats the tool flange as the tip and the gripper as a
-zero-volume point.
+retract poses all drive the TCP, not the tool flange, to a target pose. With
+no `frame`, the planner has no TCP defined and treats the gripper as a
+zero-volume point at the flange.
 
 Symptoms if wrong: motion plans validate, then the physical gripper tip lands
 short or long of the target, or the planner returns "outside workspace" for


### PR DESCRIPTION
## Summary

Many component models (every `fake` model, plus some real ones) have empty or near-empty `attributes` blocks. Their physical extent — TCP offset, collision volume, mounted orientation — is configured through the `frame` field, not through `attributes`. The docs were silent on this exactly where it matters most: a user configuring a fake gripper for a palletizing simulation has no way to discover that gripper length lives in `frame.translation.z` and `frame.geometry`. With the gripper length wrong, motion planning fails with "outside workspace" errors that surface hours later, far from the actual cause.

This PR closes that gap with one canonical explanation plus targeted fixes on the highest-impact pages.

## Changes

1. **New canonical section** — `docs/motion-planning/frame-system/overview.md`
   - New H3 `### When the model has no physical-extent attribute` inside the Concepts section, after Geometry. Names the pattern, gives gripper/camera/IMU examples, and states the silent-failure consequence explicitly.

2. **Fix contradictory walkthrough** — `docs/motion-planning/frame-system/arm-gripper-camera.md`
   - The previous Step 4 told the user to put the gripper frame origin "near the center of the gripper jaws," then offered a `{0,0,0}` translation example for "no adapter plate." Those two contradict for any non-zero-length gripper. Replaced with a realistic 120 mm parallel-jaw example, plus an "add the plate height" note for the adapter case.

3. **Fix misleading guide** — `docs/hardware/common-components/add-a-gripper.md`
   - Rewrote the "Configure a frame (recommended)" section. The previous example used a zero translation, which silently taught the wrong mental model that gripper TCP equals tool flange. New example shows both `translation.z: 120` and a matching `frame.geometry` box, with a note that you can omit `geometry` when the gripper module ships kinematics.

4. **Inline the pattern on the trigger page** — `docs/reference/components/gripper/fake.md`
   - Added an H2 "Configure physical properties through the frame" between the API reference link and the test-control include. Includes a complete config example, a "why this matters" line, a "symptoms if wrong" line, and a link to the canonical section.

## Verification

Code-grounded against:

- `rdk/components/gripper/fake/gripper.go` lines 17–97 — Config struct has only `model-path`; geometry is read from `conf.Frame.Geometry` and stored as the gripper's geometry list.
- `rdk/components/gripper/gripper.go` lines 120–144 (`MakeModel`) — Without a kinematics file, the gripper's kinematic model is built directly from the frame geometries; with no geometries, `NewSimpleModel` returns a zero-link model.
- Frame translation unit convention confirmed in mm against `docs/motion-planning/frame-system/arm-fixed-camera.md`, `docs/motion-planning/3d-scene/calibrate-frame-offsets.md`, and `docs/motion-planning/reference/kinematics.md`.

## Test plan

- [ ] `motion-planning/frame-system/overview/` renders the new H3 inside Concepts, after Geometry.
- [ ] The anchor `#when-the-model-has-no-physical-extent-attribute` resolves on the deploy preview (linked from items 3 and 4).
- [ ] `motion-planning/frame-system/arm-gripper-camera/` Step 4 no longer contains the `{0,0,0}` example.
- [ ] `hardware/common-components/add-a-gripper/` Section 3 shows the 120 mm example with `frame.geometry`.
- [ ] `reference/components/gripper/fake/` shows the new "Configure physical properties through the frame" H2 with the full config example.

## Out of scope

Fake arm and fake base have the same gap (world position is frame-only; collision volume is frame-only). Audited but deferred to a follow-up PR. Real component pages and other fake components (camera, movement sensor, gantry, sensor) also have the gap and will get short link-back callouts in a separate sweep.