### PR TITLE
Update TypeScript tab references to Browser TS / Server-side TS

### DIFF
--- a/docs/build-apps/setup/node.md
+++ b/docs/build-apps/setup/node.md
@@ -16,7 +16,7 @@ Set up a project for running Viam SDK code from a Node.js process: a backend ser
 - A configured Viam machine
 - The machine's host address, an API key, and an API key ID
 
-Get the three credentials from the machine's **CONNECT** tab in the Viam app: go to the machine's page, click **CONNECT**, select **TypeScript**, and toggle **Include API key** on. Copy the `host`, `authEntity` (API key ID), and `payload` (API key) from the generated code sample.
+Get the three credentials from the machine's **CONNECT** tab in the Viam app: go to the machine's page, click **CONNECT**, select **Server-side TS**, and toggle **Include API key** on. Copy the `host`, `authEntity` (API key ID), and `payload` (API key) from the generated code sample.
 
 ## Create a project
 

--- a/docs/build-apps/setup/react-native.md
+++ b/docs/build-apps/setup/react-native.md
@@ -21,7 +21,7 @@ The Viam TypeScript SDK does not work with Expo (neither Expo Go nor development
 - A configured Viam machine
 - The machine's address, an API key, and an API key ID
 
-Get the credentials from the machine's **CONNECT** tab in the Viam app. Click **CONNECT**, select **TypeScript**, toggle **Include API key** on, and copy the `host`, `authEntity`, and `payload` values.
+Get the credentials from the machine's **CONNECT** tab in the Viam app. Click **CONNECT**, select **Browser TS**, toggle **Include API key** on, and copy the `host`, `authEntity`, and `payload` values.
 
 ## Create a project
 

--- a/docs/build-apps/setup/typescript.md
+++ b/docs/build-apps/setup/typescript.md
@@ -16,7 +16,7 @@ Set up a project for building a Viam web app with TypeScript: a custom dashboard
 - A configured Viam machine
 - The machine's host address, an API key, and an API key ID
 
-Get all three credentials from the machine's **CONNECT** tab in the Viam app: go to the machine's page, click **CONNECT**, select **TypeScript**, and toggle **Include API key** on. Copy the `host`, `authEntity` (the API key ID), and `payload` (the API key) from the generated code sample.
+Get all three credentials from the machine's **CONNECT** tab in the Viam app: go to the machine's page, click **CONNECT**, select **Browser TS**, and toggle **Include API key** on. Copy the `host`, `authEntity` (the API key ID), and `payload` (the API key) from the generated code sample.
 
 ## Create a project
 

--- a/docs/try/viam-rover/drive-rover.md
+++ b/docs/try/viam-rover/drive-rover.md
@@ -201,7 +201,7 @@ If you have run this command and added your environment variables, skip ahead to
 
 {{< /alert >}}
 
-Go to the **CONNECT** tab and select **TypeScript**.
+Go to the **CONNECT** tab and select **Browser TS**.
 Save your API key and API key ID as environment variables or include them in the code:
 
 {{% snippet "show-secret.md" %}}

--- a/docs/tutorials/control/drive-rover.md
+++ b/docs/tutorials/control/drive-rover.md
@@ -205,7 +205,7 @@ If you have run this command and added your environment variables, skip ahead to
 
 {{< /alert >}}
 
-Go to the **CONNECT** tab and select **TypeScript**.
+Go to the **CONNECT** tab and select **Browser TS**.
 Save your API key and API key ID as environment variables or include them in the code:
 
 {{% snippet "show-secret.md" %}}


### PR DESCRIPTION
## Source changes

- viamrobotics/app#11937: Split TypeScript code sample tab into Browser TS and Server-side TS

## Docs changes

- `docs/build-apps/setup/typescript.md`: Change "select **TypeScript**" to "select **Browser TS**" (this is the browser setup page)
- `docs/build-apps/setup/node.md`: Change "select **TypeScript**" to "select **Server-side TS**" (this is the Node.js setup page)
- `docs/build-apps/setup/react-native.md`: Change "select **TypeScript**" to "select **Browser TS**" (React Native uses the browser SDK pattern for credentials)
- `docs/tutorials/control/drive-rover.md`: Change "select **TypeScript**" to "select **Browser TS**" (browser-based tutorial)

## How I found these

- Grep matches: searched all docs for `select.*TypeScript` in the context of the CONNECT tab; found 4 pages

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRuiJ5iU9XHfnG3aJipKtg)_