### PR TITLE
Update CLI configuration of OAuth to mention setting logo and support email before enabling

### DIFF
--- a/docs/cli/administer-your-organization.md
+++ b/docs/cli/administer-your-organization.md
@@ -89,13 +89,7 @@ viam machines api-key create --machine-id=<machine-id>
 
 ## Set up OAuth
 
-OAuth setup is CLI-only. There is no web UI for these operations.
-
-### Enable the auth service
-
-```sh {class="command-line" data-prompt="$"}
-viam organizations auth-service enable --org-id=<org-id>
-```
+OAuth setup is CLI-only. There is no web UI for these operations. Before OAuth can be enabled, first ensure a logo and support email are set on your organization.
 
 ### Set branding
 
@@ -105,6 +99,12 @@ viam organizations logo set --org-id=<org-id> --logo-path=./logo.png
 
 ```sh {class="command-line" data-prompt="$"}
 viam organizations support-email set --org-id=<org-id> --support-email=support@example.com
+```
+
+### Enable the auth service
+
+```sh {class="command-line" data-prompt="$"}
+viam organizations auth-service enable --org-id=<org-id>
 ```
 
 ### Create an OAuth application


### PR DESCRIPTION
_Please include a summary of the change and what is does. Please also include relevant motivation and context._

Today the steps for enabling OAuth on an organization through the CLI are listed in the reverse order. Setting a logo and support email on your organization are required before enabling OAuth. It's a (confusing) error if you try in the order it's documented today:

https://docs.viam.com/cli/administer-your-organization/#set-up-oauth