### PR TITLE
Add Python tab to TransformPCD in robot API docs

### DIFF
--- a/static/include/robot/apis/generated/robot.md
+++ b/static/include/robot/apis/generated/robot.md
@@ -11,7 +11,7 @@ Get the list of operations currently running on the machine.
 
 **Returns:**
 
-- ([List[viam.proto.robot.Operation]](https://python.viam.dev/autoapi/viam/proto/robot/index.html#viam.proto.robot.Operation)): :   The list of operations currently running on a given machine.
+- ([List[viam.proto.robot.Operation]](https://python.viam.dev/autoapi/viam/proto/robot/index.html#viam.proto.robot.Operation)): : The list of operations currently running on a given machine.
 
 **Example:**
 
@@ -56,7 +56,7 @@ Get status information about the machine including the status of the machine and
 
 **Returns:**
 
-- ([viam.proto.robot.GetMachineStatusResponse](https://python.viam.dev/autoapi/viam/proto/robot/index.html#viam.proto.robot.GetMachineStatusResponse)): :   current status of the machine (initializing or running), current status of the resources (List[ResourceStatus]) and the revision of the config of the machine.
+- ([viam.proto.robot.GetMachineStatusResponse](https://python.viam.dev/autoapi/viam/proto/robot/index.html#viam.proto.robot.GetMachineStatusResponse)): : current status of the machine (initializing or running), current status of the resources (List[ResourceStatus]) and the revision of the config of the machine.
 
 **Example:**
 
@@ -278,7 +278,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await machine.cancelOperation('INSERT OPERATION ID');
+await machine.cancelOperation("INSERT OPERATION ID");
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/Client.html#canceloperation).
@@ -324,7 +324,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await machine.blockForOperation('INSERT OPERATION ID');
+await machine.blockForOperation("INSERT OPERATION ID");
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/Client.html#blockforoperation).
@@ -345,7 +345,7 @@ Get the configuration of the frame system of a given machine.
 
 **Returns:**
 
-- ([List[viam.proto.robot.FrameSystemConfig]](https://python.viam.dev/autoapi/viam/proto/robot/index.html#viam.proto.robot.FrameSystemConfig)): :   The configuration of a given machine’s frame system.
+- ([List[viam.proto.robot.FrameSystemConfig]](https://python.viam.dev/autoapi/viam/proto/robot/index.html#viam.proto.robot.FrameSystemConfig)): : The configuration of a given machine’s frame system.
 
 **Example:**
 
@@ -394,7 +394,7 @@ Transform a given source Pose from the original reference frame to a new destina
 
 **Returns:**
 
-- ([viam.proto.common.PoseInFrame](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.PoseInFrame)): :   The pose and the reference frame for the new destination.
+- ([viam.proto.common.PoseInFrame](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.PoseInFrame)): : The pose and the reference frame for the new destination.
 
 **Example:**
 
@@ -446,6 +446,32 @@ Transforms the pointcloud to the desired frame in the robot's frame system.
 Do not move the robot between the generation of the initial pointcloud and the receipt of the transformed pointcloud, as doing so will make the transformations inaccurate.
 
 {{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `point_cloud_pcd` ([bytes](https://docs.python.org/3/library/stdtypes.html#bytes-objects)) (required): The point cloud data to transform, in PCD format.
+- `source` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The reference frame of the point cloud.
+- `destination` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The reference frame to transform the point cloud into.
+
+**Returns:**
+
+- ([bytes](https://docs.python.org/3/library/stdtypes.html#bytes-objects)): The point cloud data relative to the destination reference frame.
+
+**Example:**
+
+```python {class="line-numbers linkable-line-numbers"}
+from viam.components.camera import Camera
+
+my_camera = Camera.from_robot(robot=machine, name="my_camera")
+data, _ = await my_camera.get_point_cloud()
+
+transformed_pcd = await machine.transform_pcd(data, "my_camera", "world")
+```
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient.transform_pcd).
+
+{{% /tab %}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -482,7 +508,7 @@ This includes models that are not currently configured on the machine.
 
 **Returns:**
 
-- ([List[viam.proto.robot.ModuleModel]](https://python.viam.dev/autoapi/viam/proto/robot/index.html#viam.proto.robot.ModuleModel)): :   A list of discovered models.
+- ([List[viam.proto.robot.ModuleModel]](https://python.viam.dev/autoapi/viam/proto/robot/index.html#viam.proto.robot.ModuleModel)): : A list of discovered models.
 
 **Example:**
 
@@ -669,7 +695,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Parameters:**
 
-- `moduleId` (string) (optional): The id matching the module\_id field of the registry
+- `moduleId` (string) (optional): The id matching the module_id field of the registry
   module in your part configuration.
 - `moduleName` (string) (optional): The name matching the name field of the local/registry
   module in your part configuration.
@@ -681,7 +707,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await machine.restartModule('namespace:module:model', 'my_model_name');
+await machine.restartModule("namespace:module:model", "my_model_name");
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/Client.html#restartmodule).
@@ -726,7 +752,7 @@ Get app-related information about the robot.
 
 **Returns:**
 
-- ([viam.proto.robot.GetCloudMetadataResponse](https://python.viam.dev/autoapi/viam/proto/robot/index.html#viam.proto.robot.GetCloudMetadataResponse)): :   App-related metadata.
+- ([viam.proto.robot.GetCloudMetadataResponse](https://python.viam.dev/autoapi/viam/proto/robot/index.html#viam.proto.robot.GetCloudMetadataResponse)): : App-related metadata.
 
 **Example:**
 
@@ -818,7 +844,7 @@ Return version information about the machine.
 
 **Returns:**
 
-- ([viam.proto.robot.GetVersionResponse](https://python.viam.dev/autoapi/viam/proto/robot/index.html#viam.proto.robot.GetVersionResponse)): :   Machine version related information.
+- ([viam.proto.robot.GetVersionResponse](https://python.viam.dev/autoapi/viam/proto/robot/index.html#viam.proto.robot.GetVersionResponse)): : Machine version related information.
 
 **Example:**
 
@@ -876,7 +902,7 @@ Pass these options to [`AtAddress`](#ataddress).
 
 **Returns:**
 
-- (Self): :   the RobotClient.Options.
+- (Self): : the RobotClient.Options.
 
 **Raises:**
 


### PR DESCRIPTION
## Source changes\n\n- viamrobotics/viam-python-sdk#1213: Implement `transform_pcd()` on `RobotClient`, replacing the previous `NotImplementedError` stub\n\n## Docs changes\n\n- `static/include/robot/apis/generated/robot.md`: Added Python tab to the `TransformPCD` section with parameters, return type, and usage example matching the new SDK method\n\n## How I found these\n\n- Xref lookup: robot API xref for TransformPCD\n- Grep matches: 4 files reference TransformPCD (`robot.md`, `robot-table.md`, `frame-system-api.md`)\n- The frame-system API page uses a language-agnostic table format and needs no SDK-specific update\n\n---\nGenerated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_017TuRVvVm9NZztBE6mYtazv)_