### PR TITLE
Note supported Debian distros for os_auto_upgrade_type

### DIFF
--- a/docs/fleet/system-settings.md
+++ b/docs/fleet/system-settings.md
@@ -119,6 +119,9 @@ In the machine settings card, open **Settings** and expand **System**. Set `os_a
 | `"disable"`  | Disable automatic OS updates.                                            |
 | `""` (empty) | Do not change the system's current update settings. This is the default. |
 
+Automatic OS package updates require Debian Linux with one of these release codenames: Bullseye, Bookworm, or Trixie.
+On unsupported distributions, the agent logs a warning and the setting has no effect.
+
 ## Configure OS log forwarding
 
 Forward operating system logs from the machine to Viam's cloud log viewer.

--- a/docs/reference/viam-agent.md
+++ b/docs/reference/viam-agent.md
@@ -85,6 +85,9 @@ In the machine settings card, open **Settings** and expand **System**:
 | ---------------------- | ------ | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `os_auto_upgrade_type` | string | `""`    | Controls automatic OS package updates. Options: `"all"` (upgrade all packages), `"security"` (security updates only), `"disable"` (no automatic updates), `""` (do not manage, leave OS defaults). |
 
+Automatic OS package updates require Debian Linux with one of these release codenames: Bullseye, Bookworm, or Trixie.
+On unsupported distributions, the agent logs a warning and the setting has no effect.
+
 ### Log forwarding
 
 | Field                                        | Type    | Default | Description                                                                                                                                                                                                                                                                                                         |


### PR DESCRIPTION
## Source changes

- viamrobotics/agent#233 (commit 1a81dd3): Added Debian Trixie to supported distros for unattended upgrades

## Docs changes

- docs/reference/viam-agent.md: Added note that automatic OS package updates require Debian Bullseye, Bookworm, or Trixie, and that unsupported distributions log a warning
- docs/fleet/system-settings.md: Added the same note after the os_auto_upgrade_type options table

## How I found these

- Backlog item `agent-1a81dd3-trixie-support` from 2026-05-05 run
- Code reference: `agent/subsystems/syscfg/upgrades_linux.go` line 25 defines `supportedCodenames` and line 89-103 implements `checkSupportedDistro()` which returns an error on unsupported distributions

---
Generated by daily docs change agent

https://claude.ai/code/session_011ZAuGfa4KV8hLFUa7mLvmz

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZAuGfa4KV8hLFUa7mLvmz)_