### PR TITLE
fragments: --fragment name-or-id in two remaining CLI docs

### DIFF
--- a/docs/fleet/deploy-software.md
+++ b/docs/fleet/deploy-software.md
@@ -53,10 +53,10 @@ Include the fragment ID in your `viam-defaults.json` file. New machines apply th
 **Through the CLI:**
 
 ```sh {class="command-line" data-prompt="$"}
-viam machines part fragments add --part=<part-id> --fragment=<fragment-id>
+viam machines part fragments add --part=<part-id> --fragment=<fragment-name-or-id>
 ```
 
-To find your part ID, run `viam machines part list --machine=<machine-id>`. To find the fragment ID, copy it from the fragment's page in the Viam app or run `viam organizations list` and check your fragments.
+To find your part ID, run `viam machines part list --machine=<machine-id>`. Pass either the fragment's name or its ID; find the ID on the fragment's page in the Viam app, or run `viam organizations list` and check your fragments.
 
 ## 4. Verify the deployment
 

--- a/docs/set-up-a-machine/with-cli.md
+++ b/docs/set-up-a-machine/with-cli.md
@@ -76,7 +76,7 @@ If the machine is connected, the CLI prints its part list and status. If not, se
 If you have a fragment defining your standard component setup, attach it to the machine's main part:
 
 ```sh {class="command-line" data-prompt="$"}
-viam machines part fragments add --part=<part-id> --fragment=<fragment-id>
+viam machines part fragments add --part=<part-id> --fragment=<fragment-name-or-id>
 ```
 
 See [Reuse machine configuration](/fleet/reuse-configuration/) for the fragment authoring workflow.


### PR DESCRIPTION
## Summary

Follow-up to #5023. That PR corrected the `--fragment` placeholder from ID-only to name-or-id on `reuse-configuration.md`, `cli/configure-machines.md`, and `cli/reference.md`, but two other pages show the same `viam machines part fragments add` command with the old `<fragment-id>` placeholder. This updates them for consistency with the same flag's documented behavior:

- **`docs/set-up-a-machine/with-cli.md`** — the CLI setup path that #5023's "With the CLI" section points readers to.
- **`docs/fleet/deploy-software.md`** — the "Through the CLI" block (placeholder + the find-the-fragment prose).

## Verification

Same source as #5023 — `rdk/cli/client.go`:

- `RobotsPartAddFragmentAction` matches by `fragment.Name == args.Fragment || fragment.Id == args.Fragment`, so the flag accepts either a fragment name or an ID.

## Test plan

- [ ] `/set-up-a-machine/with-cli/` shows `--fragment=<fragment-name-or-id>` in the "Apply a baseline configuration" step.
- [ ] `/fleet/deploy-software/` "Through the CLI" block shows the name-or-id placeholder and the updated prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)