### PR TITLE
docs(gazebo-setup): add missing location step before Add machine

### DIFF
--- a/docs/try/gazebo-setup.md
+++ b/docs/try/gazebo-setup.md
@@ -41,7 +41,7 @@ This takes 5-10 minutes depending on your internet connection.
 ## Step 2: Create a Machine in Viam
 
 1. Go to [app.viam.com](https://app.viam.com) and log in
-2. Click the **Locations** tab
+2. Click the **Locations** tab and open a location
 3. Click **+ Add machine**
 4. Name it `inspection-station-1`
 5. Click **Add machine**


### PR DESCRIPTION
## Summary

In **Step 2: Create a Machine in Viam**, clicking **+ Add machine** from the top-level Locations list triggers a dialog asking the user to select a location first. The current instructions skip this step, sending users to the Locations tab but never telling them to open a specific location before clicking **+ Add machine**.

This matches the pattern in `set-up-a-machine/first-machine.md`, which explicitly says "Open a location" before "Click **Add machine**".

**Before:**
```
2. Click the **Locations** tab
3. Click **+ Add machine**
```

**After:**
```
2. Click the **Locations** tab and open a location
3. Click **+ Add machine**
```

## Test plan

- [ ] Follow Step 2 from a fresh login at app.viam.com
- [ ] Confirm that opening a location before clicking **+ Add machine** skips the location-selection dialog
- [ ] Confirm the machine is created in the expected location