### PR TITLE
Fix dead "Give Feedback" button on every docs page

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -112,7 +112,6 @@ window.markmap = {
 {{ $jsZoom := resources.Get "js/zoom.js" }}
 {{ $jsAnchor := resources.Get "js/anchor.js" }}
 {{ $jsSearch := resources.Get "js/search.js" | resources.ExecuteAsTemplate "js/search.js" .Site.Home }}
-{{ $jsMermaid := resources.Get "js/mermaid.js" | resources.ExecuteAsTemplate "js/mermaid.js" . }}
 {{ $jsMarkmap := resources.Get "js/markmap.js" | resources.ExecuteAsTemplate "js/markmap.js" . }}
 {{ $jsPlantuml := resources.Get "js/plantuml.js" | resources.ExecuteAsTemplate "js/plantuml.js" . }}
 {{ $jsDrawio := resources.Get "js/drawio.js" | resources.ExecuteAsTemplate "js/plantuml.js" .}}
@@ -123,10 +122,10 @@ window.markmap = {
 {{ $jsSearch = resources.Get "js/offline-search.js" }}
 {{ end }}
 {{ if not hugo.IsProduction }}
-{{ $js := (slice $jsIndex $jsTabpanePersist $jsToc $jsBase $jsAnchor $jsSearch $jsMermaid $jsPlantuml $jsMarkmap $jsDrawio $jsPrismViam $jsZoom $jsFeedback) | resources.Concat "js/main.js" }}
+{{ $js := (slice $jsIndex $jsTabpanePersist $jsToc $jsBase $jsAnchor $jsSearch $jsPlantuml $jsMarkmap $jsDrawio $jsPrismViam $jsZoom $jsFeedback) | resources.Concat "js/main.js" }}
 <script src="{{ $js.RelPermalink }}"></script>
 {{ else }}
-{{ $js := (slice $jsIndex $jsTabpanePersist $jsToc $jsBase $jsAnchor $jsSearch $jsMermaid $jsPlantuml $jsMarkmap $jsDrawio $jsPrismViam $jsZoom $jsFeedback) | resources.Concat "js/main.js" }}
+{{ $js := (slice $jsIndex $jsTabpanePersist $jsToc $jsBase $jsAnchor $jsSearch $jsPlantuml $jsMarkmap $jsDrawio $jsPrismViam $jsZoom $jsFeedback) | resources.Concat "js/main.js" }}
 {{ $js := $js | minify | fingerprint }}
 {{ $jsSentry := $jsSentry | minify }}
 <script async src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary

The "Give Feedback" button in the right-hand TOC currently does nothing on every docs page (e.g. [/set-up-a-machine/first-machine/](https://docs.viam.com/set-up-a-machine/first-machine/)) — clicking it produces no visible response, not even the label change to "Cancel Feedback."

**Root cause.** docsy's `assets/js/mermaid.js` is unconditionally bundled into `main.js` via `layouts/partials/scripts.html`, even though mermaid is not enabled (no `[params.mermaid]` block in `config.toml`, no `.mermaid` code blocks anywhere under `docs/`). Its IIFE calls `mermaid.initialize(...)` in the "no mermaid blocks on page" branch, but the mermaid library `<script>` tag is gated behind `{{ if .Site.Params.mermaid.enable }}` so the global is never loaded. Result: every page throws `Uncaught ReferenceError: mermaid is not defined` at script-eval time. Because `main.js` is one giant comma-chained expression (`}(jQuery),function(){…}(),…`), that throw aborts the rest of the chain — including the very last expression in the bundle:

```js
document.addEventListener("DOMContentLoaded", () => { new FeedbackSystem })
```

so `FeedbackSystem` never instantiates and no click handler is bound to `#feedbackButtonToc`.

The "Was this page helpful? Yes/No" footer widget still works because it's wired by an inline `<script>` in the page HTML, not by `main.js`.

**Fix.** Drop `$jsMermaid` from the bundle. The asset was already dead code on this site (no mermaid blocks, no library tag). If mermaid is ever re-enabled, the entry should be re-added alongside the library `<script>` tag — both gated on `.Site.Params.mermaid.enable`.

**Reproduced on prod** by navigating headless Chrome to `/set-up-a-machine/first-machine/`: two `mermaid is not defined` exceptions thrown during page load, and `document.getElementById('feedbackButtonToc').click()` leaves `#feedbackForm` at `display: none` with the button label unchanged.

## Test plan

- [ ] Build the site (`hugo server` or netlify preview) and confirm `main.js` no longer references `mermaid`
- [ ] Open any docs page and click "Give Feedback" in the right TOC — the inline form should expand and the button label should toggle to "Cancel Feedback"
- [ ] DevTools console should be free of `ReferenceError: mermaid is not defined`
- [ ] "Was this page helpful? Yes / No" footer widget still works (regression check)