### PR TITLE
Update trigger UI labels: Webhooks to Webhook, Alert options to Email

### DIFF
--- a/docs/data/trigger-on-data.md
+++ b/docs/data/trigger-on-data.md
@@ -59,11 +59,11 @@ For the full attribute reference for all trigger types, see [Trigger configurati
         For a full reference of trigger configuration attributes, see [Trigger configuration](/reference/triggers/).
 
 1. Next, configure what should happen when an event occurs.
-   You can add **Webhooks**, **Email**, and **Push** notifications:
+   You can add **Webhook**, **Email**, and **Push** notifications:
 
    To add a webhook:
 
-   1. Click **Add Webhook**.
+   1. Click **Add webhook**.
    1. Add the URL of your cloud function.
    1. Configure the time between notifications.
    1. Write your cloud function to process the webhook payload.

--- a/docs/data/trigger-on-data.md
+++ b/docs/data/trigger-on-data.md
@@ -59,11 +59,11 @@ For the full attribute reference for all trigger types, see [Trigger configurati
         For a full reference of trigger configuration attributes, see [Trigger configuration](/reference/triggers/).
 
 1. Next, configure what should happen when an event occurs.
-   You can add **Webhooks** and **Email** notifications:
+   You can add **Webhook** and **Email** notifications:
 
    To add a webhook:
 
-   1. Click **Add Webhook**.
+   1. Click **Add webhook**.
    1. Add the URL of your cloud function.
    1. Configure the time between notifications.
    1. Write your cloud function to process the webhook payload.

--- a/docs/monitor/alert.md
+++ b/docs/monitor/alert.md
@@ -100,7 +100,7 @@ Wait a minute for data to capture and sync, then refresh.
 1. Add notification methods:
    - **Email specific addresses**: toggle on, add addresses, set alert frequency.
    - **Email all machine owners**: toggle on, set alert frequency.
-   - **Webhook**: click **Add Webhook**, enter your cloud function URL, set alert frequency.
+   - **Webhook**: click **Add webhook**, enter your cloud function URL, set alert frequency.
      See [Trigger configuration](/reference/triggers/#webhook-attributes) for webhook payload details.
    - **Push notifications**: click **Add push notifications**, choose the target mobile app, add recipient email addresses or enable notifications for all machine owners, and set alert frequency.
      Recipients must be machine owners or operators.

--- a/docs/monitor/alert.md
+++ b/docs/monitor/alert.md
@@ -100,7 +100,7 @@ Wait a minute for data to capture and sync, then refresh.
 1. Add notification methods:
    - **Email specific addresses**: toggle on, add addresses, set alert frequency.
    - **Email all machine owners**: toggle on, set alert frequency.
-   - **Webhook**: click **Add Webhook**, enter your cloud function URL, set alert frequency.
+   - **Webhook**: click **Add webhook**, enter your cloud function URL, set alert frequency.
      See [Trigger configuration](/reference/triggers/#webhook-attributes) for webhook payload details.
 1. Click **Save**.
 

--- a/docs/vision/object-detection/alert-on-detections.md
+++ b/docs/vision/object-detection/alert-on-detections.md
@@ -124,16 +124,13 @@ Add a trigger to send alerts when filtered images sync:
 2. Enter a name and click **Create**.
 3. Set **Type** to **Data has been synced to the cloud**.
 4. Set **Data Types** to **Binary (image)**.
+5. Add notification methods. The following options live in the **Email**, **Webhook**, and **Push notifications** sections of the trigger card:
 
-   {{<imgproc src="/tutorials/helmet/trigger.png" resize="x600" style="width: 500px" declaredimensions=true alt="The trigger configured with 'Data has been synced to the cloud' as the type and 'Binary (image)' as the data type." class="shadow imgzoom" >}}
+   **Email**: In the **Email** section, toggle **Send to specific users** on, enter each email address, and set the **Alert frequency** per row. Or toggle **Send to all machine owners** on and set the **Alert frequency** for the all-owners row.
 
-5. Add notification methods. The following options live in the **ALERT OPTIONS** and **WEBHOOKS** sections of the trigger card:
+   **Webhook**: In the **Webhook** section click **Add webhook**, enter the URL of your cloud function, and implement logic to process the [webhook payload](/reference/triggers/#webhook-attributes). Use this to integrate with external services like Twilio, PagerDuty, or Zapier.
 
-   **Email specific addresses**: Toggle on and add email addresses. Each row has its own **Alert frequency**.
-
-   **Email all machine owners**: Toggle on. Set the **Alert frequency** for the all-owners row.
-
-   **Webhook**: In the **WEBHOOKS** section click **Add Webhook**, enter the URL of your cloud function, and implement logic to process the [webhook payload](/reference/triggers/#webhook-attributes). Use this to integrate with external services like Twilio, PagerDuty, or Zapier.
+   **Push notifications**: In the **Push notifications** section click **Add push notifications**. Choose the **Application** (Viam mobile or a custom app ID). Then toggle **Send to all machine owners** on, or toggle **Send to specific users** on, add each recipient's **User email**, and click **Add user**. Recipients must be machine owners or operators. Set the **Alert frequency**.
 
 6. Set each **Alert frequency** you enabled (for example, maximum one alert per hour).
 7. Click **Save**.

--- a/docs/vision/object-detection/alert-on-detections.md
+++ b/docs/vision/object-detection/alert-on-detections.md
@@ -127,13 +127,13 @@ Add a trigger to send alerts when filtered images sync:
 
    {{<imgproc src="/tutorials/helmet/trigger.png" resize="x600" style="width: 500px" declaredimensions=true alt="The trigger configured with 'Data has been synced to the cloud' as the type and 'Binary (image)' as the data type." class="shadow imgzoom" >}}
 
-5. Add notification methods. The following options live in the **ALERT OPTIONS** and **WEBHOOKS** sections of the trigger card:
+5. Add notification methods. The following options live in the **EMAIL** and **WEBHOOK** sections of the trigger card:
 
    **Email specific addresses**: Toggle on and add email addresses. Each row has its own **Alert frequency**.
 
    **Email all machine owners**: Toggle on. Set the **Alert frequency** for the all-owners row.
 
-   **Webhook**: In the **WEBHOOKS** section click **Add Webhook**, enter the URL of your cloud function, and implement logic to process the [webhook payload](/reference/triggers/#webhook-attributes). Use this to integrate with external services like Twilio, PagerDuty, or Zapier.
+   **Webhook**: In the **WEBHOOK** section click **Add webhook**, enter the URL of your cloud function, and implement logic to process the [webhook payload](/reference/triggers/#webhook-attributes). Use this to integrate with external services like Twilio, PagerDuty, or Zapier.
 
 6. Set each **Alert frequency** you enabled (for example, maximum one alert per hour).
 7. Click **Save**.


### PR DESCRIPTION
## Source changes

- viamrobotics/app#11852: trigger card UI restructure renamed section headings and button text

## Docs changes

- `docs/vision/object-detection/alert-on-detections.md`: "**ALERT OPTIONS** and **WEBHOOKS** sections" → "**EMAIL** and **WEBHOOK** sections"; "click **Add Webhook**" → "click **Add webhook**"
- `docs/data/trigger-on-data.md`: "**Webhooks** and **Email**" → "**Webhook** and **Email**" (singular); "Click **Add Webhook**" → "Click **Add webhook**"
- `docs/monitor/alert.md`: "click **Add Webhook**" → "click **Add webhook**"

## How I found these

- Grep matches: searched entire docs repo for `ALERT OPTIONS`, `WEBHOOKS` (as section heading), and `Add Webhook`; found 3 pages with stale UI labels

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHGqDtUDo7U3psP6p9dsi1)_