### PR TITLE
Add Viam app UI instructions for data pipelines

### DIFF
--- a/docs/data/pipelines/create-a-pipeline.md
+++ b/docs/data/pipelines/create-a-pipeline.md
@@ -18,8 +18,32 @@ Create a pipeline that runs a scheduled MQL aggregation against your captured da
 ## Prerequisites
 
 - Captured tabular data in the cloud (see [Start data capture](/data/capture-sync/capture-and-sync-data/))
-- Your organization ID (find it in the Viam app under **Settings**)
-- Viam CLI installed, or the Python/Go SDK
+- For CLI or SDK: your organization ID (find it in the Viam app under **Settings**)
+
+## Create in the Viam app
+
+1. Navigate to the [**DATA** page](https://app.viam.com/data) in the Viam app, then select the **Pipelines** subtab.
+1. Click **Create pipeline**.
+1. In the **Details** step, fill in:
+
+   - **Name**: A descriptive, unique name for the pipeline within your organization.
+   - **Schedule**: A cron expression in UTC that sets how often the pipeline runs and the data time window for each run.
+     Expand **Show examples** for common cron patterns, or see [Cron schedule](/data/pipelines/reference/#cron-schedule) for the full syntax.
+   - **Enable backfill**: Toggle on to process all historical data when the pipeline is created.
+     This can take a while for large datasets.
+
+1. Click **Next** to proceed to the **Query** step.
+1. Build your MQL aggregation pipeline using the visual stage editor or switch to text mode with the **Stages** / **Text** toggle.
+   Use the data source dropdown to choose between **Standard storage** and **Hot data store** as the input for your pipeline.
+
+   The editor shows a preview of the first stage's intermediate results to help you iterate.
+   Click **Test query** to run the full pipeline against a sample time window and verify the output before creating.
+
+1. Click **Next** to proceed to the **Review and run** step.
+   Confirm the pipeline name, schedule, query, data source, and backfill setting.
+1. Click **Create and run**.
+
+After the pipeline is created, the app redirects to the pipeline detail page where you can monitor runs.
 
 ## Create with the CLI
 

--- a/docs/data/pipelines/manage-pipelines.md
+++ b/docs/data/pipelines/manage-pipelines.md
@@ -28,6 +28,11 @@ Click a pipeline name to open its detail page, which has three tabs:
 
 Use the three-dot menu next to any pipeline to **Copy ID**, **Query pipeline data**, **Enable** or **Disable** the pipeline, or **Delete** it.
 
+{{< alert title="Note" color="note" >}}
+To rename a pipeline or edit its MQL query and schedule after creation, use the CLI or SDK.
+The app does not support renaming or editing pipelines.
+{{< /alert >}}
+
 ## List pipelines
 
 {{< tabs >}}
@@ -311,8 +316,8 @@ You can create, list, and delete indexes from the Viam app, the CLI, or the SDK.
 1. Click **Create index**.
 
 The index build starts in the background.
-The **Custom indexes** tab shows the build status, which progresses from **Pending** to **In progress** to **Completed**.
-If the build fails, the tab shows the error.
+The **Custom indexes** tab shows a status badge on each index: **Building** while the index is being created, **Ready** when complete, or **Failed** if the build encountered an error.
+You can only delete an index once it reaches the **Ready** or **Failed** state.
 
 To delete an index, click the delete icon on the index card.
 

--- a/docs/data/pipelines/manage-pipelines.md
+++ b/docs/data/pipelines/manage-pipelines.md
@@ -10,6 +10,24 @@ date: "2026-03-27"
 
 Monitor and manage your data pipelines after creation. For creating pipelines, see [Create a pipeline](/data/pipelines/create-a-pipeline/).
 
+## View pipelines in the Viam app
+
+Navigate to the [**DATA** page](https://app.viam.com/data) in the Viam app, then select the **Pipelines** subtab.
+
+The pipelines list shows each pipeline's name, schedule, last execution time, and error count.
+Disabled pipelines display a **Disabled** badge next to the name.
+Pipelines with backfill in progress show the completion percentage.
+
+Click a pipeline name to open its detail page, which has three tabs:
+
+- **Runs**: A table of all pipeline executions with the data window, status, runtime, and start time for each run.
+  Failed runs show an error icon you can expand for details.
+- **Details**: The pipeline's configuration, including its ID, schedule, data source type, creation date, backfill status, and the full MQL query.
+- **Custom indexes**: MongoDB indexes on the pipeline's output collection.
+  See [Manage custom indexes](#manage-custom-indexes) for details.
+
+Use the three-dot menu next to any pipeline to **Copy ID**, **Query pipeline data**, **Enable** or **Disable** the pipeline, or **Delete** it.
+
 ## List pipelines
 
 {{< tabs >}}
@@ -270,6 +288,37 @@ err = dataClient.DeleteDataPipeline(ctx, "YOUR-PIPELINE-ID")
 {{< alert title="Deleting a pipeline is irreversible" color="caution" >}}
 Deleting a pipeline removes the pipeline configuration, its execution history, and all output data in the pipeline sink. If you need to preserve pipeline results, export them first.
 {{< /alert >}}
+
+## Manage custom indexes
+
+Custom indexes speed up queries against a pipeline's output collection.
+You can create, list, and delete indexes from the Viam app, the CLI, or the SDK.
+
+### Create an index in the Viam app
+
+1. Open the pipeline detail page by clicking the pipeline name on the **Pipelines** subtab.
+1. Select the **Custom indexes** tab.
+1. Click **Create custom index**.
+1. Enter a [MongoDB index specification](https://www.mongodb.com/docs/manual/reference/method/db.collection.createIndex/#options-for-all-index-types) in JSON format with a `key` field and optional `options`:
+
+   ```json
+   {
+     "key": { "location_id": 1, "avg_temp": -1 },
+     "options": { "name": "location-avg-temp" }
+   }
+   ```
+
+1. Click **Create index**.
+
+The index build starts in the background.
+The **Custom indexes** tab shows the build status, which progresses from **Pending** to **In progress** to **Completed**.
+If the build fails, the tab shows the error.
+
+To delete an index, click the delete icon on the index card.
+
+### Create an index with the CLI or SDK
+
+See [Manage data indexes](/cli/manage-data/#manage-data-indexes) for CLI commands, or use the SDK's `CreateIndex`, `ListIndexes`, and `DeleteIndex` methods documented in the [data client API reference](/reference/apis/data-client/).
 
 ## Troubleshooting
 

--- a/docs/data/pipelines/query-results.md
+++ b/docs/data/pipelines/query-results.md
@@ -4,7 +4,7 @@ title: "Query pipeline results"
 weight: 15
 layout: "docs"
 type: "docs"
-description: "Query the output of a data pipeline from Python, Go, or TypeScript."
+description: "Query the output of a data pipeline from the Viam app, Python, Go, or TypeScript."
 date: "2026-03-27"
 ---
 
@@ -23,6 +23,18 @@ viam datapipelines describe --id=<pipeline-id>
 ```
 
 Both commands are also documented in [Manage pipelines](/data/pipelines/manage-pipelines/).
+
+## Query in the Viam app
+
+You can query pipeline results directly in the app's query editor:
+
+1. Navigate to the [**DATA** page](https://app.viam.com/data) and select the **Query** subtab, or click **Query pipeline data** in the three-dot menu next to a pipeline on the **Pipelines** subtab.
+1. In the query header, open the data source dropdown and select **Pipeline sink**.
+1. A second dropdown labeled **Pipeline** appears. Select the pipeline whose results you want to query.
+1. Write your MQL query and click **Run query**.
+
+The query runs against the pipeline's output collection.
+All MQL stages you add operate on the pipeline's result documents, not the raw readings.
 
 ## Query with the SDK
 


### PR DESCRIPTION
## Summary

- Add step-by-step instructions for creating data pipelines through the Viam app UI (3-step wizard: Details, Query, Review & run)
- Document the pipeline list view, detail page tabs (Runs, Details, Custom indexes), and three-dot menu actions
- Add a new "Manage custom indexes" section covering creating, monitoring, and deleting indexes on pipeline sink collections from the app UI

## Context

The data pipeline docs previously only covered CLI and SDK workflows. The Viam app has a full pipeline management UI including a visual MQL stage editor, test query functionality, run monitoring, and custom index management. These instructions document the app UI path so users who prefer the web interface can follow along.

All UI labels, button text, and workflow steps were verified against the current app source code (`app/ui/src/routes/(auth-required)/data/pipelines/`).

## Docs changes

- `docs/data/pipelines/create-a-pipeline.md`: Added "Create in the Viam app" section before the CLI section, walking through the 3-step creation wizard
- `docs/data/pipelines/manage-pipelines.md`: Added "View pipelines in the Viam app" overview section and "Manage custom indexes" section with app UI and CLI/SDK cross-references

## Test plan

- [ ] Verify the pipeline creation wizard steps match the live app
- [ ] Verify the pipeline detail page tabs and menu actions match the live app
- [ ] Verify custom index creation flow matches the live app
- [ ] Check that all internal links resolve correctly

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJwMiUGXpSZeDGv1PGMNWd)_