### PR TITLE
Update org invite button label to match current UI [On Hold until this hits the UI]

### DIFF
--- a/docs/organization/access.md
+++ b/docs/organization/access.md
@@ -41,7 +41,7 @@ You must have the **Owner** role to be able to grant permissions.
 
    For more information on roles and the permissions they provide, see [Manage access with Role-Based Access Control](/organization/rbac/).
 
-8. Click **invite**.
+8. Click **Send invitation**.
 
    {{<imgproc src="/fleet/app-usage/limit-access.png" resize="1000x" style="width: 600px" class="shadow" declaredimensions=true alt="Limit user access">}}
 


### PR DESCRIPTION
## Source changes

- viamrobotics/app#12513: Clarify org invite button & error to differentiate granting initial vs additional access

## Docs changes

- `docs/organization/access.md`: Updated step 8 from `Click **invite**` to `Click **Send invitation**` to match the current button label in the org settings member invitation form. The button was renamed from "Grant access" to "Send invitation" in app#12513. The docs previously said "invite" which didn't match the old label either.

## How I found these

- Grep matches: searched for "Grant access", "Send invitation", "invite" across all docs pages
- Code diff: `create-org-invite.svelte` button text changed from `>Grant access` to `>Send invitation`

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJwMiUGXpSZeDGv1PGMNWd)_