### PR TITLE
Add deploy-from-model-page workflow to deploy docs

### DIFF
--- a/docs/train/deploy-a-model.md
+++ b/docs/train/deploy-a-model.md
@@ -21,7 +21,7 @@ The fastest way to deploy a model is from the model's page in the Viam app:
 
 1. Navigate to **Models** and click the model you want to deploy.
 1. Click **Deploy** in the model header to open the deploy dialog, which walks you through a few steps.
-1. On the first step, select a model version, location, machine, and machine part, then click **Continue**.
+1. Select a model version, location, machine, and machine part, then click **Continue**.
 1. Name the ML model service, then click **Continue**.
 1. Name the vision service. By default, it uses an existing camera on your machine.
 1. Click **Deploy** to add the services to the machine's configuration.

--- a/docs/train/deploy-a-model.md
+++ b/docs/train/deploy-a-model.md
@@ -21,12 +21,12 @@ The fastest way to deploy a model is from the model's page in the Viam app:
 
 1. Navigate to **Models** and click the model you want to deploy.
 1. Click **Deploy** in the model header.
-1. Select a model version (or leave it on **Latest**).
-1. Select a location, machine, and machine part.
-1. Enter a name for the ML model service and optionally check **Include vision service** to create a vision service at the same time.
-1. Click **Deploy**. The ML model service (and vision service, if selected) are added to the machine's configuration automatically.
+1. Select a model version, location, machine, and machine part.
+1. Name the ML model service. **Include Vision service** is selected by default; clear it to deploy only the model.
+1. If you keep the vision service, name it. It uses a camera already configured on the machine.
+1. Click **Deploy**. The services are added to the machine's configuration.
 
-After deploying, verify the model is running by navigating to the machine's **CONTROL** tab and testing the vision service.
+After deploying, verify the model on the machine's **CONTROL** tab.
 
 ## Deploy from the machine's configure tab
 

--- a/docs/train/deploy-a-model.md
+++ b/docs/train/deploy-a-model.md
@@ -20,11 +20,11 @@ For the full guide to configuring vision services and cloud inference, see [Conf
 The fastest way to deploy a model is from the model's page in the Viam app:
 
 1. Navigate to **Models** and click the model you want to deploy.
-1. Click **Deploy** in the model header.
-1. Select a model version, location, machine, and machine part.
-1. Name the ML model service. **Include Vision service** is selected by default; clear it to deploy only the model.
-1. If you keep the vision service, name it. It uses a camera already configured on the machine.
-1. Click **Deploy**. The services are added to the machine's configuration.
+1. Click **Deploy** in the model header to open the deploy dialog, which walks you through a few steps.
+1. On the first step, select a model version, location, machine, and machine part, then click **Continue**.
+1. Name the ML model service, then click **Continue**.
+1. Name the vision service. By default, it uses an existing camera on your machine.
+1. Click **Deploy** to add the services to the machine's configuration.
 
 After deploying, verify the model on the machine's **CONTROL** tab.
 

--- a/docs/train/deploy-a-model.md
+++ b/docs/train/deploy-a-model.md
@@ -15,7 +15,24 @@ vision service to run it against camera input.
 For the full guide to configuring vision services and cloud inference, see [Configure computer vision](/vision/configure/).
 {{< /alert >}}
 
-## 1. Add the ML model service
+## Deploy from the model details page
+
+The fastest way to deploy a model is from the model's page in the Viam app:
+
+1. Navigate to **Models** and click the model you want to deploy.
+1. Click **Deploy** in the model header.
+1. Select a model version (or leave it on **Latest**).
+1. Select a location, machine, and machine part.
+1. Enter a name for the ML model service and optionally check **Include vision service** to create a vision service at the same time.
+1. Click **Deploy**. The ML model service (and vision service, if selected) are added to the machine's configuration automatically.
+
+After deploying, verify the model is running by navigating to the machine's **CONTROL** tab and testing the vision service.
+
+## Deploy from the machine's configure tab
+
+To deploy a model by configuring services manually:
+
+### 1. Add the ML model service
 
 The ML model service loads the model. Pick the module that matches your
 trained model's framework:
@@ -43,7 +60,7 @@ see [Supported frameworks and hardware](/train/overview/#supported-frameworks-an
    **Choose**. The model path and label path are set automatically.
 9. Click **Save** in the top right.
 
-## 2. Add the vision service
+### 2. Add the vision service
 
 1. Click **+** and select **Configuration block**.
 2. Search for `mlmodel` and find the **mlmodel** block (type: **VISION**,
@@ -57,7 +74,7 @@ see [Supported frameworks and hardware](/train/overview/#supported-frameworks-an
    **Minimum confidence threshold** (default: 0.5).
 7. Click **Save**.
 
-## 3. Verify
+### 3. Verify
 
 1. In the vision service's configuration card, click **Test**.
 2. Select a camera to run the model against.


### PR DESCRIPTION
## Source changes

- viamrobotics/app#11977: Deploy models (APP-16216). Adds a Deploy button to the model details page header and a multi-step dialog that creates an ML model service and optional vision service on a selected machine.

## Docs changes

- `docs/train/deploy-a-model.md`: Added a "Deploy from the model details page" section documenting the new one-click deploy workflow. Restructured the existing manual CONFIGURE tab steps under a "Deploy from the machine's configure tab" heading with nested sub-headings.

## How I found these

- Grep matches: `deploy model`, `Deploy model`, `tflite_cpu` matched 8+ files across the docs. The existing deploy-a-model.md page only described the manual CONFIGURE tab flow.

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7cWYC17gfsc8w7vLx82q7)_