### PR TITLE
first-machine: add step 8 to add hardware in the CONFIGURE tab

### DIFF
--- a/docs/set-up-a-machine/first-machine.md
+++ b/docs/set-up-a-machine/first-machine.md
@@ -127,7 +127,21 @@ Your machine is online. Now connect to it programmatically.
 
 If the connection succeeds, the script prints your machine's available resources.
 
+## 8. Add hardware in the CONFIGURE tab
+
+Your machine is connected, but it has no components configured yet.
+To make the machine do anything, add the hardware you want to use through the **CONFIGURE** tab on your machine's page.
+
+For each piece of hardware (camera, motor, sensor, arm, gripper, base):
+
+1. Click the **+** button on the **CONFIGURE** tab.
+2. Select **Component**.
+3. Search for the model that matches your hardware. Search by manufacturer or hardware type (for example, `webcam`, `viam:raspberry-pi:rpi5`, `ufactory:xarm6`).
+4. Name the component and click **Create**.
+5. Fill in the required attributes (pin numbers, device paths, API keys) and click **Save**.
+
+For walkthroughs by component type and the full configuration reference, see [Configure hardware](/hardware/configure-hardware/).
+
 ## What's next
 
-- [Configure hardware](/hardware/configure-hardware/) to add cameras, motors, sensors, and other components to your machine.
 - [Set up machines with the CLI](/set-up-a-machine/with-cli/) to provision additional machines from the command line.


### PR DESCRIPTION
## Summary

Adds a step 8 to `/set-up-a-machine/first-machine/` that points users at the **CONFIGURE** tab to add the hardware they want to use. The walkthrough previously ended at step 7 ("Connect with code") and pushed hardware configuration into a "What's next" link, but a machine that is online with no components configured is not yet useful — adding hardware belongs inside the first-machine flow.

## Changes

- New step 8 "Add hardware in the CONFIGURE tab" between step 7 and "What's next." Brief, action-oriented: click +, select Component, search for the model, name, fill attributes, save. Links to `/hardware/configure-hardware/` for the deep walkthrough rather than duplicating it.
- Removed the now-redundant "Configure hardware" bullet from "What's next" (the link now lives in step 8).

## Test plan

- [ ] `/set-up-a-machine/first-machine/` renders step 8 between step 7 and "What's next."
- [ ] The link to `/hardware/configure-hardware/` resolves on the deploy preview.

## Note for review

I kept the existing order (step 7 Connect, then step 8 Add hardware) per the request. The reverse order (Add hardware → Connect with code) would let the SDK code sample see the configured resources, which is arguably the more natural flow. Happy to swap if preferred.