### PR TITLE
Fix spacing in OAuth app creation command

### DIFF
--- a/docs/organization/oauth.md
+++ b/docs/organization/oauth.md
@@ -61,7 +61,7 @@ enabled auth service for organization "<org-id>":
 
 ```sh {class="command-line" data-prompt="$" data-output="6-10"}
 viam organization auth-service oauth-app create --client-authentication=required \
-    --client-name="OAuth Test App" --enabled-grants="password, authorization_code" \
+    --client-name="OAuth Test App" --enabled-grants="password,authorization_code" \
     --logout-uri="https://logoipsum.com/logout" --origin-uris="https://logoipsum.com,http://localhost:3000" \
     --pkce=not_required --redirect-uris="https://logoipsum.com/oauth-redirect,http://localhost:3000/oauth-redirect" \
     --url-validation=allow_wildcards --org-id=<org-id>


### PR DESCRIPTION
Removed space in enabled-grants parameter for OAuth app creation.

Please include a summary of the change and what is does. Please also include relevant motivation and context.

Review process:

- No need to request review from any specific docs team members; we will see your PR and one of us will review.
- If you need technical review from engineering, please request review from the relevant person.
- Docs team might commit styling nit fixes to save you the trouble :)
- You can merge after approval from one docs team member (as well as any necessary technical review).
