### PR TITLE
Fix markdownlint: disable MD060 (conflicts with prettier), fix stray MD001

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -37,3 +37,8 @@ MD030: false
 
 MD055:
   style: "leading_and_trailing"
+
+# MD060/table-column-style - conflicts with prettier's table formatting.
+# prettier is the canonical formatter (its CI check passes on these tables), so
+# enforcing MD060 would fight it. Disabled, consistent with MD030 above.
+MD060: false

--- a/docs/reference/components/motor/gpiostepper.md
+++ b/docs/reference/components/motor/gpiostepper.md
@@ -102,7 +102,7 @@ The following attributes are available for `gpiostepper` motors:
 
 Refer to your motor and motor driver data sheets for specifics.
 
-### Microstepping and speed math
+## Microstepping and speed math
 
 The step-pin pulse frequency required to spin the motor at a given RPM is:
 


### PR DESCRIPTION
## What

Fix the repo-wide `Check Markdown files` (markdownlint) failure by disabling **MD060/table-column-style**, and fix the one unrelated **MD001** heading error.

## Why this started failing (no docs changed)

- `MD060/table-column-style` was **added in markdownlint v0.39.0** (2025-10-13) and ships **enabled by default**.
- `.markdownlint.yaml` starts with `default: true`, so a newly added rule turns on automatically unless explicitly disabled.
- CI runs `ruzickap/action-my-markdown-linter@v1` (a floating tag; its bundled `markdownlint-cli` is renovate-bumped to 0.49.0 → markdownlint lib with MD060). When that version landed, the rule activated against tables that had been unchanged for months.
- Those tables are formatted by **prettier** (a different style), and the prettier CI check passes on all of them — so MD060 directly conflicts with prettier. You can't satisfy both.

Result: **49 MD060 violations across 13 files** appeared with zero content changes, failing on whatever PR ran CI next (e.g. #5116, #5118) even though those PRs never touched the affected files.

## The fix

- **`.markdownlint.yaml`**: add `MD060: false`, consistent with the existing prettier-driven rule exclusions (MD030, MD013, MD046, …). prettier stays the canonical table formatter.
- **`docs/reference/components/motor/gpiostepper.md`**: promote `### Microstepping and speed math` → `##` (peer of the sibling `## Wiring example`), fixing the lone `MD001/heading-increment` error. The heading text — and its anchor — are unchanged, so no links break.

## Verification

- `markdownlint-cli@latest --config .markdownlint.yaml "docs/**/*.md"` → **0 errors** (was 50).
- `prettier --check` still passes on the edited file.

## Note

The `Check Markdown files` job is `continue-on-error: true`, so it was non-blocking by design — this makes it green rather than perma-red. Pinning the `ruzickap/...@v1` action to a SHA later would prevent the next surprise-rule bump; disabling MD060 explicitly is robust regardless.
