### PR TITLE
try/viam-rover: redirect section landing to overview

### DIFF
--- a/docs/try/viam-rover/_index.md
+++ b/docs/try/viam-rover/_index.md
@@ -2,10 +2,8 @@
 linkTitle: "Viam Rover"
 title: "Viam Rover"
 weight: 60
-layout: "docs"
+empty_node: true
+layout: "empty"
+canonical: "/try/viam-rover/overview/"
 type: "docs"
-no_list: true
-manualLink: "/try/viam-rover/overview/"
-description: "Order a Viam Rover, set it up, and configure it for use with Viam."
-date: "2026-05-23"
 ---


### PR DESCRIPTION
The /try/viam-rover/ stub used layout: docs with manualLink, which only sets the sidebar link and rendered a blank page. Switch to the empty redirect pattern (layout: empty + canonical) so the landing page issues a meta-refresh to /try/viam-rover/overview/.

Please include a summary of the change and what is does. Please also include relevant motivation and context.

Review process:

- No need to request review from any specific docs team members; we will see your PR and one of us will review.
- If you need technical review from engineering, please request review from the relevant person.
- Docs team might commit styling nit fixes to save you the trouble :)
- You can merge after approval from one docs team member (as well as any necessary technical review).
