### PR TITLE
first-machine: fix xArm6 model name in step 8

### DIFF
--- a/docs/set-up-a-machine/first-machine.md
+++ b/docs/set-up-a-machine/first-machine.md
@@ -60,7 +60,7 @@ For each piece of hardware (camera, motor, sensor, arm, gripper, base):
 
 1. Click the **+** button on the **CONFIGURE** tab.
 2. Select **Component**.
-3. Search for the model that matches your hardware. Search by manufacturer or hardware type (for example, `webcam`, `viam:raspberry-pi:rpi5`, `ufactory:xarm6`).
+3. Search for the model that matches your hardware. Search by manufacturer or hardware type (for example, `webcam`, `viam:raspberry-pi:rpi5`, `viam:ufactory:xArm6`).
 4. Name the component and click **Create**.
 5. Fill in the required attributes (pin numbers, device paths, API keys) and click **Save**.
 


### PR DESCRIPTION
## Summary

Follow-up to #5034. Step 8's search example used `ufactory:xarm6`, which is not a valid registry model name and won't match in the model search:

- Registry models are three-part (`namespace:module:model`); `ufactory:xarm6` is missing the `viam:` namespace.
- The correct capitalization is `xArm6`.

Fix: `ufactory:xarm6` → `viam:ufactory:xArm6`.

The other two examples (`webcam`, `viam:raspberry-pi:rpi5`) are correct and unchanged.

## Verification

- `viam-modules/viam-ufactory-xarm/meta.json` lists `"model": "viam:ufactory:xArm6"`.
- The docs already use `viam:ufactory:xArm6` elsewhere (for example `docs/hardware/fragments.md`, `docs/tutorials/projects/claw-game.md`).

## Test plan

- [ ] `/set-up-a-machine/first-machine/` step 8 shows `viam:ufactory:xArm6` in the search example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)