### PR TITLE
Update Windows installer link from .exe to .msi

### DIFF
--- a/docs/reference/viam-server.md
+++ b/docs/reference/viam-server.md
@@ -383,7 +383,7 @@ curl https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-serv
 {{% /tab %}}
 {{% tab name="Windows native" %}}
 
-Manual installation is not available for native Windows; you must download the [Viam Agent installer](https://storage.googleapis.com/packages.viam.com/apps/viam-agent/viam-agent-windows-installer.exe).
+Manual installation is not available for native Windows; you must download the [Viam Agent installer](https://storage.googleapis.com/packages.viam.com/apps/viam-agent/viam-agent-stable-windows-x86_64.msi) and follow the on-screen instructions to complete the installation.
 
 The `viam-agent` and `viam-server` binaries are installed at <FILE>C:\opt\viam\cache</FILE>.
 


### PR DESCRIPTION
## Source changes

- viamrobotics/app#12246: Use Windows msi in install links

## Docs changes

- `docs/reference/viam-server.md`: Updated the Windows native installer URL from the old `.exe` format (`viam-agent-windows-installer.exe`) to the new `.msi` format (`viam-agent-stable-windows-x86_64.msi`). Also updated the installation instruction text to match the new MSI installer flow ("follow the on-screen instructions to complete the installation" instead of the implicit "download and run").

## How I found these

- Grep matches: searched for `viam-agent-windows-installer.exe` across the entire docs repo; found 1 match in `docs/reference/viam-server.md` line 386.

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_0159eg5bY2jeG7ZVt9QVs3VY)_