### PR TITLE
Add cylinder geometry type to obstacle docs

### DIFF
--- a/docs/motion-planning/3d-scene/set-up-obstacle-avoidance.md
+++ b/docs/motion-planning/3d-scene/set-up-obstacle-avoidance.md
@@ -7,7 +7,7 @@ type: "docs"
 description: "Visualize and adjust obstacle geometry so the motion planner routes around physical objects."
 ---
 
-The motion planner avoids obstacles only if it knows about them, and it knows about them only as geometries you define: boxes, spheres, or capsules positioned in the frame system. That definition is invisible in JSON. A box specified as `{x: 800, y: 1200, z: 20}` at some parent-relative translation either covers the table or it doesn't, and you can't tell which from the numbers. The **3D SCENE** tab lets you see what the planner sees, so you can check coverage before running a plan.
+The motion planner avoids obstacles only if it knows about them, and it knows about them only as geometries you define: boxes, spheres, capsules, or cylinders positioned in the frame system. That definition is invisible in JSON. A box specified as `{x: 800, y: 1200, z: 20}` at some parent-relative translation either covers the table or it doesn't, and you can't tell which from the numbers. The **3D SCENE** tab lets you see what the planner sees, so you can check coverage before running a plan.
 
 ## Prerequisites
 

--- a/docs/motion-planning/obstacles/configure-workspace-obstacles.md
+++ b/docs/motion-planning/obstacles/configure-workspace-obstacles.md
@@ -15,7 +15,7 @@ Three config patterns cover most cases:
 | Pattern                                                                   | Use when                                                                                               |
 | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | [`erh:vmodutils:obstacle`](#default-obstacle-pattern)                     | Most workspace obstacles: tables, walls, fixtures, bespoke shapes. One component, any geometry.        |
-| [`rdk:builtin:fake` generic component](#configure-a-single-primitive)     | A single box, sphere, or capsule when you do not want to add a registry module.                        |
+| [`rdk:builtin:fake` generic component](#configure-a-single-primitive)     | A single box, sphere, capsule, or cylinder when you do not want to add a registry module.              |
 | [`erh:vmodutils:obstacle-open-box`](#containers-and-work-cell-boundaries) | Containers, bins, or rectangular work-cell envelopes. Generates five geometries from outer dimensions. |
 
 For obstacles your code builds at runtime (objects detected by vision, temporary keep-out zones), see [Plan collision-free paths](/motion-planning/obstacles/avoid-obstacles/) instead.
@@ -368,7 +368,7 @@ For the full visualization and verification workflow, see [Verify obstacles](/mo
 
 - A box with fewer than three dimensions (a box needs all three: `x`, `y`, `z`).
 - A capsule with `l` less than twice `r` (capsule length must be at least twice the radius).
-- A mistyped `type` value (valid values are `box`, `sphere`, `capsule`, `point`, `mesh`).
+- A mistyped `type` value (valid values are `box`, `sphere`, `capsule`, `cylinder`, `point`, `mesh`).
 
 Fix the geometry in the component's attributes and save again.
 

--- a/docs/motion-planning/obstacles/overview.md
+++ b/docs/motion-planning/obstacles/overview.md
@@ -40,16 +40,17 @@ serve as keep-out zones; the planner treats them identically.
 
 ### Geometry types
 
-Viam supports five geometry types for defining obstacles. The three primitives
+Viam supports six geometry types for defining obstacles. The four primitives
 are the most commonly used:
 
-| Type        | JSON `type` | Config fields                          | Best for                                                                                                                                         |
-| ----------- | ----------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Box**     | `"box"`     | `x`, `y`, `z` (dimensions in mm)       | Tables, shelves, walls, rectangular equipment. Match surface dimensions; include thickness if the arm could approach from below.                 |
-| **Sphere**  | `"sphere"`  | `r` (radius in mm)                     | Balls, round obstacles, keep-out zones. Use the bounding radius.                                                                                 |
-| **Capsule** | `"capsule"` | `r` (radius in mm), `l` (length in mm) | Posts, columns, pipes. Set the radius to match the column width and length to the height.                                                        |
-| **Point**   | `"point"`   | (none, position only)                  | Single points in space.                                                                                                                          |
-| **Mesh**    | `"mesh"`    | `mesh_data`, `mesh_content_type`       | Complex shapes from STL/PLY files when no primitive fits. More expensive to collision-check; use a primitive bounding shape if accuracy permits. |
+| Type         | JSON `type`  | Config fields                          | Best for                                                                                                                                         |
+| ------------ | ------------ | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Box**      | `"box"`      | `x`, `y`, `z` (dimensions in mm)       | Tables, shelves, walls, rectangular equipment. Match surface dimensions; include thickness if the arm could approach from below.                 |
+| **Sphere**   | `"sphere"`   | `r` (radius in mm)                     | Balls, round obstacles, keep-out zones. Use the bounding radius.                                                                                 |
+| **Capsule**  | `"capsule"`  | `r` (radius in mm), `l` (length in mm) | Posts, columns, pipes. Set the radius to match the column width and length to the height.                                                        |
+| **Cylinder** | `"cylinder"` | `r` (radius in mm), `l` (height in mm) | Cylindrical obstacles like cans, drums, and flat discs. Unlike capsule, a cylinder can be arbitrarily flat (no minimum height-to-radius ratio).  |
+| **Point**    | `"point"`    | (none, position only)                  | Single points in space.                                                                                                                          |
+| **Mesh**     | `"mesh"`     | `mesh_data`, `mesh_content_type`       | Complex shapes from STL/PLY files when no primitive fits. More expensive to collision-check; use a primitive bounding shape if accuracy permits. |
 
 For irregular objects, use a Box that fully encloses the object (over-approximation is safer than under-approximation, even though it shrinks the planner's solution space).
 

--- a/docs/motion-planning/reference/kinematics.md
+++ b/docs/motion-planning/reference/kinematics.md
@@ -190,7 +190,7 @@ Each field:
 - **`links[].id`**: unique name for the link
 - **`links[].parent`**: the joint or frame this link attaches to
 - **`links[].translation`**: offset in mm from the parent's origin
-- **`links[].geometry`**: optional collision shape (uses `type`, `x`/`y`/`z` for box, `r` for sphere/capsule, `l` for capsule length)
+- **`links[].geometry`**: optional collision shape (uses `type`, `x`/`y`/`z` for box, `r` for sphere/capsule/cylinder, `l` for capsule length or cylinder height)
 - **`joints[].id`**: unique name for the joint
 - **`joints[].type`**: `"revolute"` (rotates) or `"prismatic"` (slides)
 - **`joints[].parent`**: the link this joint attaches to

--- a/docs/reference/services/frame-system/_index.md
+++ b/docs/reference/services/frame-system/_index.md
@@ -50,7 +50,7 @@ You can configure a reference frame within the frame system for each of your mac
 | `parent`  | **Required** | The name of the reference frame you want to act as the parent of this frame. <br> Default: `world`. |
 | `translation` | **Required** | The coordinates that the origin of this component's reference frame has within its parent reference frame. <br> Units: Millimeters. <br> Default: `(0, 0, 0)`. |
 | `orientation`  | **Required** | The [orientation vector](/motion-planning/reference/orientation-vectors/) that yields the axes of the component's reference frame when applied as a rotation to the axes of the parent reference frame. <br> Types: Orientation vector in degrees (`ov_degrees`), orientation vector in radians (`ov_radians`), Euler angles (`euler_angles`), and quaternion (`quaternion`). <br> Default: `(0, 0, 1), 0`. |
-| `geometry`  | Optional | Collision geometries for defining bounds in the environment of the machine. <br> Units: Millimeters. <br> Types: `sphere`, `box`, and `capsule`. <br> Default: `none`. |
+| `geometry`  | Optional | Collision geometries for defining bounds in the environment of the machine. <br> Units: Millimeters. <br> Types: `sphere`, `box`, `capsule`, and `cylinder`. <br> Default: `none`. |
 
 {{< tabs >}}
 {{% tab name="JSON Template" %}}


### PR DESCRIPTION
## Source changes

- viamrobotics/rdk#6014: Add cylinder geometry (RSDK-13940) — adds `CylinderType = GeometryType("cylinder")` to the geometry config system, with `r` (radius) and `l` (height) config fields.

## Docs changes

- docs/motion-planning/obstacles/overview.md: Updated geometry types table from 5 to 6 types, added Cylinder row with config fields and usage guidance
- docs/motion-planning/obstacles/configure-workspace-obstacles.md: Added "cylinder" to valid type values list in troubleshooting section; added cylinder to the method comparison table
- docs/motion-planning/3d-scene/set-up-obstacle-avoidance.md: Added "cylinders" to the list of geometry types in the opening paragraph
- docs/motion-planning/reference/kinematics.md: Added cylinder to the geometry field description for kinematic links

## How I found these

- Xref lookup: `config-xref.md` → geometry types in motion-planning section
- Grep matches: `grep -rn "cylinder|geometry.*type"` found 4 files with relevant references to the geometry type enumeration

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_019Tvr6JxD2UJ9pcCqZLXHq3)_