### PR TITLE
glossary: render full term content; fix gantry id collision

### DIFF
--- a/docs/reference/glossary/gantry.md
+++ b/docs/reference/glossary/gantry.md
@@ -1,6 +1,6 @@
 ---
 title: Gantry
-id: attribute
+id: gantry
 full_link: /components/gantry/
 short_description: A mechanical system that only uses linear motion to carry out a task.
 aliases:

--- a/docs/reference/glossary/ml.md
+++ b/docs/reference/glossary/ml.md
@@ -11,4 +11,4 @@ aliases:
 
 ML stands for machine learning, a field of artificial intelligence that focuses on building systems that can learn from and make decisions based on data.
 
-Viam provides tools for [training ML models](/train/custom-training-scripts/), [deploying them to machines](/vision/configure/), [running inference](/vision/detect/), and [interpret visual data from cameras](/vision/alert-on-detections/) to enable intelligent behavior in robotic systems.
+Viam provides tools for [training ML models](/train/custom-training-scripts/), [deploying them to machines](/vision/configure/), [running inference](/vision/object-detection/detect/), and [interpret visual data from cameras](/vision/object-detection/alert-on-detections/) to enable intelligent behavior in robotic systems.

--- a/layouts/docs/glossary.html
+++ b/layouts/docs/glossary.html
@@ -44,7 +44,7 @@
                           </h4>
                         </div>
                         <div id="{{ .Params.id }}">
-                            {{ .Content | strings.TrimPrefix .Summary | safeHTML }}
+                            {{ .Content | safeHTML }}
                         </div>
                       </div>
                     {{ end }}


### PR DESCRIPTION
## Summary

- The glossary layout was stripping each term's `Summary` from its `Content` before rendering, leaving **40 of 54 short-bodied terms blank** on the rendered page (`component`, `job`, `frame`, `part`, `service`, `module`, etc.). There's no separate `Summary` render above this line, so the trim served no purpose and silently wiped any body that Hugo's 70-word auto-summary covered in full. Long terms (`flashed`, `world-frame`, `api-namespace-triplet`, etc.) rendered correctly because their content exceeded the auto-summary length.
- The `strings.TrimPrefix .Summary` line has been in the template since PR #975 (2022) — this isn't a new-docs-site regression, just a long-standing bug that nobody noticed because the most-linked terms also had short bodies.
- Removing the trim exposed a latent id collision: `gantry.md` had `id: attribute`, which previously produced two empty divs but now produces two duplicate `<div id="attribute">` blocks. Corrected to `id: gantry`. No docs reference the old anchor.

## Test plan

- [ ] Netlify deploy preview: `/reference/glossary/` shows definitions for every term (component, job, frame, part, service, module, base, board, location, etc. — previously blank).
- [ ] Spot-check that anchors still work: `#term-component`, `#term-gantry`, `#term-flash` all scroll to their entry.
- [ ] Glossary tooltips elsewhere in docs still resolve (e.g. any page using `{{< glossary_tooltip term_id="machine" ... >}}`).