### PR TITLE
fix landing page

### DIFF
--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -3,8 +3,7 @@ title: "Tutorials"
 linkTitle: "Tutorials"
 weight: 300
 type: docs
-layout: "empty"
-canonical: "/tutorials/"
+layout: "tutorials"
 aliases:
   - /dev/tools/tutorials/
 toc_hide: true

--- a/layouts/docs/tutorials.html
+++ b/layouts/docs/tutorials.html
@@ -184,7 +184,7 @@
                     partial "tutorialcard-no-js.html" (dict "link"
                     "/tutorials/services/webcam-line-follower-robot/") }} {{
                     partial "tutorialcard-no-js.html" (dict "link"
-                    "/data-ai/train/train-tf-tflite/") }} {{ partial
+                    "/train/train-a-model/") }} {{ partial
                     "tutorialcard-no-js.html" (dict "link"
                     "/tutorials/projects/verification-system/") }}
                   </div>


### PR DESCRIPTION
## Problem

Visiting `/tutorials/` redirects to `/tutorials/` in an infinite loop. The page is served as a meta-refresh stub:

```html
<meta http-equiv="refresh" content="0; url=/tutorials/">
```

The new-docs-site cutover (#4963) intended `/tutorials/` to become the canonical tutorials landing page (it added an alias so the old `/dev/tools/tutorials/` URL now points into `/tutorials/`), but it left `layout: empty` in `docs/tutorials/_index.md` and set `canonical: "/tutorials/"`. The `empty` layout meta-refreshes to its `canonical`, so the page redirects to itself.

Every path that targets `/tutorials/` inherited the loop: the legacy section indexes (`/tutorials/configure/`, `/tutorials/control/`, etc.), the `/dev/tools/tutorials/` alias, and the long-deleted mock-robot redirects in `netlify.toml`.

## Fix

- Switch `docs/tutorials/_index.md` to `layout: "tutorials"` so it renders the real tutorials landing page (the filterable card grid) instead of a self-redirect, and drop the now-dead `canonical` param. `head.html` derives the canonical `<link>` tag from `.Permalink`, so canonical metadata is unaffected.
- Fix a stale link this surfaced in the no-js fallback cards: the train-TFLite tutorial moved out of `/data-ai/` in the cutover. Point that card at its current home, `/train/train-a-model/`.

## Verification

- `make build-prod` passes (exit 0); before this fix it failed once the landing page rendered, due to the stale card link.
- `public/tutorials/index.html` is now a real 20 KB page with zero meta-refresh tags (previously a 266-byte self-refresh stub).
- prettier, markdownlint, and vale all clean on the changed markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)