### PR TITLE
Update credential instructions for removed Connection details page

### DIFF
--- a/docs/hardware/common-components/add-a-base.md
+++ b/docs/hardware/common-components/add-a-base.md
@@ -116,9 +116,8 @@ area. Start with low speeds.
 
 Drive the base forward, spin it, and stop.
 
-To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
-Copy the **API key** and **API key ID**.
-Copy the **machine address** from the **Connection details** section on the same tab.
+To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
+Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
 If you're using real hardware, you'll see the robot drive forward and spin when you run the code below.
 With a fake base, the commands complete without physical motion.
 {{< tabs >}}

--- a/docs/hardware/common-components/add-a-base.md
+++ b/docs/hardware/common-components/add-a-base.md
@@ -116,8 +116,9 @@ area. Start with low speeds.
 
 Drive the base forward, spin it, and stop.
 
-To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
-Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
+To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
+Copy the **Key** and **ID**.
+Then click the **CONFIGURE** tab, and click **Details**, and copy the **Remote address**.
 If you're using real hardware, you'll see the robot drive forward and spin when you run the code below.
 With a fake base, the commands complete without physical motion.
 {{< tabs >}}

--- a/docs/hardware/common-components/add-a-board.md
+++ b/docs/hardware/common-components/add-a-board.md
@@ -124,8 +124,9 @@ it up.
 
 Toggle a GPIO pin and read its state programmatically.
 
-To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
-Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
+To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
+Copy the **Key** and **ID**.
+Then click the **CONFIGURE** tab, and click **Details**, and copy the **Remote address**.
 If you have an LED wired to pin 11, you'll see it turn on and off when you run the code below.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-board.md
+++ b/docs/hardware/common-components/add-a-board.md
@@ -124,9 +124,8 @@ it up.
 
 Toggle a GPIO pin and read its state programmatically.
 
-To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
-Copy the **API key** and **API key ID**.
-Copy the **machine address** from the **Connection details** section on the same tab.
+To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
+Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
 If you have an LED wired to pin 11, you'll see it turn on and off when you run the code below.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-button.md
+++ b/docs/hardware/common-components/add-a-button.md
@@ -68,8 +68,9 @@ Click **Save**, then expand the **Test** section.
 
 Push the button programmatically.
 
-To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
-Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
+To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
+Copy the **Key** and **ID**.
+Then click the **CONFIGURE** tab, and click **Details**, and copy the **Remote address**.
 When you run the code below, the button's Push method fires. With a physical button connected with a module, this triggers whatever action the module defines.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-button.md
+++ b/docs/hardware/common-components/add-a-button.md
@@ -68,9 +68,8 @@ Click **Save**, then expand the **Test** section.
 
 Push the button programmatically.
 
-To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
-Copy the **API key** and **API key ID**.
-Copy the **machine address** from the **Connection details** section on the same tab.
+To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
+Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
 When you run the code below, the button's Push method fires. With a physical button connected with a module, this triggers whatever action the module defines.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-camera.md
+++ b/docs/hardware/common-components/add-a-camera.md
@@ -123,9 +123,8 @@ You should see a live feed from the camera.
 
 Capture an image from your camera programmatically.
 
-To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
-Copy the **API key** and **API key ID**.
-Copy the **machine address** from the **Connection details** section on the same tab.
+To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
+Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
 
 When you run the code below, it saves an image file to your current directory. Check that the image shows what the camera sees.
 {{< tabs >}}

--- a/docs/hardware/common-components/add-a-camera.md
+++ b/docs/hardware/common-components/add-a-camera.md
@@ -123,8 +123,9 @@ You should see a live feed from the camera.
 
 Capture an image from your camera programmatically.
 
-To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
-Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
+To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
+Copy the **Key** and **ID**.
+Then click the **CONFIGURE** tab, and click **Details**, and copy the **Remote address**.
 
 When you run the code below, it saves an image file to your current directory. Check that the image shows what the camera sees.
 {{< tabs >}}

--- a/docs/hardware/common-components/add-a-gantry.md
+++ b/docs/hardware/common-components/add-a-gantry.md
@@ -120,8 +120,9 @@ Click **Save**, then expand the **Test** section.
 
 Read the gantry's position and move it along the axis.
 
-To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
-Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
+To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
+Copy the **Key** and **ID**.
+Then click the **CONFIGURE** tab, and click **Details**, and copy the **Remote address**.
 If you're using real hardware, you'll see the gantry move along its axis when you run the code below.
 With a fake gantry, position values update without physical motion.
 {{< tabs >}}

--- a/docs/hardware/common-components/add-a-gantry.md
+++ b/docs/hardware/common-components/add-a-gantry.md
@@ -120,9 +120,8 @@ Click **Save**, then expand the **Test** section.
 
 Read the gantry's position and move it along the axis.
 
-To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
-Copy the **API key** and **API key ID**.
-Copy the **machine address** from the **Connection details** section on the same tab.
+To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
+Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
 If you're using real hardware, you'll see the gantry move along its axis when you run the code below.
 With a fake gantry, position values update without physical motion.
 {{< tabs >}}

--- a/docs/hardware/common-components/add-a-generic.md
+++ b/docs/hardware/common-components/add-a-generic.md
@@ -74,9 +74,8 @@ or the Viam app's test panel.
 
 Send a command to the generic component and read the response.
 
-To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
-Copy the **API key** and **API key ID**.
-Copy the **machine address** from the **Connection details** section on the same tab.
+To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
+Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
 With the fake model, you'll see your command echoed back. With a real module, the response depends on what commands the module supports.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-generic.md
+++ b/docs/hardware/common-components/add-a-generic.md
@@ -74,8 +74,9 @@ or the Viam app's test panel.
 
 Send a command to the generic component and read the response.
 
-To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
-Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
+To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
+Copy the **Key** and **ID**.
+Then click the **CONFIGURE** tab, and click **Details**, and copy the **Remote address**.
 With the fake model, you'll see your command echoed back. With a real module, the response depends on what commands the module supports.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-gripper.md
+++ b/docs/hardware/common-components/add-a-gripper.md
@@ -130,9 +130,8 @@ with no objects in the workspace until you're confident in the configuration.
 
 Open the gripper, grab an object, and check if it's held.
 
-To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
-Copy the **API key** and **API key ID**.
-Copy the **machine address** from the **Connection details** section on the same tab.
+To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
+Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
 If you're using real hardware, you'll see the gripper open and close when you run the code below.
 With the fake model, Grab always returns true.
 {{< tabs >}}

--- a/docs/hardware/common-components/add-a-gripper.md
+++ b/docs/hardware/common-components/add-a-gripper.md
@@ -130,8 +130,9 @@ with no objects in the workspace until you're confident in the configuration.
 
 Open the gripper, grab an object, and check if it's held.
 
-To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
-Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
+To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
+Copy the **Key** and **ID**.
+Then click the **CONFIGURE** tab, and click **Details**, and copy the **Remote address**.
 If you're using real hardware, you'll see the gripper open and close when you run the code below.
 With the fake model, Grab always returns true.
 {{< tabs >}}

--- a/docs/hardware/common-components/add-a-motor.md
+++ b/docs/hardware/common-components/add-a-motor.md
@@ -132,9 +132,8 @@ Click **Save**, then expand the **Test** section for the motor.
 
 Spin the motor forward for 2 revolutions, then check if it's still moving.
 
-To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
-Copy the **API key** and **API key ID**.
-Copy the **machine address** from the **Connection details** section on the same tab.
+To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
+Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
 If you're using real hardware, you'll see the motor spin when you run the code below.
 Without an encoder, position readings will be estimates based on time and max RPM.
 {{< tabs >}}

--- a/docs/hardware/common-components/add-a-motor.md
+++ b/docs/hardware/common-components/add-a-motor.md
@@ -132,8 +132,9 @@ Click **Save**, then expand the **Test** section for the motor.
 
 Spin the motor forward for 2 revolutions, then check if it's still moving.
 
-To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
-Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
+To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
+Copy the **Key** and **ID**.
+Then click the **CONFIGURE** tab, and click **Details**, and copy the **Remote address**.
 If you're using real hardware, you'll see the motor spin when you run the code below.
 Without an encoder, position readings will be estimates based on time and max RPM.
 {{< tabs >}}

--- a/docs/hardware/common-components/add-a-movement-sensor.md
+++ b/docs/hardware/common-components/add-a-movement-sensor.md
@@ -132,8 +132,9 @@ Click **Save**, then expand the **Test** section.
 
 Read position and velocity data from the movement sensor.
 
-To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
-Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
+To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
+Copy the **Key** and **ID**.
+Then click the **CONFIGURE** tab, and click **Details**, and copy the **Remote address**.
 When you run the code below, you'll see which methods your sensor supports and the current readings for each.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-movement-sensor.md
+++ b/docs/hardware/common-components/add-a-movement-sensor.md
@@ -132,9 +132,8 @@ Click **Save**, then expand the **Test** section.
 
 Read position and velocity data from the movement sensor.
 
-To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
-Copy the **API key** and **API key ID**.
-Copy the **machine address** from the **Connection details** section on the same tab.
+To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
+Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
 When you run the code below, you'll see which methods your sensor supports and the current readings for each.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-power-sensor.md
+++ b/docs/hardware/common-components/add-a-power-sensor.md
@@ -83,8 +83,9 @@ Click **Save**, then expand the **Test** section.
 
 Read voltage, current, and power programmatically.
 
-To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
-Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
+To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
+Copy the **Key** and **ID**.
+Then click the **CONFIGURE** tab, and click **Details**, and copy the **Remote address**.
 When you run the code below, you'll see voltage, current, and power readings. Verify the voltage matches your power supply.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-power-sensor.md
+++ b/docs/hardware/common-components/add-a-power-sensor.md
@@ -83,9 +83,8 @@ Click **Save**, then expand the **Test** section.
 
 Read voltage, current, and power programmatically.
 
-To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
-Copy the **API key** and **API key ID**.
-Copy the **machine address** from the **Connection details** section on the same tab.
+To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
+Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
 When you run the code below, you'll see voltage, current, and power readings. Verify the voltage matches your power supply.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-sensor.md
+++ b/docs/hardware/common-components/add-a-sensor.md
@@ -107,9 +107,8 @@ Click **Save**, then expand the **Test** section.
 
 Read sensor data programmatically and print it.
 
-To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
-Copy the **API key** and **API key ID**.
-Copy the **machine address** from the **Connection details** section on the same tab.
+To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
+Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
 When you run the code below, you'll see sensor readings printed once per second. Verify the values make sense for your environment.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-sensor.md
+++ b/docs/hardware/common-components/add-a-sensor.md
@@ -107,8 +107,9 @@ Click **Save**, then expand the **Test** section.
 
 Read sensor data programmatically and print it.
 
-To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
-Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
+To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
+Copy the **Key** and **ID**.
+Then click the **CONFIGURE** tab, and click **Details**, and copy the **Remote address**.
 When you run the code below, you'll see sensor readings printed once per second. Verify the values make sense for your environment.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-servo.md
+++ b/docs/hardware/common-components/add-a-servo.md
@@ -94,9 +94,8 @@ Click **Save**, then expand the **Test** section.
 
 Sweep the servo through a range of positions.
 
-To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
-Copy the **API key** and **API key ID**.
-Copy the **machine address** from the **Connection details** section on the same tab.
+To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
+Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
 If you're using real hardware, you'll see the servo sweep through positions when you run the code below.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-servo.md
+++ b/docs/hardware/common-components/add-a-servo.md
@@ -94,8 +94,9 @@ Click **Save**, then expand the **Test** section.
 
 Sweep the servo through a range of positions.
 
-To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
-Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
+To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
+Copy the **Key** and **ID**.
+Then click the **CONFIGURE** tab, and click **Details**, and copy the **Remote address**.
 If you're using real hardware, you'll see the servo sweep through positions when you run the code below.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-switch.md
+++ b/docs/hardware/common-components/add-a-switch.md
@@ -76,9 +76,8 @@ Click **Save**, then expand the **Test** section.
 
 Read the switch position, cycle through positions, and read labels.
 
-To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
-Copy the **API key** and **API key ID**.
-Copy the **machine address** from the **Connection details** section on the same tab.
+To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
+Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
 When you run the code below, you'll see the switch cycle through all positions. With the fake model, positions update in memory. With real hardware, verify the switch physically changes state.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-a-switch.md
+++ b/docs/hardware/common-components/add-a-switch.md
@@ -76,8 +76,9 @@ Click **Save**, then expand the **Test** section.
 
 Read the switch position, cycle through positions, and read labels.
 
-To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
-Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
+To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
+Copy the **Key** and **ID**.
+Then click the **CONFIGURE** tab, and click **Details**, and copy the **Remote address**.
 When you run the code below, you'll see the switch cycle through all positions. With the fake model, positions update in memory. With real hardware, verify the switch physically changes state.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-an-arm.md
+++ b/docs/hardware/common-components/add-an-arm.md
@@ -132,8 +132,9 @@ The fake arm simulates kinematics for the specified model. Set `arm-model` to `u
 
 Read the arm's current joint positions, move two joints, and confirm the positions changed.
 
-To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
-Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
+To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
+Copy the **Key** and **ID**.
+Then click the **CONFIGURE** tab, and click **Details**, and copy the **Remote address**.
 
 If you're using a real arm, you'll see it physically move when you run the code below.
 With a fake arm, the positions update in memory without physical motion, but you can watch the joint values update in real time by expanding the **test** section on the arm's component card in the **CONFIGURE** tab.

--- a/docs/hardware/common-components/add-an-arm.md
+++ b/docs/hardware/common-components/add-an-arm.md
@@ -132,9 +132,8 @@ The fake arm simulates kinematics for the specified model. Set `arm-model` to `u
 
 Read the arm's current joint positions, move two joints, and confirm the positions changed.
 
-To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
-Copy the **API key** and **API key ID**.
-Copy the **machine address** from the **Connection details** section on the same tab.
+To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
+Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
 
 If you're using a real arm, you'll see it physically move when you run the code below.
 With a fake arm, the positions update in memory without physical motion, but you can watch the joint values update in real time by expanding the **test** section on the arm's component card in the **CONFIGURE** tab.

--- a/docs/hardware/common-components/add-an-encoder.md
+++ b/docs/hardware/common-components/add-an-encoder.md
@@ -136,8 +136,9 @@ position.
 
 Read the encoder position and reset it.
 
-To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
-Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
+To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
+Copy the **Key** and **ID**.
+Then click the **CONFIGURE** tab, and click **Details**, and copy the **Remote address**.
 When you run the code below, you'll see the encoder's current position, then reset it to zero. Manually rotate the motor shaft to verify the count changes.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-an-encoder.md
+++ b/docs/hardware/common-components/add-an-encoder.md
@@ -136,9 +136,8 @@ position.
 
 Read the encoder position and reset it.
 
-To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
-Copy the **API key** and **API key ID**.
-Copy the **machine address** from the **Connection details** section on the same tab.
+To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
+Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
 When you run the code below, you'll see the encoder's current position, then reset it to zero. Manually rotate the motor shaft to verify the count changes.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-an-input-controller.md
+++ b/docs/hardware/common-components/add-an-input-controller.md
@@ -107,9 +107,8 @@ Click **Save**, then expand the **Test** section.
 
 List available controls and print events as they happen.
 
-To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
-Copy the **API key** and **API key ID**.
-Copy the **machine address** from the **Connection details** section on the same tab.
+To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
+Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
 When you run the code below, press buttons on your gamepad and watch the events print in real time.
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/hardware/common-components/add-an-input-controller.md
+++ b/docs/hardware/common-components/add-an-input-controller.md
@@ -107,8 +107,9 @@ Click **Save**, then expand the **Test** section.
 
 List available controls and print events as they happen.
 
-To get the credentials for the code below, go to your machine's page in the Viam app and navigate to the **CONNECT** tab.
-Select **SDK code sample** and toggle **Include API key** on to view your **machine address**, **API key**, and **API key ID** within the code sample.
+To get the credentials for the code below, go to your machine's page in the Viam app, click the **CONNECT** tab, and select **API keys**.
+Copy the **Key** and **ID**.
+Then click the **CONFIGURE** tab, and click **Details**, and copy the **Remote address**.
 When you run the code below, press buttons on your gamepad and watch the events print in real time.
 {{< tabs >}}
 {{% tab name="Python" %}}


### PR DESCRIPTION
## Source changes

- viamrobotics/app#11972: Removed "Control Code Sample" and "Connection details" sidebar items from the Connect tab. Connection details info is now available on the machine settings page.

## Docs changes

- 16 files in `docs/hardware/common-components/`: Updated credential instructions that referenced the removed **Connection details** section. The old 3-line block directed users to select "API keys" and then copy the machine address from "Connection details." The new 2-line block directs users to the **SDK code sample** page and the **Include API key** toggle, which shows machine address, API key, and API key ID in the generated code snippet.

### Files changed

- `add-a-camera.md`, `add-a-base.md`, `add-a-board.md`, `add-a-button.md`, `add-a-generic.md`, `add-a-gantry.md`, `add-a-power-sensor.md`, `add-a-motor.md`, `add-a-movement-sensor.md`, `add-a-switch.md`, `add-a-gripper.md`, `add-a-sensor.md`, `add-a-servo.md`, `add-an-arm.md`, `add-an-input-controller.md`, `add-an-encoder.md`

## How I found these

- Xref lookup: app UI changes to Connect tab sidebar
- Grep matches: 16 pages contained `Copy the **machine address** from the **Connection details** section on the same tab.` — all updated, zero remaining instances confirmed

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7VtWEYs2xdXQM8ASzvtf4)_