### PR TITLE
[Claude CI Failure] Fix 10 broken internal /cli/ anchors after reference page split

### DIFF
--- a/docs/build-modules/manage-modules.md
+++ b/docs/build-modules/manage-modules.md
@@ -182,7 +182,7 @@ tar -czvf dist/archive.tar.gz ./dist/main
 
 {{< /expand >}}
 
-You can test this build configuration by running the Viam CLI's [`build local` command](/cli/#using-the-build-subcommand) on your development machine:
+You can test this build configuration by running the Viam CLI's [`build local` command](/cli/reference/#using-the-build-subcommand) on your development machine:
 
 ```sh {class="command-line" data-prompt="$"}
 viam module build local
@@ -232,9 +232,9 @@ When you are ready to test the action, uncomment `if: github.event_name == 'rele
 
 For guidance on configuring the other parameters, see the documentation for each:
 
-- [`org-id`](/cli/#using-the---org-id-and---public-namespace-arguments): Not required if your module is public.
-- [`platform`](/cli/#using-the---platform-argument): You can only upload one platform at a time.
-- [`version`](https://github.com/viamrobotics/upload-module/blob/main/README.md#versioning): See [Using the --version argument](/cli/#using-the---version-argument) for more details on the types of versioning supported.
+- [`org-id`](/cli/reference/#using-the---org-id-and---public-namespace-arguments): Not required if your module is public.
+- [`platform`](/cli/reference/#using-the---platform-argument): You can only upload one platform at a time.
+- [`version`](https://github.com/viamrobotics/upload-module/blob/main/README.md#versioning): See [Using the --version argument](/cli/reference/#using-the---version-argument) for more details on the types of versioning supported.
 
 For more details, see the [`upload-module` GitHub Action documentation](https://github.com/viamrobotics/upload-module), or take a look through one of the following example repositories that show how to package and deploy modules using the Viam SDKs:
 
@@ -246,7 +246,7 @@ For more details, see the [`upload-module` GitHub Action documentation](https://
   {{% /tab %}}
   {{< /tabs >}}
 
-3. [Create an organization API key](/cli/#create-an-organization-api-key) with owner role:
+3. [Create an organization API key](/cli/reference/#organizations-api-key-create) with owner role:
 
    ```sh {class="command-line" data-prompt="$"}
    viam organizations api-key create --org-id <org-id> --name <key-name>
@@ -308,9 +308,9 @@ Use the [Viam CLI](/cli/) to manually update your module:
 
    For example, `viam module upload --version 1.0.1 --platform darwin/arm64 my-module.tar.gz`.
 
-When you `upload` a module, the command performs basic [validation](/cli/#upload-validation) of your module to check for common errors.
+When you `upload` a module, the command performs basic [validation](/cli/reference/#upload-validation) of your module to check for common errors.
 
-For more information, see the [`viam module` command](/cli/#module).
+For more information, see the [`viam module` command](/cli/reference/#module).
 
 ## Pin a module to a specific version
 
@@ -382,7 +382,7 @@ To change the visibility:
      Only organization members can edit the module.
      Not listed in the registry for users outside of your organization.
 
-You can also edit the visibility by editing the [meta.json](/build-modules/module-reference/) file and then running the following [CLI](/cli/#module) command:
+You can also edit the visibility by editing the [meta.json](/build-modules/module-reference/) file and then running the following [CLI](/cli/reference/#module) command:
 
 ```sh {id="terminal-prompt" class="command-line" data-prompt="$"}
 viam module update

--- a/docs/cli/manage-data.md
+++ b/docs/cli/manage-data.md
@@ -300,4 +300,4 @@ viam data index delete --collection-type=hot-storage --index-name=my-index
 - [Export data](/data/export-data/) for step-by-step export instructions with the Viam app
 - [Data pipelines with the CLI](/cli/data-pipelines/) for scheduled data transformations
 - [Datasets and training with the CLI](/cli/datasets-and-training/) for managing ML datasets
-- [CLI reference](/cli/#data) for the complete `data` command reference
+- [CLI reference](/cli/reference/#data) for the complete `data` command reference

--- a/docs/cli/manage-your-fleet.md
+++ b/docs/cli/manage-your-fleet.md
@@ -298,4 +298,4 @@ Key Value: your-secret-key-value
 - [Monitor machine status](/monitor/monitor/) for monitoring with the Viam app
 - [Troubleshoot](/monitor/troubleshoot/) for debugging machine issues
 - [Deploy software](/fleet/deploy-software/) for deploying with fragments
-- [CLI reference](/cli/#machines-alias-robots-and-machine) for the complete `machines` command reference
+- [CLI reference](/cli/reference/#machines-aliases-robots-robot-machine) for the complete `machines` command reference


### PR DESCRIPTION
## What

`docs/cli/_index.md` was refactored from one long page into subpages (now a landing page pointing at `/cli/overview/`), and the section content moved to `docs/cli/reference.md`. Every in-repo link that still pointed at the old `/cli/#` single-page structure now 404s/hash-fails, and `run-htmltest-external` (#5127) flags them as `hash does not exist`.

This retargets **all 10** internal broken anchors (found by a repo-wide grep for `/cli/#` across `docs/**/*.md`) across the 3 affected files:

| File | Old (broken) | New | Note |
|------|--------------|-----|------|
| `docs/build-modules/manage-modules.md` | `/cli/#using-the-build-subcommand` | `/cli/reference/#using-the-build-subcommand` | clean retarget |
| `docs/build-modules/manage-modules.md` | `/cli/#using-the---org-id-and---public-namespace-arguments` | `/cli/reference/#using-the---org-id-and---public-namespace-arguments` | clean retarget |
| `docs/build-modules/manage-modules.md` | `/cli/#using-the---platform-argument` | `/cli/reference/#using-the---platform-argument` | clean retarget |
| `docs/build-modules/manage-modules.md` | `/cli/#using-the---version-argument` | `/cli/reference/#using-the---version-argument` | clean retarget |
| `docs/build-modules/manage-modules.md` | `/cli/#create-an-organization-api-key` | `/cli/reference/#organizations-api-key-create` | renamed section — heading is now `organizations api-key create` |
| `docs/build-modules/manage-modules.md` | `/cli/#upload-validation` | `/cli/reference/#upload-validation` | clean retarget |
| `docs/build-modules/manage-modules.md` | `/cli/#module` (×2) | `/cli/reference/#module` | clean retarget |
| `docs/cli/manage-your-fleet.md` | `/cli/#machines-alias-robots-and-machine` | `/cli/reference/#machines-aliases-robots-robot-machine` | clean retarget |
| `docs/cli/manage-data.md` | `/cli/#data` | `/cli/reference/#data` | clean retarget |

Every new target was verified directly against the current heading text in `docs/cli/reference.md`. The `machines` retarget also matches an already-working precedent link in `docs/cli/configure-machines.md`.

## Out of scope

The full `run-htmltest-external` run reports far more errors than these 10, but the rest are external (`403`/`404`/`429` third-party churn, e.g. rate-limited or blocking sites, and at least one genuinely dead external blog link) — out of this repo's control and not touched here.

Refs #5127 (fixes the internal-anchor class of failures in full; does not resolve the external-link failures, so intentionally not `Fixes`).

## Verification

- `npx prettier@3.2.5 --write` (CI-pinned version) on the 3 changed files: no changes (already clean)
- `npx markdownlint-cli --config .markdownlint.yaml` on the 3 changed files: 0 errors
- `vale` binary is unavailable in this sandbox; not a concern here since no prose changed, only `href` targets
- `make build-prod` could not run in this sandbox — the `themes/docsy` git submodule isn't reachable (GitHub access here is scoped to `viamrobotics/docs` only); anchor targets were instead verified by grepping the actual current headings in `docs/cli/reference.md`


---
_Generated by [Claude Code](https://claude.ai/code/session_012BRkvcYWsjsXBicRmoHAga)_