### PR TITLE
Document CLI non-interactive mode flag requirements

### DIFF
--- a/docs/cli/automate-with-scripts.md
+++ b/docs/cli/automate-with-scripts.md
@@ -189,6 +189,16 @@ viam data export binary filter \
 The `--parallel` flag controls how many concurrent downloads run (default: 100).
 Increase it for faster exports on high-bandwidth connections, or decrease it to reduce load.
 
+## Non-interactive mode
+
+The CLI detects whether it is connected to a terminal.
+When running without a terminal, commands that normally prompt for user input instead require explicit flags:
+
+- `viam module generate` requires `--name`, `--language`, `--public-namespace`, `--resource-subtype`, and `--model-name`.
+- `viam machines part fragments remove` requires `--fragment`.
+
+If you omit a required flag in non-interactive mode, the CLI prints an error listing the missing flags.
+
 ## Tips for scripting
 
 - Use `--quiet` (`-q`) to suppress non-essential output when parsing command results

--- a/docs/cli/automate-with-scripts.md
+++ b/docs/cli/automate-with-scripts.md
@@ -194,7 +194,7 @@ Increase it for faster exports on high-bandwidth connections, or decrease it to 
 The CLI detects whether it is connected to a terminal.
 When running without a terminal, commands that normally prompt for user input instead require explicit flags:
 
-- `viam module generate` requires `--name`, `--language`, `--public-namespace`, `--resource-subtype`, and `--model-name`.
+- `viam module generate`, when generating a module, requires `--name`, `--language`, `--public-namespace`, `--resource-subtype`, and `--model-name`.
 - `viam machines part fragments remove` requires `--fragment`.
 
 If you omit a required flag in non-interactive mode, the CLI prints an error listing the missing flags.

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -1304,7 +1304,7 @@ viam machines part fragments remove --part=<part id> [--fragment=<fragment id>]
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
 | `--part` | Part ID for which the command is being issued. | **Required** |
-| `--fragment` | Fragment ID to remove. | Optional |
+| `--fragment` | Fragment ID to remove. If omitted, the CLI prompts interactively. Required when running without a terminal (scripts, CI/CD). | Optional |
 
 ### `machines part motion print-config`
 
@@ -1575,6 +1575,10 @@ The first prompt asks whether you want to generate a **module** (a modular resou
 If you are generating a module using Python, you must have Python version 3.11 or newer installed on your computer for the `viam module generate` command to work.
 {{% /alert %}}
 
+When running without a terminal (in scripts or CI/CD), you must provide `--name`, `--language`, `--public-namespace`, `--resource-subtype`, and `--model-name` as flags.
+You must also authenticate before running the command.
+See [Automate with scripts](/cli/automate-with-scripts/) for details on non-interactive authentication.
+
 {{% hiddencontent %}}
 
 When generating a module, the command can generate code for the following resource types:
@@ -1613,12 +1617,12 @@ Services:
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
 | `--generate-type` | Type of project to generate. Options: `module`, `app`. If omitted, the CLI prompts you to choose. | Optional |
-| `--name` | (Module only) Name to use for the module. For example, a module that contains sensor implementations might be named `sensors`. | Optional |
-| `--language` | (Module only) Language to use for the module. Options: `python`, `go`. | Optional |
+| `--name` | (Module only) Name to use for the module. For example, a module that contains sensor implementations might be named `sensors`. Required in non-interactive mode. | Optional |
+| `--language` | (Module only) Language to use for the module. Options: `python`, `go`. Required in non-interactive mode. | Optional |
 | `--visibility` | Visibility. Options: `private`, `public`, `public_unlisted`. | Optional |
-| `--public-namespace` | Namespace or organization ID. Must be either a valid organization ID or a namespace that exists within a user organization. | Optional |
-| `--resource-subtype` | (Module only) The API to implement with the modular resource. For example, `motor`. | Optional |
-| `--model-name` | (Module only) Name for the particular resource subtype implementation. For example, a sensor model that detects moisture might be named `moisture`. | Optional |
+| `--public-namespace` | Namespace or organization ID. Must be either a valid organization ID or a namespace that exists within a user organization. Required in non-interactive mode. | Optional |
+| `--resource-subtype` | (Module only) The API to implement with the modular resource. For example, `motor`. Required in non-interactive mode. | Optional |
+| `--model-name` | (Module only) Name for the particular resource subtype implementation. For example, a sensor model that detects moisture might be named `moisture`. Required in non-interactive mode. | Optional |
 | `--register` | Register with Viam to associate it with your organization. Default: `false`. | Optional |
 | `--app-name` | (App only) Name for the app. Alphanumeric characters, dashes, and underscores only. Must start with a letter. | Optional |
 | `--app-type` | (App only) App type. Options: `single_machine`, `multi_machine`. See [Two application types](/build-apps/hosting/overview/#two-application-types). | Optional |

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -1575,7 +1575,7 @@ The first prompt asks whether you want to generate a **module** (a modular resou
 If you are generating a module using Python, you must have Python version 3.11 or newer installed on your computer for the `viam module generate` command to work.
 {{% /alert %}}
 
-When running without a terminal (in scripts or CI/CD), you must provide `--name`, `--language`, `--public-namespace`, `--resource-subtype`, and `--model-name` as flags.
+When generating a module without a terminal (in scripts or CI/CD), you must provide `--name`, `--language`, `--public-namespace`, `--resource-subtype`, and `--model-name` as flags.
 You must also authenticate before running the command.
 See [Automate with scripts](/cli/automate-with-scripts/) for details on non-interactive authentication.
 
@@ -1620,7 +1620,7 @@ Services:
 | `--name` | (Module only) Name to use for the module. For example, a module that contains sensor implementations might be named `sensors`. Required in non-interactive mode. | Optional |
 | `--language` | (Module only) Language to use for the module. Options: `python`, `go`. Required in non-interactive mode. | Optional |
 | `--visibility` | Visibility. Options: `private`, `public`, `public_unlisted`. | Optional |
-| `--public-namespace` | Namespace or organization ID. Must be either a valid organization ID or a namespace that exists within a user organization. Required in non-interactive mode. | Optional |
+| `--public-namespace` | Namespace or organization ID. Must be either a valid organization ID or a namespace that exists within a user organization. Required in non-interactive module generation. | Optional |
 | `--resource-subtype` | (Module only) The API to implement with the modular resource. For example, `motor`. Required in non-interactive mode. | Optional |
 | `--model-name` | (Module only) Name for the particular resource subtype implementation. For example, a sensor model that detects moisture might be named `moisture`. Required in non-interactive mode. | Optional |
 | `--register` | Register with Viam to associate it with your organization. Default: `false`. | Optional |


### PR DESCRIPTION
## Source changes

- viamrobotics/rdk#5854: Allow CLI commands to run without a TTY. The CLI now detects whether stdin is connected to a terminal and requires explicit flags for commands that normally prompt interactively.

## Docs changes

- `docs/cli/reference.md`: Updated `module generate` flag table to note that `--name`, `--language`, `--public-namespace`, `--resource-subtype`, and `--model-name` are required in non-interactive mode. Added a paragraph above the flag table explaining this. Updated `fragments remove --fragment` description to note it is required in non-interactive mode.
- `docs/cli/automate-with-scripts.md`: Added a "Non-interactive mode" section documenting which commands require explicit flags when running without a terminal.

## How I found these

- Xref lookup: `cli-xref.md` for `module generate` and `fragments remove`
- Grep matches: 21 files reference `module generate` or `fragments remove`; only the reference page and scripting guide needed updates (other pages already use explicit flags in their examples)

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01NytZJdHY4wUwNdaDJzGtsr)_