### PR TITLE
Add --pipeline-name flag to data index list CLI reference

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -70,7 +70,7 @@ viam data tag filter add --tags=<tags> [...named args from filter]
 viam data tag filter remove --tags=<tags> [...named args from filter]
 viam data index create --collection-type=<type> --index-path=<file> [--org-id=<org-id>] [--pipeline-name=<name>]
 viam data index delete --collection-type=<type> --index-name=<name> [--org-id=<org-id>] [--pipeline-name=<name>]
-viam data index list --collection-type=<type> [--org-id=<org-id>]
+viam data index list --collection-type=<type> [--org-id=<org-id>] [--pipeline-name=<name>]
 ```
 
 ### `data export tabular`
@@ -345,7 +345,7 @@ viam data index delete --collection-type=<type> --index-name=<name> [--org-id=<o
 List all custom indexes for a data collection.
 
 ```sh {class="command-line" data-prompt="$"}
-viam data index list --collection-type=<type> [--org-id=<org-id>]
+viam data index list --collection-type=<type> [--org-id=<org-id>] [--pipeline-name=<name>]
 ```
 
 <!-- prettier-ignore -->
@@ -353,6 +353,7 @@ viam data index list --collection-type=<type> [--org-id=<org-id>]
 | -------- | ----------- | --------- |
 | `--collection-type` | Data collection type for index operations. Options: `hot-storage`, `pipeline-sink`. | **Required** |
 | `--org-id` | The organization ID. Uses default org if set. | Optional |
+| `--pipeline-name` | Name of the data pipeline (required when `--collection-type` is `pipeline-sink`). | Conditional |
 
 ## `datapipelines`
 


### PR DESCRIPTION
## Source changes

- viamrobotics/rdk#6047: Add `--pipeline-name` flag to `viam data index list` CLI command

## Docs changes

- `docs/cli/reference.md`: Added `--pipeline-name` to the `data index list` synopsis (both the top-of-section summary and the subcommand detail) and added a row to the flags table. The `data index create` and `data index delete` subcommands already documented this flag; `data index list` was the only one missing it.

## How I found these

- Xref lookup: `cli-xref.md` for CLI commands
- Grep matches: 4 references to `data index list` across 2 files; the `manage-data.md` example uses `--collection-type=hot-storage` which does not require `--pipeline-name`, so it is correct as-is

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEcrY1wju7HuePMfNjocdV)_