### PR TITLE
gazebo-setup, part-1: fix docker logs command and correct expected startup messages

### DIFF
--- a/docs/try/gazebo-setup.md
+++ b/docs/try/gazebo-setup.md
@@ -92,8 +92,11 @@ docker logs -f gz-station1
 
 Wait for the following messages, then press Ctrl+C:
 
-- "Can Inspection Station 1 Running!"
-- viam-server startup messages
+- `can-spawner entered RUNNING state`
+- `web-viewer entered RUNNING state`
+- `viam-server entered RUNNING state`
+
+Once running, you can also observe cans being recycled in the simulation, for example: `pool_can_01 recycled`
 
 **View the simulation:**
 

--- a/docs/try/gazebo-setup.md
+++ b/docs/try/gazebo-setup.md
@@ -87,10 +87,10 @@ docker run --name gz-station1 -d `
 **Check container logs:**
 
 ```bash
-docker logs gz-station1
+docker logs -f gz-station1
 ```
 
-Look for:
+Wait for the following messages, then press Ctrl+C:
 
 - "Can Inspection Station 1 Running!"
 - viam-server startup messages

--- a/docs/try/gazebo-setup.md
+++ b/docs/try/gazebo-setup.md
@@ -178,7 +178,7 @@ docker start gz-station1
 docker rm gz-station1
 ```
 
-**View logs:**
+**Follow logs:**
 
 ```bash
 docker logs -f gz-station1

--- a/docs/try/part-1.md
+++ b/docs/try/part-1.md
@@ -25,7 +25,7 @@ Before starting this tutorial, you need the can inspection simulation running. F
 2. Create a machine in Viam and get credentials
 3. Start the container with your Viam credentials
 
-Once you see "Can Inspection Simulation Running!" in the container logs and your machine shows **Live** in the Viam app, return here to continue.
+Once the container logs show `can-spawner`, `web-viewer`, and `viam-server` each entered RUNNING state, and your machine shows **Live** in the Viam app, return here to continue.
 
 {{< alert title="What you're working with" color="info" >}}
 The simulation runs Gazebo Harmonic inside a Docker container. It simulates a conveyor belt with cans (some dented) passing under an inspection camera. viam-server runs on the Linux virtual machine inside the container and connects to Viam's cloud, just like it would on a physical machine. Everything you configure in the Viam app applies to the simulated hardware.


### PR DESCRIPTION
## Summary

> [!NOTE]
> This discrepancy could be a candidate for a Docker smoke-test in CI. Something like:
  ```
  smoke-test:
    needs: build-and-push-local
    runs-on: ubuntu-latest
    steps:
      - uses: docker/login-action@v3
        # pull the image just built
      - run: |
          docker run -d --name smoke-test ghcr.io/viamrobotics/can-inspection-simulation:latest-local
          docker logs -f smoke-test 2>&1 | grep -m 1 "viam-server entered RUNNING state"
        timeout-minutes: 3
  ```  

Two related fixes for the can inspection simulation setup flow.

### gazebo-setup.md — Step 5: Verify the Setup

The `docker logs` command shown requires the user to run it repeatedly to catch the startup message. Replaces it with `docker logs -f` to stream output in real time, and corrects the expected log messages — the string `"Can Inspection Station 1 Running!"` does not appear in the actual container output.

Also renames **View logs** to **Follow logs** in the Container Management section to match Docker's terminology for the `-f`/`--follow` flag.

**Before:**
\`\`\`
docker logs gz-station1

Look for:
- "Can Inspection Station 1 Running!"
- viam-server startup messages
\`\`\`

**After:**
\`\`\`
docker logs -f gz-station1

Wait for the following messages, then press Ctrl+C:
- `can-spawner entered RUNNING state`
- `web-viewer entered RUNNING state`
- `viam-server entered RUNNING state`
\`\`\`

### part-1.md — Prerequisites

Updates the same incorrect log message reference in the prerequisites section.

**Before:**
> Once you see "Can Inspection Simulation Running!" in the container logs...

**After:**
> Once the container logs show `can-spawner`, `web-viewer`, and `viam-server` each entered RUNNING state...

## Verification

Log output confirming the correct messages (truncated):
\`\`\`
2026-06-03 22:07:41,707 INFO success: can-spawner entered RUNNING state, process has stayed up for > than 15 seconds (startsecs)
2026-06-03 22:07:41,707 INFO success: web-viewer entered RUNNING state, process has stayed up for > than 15 seconds (startsecs)
2026-06-03 22:07:41,708 INFO success: viam-server entered RUNNING state, process has stayed up for > than 15 seconds (startsecs)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)