### PR TITLE
Fix vision GetProperties to mention default_camera

### DIFF
--- a/docs/vision/configure.md
+++ b/docs/vision/configure.md
@@ -155,7 +155,7 @@ Bounding boxes or classification labels should appear within a second or two. If
 
 If the camera feed appears but no detections are shown, see [Tune detection quality](/vision/object-detection/tune/).
 
-From code, you can confirm which roles the vision service registered by calling [`GetProperties`](/reference/apis/services/vision/#getproperties). The response is three booleans reporting whether detections, classifications, and 3D point clouds are supported at runtime.
+From code, you can confirm which roles the vision service registered by calling [`GetProperties`](/reference/apis/services/vision/#getproperties). The response includes three booleans reporting whether detections, classifications, and 3D point clouds are supported at runtime, and optionally the name of the default camera if one is configured.
 
 ## 7. Complete configuration
 

--- a/docs/vision/configure.md
+++ b/docs/vision/configure.md
@@ -155,7 +155,7 @@ Bounding boxes or classification labels should appear within a second or two. If
 
 If the camera feed appears but no detections are shown, see [Tune detection quality](/vision/object-detection/tune/).
 
-From code, you can confirm which roles the vision service registered by calling [`GetProperties`](/reference/apis/services/vision/#getproperties). The response includes three booleans reporting whether detections, classifications, and 3D point clouds are supported at runtime, and optionally the name of the default camera if one is configured.
+From code, you can confirm which roles the vision service registered by calling [`GetProperties`](/reference/apis/services/vision/#getproperties). The response includes three booleans reporting whether detections, classifications, and 3D point clouds are supported at runtime. If a default camera is configured, the response also includes its name.
 
 ## 7. Complete configuration
 


### PR DESCRIPTION
## Source changes

- viamrobotics/api#862: Add `default_camera` field to vision service `Properties` proto
- viamrobotics/rdk#6161: Populate `DefaultCamera` on the Go `Properties` struct and return it in the `GetProperties` response

## Docs changes

- `docs/vision/configure.md`: The description of `GetProperties` said "The response is three booleans" which is now incomplete. The response also returns the name of the default camera if one is configured. Updated to "includes three booleans ... and optionally the name of the default camera".

## How I found these

- Backlog item `api-65f5efb-vision-default-camera` from prior run
- Grep: searched for "three booleans", "GetProperties", "vision.*properties" across docs repo

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_018RBJg5huGPhkJmhpnR87Ea)_