### PR TITLE
Add CLI data query commands, fix data source type values

### DIFF
--- a/docs/cli/data-pipelines.md
+++ b/docs/cli/data-pipelines.md
@@ -71,7 +71,7 @@ viam datapipelines create \
 | `--schedule`            | Yes          | Cron expression for when the pipeline runs                    |
 | `--enable-backfill`     | Yes          | `true` to run over historical data, `false` for new data only |
 | `--org-id`              | No           | Your organization ID (uses default if set)                    |
-| `--data-source-type`    | No           | `standard` (default) or `hotstorage` (hot data store)         |
+| `--data-source-type`    | No           | `standard` (default) or `hot-storage` (hot data store)        |
 | `--mql` or `--mql-path` | One required | MQL query as inline JSON or path to a JSON file               |
 
 ## List pipelines

--- a/docs/cli/manage-data.md
+++ b/docs/cli/manage-data.md
@@ -195,6 +195,8 @@ viam data query tabular sql --org-id=<org-id> \
   --destination=./query-results
 ```
 
+SQL queries run against your `standard` tabular data. To query the [hot data store](/data/hot-data-store/) or pipeline results, use MQL with `--data-source-type`, shown below.
+
 ### Query tabular data with MQL
 
 ```sh {class="command-line" data-prompt="$"}

--- a/docs/cli/manage-data.md
+++ b/docs/cli/manage-data.md
@@ -217,9 +217,13 @@ Use `--data-source-type` to query data from different sources:
 viam data query mql --org-id=<org-id> --data-source-type=hot-storage \
   --mql='[{"$limit":5}]'
 
-# query pipeline results
+# query pipeline results by ID
 viam data query mql --org-id=<org-id> --data-source-type=pipeline-sink \
   --pipeline-id=<pipeline-id> --mql='[{"$limit":5}]'
+
+# query pipeline results by name
+viam data query mql --org-id=<org-id> --data-source-type=pipeline-sink \
+  --pipeline-name=my-pipeline --mql='[{"$limit":5}]'
 ```
 
 See [Query data in the app](/data/query-data/) for SQL and MQL syntax reference.

--- a/docs/cli/manage-data.md
+++ b/docs/cli/manage-data.md
@@ -176,6 +176,54 @@ If the organization has a [hot data store](/data/hot-data-store/), matching data
 Passing `--delete-older-than-days=0` deletes **all** tabular data in the organization. This command has no component or location filter.
 {{< /alert >}}
 
+## Query data
+
+Run SQL or MQL queries against your organization's tabular data directly from the CLI.
+
+### Query with SQL
+
+```sh {class="command-line" data-prompt="$"}
+viam data query sql --org-id=<org-id> \
+  --sql="SELECT component_name, data FROM readings WHERE time_received >= CAST('2025-01-01T00:00:00Z' AS TIMESTAMP) LIMIT 10"
+```
+
+Results are printed to stdout as NDJSON (one JSON object per line). Use `--destination` to write results to a file instead:
+
+```sh {class="command-line" data-prompt="$"}
+viam data query sql --org-id=<org-id> \
+  --sql="SELECT * FROM readings WHERE time_received >= CAST('2025-01-01T00:00:00Z' AS TIMESTAMP) LIMIT 100" \
+  --destination=./query-results
+```
+
+### Query with MQL
+
+```sh {class="command-line" data-prompt="$"}
+viam data query mql --org-id=<org-id> \
+  --mql='[{"$match":{"component_name":"my-sensor"}},{"$limit":10}]'
+```
+
+For complex queries, put the MQL in a JSON file and use `--mql-path`:
+
+```sh {class="command-line" data-prompt="$"}
+viam data query mql --org-id=<org-id> --mql-path=./my-query.json
+```
+
+### Query the hot data store or pipeline results
+
+Use `--data-source-type` to query data from different sources:
+
+```sh {class="command-line" data-prompt="$"}
+# query the hot data store
+viam data query mql --org-id=<org-id> --data-source-type=hot-storage \
+  --mql='[{"$limit":5}]'
+
+# query pipeline results
+viam data query mql --org-id=<org-id> --data-source-type=pipeline-sink \
+  --pipeline-id=<pipeline-id> --mql='[{"$limit":5}]'
+```
+
+See [Query data in the app](/data/query-data/) for SQL and MQL syntax reference.
+
 ## Configure database access
 
 To query synced data directly with MongoDB-compatible tools like `mongosh` or Grafana, set up a database user:

--- a/docs/cli/manage-data.md
+++ b/docs/cli/manage-data.md
@@ -178,34 +178,34 @@ Passing `--delete-older-than-days=0` deletes **all** tabular data in the organiz
 
 ## Query data
 
-Run SQL or MQL queries against your organization's tabular data directly from the CLI.
+Run SQL or MQL queries against your organization's tabular data, or query binary data metadata by filter, directly from the CLI.
 
-### Query with SQL
+### Query tabular data with SQL
 
 ```sh {class="command-line" data-prompt="$"}
-viam data query sql --org-id=<org-id> \
+viam data query tabular sql --org-id=<org-id> \
   --sql="SELECT component_name, data FROM readings WHERE time_received >= CAST('2025-01-01T00:00:00Z' AS TIMESTAMP) LIMIT 10"
 ```
 
 Results are printed to stdout as NDJSON (one JSON object per line). Use `--destination` to write results to a file instead:
 
 ```sh {class="command-line" data-prompt="$"}
-viam data query sql --org-id=<org-id> \
+viam data query tabular sql --org-id=<org-id> \
   --sql="SELECT * FROM readings WHERE time_received >= CAST('2025-01-01T00:00:00Z' AS TIMESTAMP) LIMIT 100" \
   --destination=./query-results
 ```
 
-### Query with MQL
+### Query tabular data with MQL
 
 ```sh {class="command-line" data-prompt="$"}
-viam data query mql --org-id=<org-id> \
+viam data query tabular mql --org-id=<org-id> \
   --mql='[{"$match":{"component_name":"my-sensor"}},{"$limit":10}]'
 ```
 
 For complex queries, put the MQL in a JSON file and use `--mql-path`:
 
 ```sh {class="command-line" data-prompt="$"}
-viam data query mql --org-id=<org-id> --mql-path=./my-query.json
+viam data query tabular mql --org-id=<org-id> --mql-path=./my-query.json
 ```
 
 ### Query the hot data store or pipeline results
@@ -214,16 +214,28 @@ Use `--data-source-type` to query data from different sources:
 
 ```sh {class="command-line" data-prompt="$"}
 # query the hot data store
-viam data query mql --org-id=<org-id> --data-source-type=hot-storage \
+viam data query tabular mql --org-id=<org-id> --data-source-type=hot-storage \
   --mql='[{"$limit":5}]'
 
 # query pipeline results by ID
-viam data query mql --org-id=<org-id> --data-source-type=pipeline-sink \
+viam data query tabular mql --org-id=<org-id> --data-source-type=pipeline-sink \
   --pipeline-id=<pipeline-id> --mql='[{"$limit":5}]'
 
 # query pipeline results by name
-viam data query mql --org-id=<org-id> --data-source-type=pipeline-sink \
+viam data query tabular mql --org-id=<org-id> --data-source-type=pipeline-sink \
   --pipeline-name=my-pipeline --mql='[{"$limit":5}]'
+```
+
+### Query binary data metadata
+
+Query binary data metadata matching a filter. Returns metadata only, not binary content.
+
+```sh {class="command-line" data-prompt="$"}
+# query binary data metadata for a specific component
+viam data query binary filter --org-ids=<org-id> --component-name=front-camera --mime-types=image/jpeg --limit=10
+
+# save results to a file
+viam data query binary filter --org-ids=<org-id> --component-name=front-camera --destination=./query-results
 ```
 
 See [Query data in the app](/data/query-data/) for SQL and MQL syntax reference.

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -227,6 +227,8 @@ viam data database hostname --org-id=abc
 
 Query tabular data using SQL. Results are printed to stdout as NDJSON (one JSON object per line), or written to a file if `--destination` is specified.
 
+SQL queries run against `standard` tabular data. To query the [hot data store](/data/hot-data-store/) or a pipeline sink, use [`data query tabular mql`](#data-query-tabular-mql), which supports `--data-source-type`.
+
 ```sh {class="command-line" data-prompt="$"}
 # query tabular data with SQL and print results to stdout
 viam data query tabular sql --org-id=abc --sql="SELECT * FROM readings WHERE time_received >= CAST('2025-01-01T00:00:00Z' AS TIMESTAMP) LIMIT 10"

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -61,7 +61,7 @@ viam data export binary filter --destination=<output path> [...named args]
 viam data export binary ids --destination=<output path> [...named args]
 viam data export tabular --destination=<destination> --part-id=<part-id> --resource-name=<resource-name> --resource-subtype=<resource-subtype> --method=<method> [other options]
 viam data query sql --org-id=<org-id> --sql=<query> [--destination=<output path>]
-viam data query mql --org-id=<org-id> --mql=<query> [--data-source-type=<type>] [--destination=<output path>]
+viam data query mql --org-id=<org-id> --mql=<query> [--data-source-type=<type>] [--pipeline-id=<id> | --pipeline-name=<name>] [--destination=<output path>]
 viam data delete binary --org-ids=<org-ids> --start=<timestamp> --end=<timestamp> [...named args]
 viam data delete tabular --org-id=<org-id> --delete-older-than-days=<N>
 viam data database configure --org-id=<org-id> --password=<db-user-password>
@@ -255,8 +255,11 @@ viam data query mql --org-id=abc --mql-path=./my-query.json
 # query against the hot data store
 viam data query mql --org-id=abc --data-source-type=hot-storage --mql='[{"$limit":5}]'
 
-# query pipeline results
+# query pipeline results by ID
 viam data query mql --org-id=abc --data-source-type=pipeline-sink --pipeline-id=<pipeline-id> --mql='[{"$limit":5}]'
+
+# query pipeline results by name
+viam data query mql --org-id=abc --data-source-type=pipeline-sink --pipeline-name=my-pipeline --mql='[{"$limit":5}]'
 ```
 
 <!-- prettier-ignore -->
@@ -266,7 +269,8 @@ viam data query mql --org-id=abc --data-source-type=pipeline-sink --pipeline-id=
 | `--mql-path` | Path to a JSON file containing the MQL query. You must specify either `--mql` or `--mql-path`. | Optional |
 | `--org-id` | The organization ID. Uses default org if set. | Optional |
 | `--data-source-type` | Data source to query. Options: `standard` (default), `hot-storage`, `pipeline-sink`. | Optional |
-| `--pipeline-id` | Pipeline ID to query. Required when `--data-source-type=pipeline-sink`. | Optional |
+| `--pipeline-id` | Pipeline ID to query. Specify either `--pipeline-id` or `--pipeline-name`, not both. Required when `--data-source-type=pipeline-sink` if `--pipeline-name` is not specified. | Optional |
+| `--pipeline-name` | Pipeline name to query. Specify either `--pipeline-id` or `--pipeline-name`, not both. Required when `--data-source-type=pipeline-sink` if `--pipeline-id` is not specified. | Optional |
 | `--destination` | Output directory for query results. Prints to stdout if omitted. | Optional |
 
 ### `data tag ids add`

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -54,14 +54,15 @@ For setup instructions, see [Enable shell completion](/cli/overview/#enable-shel
 ## `data`
 
 The `data` command allows you to manage machine data.
-With it, you can export data in a variety of formats, query tabular data with SQL or MQL, delete data, add or remove tags from all data that matches a given filter, or configure a database user to enable querying synced data directly in the cloud.
+With it, you can export data in a variety of formats, query tabular or binary data with SQL or MQL, delete data, add or remove tags from all data that matches a given filter, or configure a database user to enable querying synced data directly in the cloud.
 
 ```sh {class="command-line" data-prompt="$"}
 viam data export binary filter --destination=<output path> [...named args]
 viam data export binary ids --destination=<output path> [...named args]
 viam data export tabular --destination=<destination> --part-id=<part-id> --resource-name=<resource-name> --resource-subtype=<resource-subtype> --method=<method> [other options]
-viam data query sql --org-id=<org-id> --sql=<query> [--destination=<output path>]
-viam data query mql --org-id=<org-id> --mql=<query> [--data-source-type=<type>] [--pipeline-id=<id> | --pipeline-name=<name>] [--destination=<output path>]
+viam data query tabular sql --org-id=<org-id> --sql=<query> [--destination=<output path>]
+viam data query tabular mql --org-id=<org-id> --mql=<query> [--data-source-type=<type>] [--pipeline-id=<id> | --pipeline-name=<name>] [--destination=<output path>]
+viam data query binary filter [--destination=<output path>] [--limit=<N>] [...named args from filter]
 viam data delete binary --org-ids=<org-ids> --start=<timestamp> --end=<timestamp> [...named args]
 viam data delete tabular --org-id=<org-id> --delete-older-than-days=<N>
 viam data database configure --org-id=<org-id> --password=<db-user-password>
@@ -222,16 +223,16 @@ viam data database hostname --org-id=abc
 | -------- | ----------- | --------- |
 | `--org-id` | The organization ID. Uses default org if set. | Optional |
 
-### `data query sql`
+### `data query tabular sql`
 
 Query tabular data using SQL. Results are printed to stdout as NDJSON (one JSON object per line), or written to a file if `--destination` is specified.
 
 ```sh {class="command-line" data-prompt="$"}
 # query tabular data with SQL and print results to stdout
-viam data query sql --org-id=abc --sql="SELECT * FROM readings WHERE time_received >= CAST('2025-01-01T00:00:00Z' AS TIMESTAMP) LIMIT 10"
+viam data query tabular sql --org-id=abc --sql="SELECT * FROM readings WHERE time_received >= CAST('2025-01-01T00:00:00Z' AS TIMESTAMP) LIMIT 10"
 
 # query and save results to a file
-viam data query sql --org-id=abc --sql="SELECT component_name, data FROM readings WHERE time_received >= CAST('2025-01-01T00:00:00Z' AS TIMESTAMP) LIMIT 100" --destination=./query-results
+viam data query tabular sql --org-id=abc --sql="SELECT component_name, data FROM readings WHERE time_received >= CAST('2025-01-01T00:00:00Z' AS TIMESTAMP) LIMIT 100" --destination=./query-results
 ```
 
 <!-- prettier-ignore -->
@@ -241,25 +242,25 @@ viam data query sql --org-id=abc --sql="SELECT component_name, data FROM reading
 | `--org-id` | The organization ID. Uses default org if set. | Optional |
 | `--destination` | Output directory for query results. Prints to stdout if omitted. | Optional |
 
-### `data query mql`
+### `data query tabular mql`
 
 Query tabular data using MQL (MongoDB Query Language). Results are printed to stdout as NDJSON (one JSON object per line), or written to a file if `--destination` is specified.
 
 ```sh {class="command-line" data-prompt="$"}
 # query tabular data with MQL and print results to stdout
-viam data query mql --org-id=abc --mql='[{"$match":{"component_name":"my-sensor"}},{"$limit":10}]'
+viam data query tabular mql --org-id=abc --mql='[{"$match":{"component_name":"my-sensor"}},{"$limit":10}]'
 
 # query from a JSON file
-viam data query mql --org-id=abc --mql-path=./my-query.json
+viam data query tabular mql --org-id=abc --mql-path=./my-query.json
 
 # query against the hot data store
-viam data query mql --org-id=abc --data-source-type=hot-storage --mql='[{"$limit":5}]'
+viam data query tabular mql --org-id=abc --data-source-type=hot-storage --mql='[{"$limit":5}]'
 
 # query pipeline results by ID
-viam data query mql --org-id=abc --data-source-type=pipeline-sink --pipeline-id=<pipeline-id> --mql='[{"$limit":5}]'
+viam data query tabular mql --org-id=abc --data-source-type=pipeline-sink --pipeline-id=<pipeline-id> --mql='[{"$limit":5}]'
 
 # query pipeline results by name
-viam data query mql --org-id=abc --data-source-type=pipeline-sink --pipeline-name=my-pipeline --mql='[{"$limit":5}]'
+viam data query tabular mql --org-id=abc --data-source-type=pipeline-sink --pipeline-name=my-pipeline --mql='[{"$limit":5}]'
 ```
 
 <!-- prettier-ignore -->
@@ -272,6 +273,37 @@ viam data query mql --org-id=abc --data-source-type=pipeline-sink --pipeline-nam
 | `--pipeline-id` | Pipeline ID to query. Specify either `--pipeline-id` or `--pipeline-name`, not both. Required when `--data-source-type=pipeline-sink` if `--pipeline-name` is not specified. | Optional |
 | `--pipeline-name` | Pipeline name to query. Specify either `--pipeline-id` or `--pipeline-name`, not both. Required when `--data-source-type=pipeline-sink` if `--pipeline-id` is not specified. | Optional |
 | `--destination` | Output directory for query results. Prints to stdout if omitted. | Optional |
+
+### `data query binary filter`
+
+Query binary data metadata by filter. Returns metadata only (no binary content). Results are printed to stdout as NDJSON (one JSON object per line), or written to a file if `--destination` is specified.
+
+```sh {class="command-line" data-prompt="$"}
+# query binary data metadata for a specific component
+viam data query binary filter --org-ids=<org-id> --component-name=front-camera --mime-types=image/jpeg --limit=10
+
+# save results to a file
+viam data query binary filter --org-ids=<org-id> --component-name=front-camera --destination=./query-results
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--destination` | Output directory for query results. Prints to stdout if omitted. | Optional |
+| `--limit` | Maximum number of results to return. 0 returns all matches. | Optional |
+| `--bbox-labels` | String labels corresponding to bounding boxes within images. | Optional |
+| `--component-name` | Filter by specified component name. | Optional |
+| `--component-type` | Filter by specified component type. | Optional |
+| `--location-ids` | Filter by specified location ID (accepts comma-separated list). | Optional |
+| `--machine-id` | Filter by specified machine ID. | Optional |
+| `--machine-name` | Filter by specified machine name. | Optional |
+| `--method` | Filter by specified method. | Optional |
+| `--mime-types` | Filter by specified MIME type (accepts comma-separated list). | Optional |
+| `--org-ids` | Filter by specified organization ID (accepts comma-separated list). | Optional |
+| `--part-id` | Filter by specified part ID. | Optional |
+| `--part-name` | Filter by specified part name. | Optional |
+| `--start` | ISO-8601 timestamp indicating the start of the interval. | Optional |
+| `--end` | ISO-8601 timestamp indicating the end of the interval. | Optional |
 
 ### `data tag ids add`
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -54,12 +54,14 @@ For setup instructions, see [Enable shell completion](/cli/overview/#enable-shel
 ## `data`
 
 The `data` command allows you to manage machine data.
-With it, you can export data in a variety of formats, delete data, add or remove tags from all data that matches a given filter, or configure a database user to enable querying synced data directly in the cloud.
+With it, you can export data in a variety of formats, query tabular data with SQL or MQL, delete data, add or remove tags from all data that matches a given filter, or configure a database user to enable querying synced data directly in the cloud.
 
 ```sh {class="command-line" data-prompt="$"}
 viam data export binary filter --destination=<output path> [...named args]
 viam data export binary ids --destination=<output path> [...named args]
 viam data export tabular --destination=<destination> --part-id=<part-id> --resource-name=<resource-name> --resource-subtype=<resource-subtype> --method=<method> [other options]
+viam data query sql --org-id=<org-id> --sql=<query> [--destination=<output path>]
+viam data query mql --org-id=<org-id> --mql=<query> [--data-source-type=<type>] [--destination=<output path>]
 viam data delete binary --org-ids=<org-ids> --start=<timestamp> --end=<timestamp> [...named args]
 viam data delete tabular --org-id=<org-id> --delete-older-than-days=<N>
 viam data database configure --org-id=<org-id> --password=<db-user-password>
@@ -220,6 +222,53 @@ viam data database hostname --org-id=abc
 | -------- | ----------- | --------- |
 | `--org-id` | The organization ID. Uses default org if set. | Optional |
 
+### `data query sql`
+
+Query tabular data using SQL. Results are printed to stdout as NDJSON (one JSON object per line), or written to a file if `--destination` is specified.
+
+```sh {class="command-line" data-prompt="$"}
+# query tabular data with SQL and print results to stdout
+viam data query sql --org-id=abc --sql="SELECT * FROM readings WHERE time_received >= CAST('2025-01-01T00:00:00Z' AS TIMESTAMP) LIMIT 10"
+
+# query and save results to a file
+viam data query sql --org-id=abc --sql="SELECT component_name, data FROM readings WHERE time_received >= CAST('2025-01-01T00:00:00Z' AS TIMESTAMP) LIMIT 100" --destination=./query-results
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--sql` | SQL query to run against the organization's tabular data. | **Required** |
+| `--org-id` | The organization ID. Uses default org if set. | Optional |
+| `--destination` | Output directory for query results. Prints to stdout if omitted. | Optional |
+
+### `data query mql`
+
+Query tabular data using MQL (MongoDB Query Language). Results are printed to stdout as NDJSON (one JSON object per line), or written to a file if `--destination` is specified.
+
+```sh {class="command-line" data-prompt="$"}
+# query tabular data with MQL and print results to stdout
+viam data query mql --org-id=abc --mql='[{"$match":{"component_name":"my-sensor"}},{"$limit":10}]'
+
+# query from a JSON file
+viam data query mql --org-id=abc --mql-path=./my-query.json
+
+# query against the hot data store
+viam data query mql --org-id=abc --data-source-type=hot-storage --mql='[{"$limit":5}]'
+
+# query pipeline results
+viam data query mql --org-id=abc --data-source-type=pipeline-sink --pipeline-id=<pipeline-id> --mql='[{"$limit":5}]'
+```
+
+<!-- prettier-ignore -->
+| Argument | Description | Required? |
+| -------- | ----------- | --------- |
+| `--mql` | MQL query as a JSON string. You must specify either `--mql` or `--mql-path`. | Optional |
+| `--mql-path` | Path to a JSON file containing the MQL query. You must specify either `--mql` or `--mql-path`. | Optional |
+| `--org-id` | The organization ID. Uses default org if set. | Optional |
+| `--data-source-type` | Data source to query. Options: `standard` (default), `hot-storage`, `pipeline-sink`. | Optional |
+| `--pipeline-id` | Pipeline ID to query. Required when `--data-source-type=pipeline-sink`. | Optional |
+| `--destination` | Output directory for query results. Prints to stdout if omitted. | Optional |
+
 ### `data tag ids add`
 
 Add tags to all data that matches the given binary data IDs.
@@ -378,7 +427,7 @@ Create a new data pipeline.
 viam datapipelines create --org-id=123 --name="Daily Sensor Summary" --schedule="0 9 * * *" --data-source-type=standard --mql='[{"$match": {"component_name": "sensor-1"}}]' --enable-backfill=False
 
 # create a data pipeline with hot storage data source type for faster access
-viam datapipelines create --org-id=123 --name="Real-time Analytics" --schedule="*/5 * * * *" --data-source-type=hotstorage --mql='[{"$match": {"component_name": "camera-1"}}]' --enable-backfill=False
+viam datapipelines create --org-id=123 --name="Real-time Analytics" --schedule="*/5 * * * *" --data-source-type=hot-storage --mql='[{"$match": {"component_name": "camera-1"}}]' --enable-backfill=False
 ```
 
 <!-- prettier-ignore -->
@@ -390,7 +439,7 @@ viam datapipelines create --org-id=123 --name="Real-time Analytics" --schedule="
 | `--org-id` | ID of the organization that owns the data pipeline. Uses default org if set. | Optional |
 | `--mql` | MQL (MongoDB Query Language) query as a JSON string for data processing. You must specify either `--mql` or `--mql-path` when creating a pipeline. | Optional |
 | `--mql-path` | Path to a JSON file containing the MQL query for the data pipeline. You must specify either `--mql` or `--mql-path` when creating a pipeline. | Optional |
-| `--data-source-type` | Data source type for the pipeline. Options: `standard` (default), `hotstorage`. | Optional |
+| `--data-source-type` | Data source type for the pipeline. Options: `standard` (default), `hot-storage`. | Optional |
 
 ### `datapipelines rename`
 

--- a/docs/data/pipelines/create-a-pipeline.md
+++ b/docs/data/pipelines/create-a-pipeline.md
@@ -47,7 +47,7 @@ The CLI prints the pipeline ID on success. Save this ID to query results and man
 | `--mql`              | One of `--mql` or `--mql-path` | The MQL aggregation pipeline as a JSON string.                                                                                  |
 | `--mql-path`         | One of `--mql` or `--mql-path` | Path to a file containing the MQL aggregation pipeline as JSON.                                                                 |
 | `--enable-backfill`  | Yes                            | Whether to process historical time windows. `true` or `false`.                                                                  |
-| `--data-source-type` | Yes                            | `standard` or `hotstorage`.                                                                                                     |
+| `--data-source-type` | Yes                            | `standard` or `hot-storage`.                                                                                                    |
 
 For complex queries, use `--mql-path` to read from a file:
 
@@ -216,7 +216,7 @@ Only organization owners can create data pipelines. Verify your API key has owne
 
 - **Check the `$match` stage.** Field names and values must match your actual data. Run the same MQL query in the query editor to verify it returns results.
 - **Check the time window.** If no data was captured during the pipeline's time window, the run produces no output.
-- **Check the data source type.** If you set `hotstorage` but the hot data store is not configured for your components, the pipeline has no data to query.
+- **Check the data source type.** If you set `hot-storage` but the hot data store is not configured for your components, the pipeline has no data to query.
 
 {{< /expand >}}
 

--- a/docs/data/pipelines/overview.md
+++ b/docs/data/pipelines/overview.md
@@ -36,9 +36,9 @@ A pipeline has four parts:
 
 2. **A [cron schedule](/data/pipelines/reference/#cron-schedule).** Determines how often the pipeline runs. The schedule also determines the query time window: an hourly schedule (`0 * * * *`) scopes each run to the previous hour of data. A 15-minute schedule (`*/15 * * * *`) scopes each run to the previous 15 minutes. Schedules are in UTC.
 
-3. **A data source.** Either `standard` (the raw readings collection containing all historical data) or `hotstorage` (the [hot data store](/data/hot-data-store/) containing a rolling window of recent data). See [Data source types](/data/pipelines/reference/#data-source-types) for the full list.
+3. **A data source.** Either `standard` (the raw readings collection containing all historical data) or `hot-storage` (the [hot data store](/data/hot-data-store/) containing a rolling window of recent data). See [Data source types](/data/pipelines/reference/#data-source-types) for the full list.
 
-4. **A pipeline sink.** The destination collection where results are stored. Each pipeline has its own sink. You query pipeline results by specifying the `pipeline_sink` data source type and the pipeline's ID.
+4. **A pipeline sink.** The destination collection where results are stored. Each pipeline has its own sink. You query pipeline results by specifying the `pipeline-sink` data source type and the pipeline's ID.
 
 ### Execution flow
 
@@ -72,8 +72,8 @@ When backfill is disabled, each time window is processed exactly once. Late-arri
 | Source type     | What it queries                                                                        | When to use                                                                                                                                  |
 | --------------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `standard`      | The raw `readings` collection containing all historical tabular data                   | Default. Use for aggregations over any time range.                                                                                           |
-| `hotstorage`    | The [hot data store](/data/hot-data-store/) containing a rolling window of recent data | Use when your pipeline only needs recent data and you want lower query latency.                                                              |
-| `pipeline_sink` | The output of another pipeline                                                         | Use when chaining pipelines: one pipeline produces summaries, another aggregates those summaries further. Requires the source pipeline's ID. |
+| `hot-storage`   | The [hot data store](/data/hot-data-store/) containing a rolling window of recent data | Use when your pipeline only needs recent data and you want lower query latency.                                                              |
+| `pipeline-sink` | The output of another pipeline                                                         | Use when chaining pipelines: one pipeline produces summaries, another aggregates those summaries further. Requires the source pipeline's ID. |
 
 ## What's next
 

--- a/docs/data/pipelines/query-results.md
+++ b/docs/data/pipelines/query-results.md
@@ -10,7 +10,7 @@ date: "2026-03-27"
 
 Once you have [created a pipeline](/data/pipelines/create-a-pipeline/), its results land in a dedicated sink collection that is separate from your raw data. This page covers how to query that sink.
 
-You query pipeline results the same way you query raw readings, except you specify the `pipeline_sink` data source type and the **pipeline ID** of the pipeline whose results you want. The pipeline ID is returned on creation. If you did not save it, retrieve it with:
+You query pipeline results the same way you query raw readings, except you specify the `pipeline-sink` data source type and the **pipeline ID** of the pipeline whose results you want. The pipeline ID is returned on creation. If you did not save it, retrieve it with:
 
 ```bash
 viam datapipelines list --org-id=<org-id>

--- a/docs/data/pipelines/reference.md
+++ b/docs/data/pipelines/reference.md
@@ -21,7 +21,7 @@ These are the underlying fields on the pipeline resource. The CLI flags and SDK 
 | `schedule`         | string | Yes      | `--schedule`            | Cron expression in UTC. Determines both when the pipeline runs and the query time window. See [Cron schedule](#cron-schedule).  |
 | `mql_binary`       | array  | Yes      | `--mql` or `--mql-path` | MQL aggregation pipeline as an array of stage objects. See [Supported MQL operators](/data/reference/#supported-mql-operators). |
 | `enable_backfill`  | bool   | Yes      | `--enable-backfill`     | Whether to process historical time windows. See [Backfill behavior](#backfill-behavior).                                        |
-| `data_source_type` | enum   | Yes      | `--data-source-type`    | Data source to query. Accepts `standard` or `hotstorage`. See [Data source types](#data-source-types).                          |
+| `data_source_type` | enum   | Yes      | `--data-source-type`    | Data source to query. Accepts `standard` or `hot-storage`. See [Data source types](#data-source-types).                         |
 
 ## Cron schedule
 
@@ -47,8 +47,8 @@ Pipelines support three data source types. You use them in two contexts: when cr
 | Type          | Value string    | Description                                                                                                                                                                                      |
 | ------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Standard      | `standard`      | The raw `readings` collection containing all historical tabular data.                                                                                                                            |
-| Hot storage   | `hotstorage`    | The [hot data store](/data/hot-data-store/). A rolling window of recent data, with lower latency.                                                                                                |
-| Pipeline sink | `pipeline_sink` | The output of another pipeline. **Query-time only**: you cannot pass `pipeline_sink` to `--data-source-type` when creating a pipeline; use it in query calls alongside the source pipeline's ID. |
+| Hot storage   | `hot-storage`   | The [hot data store](/data/hot-data-store/). A rolling window of recent data, with lower latency.                                                                                                |
+| Pipeline sink | `pipeline-sink` | The output of another pipeline. **Query-time only**: you cannot pass `pipeline-sink` to `--data-source-type` when creating a pipeline; use it in query calls alongside the source pipeline's ID. |
 
 The SDK constants for each type:
 
@@ -58,7 +58,7 @@ The SDK constants for each type:
 | Hot storage   | `TabularDataSourceType.TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE`   | `app.TabularDataSourceTypeHotStorage`   |
 | Pipeline sink | `TabularDataSourceType.TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK` | `app.TabularDataSourceTypePipelineSink` |
 
-To query the output of another pipeline, use `pipeline_sink` in your query call alongside the source pipeline's ID. See [Query pipeline results](/data/pipelines/query-results/).
+To query the output of another pipeline, use `pipeline-sink` in your query call alongside the source pipeline's ID. See [Query pipeline results](/data/pipelines/query-results/).
 
 ## Run statuses
 
@@ -127,7 +127,7 @@ Each pipeline stores its output in a dedicated sink collection named `sink-<pipe
 
 The `_viam_pipeline_run` field is added automatically. Your pipeline's `$project` output fields appear alongside it.
 
-To query the sink, use data source type `pipeline_sink` with the pipeline's ID. See [Query pipeline results](/data/pipelines/query-results/).
+To query the sink, use data source type `pipeline-sink` with the pipeline's ID. See [Query pipeline results](/data/pipelines/query-results/).
 
 {{< alert title="Deleting a pipeline is irreversible" color="caution" >}}
 Deleting a pipeline removes its sink collection and every result stored in it. Export the results first if you need to preserve them. See [Delete a pipeline](/data/pipelines/manage-pipelines/#delete-a-pipeline).

--- a/docs/data/query-data.md
+++ b/docs/data/query-data.md
@@ -12,7 +12,7 @@ aliases:
   - /build/data/query-data/
 ---
 
-Explore and analyze your captured data using SQL or MQL queries. You can run queries interactively in the Viam app's query editor or programmatically through the SDK for ad-hoc analysis, building dashboards, or integrating with your own tools.
+Explore and analyze your captured data using SQL or MQL queries. You can run queries interactively in the Viam app's query editor, from the command line with the [Viam CLI](/cli/manage-data/#query-data), or programmatically through the SDK for ad-hoc analysis, building dashboards, or integrating with your own tools.
 
 Tabular data (sensor readings, motor positions, encoder ticks, and other structured key-value data) is queryable through SQL and MQL. Binary data (images, point clouds) is stored separately and accessible through the [data client API](/reference/apis/data-client/).
 

--- a/docs/data/query-data.md
+++ b/docs/data/query-data.md
@@ -12,7 +12,7 @@ aliases:
   - /build/data/query-data/
 ---
 
-Explore and analyze your captured data using SQL or MQL queries. You can run queries interactively in the Viam app's query editor, from the command line with the [Viam CLI](/cli/manage-data/#query-data), or programmatically through the SDK for ad-hoc analysis, building dashboards, or integrating with your own tools.
+Explore and analyze your captured data using SQL or MQL queries. You can run queries interactively in the Viam app's query editor, from the command line with the [Viam CLI](/cli/manage-data/#query-data), or programmatically through the SDK. Use CLI or SDK queries for ad-hoc analysis, building dashboards, or integrating with your own tools.
 
 Tabular data (sensor readings, motor positions, encoder ticks, and other structured key-value data) is queryable through SQL and MQL. Binary data (images, point clouds) is stored separately and accessible through the [data client API](/reference/apis/data-client/).
 


### PR DESCRIPTION
## Source changes

- viamrobotics/rdk#6100: Added `viam data query sql` and `viam data query mql` CLI commands. Changed `--data-source-type` accepted values from `hotstorage` to `hot-storage` and `pipeline_sink` to `pipeline-sink`.
- viamrobotics/rdk#6117: Restructured `data query` into `data query tabular` and `data query binary` subcommands. `data query sql` → `data query tabular sql`, `data query mql` → `data query tabular mql`. Added new `data query binary filter` command.

## Docs changes

**Breaking fix (priority 2):** The `--data-source-type` flag on `viam datapipelines create` changed its accepted value from `hotstorage` to `hot-storage`. Users following the old docs would get an error. Fixed across 8 files:
- docs/cli/reference.md: fixed example and flag table
- docs/cli/data-pipelines.md: fixed flag table
- docs/data/pipelines/create-a-pipeline.md: fixed flag table and troubleshooting
- docs/data/pipelines/overview.md: fixed data source table and prose
- docs/data/pipelines/reference.md: fixed field table and data source types table

**Value consistency fix:** `pipeline_sink` (underscore) changed to `pipeline-sink` (hyphen) to match the CLI-accepted value. Fixed across 4 files.

**New command documentation:**
- docs/cli/reference.md: added `data query tabular sql`, `data query tabular mql`, and `data query binary filter` sections with flag tables and examples
- docs/cli/manage-data.md: added "Query data" section with tabular SQL, tabular MQL, binary filter, and data source type examples
- docs/data/query-data.md: added CLI as a query option in the introduction

## How I found these

- Diffed viamrobotics/rdk from 893945e to 46eda59
- Grep matched `hotstorage` across 6 docs files, `pipeline_sink` across 4 files
- Verified new CLI command structure against rdk/cli/app.go command tree (rdk#6117 restructuring)

---
Generated by daily docs change agent