### PR TITLE
Document saved queries and the Query Assistant [Waiting for Outside Review]

### DIFF
--- a/docs/data/overview.md
+++ b/docs/data/overview.md
@@ -26,7 +26,7 @@ To get started recording data, see [Capture and sync data](/data/capture-sync/ca
 
 ## Query and explore
 
-All captured tabular data is queryable through SQL and MQL, either in the Viam app's query editor or programmatically through the SDK. You can run ad-hoc queries for data exploration, create custom indexes to speed up frequent queries, and save queries for reuse. An AI-assisted query builder helps you write MQL aggregation pipelines.
+All captured tabular data is queryable through SQL and MQL, either in the Viam app's query editor or programmatically through the SDK. You can run ad-hoc queries for data exploration, create custom indexes to speed up frequent queries, and save MQL queries for reuse. The Query Assistant (Beta) helps you write SQL and MQL queries from a plain-language description.
 
 Binary data (images, point clouds) is browsable and filterable in the Viam app's Data tab, with viewers for images, video, and 3D point clouds.
 

--- a/docs/data/query-data-from-code.md
+++ b/docs/data/query-data-from-code.md
@@ -213,6 +213,44 @@ for _, entry := range results {
 {{% /tab %}}
 {{< /tabs >}}
 
+## Reuse a saved query
+
+If you saved a query in the Viam app's query editor, you can run it from code by passing its name as `query_prefix_name`. The saved query runs first, and any stages you include in `query` run on its output, so you can keep a common pipeline in one place and add stages when you call it.
+
+{{< tabs >}}
+{{% tab name="Python" %}}
+
+```python
+# Run the saved query "daily-averages", then keep the top 10 results
+results = await data_client.tabular_data_by_mql(
+    organization_id=ORG_ID,
+    query=[
+        {"$limit": 10},
+    ],
+    query_prefix_name="daily-averages",
+)
+```
+
+{{% /tab %}}
+{{% tab name="Go" %}}
+
+```go
+// Run the saved query "daily-averages", then keep the top 10 results
+results, err := dataClient.TabularDataByMQL(ctx, orgID,
+    []map[string]interface{}{
+        {"$limit": 10},
+    },
+    &app.TabularDataByMQLOptions{QueryPrefixName: "daily-averages"})
+if err != nil {
+    logger.Fatal(err)
+}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+Saving queries is available for MQL only. See [Save and reuse queries](/data/query-data/#save-and-reuse-queries) to create one in the app.
+
 ## What's next
 
 - [Query reference](/data/reference/): schema, supported operators, and optimization tips

--- a/docs/data/query-data.md
+++ b/docs/data/query-data.md
@@ -248,6 +248,14 @@ The `$unwind` stage is important when your data contains arrays. It flattens
 the array so each element becomes its own document, which you can then filter
 and project individually.
 
+## Save and reuse queries
+
+You can save MQL queries for reuse. To save a query, switch to MQL mode, click **Save query**, and give it a name. It appears under the **Saved** tab in the editor sidebar, next to a **Recent** tab of your recent queries. Saved queries are available to your whole organization. Saving is not available for SQL queries.
+
+## Get help writing queries with the Query Assistant
+
+The **Query Assistant** (Beta) is a chat panel that turns a plain-language description into a query. It works in both SQL and MQL: click **Assistant**, describe the data you want, and click **Insert** to add the suggested query to the editor. It helps whenever you are not sure how to express what you want, from a simple filter to a multi-stage MQL aggregation pipeline.
+
 ## Query from code
 
 You can run the same SQL and MQL queries from Python or Go using the data client API. See [Query data from code](/data/query-data-from-code/) for setup instructions and examples.

--- a/docs/data/query-data.md
+++ b/docs/data/query-data.md
@@ -250,7 +250,7 @@ and project individually.
 
 ## Save and reuse queries
 
-You can save MQL queries for reuse. To save a query, switch to MQL mode, click **Save query**, and give it a name. It appears under the **Saved** tab in the editor sidebar, next to a **Recent** tab of your recent queries. Saved queries are available to your whole organization. Saving is not available for SQL queries.
+You can save MQL queries for reuse. To save a query, switch to MQL mode, click **Save query**, and give it a name. It appears under the **Saved** tab in the editor sidebar, next to a **Recent** tab of your recent queries. Saved queries are available to your whole organization. You can also run a saved query from code by passing its name to [`TabularDataByMQL`](/data/query-data-from-code/#reuse-a-saved-query). Saving is not available for SQL queries.
 
 ## Get help writing queries with the Query Assistant
 


### PR DESCRIPTION
## What

Documents two existing features of the in-app query editor that the data section did not cover.

On `data/query-data.md`, after the MQL section:

- **Save and reuse queries** — saving MQL queries from the editor (the **Save query** button, the **Saved**/**Recent** sidebar tabs, org-wide visibility). States plainly that saving is MQL-only.
- **Get help writing queries with the Query Assistant** — the Query Assistant (Beta), which turns a plain-language description into a query and works in both SQL and MQL.

On `data/overview.md`, aligns the existing "Query and explore" sentence to the product name (Query Assistant, Beta) and notes that saving is MQL-only.

## Verification

All claims verified against the app source (`app/ui/src/routes/(auth-required)/data/query/` and `app/data/feature_models.go`):

- Save query button renders only in MQL mode; the `createSavedQuery` RPC accepts only MQL, so saving is MQL-only.
- Saved queries are listed by organization ID (org-wide visibility).
- The Query Assistant panel carries a `BETA` badge and its inference path handles both SQL and MQL.

Local checks pass: prettier, markdownlint, vale (0 errors/warnings/suggestions), and `make build-prod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)