### PR TITLE
Update docs for Resource.Reconfigure removal [On Hold until Next RDK Release]

### DIFF
--- a/docs/build-modules/module-reference.md
+++ b/docs/build-modules/module-reference.md
@@ -240,12 +240,12 @@ if __name__ == '__main__':
 
 The default behavior when you don't implement a method:
 
-| Behavior                 | Go                                                                                 | Python                                                                                |
-| ------------------------ | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| Rebuild on config change | Default (`viam-server` destroys and re-creates the resource)                       | Default (`viam-server` destroys and re-creates the resource)                          |
-| In-place reconfigure     | Implement `Reconfigure()` (replace the `AlwaysRebuild` embed with your own method) | Not supported; resources always rebuild (the `Reconfigurable` protocol is deprecated) |
-| No-op close              | Embed `resource.TriviallyCloseable`                                                | Default on `ResourceBase`                                                             |
-| Skip config validation   | Embed `resource.TriviallyValidateConfig`                                           | Default on `EasyResource`                                                             |
+| Behavior                 | Go                                                                  | Python                                                                                |
+| ------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Rebuild on config change | Default (`viam-server` destroys and re-creates the resource)        | Default (`viam-server` destroys and re-creates the resource)                          |
+| In-place reconfigure     | Not supported for modular resources (`viam-server` always rebuilds) | Not supported; resources always rebuild (the `Reconfigurable` protocol is deprecated) |
+| No-op close              | Embed `resource.TriviallyCloseable`                                 | Default on `ResourceBase`                                                             |
+| Skip config validation   | Embed `resource.TriviallyValidateConfig`                            | Default on `EasyResource`                                                             |
 
 ## Logging
 
@@ -331,13 +331,13 @@ defined in `proto/viam/module/v1/module.proto`:
 
 All RPCs are initiated by `viam-server` and handled by the module:
 
-| RPC                   | Purpose                                                  |
-| --------------------- | -------------------------------------------------------- |
-| `Ready`               | Handshake: module returns its supported API/model pairs. |
-| `AddResource`         | Create a new resource instance from config.              |
-| `ReconfigureResource` | Update an existing resource with new config.             |
-| `RemoveResource`      | Destroy a resource instance.                             |
-| `ValidateConfig`      | Validate config and return implicit dependencies.        |
+| RPC                   | Purpose                                                                                               |
+| --------------------- | ----------------------------------------------------------------------------------------------------- |
+| `Ready`               | Handshake: module returns its supported API/model pairs.                                              |
+| `AddResource`         | Create a new resource instance from config.                                                           |
+| `ReconfigureResource` | _Deprecated._ Rebuilds the resource. `viam-server` now uses `RemoveResource` + `AddResource` instead. |
+| `RemoveResource`      | Destroy a resource instance.                                                                          |
+| `ValidateConfig`      | Validate config and return implicit dependencies.                                                     |
 
 The module also connects back to the parent `viam-server` to access other
 resources (dependencies) on the machine.

--- a/docs/build-modules/platform-apis.md
+++ b/docs/build-modules/platform-apis.md
@@ -4,7 +4,7 @@ linkTitle: "Use platform APIs"
 weight: 35
 layout: "docs"
 type: "docs"
-description: "Write your validate and reconfigure functions to handle dependencies in your custom modular resource."
+description: "Write your validate function and constructor to handle dependencies in your custom modular resource."
 aliases:
   - /operate/modules/advanced/platform-apis/
 date: "2025-11-05"

--- a/docs/data/filter-at-the-edge.md
+++ b/docs/data/filter-at-the-edge.md
@@ -220,7 +220,7 @@ For filtering needs that go beyond what the `filtered-camera` module provides, y
 
 The pattern is: write a module that wraps an existing component, evaluates its data against your criteria, and only returns data worth capturing. Configure data capture on the wrapper component instead of the raw component.
 
-See [Write a module](/build-modules/write-a-driver-module/) for the general module development guide. The key technique is accessing the source component through the `dependencies` parameter in your module's `reconfigure` method.
+See [Write a module](/build-modules/write-a-driver-module/) for the general module development guide. The key technique is accessing the source component through the `dependencies` parameter in your module's constructor.
 
 ## Manage local storage
 

--- a/docs/tutorials/configure/pet-photographer.md
+++ b/docs/tutorials/configure/pet-photographer.md
@@ -558,7 +558,7 @@ func newCamera(ctx context.Context, deps resource.Dependencies, conf resource.Co
         Named: conf.ResourceName().AsNamed(),
         logger: logger,
     }
-    if err := c.Reconfigure(ctx, deps, conf); err != nil {
+    if err := c.reconfigure(ctx, deps, conf); err != nil {
         return nil, err
     }
     return c, nil
@@ -592,8 +592,8 @@ type colorFilterCam struct {
     logger loggingg.Logger
 }
 
-// Reconfigure reconfigures the modular component with new settings.
-func (c *colorFilterCam) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
+// reconfigure applies config settings to the component. Called from the constructor.
+func (c *colorFilterCam) reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {
     camConfig, err := resource.NativeConfig[*Config](conf)
     if err != nil {
         return err


### PR DESCRIPTION
## Source changes

- viamrobotics/rdk#6098: Reland removal of `Reconfigure` from the `Resource` interface. Modular resources are now always rebuilt (Close + construct) on config change. `ReconfigureResource` RPC is deprecated. Python SDK `Reconfigurable` protocol is deprecated.

## Docs changes

- `docs/build-modules/module-reference.md`: Go column in the defaults table no longer says "Implement `Reconfigure()`" — now says "Not supported for modular resources" to match the Python column. `ReconfigureResource` RPC marked as deprecated with explanation that `viam-server` now uses `RemoveResource` + `AddResource` instead.
- `docs/build-modules/platform-apis.md`: Fix frontmatter description from "validate and reconfigure functions" to "validate function and constructor".
- `docs/data/filter-at-the-edge.md`: Change "reconfigure method" to "constructor" when describing how to access dependencies.
- `docs/tutorials/configure/pet-photographer.md`: Rename Go `Reconfigure` to private `reconfigure` since it is no longer part of the public Resource interface.

## How I found these

- Xref lookup: `search-patterns.yaml` entry for `Resource.Reconfigure` with associated terms (`AlwaysRebuild`, `ReconfigureResource`, etc.)
- Grep matches: Full sweep for `Reconfigure`, `reconfigure method`, `reconfigure function` across docs repo
- Prior PRs #5001 and #5002 addressed most references but left these residual items

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_018RBJg5huGPhkJmhpnR87Ea)_