### PR TITLE
Add max_tcp_speed to arm MoveOptions docs

### DIFF
--- a/docs/motion-planning/move-an-arm/move-by-joint-positions.md
+++ b/docs/motion-planning/move-an-arm/move-by-joint-positions.md
@@ -178,14 +178,18 @@ from Python; the arm uses its module's default speed profile.
 | `max_acc_degs_per_sec2`        | `double` (optional)   | Uniform acceleration cap across every joint, in degrees per second squared.                                      |
 | `max_vel_degs_per_sec_joints`  | `[]double` (repeated) | Per-joint velocity caps. Length must match the arm's degrees of freedom. Overrides the uniform cap when set.     |
 | `max_acc_degs_per_sec2_joints` | `[]double` (repeated) | Per-joint acceleration caps. Length must match the arm's degrees of freedom. Overrides the uniform cap when set. |
+| `max_tcp_speed`                | `double` (optional)   | Maximum speed of the tool center point in meters per second. The arm moves as fast as possible up to this limit. |
 
+All fields are optional ceilings. Any combination may be set. Every
+constraint that is set is respected at every point along the trajectory.
 Per-joint fields take precedence over global fields. Pass `nil`
 options to use the module's default motion profile.
 
 The field names above are the proto field names, also used by the Python
 SDK. The Go SDK `arm.MoveOptions` struct uses shorter names and stores
 values in **radians**: `MaxVelRads`, `MaxAccRads`, `MaxVelRadsJoints`,
-`MaxAccRadsJoints`. The conversion happens at the wire boundary.
+`MaxAccRadsJoints`, `MaxTCPSpeedMPerSec`. The conversion happens at the
+wire boundary.
 
 ## Reading current joint positions
 


### PR DESCRIPTION
## Source changes

- viamrobotics/api#839: Add `max_tcp_speed` field (field 5) to `MoveOptions` message in `arm.proto`
- viamrobotics/rdk#5986: Implement `MaxTCPSpeedMPerSec` in Go SDK's `arm.MoveOptions` struct

## Docs changes

- `docs/motion-planning/move-an-arm/move-by-joint-positions.md`: Added `max_tcp_speed` row to the MoveOptions field table. Added `MaxTCPSpeedMPerSec` to the Go SDK field name list. Added a sentence clarifying that all fields are optional ceilings that can be combined.

## How I found these

- Grep matches: `grep -rn "MoveOptions" docs/` found the field table at `move-by-joint-positions.md:173`
- Proto diff showed new field 5 (`max_tcp_speed`) added to `MoveOptions` message

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd7GAtzjRzypiJK1amk4Uu)_