### PR TITLE
Update module generate docs for app scaffolding support

### DIFF
--- a/docs/build-apps/hosting/deploy.md
+++ b/docs/build-apps/hosting/deploy.md
@@ -18,9 +18,34 @@ Viam Applications are distributed through the Viam module registry, which is why
 - The [Viam CLI](/cli/) installed and authenticated (`viam login`).
 - A public namespace for your organization. Set this in the [organization settings](/organization/) if you have not already. Viam Applications require a public namespace because the app's URL uses it.
 
-## Create the module registry entry
+## Scaffold with the CLI (recommended)
 
-First-time setup only. Each Viam Application is represented as a module in the Viam registry. Create the registry entry:
+The fastest way to create a new Viam application is to run the generator:
+
+```sh {class="command-line" data-prompt="$"}
+viam module generate
+```
+
+Choose **App** when prompted, then follow the interactive prompts to set the app name and type (`single_machine` or `multi_machine`). The CLI creates a project directory with a `meta.json`, a Go-based module entrypoint, a `Makefile`, and a `dist/index.html` placeholder.
+
+You can also pass flags to skip the interactive prompts:
+
+```sh {class="command-line" data-prompt="$"}
+viam module generate \
+  --generate-type=app \
+  --app-name=my-app \
+  --app-type=single_machine \
+  --visibility=public \
+  --public-namespace=your-namespace
+```
+
+After scaffolding, skip to [Build your app](#build-your-app) to add your frontend code and upload the app.
+
+## Create the module registry entry manually
+
+If you prefer to set up the registry entry and `meta.json` yourself instead of using the generator, follow these steps.
+
+Each Viam Application is represented as a module in the Viam registry. Create the registry entry:
 
 ```sh {class="command-line" data-prompt="$"}
 viam module create --name my-app --public-namespace your-namespace

--- a/docs/cli/build-and-deploy-modules.md
+++ b/docs/cli/build-and-deploy-modules.md
@@ -45,17 +45,21 @@ This command does not require authentication, so you can scaffold a module befor
 viam module generate
 ```
 
-The generator walks you through an interactive prompt to choose:
+The generator first asks whether you want to generate a **module** or an **app**.
+Choose **Module**, then follow the interactive prompts to choose:
 
 - Module name
 - Programming language (Python or Go)
 - Namespace and visibility
 - Resource type (component or service) and API
 
+To generate a hosted web application instead of a module, choose **App** or see [Deploy a Viam application](/build-apps/hosting/deploy/).
+
 You can also pass flags to skip the interactive prompts:
 
 ```sh {class="command-line" data-prompt="$"}
 viam module generate \
+  --generate-type=module \
   --name=my-sensor-module \
   --language=python \
   --visibility=public

--- a/docs/cli/overview.md
+++ b/docs/cli/overview.md
@@ -39,7 +39,7 @@ The CLI is particularly well-suited for tasks that are awkward or impossible in 
 
 Some operations are only available through the CLI:
 
-- **Module scaffolding** (`viam module generate`) creates a new module project with boilerplate code and a build script.
+- **Module and app scaffolding** (`viam module generate`) creates a new module or [Viam application](/build-apps/hosting/) project with boilerplate code and a build script.
 - **Shell access** (`viam machines part shell`) opens an interactive terminal on a remote machine.
 - **File transfer** (`viam machines part cp`) copies files to and from machines.
 - **Port tunneling** (`viam machines part tunnel`) forwards a local port to a remote machine.

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -1538,20 +1538,22 @@ viam module local-app-testing --app-url http://localhost:3000
 
 ### `module generate`
 
-Generate a new module with stub files and a <file>meta.json</file> file. Recommended when starting a new module.
+Generate a new module or a new [Viam application](/build-apps/hosting/) with stub files and a <file>meta.json</file> file.
 
 ```sh {class="command-line" data-prompt="$"}
-# auto-generate stub files for a new modular resource by following prompts
+# follow interactive prompts to generate a module or app
 viam module generate
 ```
 
+The first prompt asks whether you want to generate a **module** (a modular resource that adds custom components or services to a machine) or an **app** (a web application that connects to machines through the Viam SDK and is hosted on [Viam Applications](/build-apps/hosting/)).
+
 {{% alert title="Note" color="note" %}}
-If you are writing your module using Python, you must have Python version 3.11 or newer installed on your computer for the `viam module generate` command to work.
+If you are generating a module using Python, you must have Python version 3.11 or newer installed on your computer for the `viam module generate` command to work.
 {{% /alert %}}
 
 {{% hiddencontent %}}
 
-The `viam module generate` command can generate code for the following resource types:
+When generating a module, the command can generate code for the following resource types:
 
 Components:
 
@@ -1586,13 +1588,16 @@ Services:
 <!-- prettier-ignore -->
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
-| `--name` | Name to use for the module. For example, a module that contains sensor implementations might be named `sensors`. We recommend _not_ using this option and instead following the prompts. | Optional |
-| `--language` | Language to use for the module. Options: `python`, `go`. We recommend _not_ using this option and instead following the prompts. | Optional |
-| `--visibility` | Module visibility. Options: `private`, `public`, `public_unlisted`. We recommend _not_ using this option and instead following the prompts. | Optional |
-| `--public-namespace` | Namespace or organization ID of the module. Must be either a valid organization ID, or a namespace that exists within a user organization. We recommend _not_ using this option and instead following the prompts. | Optional |
-| `--resource-subtype` | The API to implement with the modular resource. For example, `motor`. We recommend _not_ using this option and instead following the prompts after running the command. | Optional |
-| `--model-name` | Name for the particular resource subtype implementation. For example, a sensor model that detects moisture might be named `moisture`. We recommend _not_ using this option and instead following the prompts. | Optional |
-| `--register` | Register the module with Viam to associate it with your organization. Default: `false`. | Optional |
+| `--generate-type` | Type of project to generate. Options: `module`, `app`. If omitted, the CLI prompts you to choose. | Optional |
+| `--name` | (Module only) Name to use for the module. For example, a module that contains sensor implementations might be named `sensors`. | Optional |
+| `--language` | (Module only) Language to use for the module. Options: `python`, `go`. | Optional |
+| `--visibility` | Visibility. Options: `private`, `public`, `public_unlisted`. | Optional |
+| `--public-namespace` | Namespace or organization ID. Must be either a valid organization ID or a namespace that exists within a user organization. | Optional |
+| `--resource-subtype` | (Module only) The API to implement with the modular resource. For example, `motor`. | Optional |
+| `--model-name` | (Module only) Name for the particular resource subtype implementation. For example, a sensor model that detects moisture might be named `moisture`. | Optional |
+| `--register` | Register with Viam to associate it with your organization. Default: `false`. | Optional |
+| `--app-name` | (App only) Name for the app. Alphanumeric characters, dashes, and underscores only. Must start with a letter. | Optional |
+| `--app-type` | (App only) App type. Options: `single_machine`, `multi_machine`. See [Two application types](/build-apps/hosting/overview/#two-application-types). | Optional |
 
 ### `module create`
 


### PR DESCRIPTION
## Source changes

- viamrobotics/rdk#5950: `viam module generate` now supports generating Viam application projects (web apps hosted on Viam Applications) in addition to modules. Adds `--generate-type`, `--app-name`, and `--app-type` flags.

## Docs changes

- `docs/cli/reference.md`: Updated `module generate` description to mention app generation. Added `--generate-type`, `--app-name`, and `--app-type` flags to the argument table. Marked module-specific flags with "(Module only)" and app-specific flags with "(App only)".
- `docs/cli/build-and-deploy-modules.md`: Updated scaffold section to mention the new initial "Module or App" prompt and added a cross-reference to the app hosting docs.
- `docs/cli/overview.md`: Updated CLI-only operations list to mention app scaffolding alongside module scaffolding.
- `docs/build-apps/hosting/deploy.md`: Added a recommended "Scaffold with the CLI" section above the manual setup, documenting the `viam module generate --generate-type=app` workflow.

## How I found these

- Xref lookup: cli-xref.md mapped `module generate` to `docs/cli/reference.md`
- Grep matches: 18 pages reference `viam module generate`; 4 pages required updates (CLI reference, build-and-deploy, overview, app deploy). The remaining pages use `viam module generate` in the context of module creation tutorials and did not need changes.

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01RH64Qynyf9TLf8FJ9z5skD)_