### PR TITLE
Add GetWorldPose to data capture supported methods

### DIFF
--- a/docs/data/capture-sync/capture-and-sync-data.md
+++ b/docs/data/capture-sync/capture-and-sync-data.md
@@ -109,7 +109,7 @@ Any built-in or modular component that implements a capturable method can be con
 
 Every component and service also supports capturing `DoCommand` responses.
 All components also support `GetWorldPose`, which captures the component's position and orientation in the world reference frame using the [frame system](/motion-planning/frame-system/overview/).
-To use `GetWorldPose`, [configure a frame](/motion-planning/frame-system/overview/#configure-a-frame) for the component.
+To use `GetWorldPose`, [edit a frame](/motion-planning/frame-system/overview/#edit-a-frame-in-the-viam-app) for the component.
 Modular components that return readings through any of these methods are automatically capturable.
 
 ## Troubleshooting

--- a/docs/data/capture-sync/capture-and-sync-data.md
+++ b/docs/data/capture-sync/capture-and-sync-data.md
@@ -107,7 +107,10 @@ Any built-in or modular component that implements a capturable method can be con
 | Vision service  | `CaptureAllFromCamera`                                                                                                                  |
 | SLAM service    | `GetPosition`, `GetPointCloudMap`                                                                                                       |
 
-Every component and service also supports capturing `DoCommand` responses. Modular components that return readings through any of these methods are automatically capturable.
+Every component and service also supports capturing `DoCommand` responses.
+All components also support `GetWorldPose`, which captures the component's position and orientation in the world reference frame using the [frame system](/motion-planning/frame-system/overview/).
+To use `GetWorldPose`, [configure a frame](/motion-planning/frame-system/overview/#configure-a-frame) for the component.
+Modular components that return readings through any of these methods are automatically capturable.
 
 ## Troubleshooting
 

--- a/docs/data/schema.md
+++ b/docs/data/schema.md
@@ -60,7 +60,7 @@ The metadata fields (`organization_id` through `additional_parameters`) are the 
 | `part_id`               | String    | Machine part UUID. Identifies which part of the machine.                                                           |
 | `component_type`        | String    | Resource type as a triplet (for example, `rdk:component:sensor`).                                                  |
 | `component_name`        | String    | The name you gave this component in your config (for example, `my-sensor`). This is what you filter on most often. |
-| `method_name`           | String    | The capture method (for example, `Readings`, `GetImages`, `EndPosition`).                                          |
+| `method_name`           | String    | The capture method (for example, `Readings`, `GetImages`, `EndPosition`, `GetWorldPose`).                          |
 | `time_requested`        | Timestamp | When the capture was requested on the machine (machine's clock).                                                   |
 | `time_received`         | Timestamp | When the cloud received and stored the data. Use this for time-range queries since it's indexed.                   |
 | `tags`                  | Array     | User-applied tags from your data management config.                                                                |
@@ -166,6 +166,43 @@ To query detections, use MQL since SQL cannot easily traverse arrays:
 ```
 
 To query: `data.position`
+
+{{% /tab %}}
+{{% tab name="GetWorldPose" %}}
+
+`GetWorldPose` captures the component's position and orientation in the world reference frame. This method is available for all component types when a [frame](/motion-planning/frame-system/overview/) is configured.
+
+```json
+{
+  "pose": {
+    "x": 100.0,
+    "y": 200.0,
+    "z": 300.0,
+    "o_x": 0.0,
+    "o_y": 0.0,
+    "o_z": 1.0,
+    "theta": 45.0
+  }
+}
+```
+
+To query: `data.pose.x`, `data.pose.y`, `data.pose.z`
+
+Example:
+
+```sql
+SELECT time_received,
+  data.pose.x AS x,
+  data.pose.y AS y,
+  data.pose.z AS z,
+  data.pose.theta AS theta
+FROM readings
+WHERE component_name = 'my-arm'
+  AND method_name = 'GetWorldPose'
+  AND time_received >= CAST('2000-01-01T00:00:00.000Z' AS TIMESTAMP)
+ORDER BY time_received DESC
+LIMIT 10
+```
 
 {{% /tab %}}
 {{% tab name="Encoder (Position)" %}}

--- a/static/include/data/capture-supported.md
+++ b/static/include/data/capture-supported.md
@@ -2,30 +2,33 @@
 {{% tab name="viam-server" %}}
 
 <!-- prettier-ignore -->
-| Type                                            | Method |
-| ----------------------------------------------- | ------ |
-| [Arm](/hardware/common-components/add-an-arm/)                         | `EndPosition`, `JointPositions`, `DoCommand` |
-| [Base](/hardware/common-components/add-a-base/)                       | `Position`, `DoCommand` |
-| [Board](/hardware/common-components/add-a-board/)                     | `Analogs`, `Gpios`, `DoCommand` |
-| [Button](/hardware/common-components/add-a-button/)                   | `DoCommand` |
-| [Camera](/hardware/common-components/add-a-camera/)                   | `GetImages`, `ReadImage` (deprecated), `NextPointCloud`, `DoCommand` |
-| [Encoder](/hardware/common-components/add-an-encoder/)                 | `TicksCount`, `DoCommand` |
-| [Gantry](/hardware/common-components/add-a-gantry/)                   | `Lengths`, `Position`, `DoCommand` |
-| [Gripper](/hardware/common-components/add-a-gripper/)                 | `DoCommand` |
-| [Input Controller](/hardware/common-components/add-an-input-controller/) | `DoCommand` | 
-| [Motor](/hardware/common-components/add-a-motor/)                     | `Position`, `IsPowered`, `DoCommand` |
-| [Movement sensor](/hardware/common-components/add-a-movement-sensor/) | `AngularVelocity`, `CompassHeading`, `LinearAcceleration`, `LinearVelocity`, `Orientation`, `Position`, `DoCommand` |
-| [Sensor](/hardware/common-components/add-a-sensor/)                   | `Readings`, `DoCommand` |
-| [Power sensor](/hardware/common-components/add-a-power-sensor/)       | `Voltage`, `Current`, `Power`, `DoCommand` |
-| [Servo](/hardware/common-components/add-a-servo/)                     | `Position`, `DoCommand` |
-| [Switch](/hardware/common-components/add-a-switch/)                   | `DoCommand` |
-| [Generic](/hardware/common-components/add-a-generic/)                 | `DoCommand` |
+| Type | Method |
+| ---- | ------ |
+| [Arm](/hardware/common-components/add-an-arm/) | `EndPosition`, `JointPositions`, `GetWorldPose`, `DoCommand` |
+| [Audio out](/reference/apis/components/audio-out/) | `GetWorldPose` |
+| [Base](/hardware/common-components/add-a-base/) | `GetWorldPose`, `DoCommand` |
+| [Board](/hardware/common-components/add-a-board/) | `Analogs`, `Gpios`, `GetWorldPose`, `DoCommand` |
+| [Button](/hardware/common-components/add-a-button/) | `GetWorldPose`, `DoCommand` |
+| [Camera](/hardware/common-components/add-a-camera/) | `GetImages`, `ReadImage` (deprecated), `NextPointCloud`, `GetWorldPose`, `DoCommand` |
+| [Encoder](/hardware/common-components/add-an-encoder/) | `TicksCount`, `GetWorldPose`, `DoCommand` |
+| [Gantry](/hardware/common-components/add-a-gantry/) | `Lengths`, `Position`, `GetWorldPose`, `DoCommand` |
+| [Generic](/hardware/common-components/add-a-generic/) | `GetWorldPose`, `DoCommand` |
+| [Gripper](/hardware/common-components/add-a-gripper/) | `GetWorldPose`, `DoCommand` |
+| [Input controller](/hardware/common-components/add-an-input-controller/) | `GetWorldPose`, `DoCommand` |
+| [Motor](/hardware/common-components/add-a-motor/) | `Position`, `IsPowered`, `GetWorldPose`, `DoCommand` |
+| [Movement sensor](/hardware/common-components/add-a-movement-sensor/) | `AngularVelocity`, `CompassHeading`, `LinearAcceleration`, `LinearVelocity`, `Orientation`, `Position`, `GetWorldPose`, `DoCommand` |
+| [Power sensor](/hardware/common-components/add-a-power-sensor/) | `Voltage`, `Current`, `Power`, `GetWorldPose`, `DoCommand` |
+| [Sensor](/hardware/common-components/add-a-sensor/) | `Readings`, `GetWorldPose`, `DoCommand` |
+| [Servo](/hardware/common-components/add-a-servo/) | `Position`, `GetWorldPose`, `DoCommand` |
+| [Switch](/hardware/common-components/add-a-switch/) | `GetWorldPose`, `DoCommand` |
 | [Base remote control service](/reference/services/base-rc/) | `DoCommand` |
-| [Discovery service](/reference/services/discovery/)       | `DoCommand` |
-| [Vision service](/vision/configure/)             | `CaptureAllFromCamera`, `DoCommand` |
-| [Motion service](/reference/services/motion/)             | `DoCommand` |
-| [Navigation service](/reference/services/navigation/)     | `DoCommand` |
+| [Discovery service](/reference/services/discovery/) | `DoCommand` |
+| [Vision service](/vision/configure/) | `CaptureAllFromCamera`, `DoCommand` |
+| [Motion service](/reference/services/motion/) | `DoCommand` |
+| [Navigation service](/reference/services/navigation/) | `DoCommand` |
 | Shell service | `DoCommand` |
+
+`GetWorldPose` captures the component's position and orientation in the world reference frame using the [frame system](/motion-planning/frame-system/overview/). It is available for all component types. To use it, [configure a frame](/motion-planning/frame-system/overview/#configure-a-frame) for the component.
 
 {{% /tab %}}
 {{% tab name="Micro-RDK" %}}

--- a/static/include/data/capture-supported.md
+++ b/static/include/data/capture-supported.md
@@ -28,7 +28,7 @@
 | [Navigation service](/reference/services/navigation/) | `DoCommand` |
 | Shell service | `DoCommand` |
 
-`GetWorldPose` captures the component's position and orientation in the world reference frame using the [frame system](/motion-planning/frame-system/overview/). It is available for all component types. To use it, [configure a frame](/motion-planning/frame-system/overview/#configure-a-frame) for the component.
+`GetWorldPose` captures the component's position and orientation in the world reference frame using the [frame system](/motion-planning/frame-system/overview/). It is available for all component types. To use it, [edit a frame](/motion-planning/frame-system/overview/#edit-a-frame-in-the-viam-app) for the component.
 
 {{% /tab %}}
 {{% tab name="Micro-RDK" %}}


### PR DESCRIPTION
## Source changes

- viamrobotics/rdk#5984: Add `GetWorldPose` as a data capture method to all 19 RDK component types via the frame system
- viamrobotics/app#11892: Backend support for GetWorldPose data capture (merged earlier, RDK side was blocking)

## Docs changes

- `static/include/data/capture-supported.md`: Add `GetWorldPose` to every component row in the supported capture methods table. Add Audio out as a new row (this PR gives it its first capture method). Remove incorrect `Position` method from Base (Base only registers `DoCommand`; `Position` was never a registered collector). Fix table column padding for markdownlint compliance. Add explanatory note about GetWorldPose requiring a configured frame.
- `docs/data/capture-sync/capture-and-sync-data.md`: Add note about `GetWorldPose` availability for all components (parallel to the existing `DoCommand` note), with frame system requirement.
- `docs/data/schema.md`: Add `GetWorldPose` tab to the "Common data structures" section showing the captured pose JSON structure and a SQL query example. Add `GetWorldPose` to the `method_name` column examples.

## How I found these

- Backlog item `app-6117e0f-getworldpose-capture` was deferred pending RDK #5984 merge; that merge landed 2026-05-08
- Xref lookup: data capture flow in `flows.md`
- Grep matches: `capture-supported` inclusion found in `docs/data/reference.md`; secondary capture methods table found in `docs/data/capture-sync/capture-and-sync-data.md`; schema examples in `docs/data/schema.md`

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4EKULYXXnKsqyUmkC46vX)_