### PR TITLE
Update fragment usage docs for new Fragments in use tab

### DIFF
--- a/docs/fleet/reuse-configuration.md
+++ b/docs/fleet/reuse-configuration.md
@@ -179,7 +179,7 @@ On the machine's **CONFIGURE** tab, find the fragment card and look for the **Up
 
 Before changing or removing a fragment, you usually want to know which machines use it.
 
-**In the Viam app**, navigate to [app.viam.com/fragments](https://app.viam.com/fragments) and click the **Fragments in use** tab. This shows every fragment that at least one machine in your organization uses, along with the version each machine resolved to. Click a fragment to see a per-machine breakdown of which version or tag each machine is pinned to, and whether an upgrade is available.
+**In the Viam app**, navigate to [app.viam.com/fragments](https://app.viam.com/fragments) and click the **Fragments in use** tab. This shows every fragment that at least one machine in your organization uses, along with the version pinned in your configuration and the version actually deployed on machines. It also flags how many machines are running a version older than the latest available. Click a fragment to see a per-machine breakdown of which version or tag each machine is pinned to, and whether an upgrade is available.
 
 **Through the API**, Viam exposes `GetFragmentUsage` (returns a count of machines per revision) and `ListMachineSummaries` (returns the full list of machines and their resolved fragments). Neither is yet wrapped as a high-level method on the Python SDK's `AppClient`. To use them today, call the gRPC stubs from the proto bindings directly, or use any other gRPC client.
 

--- a/docs/fleet/reuse-configuration.md
+++ b/docs/fleet/reuse-configuration.md
@@ -177,7 +177,11 @@ On the machine's **CONFIGURE** tab, find the fragment card and look for the **Up
 
 ## Find which machines use a fragment
 
-Before changing or removing a fragment, you usually want to know which machines use it. Viam exposes this through `GetFragmentUsage` (returns a count of machines per revision) and `ListMachineSummaries` (returns the full list of machines and their resolved fragments). Neither is yet wrapped as a high-level method on the Python SDK's `AppClient`. To use them today, call the gRPC stubs from the proto bindings directly, or use any other gRPC client.
+Before changing or removing a fragment, you usually want to know which machines use it.
+
+**In the Viam app**, navigate to [app.viam.com/fragments](https://app.viam.com/fragments) and click the **Fragments in use** tab. This shows every fragment that at least one machine in your organization uses, along with the version each machine resolved to. Click a fragment to see a per-machine breakdown of which version or tag each machine is pinned to, and whether an upgrade is available.
+
+**Through the API**, Viam exposes `GetFragmentUsage` (returns a count of machines per revision) and `ListMachineSummaries` (returns the full list of machines and their resolved fragments). Neither is yet wrapped as a high-level method on the Python SDK's `AppClient`. To use them today, call the gRPC stubs from the proto bindings directly, or use any other gRPC client.
 
 ## Set default fragments for an organization
 


### PR DESCRIPTION
## Source changes

- viamrobotics/app#12189 (APP-16706): New "Fragments in use" page showing which fragments are actively used across machines
- viamrobotics/app#12247 (APP-16728): Fragment version details page with per-machine version counts
- viamrobotics/app#12232 (APP-16723): Backend RPCs for fragment version summaries and usage

## Docs changes

- `docs/fleet/reuse-configuration.md`: The "Find which machines use a fragment" section previously only mentioned the API path (`GetFragmentUsage` and `ListMachineSummaries`). Updated to also describe the new **Fragments in use** tab in the Viam app UI, which shows per-machine fragment version and pin information.

## How I found these

- Xref lookup: `maintenance.md` staleness table flagged `app/ui/src/routes/` changes
- Grep matches: searched `fragment.*tab`, `fragment.*page`, `fragment.*list`, `fragment.*in use` across all docs; found the incomplete paragraph at `reuse-configuration.md:180`

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJxLqj6oo3gVbweWBCXFxB)_