### PR TITLE
Remove deprecated Python Reconfigurable from docs

### DIFF
--- a/docs/build-modules/module-reference.md
+++ b/docs/build-modules/module-reference.md
@@ -240,12 +240,11 @@ if __name__ == '__main__':
 
 The default behavior when you don't implement a method:
 
-| Behavior                 | Go                                                           | Python                                                                                   |
-| ------------------------ | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| Rebuild on config change | Default (`viam-server` destroys and re-creates the resource) | Default (`viam-server` destroys and re-creates the resource)                             |
-| In-place reconfigure     | Not supported for modular resources                          | Implement `reconfigure()` (called if your class satisfies the `Reconfigurable` protocol) |
-| No-op close              | Embed `resource.TriviallyCloseable`                          | Default on `ResourceBase`                                                                |
-| Skip config validation   | Embed `resource.TriviallyValidateConfig`                     | Default on `EasyResource`                                                                |
+| Behavior                 | Go                                                           | Python                                                       |
+| ------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| Rebuild on config change | Default (`viam-server` destroys and re-creates the resource) | Default (`viam-server` destroys and re-creates the resource) |
+| No-op close              | Embed `resource.TriviallyCloseable`                          | Default on `ResourceBase`                                    |
+| Skip config validation   | Embed `resource.TriviallyValidateConfig`                     | Default on `EasyResource`                                    |
 
 ## Logging
 

--- a/docs/tutorials/configure/pet-photographer.md
+++ b/docs/tutorials/configure/pet-photographer.md
@@ -366,7 +366,6 @@ from typing import (
     ClassVar, Mapping, Sequence, Optional, cast, Tuple, List, Any, Dict
 )
 from typing_extensions import Self
-from viam.module.types import Reconfigurable
 from viam.proto.app.robot import ComponentConfig
 from viam.proto.common import ResourceName, ResponseMetadata, Geometry
 from viam.components.camera import Camera
@@ -380,10 +379,7 @@ from viam.utils import from_dm_from_extra
 from viam.media.utils.pil import viam_to_pil_image
 
 
-class ColorFilterCam(
-        Camera,
-        Reconfigurable
-  ):
+class ColorFilterCam(Camera):
 
     """A ColorFilterCam wraps the underlying camera
     `actual_cam` and only keeps the data captured on the

--- a/docs/tutorials/custom/custom-base-dog.md
+++ b/docs/tutorials/custom/custom-base-dog.md
@@ -285,7 +285,7 @@ Modify the `validate` and `reconfigure` methods to use these attributes, and def
 The code below shows what the top of your class definition should look like.
 
 ```python {class="line-numbers linkable-line-numbers"}
-class robotdog(Base, Reconfigurable):
+class robotdog(Base):
     MODEL: ClassVar[Model] = Model(ModelFamily("viamlabs", "base"), "robotdog")
 
     # Class parameters


### PR DESCRIPTION
## Source changes

- viam-python-sdk#1167: Remove `Reconfigurable` class from Python SDK. The class is now deprecated with a `DeprecationWarning`. Modules always rebuild on reconfigure (stop → remove → re-add) instead of calling `reconfigure()` in-place.

## Docs changes

- `docs/build-modules/module-reference.md`: Remove the "In-place reconfigure" row from the default behavior table. Python no longer supports in-place reconfiguration — both Go and Python now always rebuild on config change.
- `docs/tutorials/configure/pet-photographer.md`: Remove `from viam.module.types import Reconfigurable` import and `Reconfigurable` from class inheritance. The `reconfigure()` method remains as a regular helper called from the constructor.
- `docs/tutorials/custom/custom-base-dog.md`: Remove `Reconfigurable` from `robotdog` class inheritance. Same pattern — `reconfigure()` stays as a regular method.

## How I found these

- Xref lookup: `search-patterns.yaml` entry for `Resource.Reconfigure`
- Grep matches: searched for `Reconfigurable`, `viam.module.types`, `reconfigure`, `in-place reconfigur` across all docs. Found 3 affected files.

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLL6HXYtyzY1BCYYNtTaH7)_