### PR TITLE
gazebo-setup: clarify origin of can-inspection-simulation directory in Step 3

### DIFF
--- a/docs/try/gazebo-setup.md
+++ b/docs/try/gazebo-setup.md
@@ -50,7 +50,7 @@ This takes 5-10 minutes depending on your internet connection.
 
 1. Click the 1. Click the <span style="display:inline-flex; align-items:center; gap:5px; background-color:#eff6ff; color:#3b82f6; border:1.5px solid #93c5fd; padding:2px 8px; border-radius:6px; font-size:0.85em; font-weight:500;">Awaiting setup</span> button
 2. Click **Machine cloud credentials** to copy your machine's credentials
-3. In the `can-inspection-simulation` directory you cloned in Step 1, create a file called `station1-viam.json`
+3. In the `can-inspection-simulation` directory created when you cloned the repository, create a file called `station1-viam.json`
 4. Paste your machine's credentials into this file and save
 
 ## Step 4: Start the Container

--- a/docs/try/gazebo-setup.md
+++ b/docs/try/gazebo-setup.md
@@ -50,7 +50,7 @@ This takes 5-10 minutes depending on your internet connection.
 
 1. Click the 1. Click the <span style="display:inline-flex; align-items:center; gap:5px; background-color:#eff6ff; color:#3b82f6; border:1.5px solid #93c5fd; padding:2px 8px; border-radius:6px; font-size:0.85em; font-weight:500;">Awaiting setup</span> button
 2. Click **Machine cloud credentials** to copy your machine's credentials
-3. In the `can-inspection-simulation` directory, create a file called `station1-viam.json`
+3. In the `can-inspection-simulation` directory you cloned in Step 1, create a file called `station1-viam.json`
 4. Paste your machine's credentials into this file and save
 
 ## Step 4: Start the Container


### PR DESCRIPTION
## Summary

In **Step 3: Create a credentials file**, substep 3 refers to the \`can-inspection-simulation\` directory without indicating where it comes from. A reader who has lost track of the earlier clone command, or who arrives at this step from a link or bookmark, won't know what directory is being referenced.

**Before:**
```
In the `can-inspection-simulation` directory, create a file called `station1-viam.json`
```

**After:**
```
In the `can-inspection-simulation` directory created when you cloned the repository, create a file called `station1-viam.json`
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)