### PR TITLE
Fix Test Code Samples: select a non-owner member in fleet-api orgs sample

### DIFF
--- a/static/include/examples/fleet-api/fleet-management-api-orgs.py
+++ b/static/include/examples/fleet-api/fleet-management-api-orgs.py
@@ -192,7 +192,27 @@ async def main():
         assert new_num_keys == num_keys
 
         # setup
-        user_id = member_list[-1].user_id
+        # Pick an organization member who does not already hold (or inherit)
+        # owner permissions, so that add_role grants a brand-new authorization.
+        # Members who are already owners -- for example org owners, who inherit
+        # location ownership -- cannot have the role added again, which would
+        # make add_role fail.
+        existing_authorizations = await cloud.list_authorizations(org_id=ORG_ID)
+        privileged_identity_ids = {
+            authorization.identity_id for authorization in existing_authorizations
+        }
+        user_id = next(
+            (
+                member.user_id
+                for member in member_list
+                if member.user_id not in privileged_identity_ids
+            ),
+            None,
+        )
+        assert user_id is not None, (
+            "Expected at least one organization member without existing "
+            "authorizations to test add_role/change_role/remove_role."
+        )
 
         await cloud.add_role(
           org_id=ORG_ID,


### PR DESCRIPTION
## Problem

The **Test Code Samples** job (`test-code-snippets.yml`) has failed on **every run since 2025-11-10** — both the weekly scheduled runs and every dependabot/push run. Because the Python step runs first and exits non-zero, the Go and TypeScript sample steps never run, so this also blocks validation of unrelated dependency bumps.

The single failing file is `static/include/examples/fleet-api/fleet-management-api-orgs.py`. Today's run: 28/29 Python samples pass; this one fails at the `add_role` call (line ~197):

```
grpclib.exceptions.GRPCError: (<Status.INTERNAL: 13>,
  'cannot add authorization: user a46bc9ee-… has inherited location_owner
   permissions on resource pg5q3j3h95 with resource type location')
```

## Root cause

The sample selected `member_list[-1]` (the **last** org member) for the `add_role → change_role → remove_role` lifecycle. Member ordering isn't guaranteed, and the test org's membership has since changed so the last member is now an **org owner**. Org owners **inherit** `location_owner` on every location, so adding a location-level `owner` role to them is rejected by the backend.

This is an **environmental regression**, not a code change — the file was unchanged when the job went red on Nov 10 (the next edits to it were Nov 13/27/28, after it was already failing).

## Fix

Select a member who holds **no existing authorizations** (so they can't inherit `location_owner`) instead of relying on list position:

```python
existing_authorizations = await cloud.list_authorizations(org_id=ORG_ID)
privileged_identity_ids = {a.identity_id for a in existing_authorizations}
user_id = next(
    (m.user_id for m in member_list if m.user_id not in privileged_identity_ids),
    None,
)
assert user_id is not None, "Expected at least one organization member without existing authorizations ..."
```

`add_role` then grants a genuinely new authorization regardless of member ordering, and the downstream `change_role`/`remove_role` and count assertions hold. If no roleless member exists, the new assert fails with a clear message instead of a cryptic `GRPCError`.

## Verification

- `python -m py_compile` passes; AST parses.
- ⚠️ **Not run against the live Viam API** — the test requires `VIAM_API_KEY`/`TEST_ORG_ID`/etc., which are GitHub Actions secrets unavailable locally. Please confirm via the **Test Code Samples** workflow on this branch (or a maintainer re-run) that the org has at least one member without existing authorizations. If the test org happens to contain *only* owners, the new assert will surface that explicitly and a non-owner member should be added to the org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)