### PR TITLE
Add PlayStream to audio out API docs

### DIFF
--- a/.github/workflows/sdk_protos_map.csv
+++ b/.github/workflows/sdk_protos_map.csv
@@ -28,6 +28,7 @@ audio_in,Close,,close,Close,,
 
 ## AudioOut
 audio_out,Play,,play,Play,play,play
+audio_out,PlayStream,,play_stream,PlayStream,,
 audio_out,GetProperties,,get_properties,Properties,getProperties,getProperties
 audio_out,GetGeometries,,get_geometries,,,
 audio_out,Reconfigure,,,Reconfigure,,

--- a/.github/workflows/sdk_protos_map.csv
+++ b/.github/workflows/sdk_protos_map.csv
@@ -28,7 +28,7 @@ audio_in,Close,,close,Close,,
 
 ## AudioOut
 audio_out,Play,,play,Play,play,play
-audio_out,PlayStream,,play_stream,PlayStream,,
+audio_out,PlayStream,,play_stream,PlayStream,playStream,playStream
 audio_out,GetProperties,,get_properties,Properties,getProperties,getProperties
 audio_out,GetGeometries,,get_geometries,,,
 audio_out,Reconfigure,,,Reconfigure,,

--- a/static/include/components/apis/generated/audio_out-table.md
+++ b/static/include/components/apis/generated/audio_out-table.md
@@ -2,6 +2,7 @@
 | Method Name | Description |
 | ----------- | ----------- |
 | [`Play`](/reference/apis/components/audio-out/#play) | Play the given audio data. |
+| [`PlayStream`](/reference/apis/components/audio-out/#playstream) | Stream audio data in chunks for playback. |
 | [`GetProperties`](/reference/apis/components/audio-out/#getproperties) | Get the audio device’s properties. |
 | [`GetGeometries`](/reference/apis/components/audio-out/#getgeometries) | Get all the geometries associated with the audio out component in its current configuration, in the frame of the audio out component. |
 | [`Reconfigure`](/reference/apis/components/audio-out/#reconfigure) | Reconfigure this resource. |

--- a/static/include/components/apis/generated/audio_out.md
+++ b/static/include/components/apis/generated/audio_out.md
@@ -38,7 +38,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 - `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
 - `data` [([]byte)](https://pkg.go.dev/builtin#byte)
-- `info` [(*utils.AudioInfo)](https://pkg.go.dev/go.viam.com/rdk/utils#AudioInfo)
+- `info` [(\*utils.AudioInfo)](https://pkg.go.dev/go.viam.com/rdk/utils#AudioInfo)
 - `extra` [(map[string]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
 
 **Returns:**
@@ -91,6 +91,77 @@ For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_s
 {{% /tab %}}
 {{< /tabs >}}
 
+### PlayStream
+
+Stream audio data in chunks for playback.
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+**Parameters:**
+
+- `chunks` ([AsyncIterator](https://docs.python.org/3/library/collections.abc.html#collections.abc.AsyncIterator)[[bytes](https://docs.python.org/3/library/stdtypes.html#bytes-objects)]) (required): Async iterator of audio data chunks to play.
+- `info` (viam.components.audio_out.audio_out.AudioInfo) (optional): Information about the audio data such as codec, sample rate, and channel count.
+- `extra` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (optional): Extra options to pass to the underlying RPC call.
+- `timeout` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
+
+**Returns:**
+
+- None.
+
+**Example:**
+
+```python {class="line-numbers linkable-line-numbers"}
+my_audio_out = AudioOut.from_robot(robot=machine, name="my_audio_out")
+
+async def audio_generator():
+    for chunk in audio_chunks:
+        yield chunk
+
+audio_info = AudioInfo(codec=AudioCodec.PCM16, sample_rate_hz=44100, num_channels=2)
+await my_audio_out.play_stream(audio_generator(), audio_info)
+```
+
+For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/audio_out/client/index.html#viam.components.audio_out.client.AudioOutClient.play_stream).
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+**Parameters:**
+
+- `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
+- `info` [(\*utils.AudioInfo)](https://pkg.go.dev/go.viam.com/rdk/utils#AudioInfo): Information about the audio data such as codec, sample rate, and channel count.
+- `chunks` [(<-chan []byte)](https://pkg.go.dev/builtin#byte): A receive-only channel of audio data chunks. Close the channel to signal end of stream.
+- `extra` [(map[string]interface{})](https://go.dev/blog/maps): Extra options to pass to the underlying RPC call.
+
+**Returns:**
+
+- [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
+
+**Example:**
+
+```go {class="line-numbers linkable-line-numbers"}
+myAudioOut, err := audioout.FromProvider(machine, "my_audio_out")
+
+info := &utils.AudioInfo{
+  Codec:        utils.CodecPCM16,
+  SampleRateHz: 44100,
+  NumChannels:  2,
+}
+
+chunks := make(chan []byte, 2)
+chunks <- audioChunk1
+chunks <- audioChunk2
+close(chunks)
+
+err = myAudioOut.PlayStream(context.Background(), info, chunks, nil)
+```
+
+For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/audioout#AudioOut).
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ### GetProperties
 
 Get the audio device’s properties.
@@ -105,7 +176,7 @@ Get the audio device’s properties.
 
 **Returns:**
 
-- ([viam.components.audio_out.audio_out.AudioOut.Properties](https://python.viam.dev/autoapi/viam/components/audio_out/audio_out/index.html#viam.components.audio_out.audio_out.AudioOut.Properties)): :   The properties of the audio output device.
+- ([viam.components.audio_out.audio_out.AudioOut.Properties](https://python.viam.dev/autoapi/viam/components/audio_out/audio_out/index.html#viam.components.audio_out.audio_out.AudioOut.Properties)): : The properties of the audio output device.
 
 **Example:**
 
@@ -146,7 +217,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/c
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const audioOut = new VIAM.AudioOutClient(machine, 'my_audio_out');
+const audioOut = new VIAM.AudioOutClient(machine, "my_audio_out");
 const properties = await audioOut.getProperties();
 ```
 
@@ -183,7 +254,7 @@ The [motion](/reference/services/motion/) and [navigation](/reference/services/n
 
 **Returns:**
 
-- ([List[viam.proto.common.Geometry]](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.Geometry)): :   The geometries associated with the Component.
+- ([List[viam.proto.common.Geometry]](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.Geometry)): : The geometries associated with the Component.
 
 **Example:**
 
@@ -241,7 +312,7 @@ If you are implementing your own arm and want to add features that have no corre
 
 **Returns:**
 
-- (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), viam.utils.ValueTypes]): :   Result of the executed command.
+- (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), viam.utils.ValueTypes]): : Result of the executed command.
 
 **Raises:**
 
@@ -299,14 +370,14 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 ```ts {class="line-numbers linkable-line-numbers"}
 // Plain object (recommended)
 const result = await resource.doCommand({
-  myCommand: { key: 'value' },
+  myCommand: { key: "value" },
 });
 
 // Struct (still supported)
-import { Struct } from '@viamrobotics/sdk';
+import { Struct } from "@viamrobotics/sdk";
 
 const result = await resource.doCommand(
-  Struct.fromJson({ myCommand: { key: 'value' } })
+  Struct.fromJson({ myCommand: { key: "value" } }),
 );
 ```
 
@@ -349,7 +420,7 @@ Get the `ResourceName` for this audio out component.
 
 **Returns:**
 
-- ([viam.proto.common.ResourceName](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.ResourceName)): :   The ResourceName of this Resource.
+- ([viam.proto.common.ResourceName](https://python.viam.dev/autoapi/viam/proto/common/index.html#viam.proto.common.ResourceName)): : The ResourceName of this Resource.
 
 **Example:**
 
@@ -394,7 +465,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-audio_out.name
+audio_out.name;
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AudioOutClient.html#name).

--- a/static/include/components/apis/generated/audio_out.md
+++ b/static/include/components/apis/generated/audio_out.md
@@ -160,6 +160,67 @@ err = myAudioOut.PlayStream(context.Background(), info, chunks, nil)
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/components/audioout#AudioOut).
 
 {{% /tab %}}
+{{% tab name="TypeScript" %}}
+
+**Parameters:**
+
+- `audioInfo` ([AudioInfo](https://ts.viam.dev/classes/commonApi.AudioInfo.html)) (required): Information about the audio format (codec, sample rate, channels) that applies to every chunk.
+- `chunks` (AsyncIterable\<Uint8Array\>) (required): Async iterable of audio byte chunks to play in order.
+- `extra` (None) (optional)
+- `callOptions` (CallOptions) (optional)
+
+**Returns:**
+
+- (Promise\<void\>)
+
+**Example:**
+
+```ts {class="line-numbers linkable-line-numbers"}
+const audioOut = new VIAM.AudioOutClient(machine, "my_audio_out");
+const audioInfo = {
+  codec: "pcm16",
+  sampleRateHz: 22050,
+  numChannels: 1,
+};
+
+async function* chunks() {
+  for (const chunk of pcmChunks) yield chunk;
+}
+
+await audioOut.playStream(audioInfo, chunks());
+```
+
+For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/classes/AudioOutClient.html#playstream).
+
+{{% /tab %}}
+{{% tab name="Flutter" %}}
+
+**Parameters:**
+
+- `audioInfo` [AudioInfo](https://flutter.viam.dev/viam_protos.common.common/AudioInfo-class.html) (required): Information about the audio format (codec, sample rate, channels) that applies to every chunk.
+- `audioStream` [Stream](https://api.flutter.dev/flutter/dart-async/Stream-class.html)\<[Uint8List](https://api.flutter.dev/flutter/dart-typed_data/Uint8List-class.html)\> (required): A stream of raw audio byte chunks to play in order.
+- `extra` [Map](https://api.flutter.dev/flutter/dart-core/Map-class.html)\<[String](https://api.flutter.dev/flutter/dart-core/String-class.html), dynamic\>? (optional)
+
+**Returns:**
+
+- [Future](https://api.flutter.dev/flutter/dart-async/Future-class.html)\<[PlayStreamResponse](https://flutter.viam.dev/viam_protos.component.audioout/PlayStreamResponse-class.html)\>
+
+**Example:**
+
+```dart {class="line-numbers linkable-line-numbers"}
+final audioOut = AudioOut.fromRobot(robot, 'my_audio_out');
+final audioInfo = AudioInfo()
+  ..codec = AudioCodec.PCM16
+  ..sampleRateHz = 22050
+  ..numChannels = 1;
+
+final stream = Stream.fromIterable(audioChunks);
+await audioOut.playStream(audioInfo: audioInfo, audioStream: stream);
+```
+
+For more information, see the [Flutter SDK Docs](https://flutter.viam.dev/viam_sdk/AudioOutClient/playStream.html).
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ### GetProperties

--- a/static/include/components/apis/overrides/protos/audio_out.PlayStream.md
+++ b/static/include/components/apis/overrides/protos/audio_out.PlayStream.md
@@ -1,0 +1,1 @@
+Stream audio data in chunks for playback.


### PR DESCRIPTION
## Source changes

- viamrobotics/api#850: Add PlayStream client-streaming RPC to AudioOutService proto
- viamrobotics/rdk#6012: Implement PlayStream in Go SDK (RSDK-13973)
- viamrobotics/viam-python-sdk#1219: Python SDK play_stream() implementation
- viamrobotics/viam-cpp-sdk#637: C++ SDK play_stream() implementation
- viamrobotics/viam-typescript-sdk#950: TypeScript SDK playStream() implementation (RSDK-13975)
- viamrobotics/viam-flutter-sdk#537: Flutter SDK playStream() implementation (RSDK-13978)

## Docs changes

- `static/include/components/apis/generated/audio_out-table.md`: Add PlayStream row to method table
- `static/include/components/apis/generated/audio_out.md`: Add PlayStream section with Python, Go, TypeScript, and Flutter tabs (parameters, return types, code examples)
- `static/include/components/apis/overrides/protos/audio_out.PlayStream.md`: Add override description
- `.github/workflows/sdk_protos_map.csv`: Add PlayStream mapping entry for all four SDKs

## How I found these

- Backlog item `api-d38336e-audioout-playstream` was deferred until Go or TypeScript SDK added a wrapper. Go SDK added PlayStream in rdk#6012 (2026-05-22), meeting the deferral condition.
- TypeScript SDK (#950) and Flutter SDK (#537) added PlayStream after the initial PR was created. Updated 2026-06-09 to add TS and Flutter tabs.
- Grep matches: zero existing docs references to PlayStream (new method, not a fix to stale content).

---
Generated by daily docs change agent