### PR TITLE
Update button labels: Add component/fragment → Add to machine

### DIFF
--- a/docs/fleet/deploy-software.md
+++ b/docs/fleet/deploy-software.md
@@ -43,8 +43,8 @@ To control when updates are applied, configure a maintenance window. See [manage
 1. Navigate to each machine's **CONFIGURE** tab.
 1. Click **+** and select **Configuration block**.
 1. Search for your fragment and select it.
-1. Click **Add fragment**.
-1. Click **Add fragment** again to confirm, then **Save**.
+1. Click **Add to machine**.
+1. Click **Add to machine** again to confirm, then **Save**.
 
 **Through provisioning:**
 

--- a/docs/fleet/reuse-configuration.md
+++ b/docs/fleet/reuse-configuration.md
@@ -59,8 +59,8 @@ Click **Save** after adding and configuring your resources.
 1. Navigate to your machine's **CONFIGURE** tab.
 1. Click **+** and select **Configuration block**.
 1. Search for your fragment by name and select it.
-1. Click **Add fragment**.
-1. Click **Add fragment** again to confirm.
+1. Click **Add to machine**.
+1. Click **Add to machine** again to confirm.
 1. Click **Save** in the upper right corner.
 
 The fragment's resources now appear on the machine's configuration page. The machine downloads and applies the configuration on its next sync.

--- a/docs/motion-planning/obstacles/configure-workspace-obstacles.md
+++ b/docs/motion-planning/obstacles/configure-workspace-obstacles.md
@@ -36,8 +36,8 @@ The `erh:vmodutils:obstacle` module accepts a list of geometries under one compo
 2. Click the **+** icon and select **Configuration block**.
 3. Search for `obstacle` and click the **gripper/obstacle** result card for the `erh:vmodutils` module.
    The Viam app installs the `erh:vmodutils` module automatically.
-4. Click **Add component** on the detail page.
-5. Name the component after what it represents (for example, `table`, `back-wall`, `ceiling`) and click **Add component**.
+4. Click **Add to machine** on the detail page.
+5. Name the component after what it represents (for example, `table`, `back-wall`, `ceiling`) and click **Add to machine**.
 
 {{< alert title="Why a gripper?" color="note" >}}
 The obstacle module is registered under the gripper API because that API natively exposes a `Geometries()` method, which is what the motion planner reads to pull custom collision shapes.
@@ -187,8 +187,8 @@ The component's frame positions the whole group.
 For a single primitive shape when you do not want to add the `erh:vmodutils` module, use a `generic`/`fake` component:
 
 1. Click the **+** icon and select **Configuration block**.
-2. Search for `generic` and click the **generic/fake** result card. Click **Add component**.
-3. Name the component (for example, `table`) and click **Add component**.
+2. Search for `generic` and click the **generic/fake** result card. Click **Add to machine**.
+3. Name the component (for example, `table`) and click **Add to machine**.
 4. Click **Frame** on the new component card. Replace the JSON:
 
    ```json
@@ -293,8 +293,8 @@ The motion planner should treat them as collision volume, but Viam has no compon
 Use the `generic`/`fake` pattern, parented to the moving component instead of `world`:
 
 1. Click the **+** icon and select **Configuration block**.
-2. Search for `generic` and click the **generic/fake** result card. Click **Add component**.
-3. Name the component descriptively (for example, `arm-camera-mount`) and click **Add component**.
+2. Search for `generic` and click the **generic/fake** result card. Click **Add to machine**.
+3. Name the component descriptively (for example, `arm-camera-mount`) and click **Add to machine**.
 4. Click **Frame** on the new component card. Set `parent` to the component the object attaches to (the arm's name for an end-effector mount, the gripper's name for a gripper attachment). Add a `geometry` field:
 
    ```json

--- a/docs/reference/services/vision/color_detector.md
+++ b/docs/reference/services/vision/color_detector.md
@@ -35,7 +35,7 @@ Object colors vary dramatically with lighting. Verify your target color value un
 1. Navigate to the **CONFIGURE** tab of your machine's page.
 2. Click the **+** icon next to your machine part and select **Configuration block**.
 3. In the search field, type `color detector` and select the `vision/color_detector` result.
-4. Click **Add component**, enter a name, and click **Add component** again to confirm.
+4. Click **Add to machine**, enter a name, and click **Add to machine** again to confirm.
 5. Choose a color and a hue tolerance, then set a segment size in pixels.
 6. Select a default camera.
 

--- a/docs/reference/services/vision/detections-to-segments.md
+++ b/docs/reference/services/vision/detections-to-segments.md
@@ -31,7 +31,7 @@ This model previously shipped with core RDK as `detector_3d_segmenter`. It now s
 1. In the Viam app, open your machine's **CONFIGURE** tab.
 2. Click the **+** icon next to your machine part and select **Configuration block**.
 3. In the search field, type `detections-to-segments` and select the matching result.
-4. Click **Add component**, enter a name for the service, and click **Add component** again to confirm. The module is installed automatically.
+4. Click **Add to machine**, enter a name for the service, and click **Add to machine** again to confirm. The module is installed automatically.
 
 The module downloads and starts automatically when you save the configuration.
 

--- a/docs/reference/services/vision/mlmodel.md
+++ b/docs/reference/services/vision/mlmodel.md
@@ -48,7 +48,7 @@ Configure an [ML model service](/vision/deploy-and-maintain/deploy-from-registry
 1. Navigate to the **CONFIGURE** tab of your machine's page.
 2. Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
 3. In the search field, type `vision` or `mlmodel` and select the `vision/mlmodel` result.
-4. Click **Add component**, enter a name for your service, and click **Add component** again to confirm.
+4. Click **Add to machine**, enter a name for your service, and click **Add to machine** again to confirm.
 5. In the **ML MODEL** section, select the ML model service your model is deployed on.
 6. In the **DEFAULT CAMERA** section, select the camera the service should use by default for calls such as `GetDetectionsFromCamera`.
 7. Adjust other attributes in the attributes table as applicable.

--- a/docs/train/deploy-a-model.md
+++ b/docs/train/deploy-a-model.md
@@ -32,9 +32,9 @@ see [Supported frameworks and hardware](/train/overview/#supported-frameworks-an
 2. Click **+** and select **Configuration block**.
 3. Search for the ML model service matching your framework (for example,
    `tflite_cpu`) and select the matching result.
-4. Click the block, then click **Add component**.
+4. Click the block, then click **Add to machine**.
 5. Enter a name for the service (for example, `my-ml-model`) and click
-   **Add component**. The supporting module is installed automatically.
+   **Add to machine**. The supporting module is installed automatically.
 6. In the service configuration card, under **Deployment**, leave
    **Deploy model on machine** selected.
 7. Click **Select model**. In the dialog, browse **My models** or
@@ -48,9 +48,9 @@ see [Supported frameworks and hardware](/train/overview/#supported-frameworks-an
 1. Click **+** and select **Configuration block**.
 2. Search for `mlmodel` and find the **mlmodel** block (type: **VISION**,
    built-in).
-3. Click the block, then click **Add component**.
+3. Click the block, then click **Add to machine**.
 4. Enter a name for the service (for example, `my-detector`) and click
-   **Add component**.
+   **Add to machine**.
 5. In the **ML Model** dropdown, select the ML model service you added in
    step 1 (for example, `my-ml-model`).
 6. Optionally, select a **Default Camera** and adjust the

--- a/docs/tutorials/control/gamepad.md
+++ b/docs/tutorials/control/gamepad.md
@@ -92,7 +92,7 @@ Configure a [gamepad](/reference/components/input-controller/gamepad/):
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
 Search for `gamepad`, then select the official `input_controller/gamepad` block from `viam-server`.
-Click **Add component**, enter a name (or use the suggested name) for your input controller, then click **Add component** to confirm.
+Click **Add to machine**, enter a name (or use the suggested name) for your input controller, then click **Add to machine** to confirm.
 
 Once added, you can set the `auto_reconnect` attribute to `true`. You'll find it by clicking `Show 2 optional` in the Attributes section. Don't forget to Save!
 
@@ -130,7 +130,7 @@ To link the controller's input to the base functionality, you need to configure 
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
 Search for 'base_remote_control' and select the official `base_remote_control/builtin` block from `viam-server`.
-Click **Add component**, enter a name (or use the suggested name) for your service, then click **Add component** to confirm.
+Click **Add to machine**, enter a name (or use the suggested name) for your service, then click **Add to machine** to confirm.
 
 In your base remote control service's configuration panel, copy and paste the following JSON object into the attributes field:
 

--- a/docs/vision/3d-vision/segment-3d.md
+++ b/docs/vision/3d-vision/segment-3d.md
@@ -55,7 +55,7 @@ Name the detector something memorable, for example `person_detector` or `red_blo
 1. Open the **CONFIGURE** tab in the Viam app.
 2. Click the **+** icon and select **Configuration block**.
 3. In the search field, type `detections-to-segments` and select the matching result.
-4. Click **Add component**, give the service a name (for example, `my_segmenter`), and click **Add component** again to confirm. The module is installed automatically.
+4. Click **Add to machine**, give the service a name (for example, `my_segmenter`), and click **Add to machine** again to confirm. The module is installed automatically.
 
 The module downloads and starts when you save the configuration.
 

--- a/docs/vision/configure.md
+++ b/docs/vision/configure.md
@@ -38,7 +38,7 @@ The ML model service matches your model file's framework. For most tasks, `tflit
 1. Navigate to the **CONFIGURE** tab of your machine in the Viam app.
 2. Click the **+** icon next to your machine part and select **Configuration block**.
 3. In the search field, type `tflite_cpu` (or the service matching your model format) and select the matching result. For other frameworks, see the [framework table](/vision/deploy-and-maintain/deploy-from-registry/#model-framework-support).
-4. Click **Add component**, name the service `my-ml-model`, and click **Add component** again to confirm.
+4. Click **Add to machine**, name the service `my-ml-model`, and click **Add to machine** again to confirm.
 
 ## 2. Configure the ML model service
 
@@ -118,7 +118,7 @@ For more on the deployment flow, see [Deploy a model from the registry](/vision/
 
 1. Click the **+** icon and select **Configuration block**.
 2. In the search field, type `vision` or `mlmodel` and select the `vision/mlmodel` result.
-3. Click **Add component**, name the service `my-detector`, and click **Add component** again to confirm.
+3. Click **Add to machine**, name the service `my-detector`, and click **Add to machine** again to confirm.
 
 ## 4. Configure the vision service
 

--- a/docs/vision/deploy-and-maintain/deploy-custom-model.md
+++ b/docs/vision/deploy-and-maintain/deploy-custom-model.md
@@ -77,7 +77,7 @@ On the machine you want the model to run on:
 1. Open the **CONFIGURE** tab.
 2. Click the **+** icon and select **Configuration block**.
 3. In the search field, type the ML model service name matching your model's framework (for example, `tflite_cpu` for TFLite models) and select the matching result.
-4. Click **Add component**, name the service (for example, `my-ml-model`), and click **Add component** again to confirm.
+4. Click **Add to machine**, name the service (for example, `my-ml-model`), and click **Add to machine** again to confirm.
 5. In the ML model service panel, click **Select model** and pick the model you just uploaded. Choose a version (or **Latest** during development).
 6. Save.
 

--- a/docs/vision/deploy-and-maintain/deploy-from-registry.md
+++ b/docs/vision/deploy-and-maintain/deploy-from-registry.md
@@ -62,7 +62,7 @@ The ML model service loads the model file and exposes it for inference. It does 
 1. Open your machine in the Viam app and go to the **CONFIGURE** tab.
 2. Click the **+** icon next to your machine part and select **Configuration block**.
 3. In the search field, type the ML model service name (for example, `tflite_cpu` for TFLite models) and select the matching result.
-4. Click **Add component**, give it a name (for example, `my-ml-model`), and click **Add component** again to confirm.
+4. Click **Add to machine**, give it a name (for example, `my-ml-model`), and click **Add to machine** again to confirm.
 
 ## 3. Select the model
 
@@ -84,7 +84,7 @@ The ML model service is a building block. To get detections, classifications, or
 
 1. Click the **+** icon and select **Configuration block**.
 2. In the search field, type `vision` or `mlmodel` and select the `vision/mlmodel` result.
-3. Click **Add component**, name the service (for example, `my-detector`), and click **Add component** again to confirm.
+3. Click **Add to machine**, name the service (for example, `my-detector`), and click **Add to machine** again to confirm.
 4. In the vision service panel's **ML MODEL** section, select the ML model service from step 3.
 5. In the **DEFAULT CAMERA** section, pick the camera the vision service should use by default.
 6. Save.

--- a/docs/vision/object-detection/alert-on-detections.md
+++ b/docs/vision/object-detection/alert-on-detections.md
@@ -49,7 +49,7 @@ Add the filtered camera module to your machine:
 1. Navigate to your machine's **CONFIGURE** tab.
 2. Click **+** and select **Configuration block**.
 3. In the search field, type `filtered-camera` and select the matching result.
-4. Click **Add component**, name the component `objectfilter-cam`, and click **Add component** again to confirm. The module is installed automatically.
+4. Click **Add to machine**, name the component `objectfilter-cam`, and click **Add to machine** again to confirm. The module is installed automatically.
 5. Add configuration attributes:
 
    {{< tabs >}}
@@ -106,7 +106,7 @@ Add the data management service to capture and sync filtered images:
 
 1. Click **+** and select **Configuration block**.
 2. In the search field, type `data management` and select `data_manager/builtin` from the results.
-3. Click **Add component**, name the service `data-manager`, and click **Add component** again to confirm.
+3. Click **Add to machine**, name the service `data-manager`, and click **Add to machine** again to confirm.
 4. Leave the default attributes and click **Save**.
 
 Enable data capture on the filtered camera:

--- a/docs/vision/object-detection/detect-by-color.md
+++ b/docs/vision/object-detection/detect-by-color.md
@@ -57,7 +57,7 @@ The practical approach:
 1. Open the **CONFIGURE** tab in the Viam app.
 2. Click the **+** icon and select **Configuration block**.
 3. In the search field, type `color detector` and select the `vision/color_detector` result.
-4. Click **Add component**, name the service (for example, `red_detector`), and click **Add component** again to confirm.
+4. Click **Add to machine**, name the service (for example, `red_detector`), and click **Add to machine** again to confirm.
 
 ## 3. Configure the detector
 

--- a/docs/vision/object-detection/track.md
+++ b/docs/vision/object-detection/track.md
@@ -43,7 +43,7 @@ For example, the first person detected becomes `person_0_20250413_143052`. The `
 
 1. Click **+** and select **Configuration block**.
 2. In the search field, type `object-tracker` and select the `viam:vision:object-tracker` result (the card shows the module name and model name; the badge says `VISION`).
-3. Click **Add component**, name the service (for example, `my-tracker`), and click **Add component** again to confirm. The module is installed automatically.
+3. Click **Add to machine**, name the service (for example, `my-tracker`), and click **Add to machine** again to confirm. The module is installed automatically.
 
 ### 2. Configure attributes
 


### PR DESCRIPTION
## Source changes

- viamrobotics/app#12057: Distinguish services/components in "add blocks" dialog — changes the confirm button text from "Add component" (or "Add fragment") to "Add to machine" in all contexts (detail page button and create-block dialog submit button).

## Docs changes

- docs/fleet/deploy-software.md: "Add fragment" → "Add to machine" (2 instances)
- docs/fleet/reuse-configuration.md: "Add fragment" → "Add to machine" (2 instances)
- docs/motion-planning/obstacles/configure-workspace-obstacles.md: "Add component" → "Add to machine" (6 instances)
- docs/reference/services/vision/color_detector.md: "Add component" → "Add to machine" (2 instances)
- docs/reference/services/vision/detections-to-segments.md: "Add component" → "Add to machine" (2 instances)
- docs/reference/services/vision/mlmodel.md: "Add component" → "Add to machine" (2 instances)
- docs/train/deploy-a-model.md: "Add component" → "Add to machine" (4 instances)
- docs/tutorials/control/gamepad.md: "Add component" → "Add to machine" (4 instances)
- docs/vision/3d-vision/segment-3d.md: "Add component" → "Add to machine" (2 instances)
- docs/vision/configure.md: "Add component" → "Add to machine" (4 instances)
- docs/vision/deploy-and-maintain/deploy-custom-model.md: "Add component" → "Add to machine" (2 instances)
- docs/vision/deploy-and-maintain/deploy-from-registry.md: "Add component" → "Add to machine" (4 instances)
- docs/vision/object-detection/alert-on-detections.md: "Add component" → "Add to machine" (4 instances)
- docs/vision/object-detection/detect-by-color.md: "Add component" → "Add to machine" (2 instances)
- docs/vision/object-detection/track.md: "Add component" → "Add to machine" (2 instances)

## How I found these

- Grep matches: `grep -rn "Add component|Add fragment"` across the entire docs repo found 30+ references in 15 files
- Verified against source code: `ui/src/lib/components/robot/add-resource-menu/create-block-modal/content-rdk-builtin.svelte`, `content-registry-item.svelte`, `content-fragment.svelte`, and `block-page-header.svelte`

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_019Tvr6JxD2UJ9pcCqZLXHq3)_