### PR TITLE
gazebo-setup: clarify location setup before adding a machine

### DIFF
--- a/docs/try/gazebo-setup.md
+++ b/docs/try/gazebo-setup.md
@@ -42,11 +42,12 @@ This takes 5-10 minutes depending on your internet connection.
 
 1. Go to [app.viam.com](https://app.viam.com) and log in
 2. Click the **Locations** tab
-   - **No locations yet:** Click **+ Add location**, enter a name (for example, `my-location`), and click **Add**.
-   - **Multiple locations:** Click the location you want to use.
-3. Click **+ Add machine**
-4. Name it `inspection-station-1`
-5. Click **Add machine**
+3. Select a location:
+   - **No locations yet:** Click **+ Add location**, enter a name (for example, `my-location`), and click **Add**
+   - **Multiple locations:** Select the location you want to use
+4. Click **+ Add machine**
+5. Name it `inspection-station-1`
+6. Click **Add machine**
 
 ## Step 3: Create a credentials file
 

--- a/docs/try/gazebo-setup.md
+++ b/docs/try/gazebo-setup.md
@@ -42,6 +42,8 @@ This takes 5-10 minutes depending on your internet connection.
 
 1. Go to [app.viam.com](https://app.viam.com) and log in
 2. Click the **Locations** tab
+   - **No locations yet:** Click **+ Add location**, enter a name (for example, `my-location`), and click **Add**.
+   - **Multiple locations:** Click the location you want to use.
 3. Click **+ Add machine**
 4. Name it `inspection-station-1`
 5. Click **Add machine**


### PR DESCRIPTION
## Summary

In **Step 2: Create a Machine in Viam**, clicking **+ Add machine** triggers a dialog asking the user to select a location first. The current instructions don't account for users who have no locations set up, or who have multiple locations and need to choose one.

Adds a dedicated step with two labeled conditions:

- **No locations yet:** directs the user to create one via **+ Add location**
- **Multiple locations:** directs the user to select the right one before proceeding

**Before:**
```
1. Go to app.viam.com and log in
2. Click the **Locations** tab
3. Click **+ Add machine**
4. Name it `inspection-station-1`
5. Click **Add machine**
```

**After:**
```
1. Go to app.viam.com and log in
2. Click the **Locations** tab
3. Select a location:
   - **No locations yet:** Click **+ Add location**, enter a name (for example, `my-location`), and click **Add**
   - **Multiple locations:** Select the location you want to use
4. Click **+ Add machine**
5. Name it `inspection-station-1`
6. Click **Add machine**
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)