### PR TITLE
motion: flag MoveOnMap as unsupported by the builtin motion service

### DIFF
--- a/static/include/services/apis/generated/motion.md
+++ b/static/include/services/apis/generated/motion.md
@@ -158,6 +158,14 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/
 
 ### MoveOnMap
 
+{{< alert title="Not supported by the builtin motion service" color="caution" >}}
+The [builtin motion service](/reference/services/motion/) no longer implements `MoveOnMap` and returns the error `MoveOnMap not supported by builtin` when called.
+The implementation was removed in [rdk#5475](https://github.com/viamrobotics/rdk/pull/5475) (November 2025).
+
+`MoveOnMap` is still part of the motion service API, so a third-party module can implement it.
+Check the [Viam registry](https://app.viam.com/registry) for a motion-service module that supports it before relying on this method.
+{{< /alert >}}
+
 Move a [base](/reference/components/base/) component to a destination [pose](/motion-planning/reference/orientation-vectors/) on a SLAM map.
 
 `MoveOnMap()` is non blocking, meaning the motion service will move the component to the destination [pose](/motion-planning/reference/orientation-vectors/) after `MoveOnMap()` returns.

--- a/static/include/services/apis/overrides/protos/motion.MoveOnMap.md
+++ b/static/include/services/apis/overrides/protos/motion.MoveOnMap.md
@@ -1,3 +1,11 @@
+{{< alert title="Not supported by the builtin motion service" color="caution" >}}
+The [builtin motion service](/reference/services/motion/) no longer implements `MoveOnMap` and returns the error `MoveOnMap not supported by builtin` when called.
+The implementation was removed in [rdk#5475](https://github.com/viamrobotics/rdk/pull/5475) (November 2025).
+
+`MoveOnMap` is still part of the motion service API, so a third-party module can implement it.
+Check the [Viam registry](https://app.viam.com/registry) for a motion-service module that supports it before relying on this method.
+{{< /alert >}}
+
 Move a [base](/reference/components/base/) component to a destination [pose](/motion-planning/reference/orientation-vectors/) on a SLAM map.
 
 `MoveOnMap()` is non blocking, meaning the motion service will move the component to the destination [pose](/motion-planning/reference/orientation-vectors/) after `MoveOnMap()` returns.


### PR DESCRIPTION
## Summary

Adds a caution alert at the top of the [\`MoveOnMap\` section](https://docs.viam.com/reference/apis/services/motion/#moveonmap) on the motion service API page. Addresses Nick Hehr's report: a community member came back to a mobile-base project from last year and discovered the feature no longer worked.

The builtin motion service has returned the error \`MoveOnMap not supported by builtin\` since [rdk#5475](https://github.com/viamrobotics/rdk/pull/5475) (2025-11-12, "remove baseplanning and from builtin service, too much confusion"). Verified at \`rdk/services/motion/builtin/builtin.go:246-247\`. The proto method itself still exists, so a third-party module can implement \`MoveOnMap\`, but I checked the registry and only one non-builtin motion service is published (\`erh:vehicle-motion:outdoor-motion-service\`, the same author who removed it from builtin), so realistically there is no plug-and-play replacement today.

The alert quotes the actual error string so people grepping logs will find this page.

## Edits

- \`static/include/services/apis/overrides/protos/motion.MoveOnMap.md\` — canonical source for the next regeneration of the API page.
- \`static/include/services/apis/generated/motion.md\` — currently-served file; alert prepended to the \`### MoveOnMap\` section so the warning ships in the next build without waiting on a regen run.

## Test plan

- [x] \`vale\` passes (0 errors)
- [x] \`prettier\` and \`markdownlint\` pass
- [x] \`make build-prod\` builds clean
- [x] Deploy preview verified — alert renders at https://deploy-preview-5040--viam-docs.netlify.app/reference/apis/services/motion/#moveonmap

🤖 Generated with [Claude Code](https://claude.com/claude-code)