### PR TITLE
Fix broken CLI reference anchors in fleet/data guides

### DIFF
--- a/docs/cli/manage-data.md
+++ b/docs/cli/manage-data.md
@@ -300,4 +300,4 @@ viam data index delete --collection-type=hot-storage --index-name=my-index
 - [Export data](/data/export-data/) for step-by-step export instructions with the Viam app
 - [Data pipelines with the CLI](/cli/data-pipelines/) for scheduled data transformations
 - [Datasets and training with the CLI](/cli/datasets-and-training/) for managing ML datasets
-- [CLI reference](/cli/#data) for the complete `data` command reference
+- [CLI reference](/cli/reference/#data) for the complete `data` command reference

--- a/docs/cli/manage-your-fleet.md
+++ b/docs/cli/manage-your-fleet.md
@@ -298,4 +298,4 @@ Key Value: your-secret-key-value
 - [Monitor machine status](/monitor/monitor/) for monitoring with the Viam app
 - [Troubleshoot](/monitor/troubleshoot/) for debugging machine issues
 - [Deploy software](/fleet/deploy-software/) for deploying with fragments
-- [CLI reference](/cli/#machines-alias-robots-and-machine) for the complete `machines` command reference
+- [CLI reference](/cli/reference/#machines-aliases-robots-robot-machine) for the complete `machines` command reference


### PR DESCRIPTION
## Summary

The `/cli/` page was refactored from one long page into subpages — `docs/cli/_index.md` is now just a landing page (`manualLink: /cli/overview/`) with no section headings. As a result, two in-page anchor links that pointed at the old single-page structure no longer resolve, and `run-htmltest-external` flags them as `hash does not exist`:

| File | Old (broken) | New |
|------|--------------|-----|
| `docs/cli/manage-your-fleet.md` | `/cli/#machines-alias-robots-and-machine` | `/cli/reference/#machines-aliases-robots-robot-machine` |
| `docs/cli/manage-data.md` | `/cli/#data` | `/cli/reference/#data` |

The new targets are verified against the headings in `docs/cli/reference.md` (`## \`machines\` (aliases \`robots\`, \`robot\`, \`machine\`)` and `## \`data\``), and match the pattern already used in `docs/cli/configure-machines.md`.

## Motivation / context

Surfaced by the scheduled `run-htmltest-external` job (issue #5127). That run reports 347 errors, but the large majority are **external** failures (third-party `403`/`404`/`429` responses, e.g. ebay, fandom, and the removed `viam.com/post/guardian` post) that are outside this repo's control. These two internal broken anchors are the genuinely fixable, in-repo link breaks, so this PR corrects those without touching the external-link noise.

Refs #5127 (scoped to the internal-anchor breakage; does not resolve the external-link failures, so intentionally not `Fixes`).

---
_Generated by [Claude Code](https://claude.ai/code/session_012ncZtChJ9kyi4bLtNLtQhq)_