### PR TITLE
Correct Python SDK installation: use venv and link to a central install page

### DIFF
--- a/docs/data/data-management-tutorial.md
+++ b/docs/data/data-management-tutorial.md
@@ -135,7 +135,9 @@ The same data is accessible from your own code through the Viam SDK.
 Install the Viam Python SDK:
 
 ```bash
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 Save this as `query_data.py`:

--- a/docs/data/data-management-tutorial.md
+++ b/docs/data/data-management-tutorial.md
@@ -134,11 +134,7 @@ The same data is accessible from your own code through the Viam SDK.
 
 Install the Viam Python SDK:
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 Save this as `query_data.py`:
 

--- a/docs/data/query-data-from-code.md
+++ b/docs/data/query-data-from-code.md
@@ -41,7 +41,9 @@ Tabular data queries (`TabularDataByMQL` and `TabularDataBySQL`) share a 100&nbs
 {{% tab name="Python" %}}
 
 ```bash
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 ```python

--- a/docs/data/query-data-from-code.md
+++ b/docs/data/query-data-from-code.md
@@ -40,11 +40,7 @@ Tabular data queries (`TabularDataByMQL` and `TabularDataBySQL`) share a 100&nbs
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 ```python
 import asyncio

--- a/docs/data/sync-data-to-your-database.md
+++ b/docs/data/sync-data-to-your-database.md
@@ -170,7 +170,9 @@ directly to your own MongoDB cluster.
 Install dependencies:
 
 ```sh
-pip install viam-sdk pymongo
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk pymongo
 ```
 
 Save this as `sync_to_db.py`:

--- a/docs/data/sync-data-to-your-database.md
+++ b/docs/data/sync-data-to-your-database.md
@@ -167,12 +167,10 @@ directly to your own MongoDB cluster.
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-Install dependencies:
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/). Then install `pymongo`:
 
 ```sh
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk pymongo
+pip3 install pymongo
 ```
 
 Save this as `sync_to_db.py`:

--- a/docs/data/visualize-data.md
+++ b/docs/data/visualize-data.md
@@ -291,12 +291,10 @@ Viam SDK to query data and a plotting library to render it.
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-Install the dependencies:
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/). Then install `matplotlib`:
 
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk matplotlib
+pip3 install matplotlib
 ```
 
 Save this as `visualize_data.py`:

--- a/docs/data/visualize-data.md
+++ b/docs/data/visualize-data.md
@@ -294,7 +294,9 @@ Viam SDK to query data and a plotting library to render it.
 Install the dependencies:
 
 ```bash
-pip install viam-sdk matplotlib
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk matplotlib
 ```
 
 Save this as `visualize_data.py`:

--- a/docs/hardware/common-components/add-a-base.md
+++ b/docs/hardware/common-components/add-a-base.md
@@ -124,11 +124,7 @@ With a fake base, the commands complete without physical motion.
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 Save this as `base_test.py`:
 

--- a/docs/hardware/common-components/add-a-base.md
+++ b/docs/hardware/common-components/add-a-base.md
@@ -125,7 +125,9 @@ With a fake base, the commands complete without physical motion.
 {{% tab name="Python" %}}
 
 ```bash
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 Save this as `base_test.py`:

--- a/docs/hardware/common-components/add-a-board.md
+++ b/docs/hardware/common-components/add-a-board.md
@@ -132,7 +132,9 @@ If you have an LED wired to pin 11, you'll see it turn on and off when you run t
 {{% tab name="Python" %}}
 
 ```bash
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 Save this as `board_test.py`:

--- a/docs/hardware/common-components/add-a-board.md
+++ b/docs/hardware/common-components/add-a-board.md
@@ -131,11 +131,7 @@ If you have an LED wired to pin 11, you'll see it turn on and off when you run t
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 Save this as `board_test.py`:
 

--- a/docs/hardware/common-components/add-a-button.md
+++ b/docs/hardware/common-components/add-a-button.md
@@ -75,11 +75,7 @@ When you run the code below, the button's Push method fires. With a physical but
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 Save this as `button_test.py`:
 

--- a/docs/hardware/common-components/add-a-button.md
+++ b/docs/hardware/common-components/add-a-button.md
@@ -76,7 +76,9 @@ When you run the code below, the button's Push method fires. With a physical but
 {{% tab name="Python" %}}
 
 ```bash
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 Save this as `button_test.py`:

--- a/docs/hardware/common-components/add-a-camera.md
+++ b/docs/hardware/common-components/add-a-camera.md
@@ -165,11 +165,7 @@ When you run the code below, it saves an image file to your current directory. C
 
 Install the SDK if you haven't already:
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 Save this as `camera_test.py`:
 

--- a/docs/hardware/common-components/add-a-camera.md
+++ b/docs/hardware/common-components/add-a-camera.md
@@ -166,7 +166,9 @@ When you run the code below, it saves an image file to your current directory. C
 Install the SDK if you haven't already:
 
 ```bash
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 Save this as `camera_test.py`:

--- a/docs/hardware/common-components/add-a-gantry.md
+++ b/docs/hardware/common-components/add-a-gantry.md
@@ -128,11 +128,7 @@ With a fake gantry, position values update without physical motion.
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 Save this as `gantry_test.py`:
 

--- a/docs/hardware/common-components/add-a-gantry.md
+++ b/docs/hardware/common-components/add-a-gantry.md
@@ -129,7 +129,9 @@ With a fake gantry, position values update without physical motion.
 {{% tab name="Python" %}}
 
 ```bash
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 Save this as `gantry_test.py`:

--- a/docs/hardware/common-components/add-a-generic.md
+++ b/docs/hardware/common-components/add-a-generic.md
@@ -81,11 +81,7 @@ With the fake model, you'll see your command echoed back. With a real module, th
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 Save this as `generic_test.py`:
 

--- a/docs/hardware/common-components/add-a-generic.md
+++ b/docs/hardware/common-components/add-a-generic.md
@@ -82,7 +82,9 @@ With the fake model, you'll see your command echoed back. With a real module, th
 {{% tab name="Python" %}}
 
 ```bash
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 Save this as `generic_test.py`:

--- a/docs/hardware/common-components/add-a-gripper.md
+++ b/docs/hardware/common-components/add-a-gripper.md
@@ -138,11 +138,7 @@ With the fake model, Grab always returns true.
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 Save this as `gripper_test.py`:
 

--- a/docs/hardware/common-components/add-a-gripper.md
+++ b/docs/hardware/common-components/add-a-gripper.md
@@ -139,7 +139,9 @@ With the fake model, Grab always returns true.
 {{% tab name="Python" %}}
 
 ```bash
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 Save this as `gripper_test.py`:

--- a/docs/hardware/common-components/add-a-motor.md
+++ b/docs/hardware/common-components/add-a-motor.md
@@ -141,7 +141,9 @@ Without an encoder, position readings will be estimates based on time and max RP
 {{% tab name="Python" %}}
 
 ```bash
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 Save this as `motor_test.py`:

--- a/docs/hardware/common-components/add-a-motor.md
+++ b/docs/hardware/common-components/add-a-motor.md
@@ -140,11 +140,7 @@ Without an encoder, position readings will be estimates based on time and max RP
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 Save this as `motor_test.py`:
 

--- a/docs/hardware/common-components/add-a-movement-sensor.md
+++ b/docs/hardware/common-components/add-a-movement-sensor.md
@@ -139,11 +139,7 @@ When you run the code below, you'll see which methods your sensor supports and t
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 Save this as `movement_sensor_test.py`:
 

--- a/docs/hardware/common-components/add-a-movement-sensor.md
+++ b/docs/hardware/common-components/add-a-movement-sensor.md
@@ -140,7 +140,9 @@ When you run the code below, you'll see which methods your sensor supports and t
 {{% tab name="Python" %}}
 
 ```bash
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 Save this as `movement_sensor_test.py`:

--- a/docs/hardware/common-components/add-a-power-sensor.md
+++ b/docs/hardware/common-components/add-a-power-sensor.md
@@ -91,7 +91,9 @@ When you run the code below, you'll see voltage, current, and power readings. Ve
 {{% tab name="Python" %}}
 
 ```bash
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 Save this as `power_sensor_test.py`:

--- a/docs/hardware/common-components/add-a-power-sensor.md
+++ b/docs/hardware/common-components/add-a-power-sensor.md
@@ -90,11 +90,7 @@ When you run the code below, you'll see voltage, current, and power readings. Ve
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 Save this as `power_sensor_test.py`:
 

--- a/docs/hardware/common-components/add-a-sensor.md
+++ b/docs/hardware/common-components/add-a-sensor.md
@@ -114,11 +114,7 @@ When you run the code below, you'll see sensor readings printed once per second.
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 Save this as `sensor_test.py`:
 

--- a/docs/hardware/common-components/add-a-sensor.md
+++ b/docs/hardware/common-components/add-a-sensor.md
@@ -115,7 +115,9 @@ When you run the code below, you'll see sensor readings printed once per second.
 {{% tab name="Python" %}}
 
 ```bash
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 Save this as `sensor_test.py`:

--- a/docs/hardware/common-components/add-a-servo.md
+++ b/docs/hardware/common-components/add-a-servo.md
@@ -102,7 +102,9 @@ If you're using real hardware, you'll see the servo sweep through positions when
 {{% tab name="Python" %}}
 
 ```bash
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 Save this as `servo_test.py`:

--- a/docs/hardware/common-components/add-a-servo.md
+++ b/docs/hardware/common-components/add-a-servo.md
@@ -101,11 +101,7 @@ If you're using real hardware, you'll see the servo sweep through positions when
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 Save this as `servo_test.py`:
 

--- a/docs/hardware/common-components/add-a-switch.md
+++ b/docs/hardware/common-components/add-a-switch.md
@@ -83,11 +83,7 @@ When you run the code below, you'll see the switch cycle through all positions. 
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 Save this as `switch_test.py`:
 

--- a/docs/hardware/common-components/add-a-switch.md
+++ b/docs/hardware/common-components/add-a-switch.md
@@ -84,7 +84,9 @@ When you run the code below, you'll see the switch cycle through all positions. 
 {{% tab name="Python" %}}
 
 ```bash
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 Save this as `switch_test.py`:

--- a/docs/hardware/common-components/add-an-arm.md
+++ b/docs/hardware/common-components/add-an-arm.md
@@ -150,7 +150,9 @@ The **3D Scene** tab on your machine's page renders the arm's live pose, which a
 {{% tab name="Python" %}}
 
 ```bash
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 Save this as `arm_test.py`:

--- a/docs/hardware/common-components/add-an-arm.md
+++ b/docs/hardware/common-components/add-an-arm.md
@@ -149,11 +149,7 @@ The **3D Scene** tab on your machine's page renders the arm's live pose, which a
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 Save this as `arm_test.py`:
 

--- a/docs/hardware/common-components/add-an-encoder.md
+++ b/docs/hardware/common-components/add-an-encoder.md
@@ -144,7 +144,9 @@ When you run the code below, you'll see the encoder's current position, then res
 {{% tab name="Python" %}}
 
 ```bash
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 Save this as `encoder_test.py`:

--- a/docs/hardware/common-components/add-an-encoder.md
+++ b/docs/hardware/common-components/add-an-encoder.md
@@ -143,11 +143,7 @@ When you run the code below, you'll see the encoder's current position, then res
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 Save this as `encoder_test.py`:
 

--- a/docs/hardware/common-components/add-an-input-controller.md
+++ b/docs/hardware/common-components/add-an-input-controller.md
@@ -115,7 +115,9 @@ When you run the code below, press buttons on your gamepad and watch the events 
 {{% tab name="Python" %}}
 
 ```bash
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 Save this as `input_test.py`:

--- a/docs/hardware/common-components/add-an-input-controller.md
+++ b/docs/hardware/common-components/add-an-input-controller.md
@@ -114,11 +114,7 @@ When you run the code below, press buttons on your gamepad and watch the events 
 {{< tabs >}}
 {{% tab name="Python" %}}
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 Save this as `input_test.py`:
 

--- a/docs/motion-planning/quickstarts/first-arm.md
+++ b/docs/motion-planning/quickstarts/first-arm.md
@@ -96,7 +96,9 @@ Replace `YOUR-API-KEY`, `YOUR-API-KEY-ID`, and `YOUR-MACHINE-ADDRESS`
 with the values from the **CONNECT** tab. Then run:
 
 ```sh
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 python first_arm.py
 ```
 

--- a/docs/motion-planning/quickstarts/first-arm.md
+++ b/docs/motion-planning/quickstarts/first-arm.md
@@ -93,12 +93,9 @@ if __name__ == "__main__":
 ```
 
 Replace `YOUR-API-KEY`, `YOUR-API-KEY-ID`, and `YOUR-MACHINE-ADDRESS`
-with the values from the **CONNECT** tab. Then run:
+with the values from the **CONNECT** tab. Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/). Then run:
 
 ```sh
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
 python first_arm.py
 ```
 

--- a/docs/reference/sdks/python/python-venv.md
+++ b/docs/reference/sdks/python/python-venv.md
@@ -3,7 +3,7 @@ title: "Install the Python SDK"
 linkTitle: "Install the Python SDK"
 weight: 10
 type: "docs"
-description: "Create a virtual environment and install the Python SDK for Viam apps."
+description: "Create a virtual environment and install the Python SDK for Viam."
 images: ["/services/icons/sdk.svg"]
 tags:
   ["client", "sdk", "application", "sdk", "fleet", "program", "python", "venv"]

--- a/docs/reference/sdks/python/python-venv.md
+++ b/docs/reference/sdks/python/python-venv.md
@@ -1,9 +1,9 @@
 ---
-title: "Prepare your Python Virtual Environment"
-linkTitle: "Virtualenv for Python SDK"
+title: "Install the Python SDK"
+linkTitle: "Install the Python SDK"
 weight: 10
 type: "docs"
-description: "Prepare your Python Virtual Environment to program machines with the Python SDK."
+description: "Create a virtual environment and install the Python SDK for Viam apps."
 images: ["/services/icons/sdk.svg"]
 tags:
   ["client", "sdk", "application", "sdk", "fleet", "program", "python", "venv"]
@@ -18,7 +18,7 @@ date: "2022-01-01"
 To manage Python packages for your code, it is recommended that you use a virtual environment, or `venv`.
 By using a `venv`, you can install Python packages like Viam's client SDK within a virtual environment, avoiding conflicts with other projects or your system.
 
-Follow this guide to set up a fresh virtual environment on your working computer and install the Python SDK as a requirement for your Viam client application.
+Follow this guide to create a fresh virtual environment on your working computer and install the Python SDK for your Viam client application.
 
 ## Install virtualenv
 

--- a/docs/tutorials/custom/custom-base-dog.md
+++ b/docs/tutorials/custom/custom-base-dog.md
@@ -110,7 +110,9 @@ If the name of the directory where you store and run your code is different, be 
 1. Install the [Viam Python SDK](https://python.viam.dev/):
 
    ```sh {class="command-line" data-prompt="$"}
-   pip install viam-sdk
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip3 install viam-sdk
    ```
 
 1. Enable I<sup>2</sup>C on your Pi using `sudo raspi-config`.

--- a/docs/tutorials/custom/custom-base-dog.md
+++ b/docs/tutorials/custom/custom-base-dog.md
@@ -107,13 +107,7 @@ If the name of the directory where you store and run your code is different, be 
 
    If it isn’t Python 3.8 or later, install an updated version of Python and double-check that you're running the latest Raspberry Pi OS.
 
-1. Install the [Viam Python SDK](https://python.viam.dev/):
-
-   ```sh {class="command-line" data-prompt="$"}
-   python3 -m venv .venv
-   source .venv/bin/activate
-   pip3 install viam-sdk
-   ```
+1. Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 1. Enable I<sup>2</sup>C on your Pi using `sudo raspi-config`.
 

--- a/docs/tutorials/get-started/servo-mousemover.md
+++ b/docs/tutorials/get-started/servo-mousemover.md
@@ -97,13 +97,7 @@ pip3 --version
 ```
 
 The [Viam Python SDK](https://python.viam.dev/) (Software Development Kit) allows you to write programs in the Python programming language to operate machines using Viam.
-To get the Python SDK working on the Raspberry Pi, run the following command in your Raspberry Pi terminal:
-
-```sh {class="command-line" data-prompt="$"}
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+To get the Python SDK working on the Raspberry Pi, follow [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 ## Test the SDK with your machine
 

--- a/docs/tutorials/get-started/servo-mousemover.md
+++ b/docs/tutorials/get-started/servo-mousemover.md
@@ -100,7 +100,9 @@ The [Viam Python SDK](https://python.viam.dev/) (Software Development Kit) allow
 To get the Python SDK working on the Raspberry Pi, run the following command in your Raspberry Pi terminal:
 
 ```sh {class="command-line" data-prompt="$"}
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 ## Test the SDK with your machine

--- a/docs/tutorials/projects/make-a-plant-watering-robot.md
+++ b/docs/tutorials/projects/make-a-plant-watering-robot.md
@@ -305,14 +305,6 @@ sudo apt update
 sudo apt upgrade
 ```
 
-Then run the following command to create and activate the virtual environment:
-If you want to read more on virtual environments, check out [the documentation](/reference/sdks/python/python-venv/).
-
-```sh {class="command-line" data-prompt="$"}
-python3 -m venv .venv
-source .venv/bin/activate
-```
-
 Make sure you have `pip` installed for Python 3:
 
 ```shell {class="command-line" data-prompt="$"}
@@ -325,13 +317,7 @@ If not, run the following command:
 sudo apt install python3-pip
 ```
 
-Run the following command to install the SDK:
-
-```sh {class="command-line" data-prompt="$"}
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+After that, follow [Install the Python SDK](/reference/sdks/python/python-venv/) to create and activate a virtual environment and install `viam-sdk` on your Pi.
 
 ### Add Python control code
 

--- a/docs/tutorials/projects/make-a-plant-watering-robot.md
+++ b/docs/tutorials/projects/make-a-plant-watering-robot.md
@@ -328,6 +328,8 @@ sudo apt install python3-pip
 Run the following command to install the SDK:
 
 ```sh {class="command-line" data-prompt="$"}
+python3 -m venv .venv
+source .venv/bin/activate
 pip3 install viam-sdk
 ```
 

--- a/docs/vision/configure.md
+++ b/docs/vision/configure.md
@@ -211,11 +211,7 @@ Verify end-to-end by pulling a detection from your own code.
 
 Install the SDK if you have not already:
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install viam-sdk
-```
+Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
 
 {{< tabs >}}
 {{% tab name="Python" %}}

--- a/docs/vision/configure.md
+++ b/docs/vision/configure.md
@@ -212,7 +212,9 @@ Verify end-to-end by pulling a detection from your own code.
 Install the SDK if you have not already:
 
 ```bash
-pip install viam-sdk
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install viam-sdk
 ```
 
 {{< tabs >}}


### PR DESCRIPTION
Bare `pip install viam-sdk` fails or is discouraged on modern Python (PEP 668 / externally-managed-environment). Installation instructions across tutorials and reference docs needed to match what the CONNECT tab already recommends.

## Changes

- **Central install page** (`docs/reference/sdks/python/python-venv.md`): retitled to "Install the Python SDK" so it serves as the canonical destination for installation instructions.
- **25 affected docs** (data, hardware/common-components, motion-planning, vision, tutorials): replaced repeated inline venv+pip blocks with a single link to the central page. Where extra dependencies are needed (`pymongo`, `matplotlib`), only the additional `pip3 install <dep>` line is kept inline.

Before (repeated in ~25 places):
```bash
python3 -m venv .venv
source .venv/bin/activate
pip3 install viam-sdk
```

After:
```
Install the Viam Python SDK in a virtual environment by following [Install the Python SDK](/reference/sdks/python/python-venv/).
```