### PR TITLE
[On hold until RDK release] Document --from-source flag for module build start

### DIFF
--- a/docs/build-modules/deploy-a-module.md
+++ b/docs/build-modules/deploy-a-module.md
@@ -138,7 +138,9 @@ With prep complete, follow one of the two sections below to publish your module.
 
 ### Publish with cloud build (recommended) {#release-with-cloud-build}
 
-Cloud build is a Viam-side build service that compiles your module from your GitHub repo for every target platform listed in `meta.json`'s `build.arch`. Both paths below require your module to be in a GitHub repo with the URL set in `meta.json`.
+Cloud build is a Viam-side build service that compiles your module for every target platform listed in `meta.json`'s `build.arch`. By default, cloud build clones your GitHub repo. Both default-mode paths below require your module to be in a GitHub repo with the URL set in `meta.json`.
+
+Alternatively, pass `--from-source` to upload your local source directory directly to the cloud builder without requiring a GitHub repo or a git push. See the [CLI reference](/cli/reference/#module-build-start) for the full flag list.
 
 If you don't have a GitHub repo yet, push your module's code to one. From your module's root directory:
 

--- a/docs/build-modules/module-reference.md
+++ b/docs/build-modules/module-reference.md
@@ -473,7 +473,9 @@ All module CLI commands are under `viam module`. You must be logged in
 | `viam module build logs --id <build-id>`     | Stream logs from a cloud build job.               |
 
 `build start` flags: `--ref` (git ref, default: `main`), `--platforms`,
-`--token` (for private repos), `--workdir`.
+`--token` (for private repos), `--workdir`, `--from-source` (upload local
+source instead of building from a git ref), `--path`, `--wait`,
+`--no-progress`.
 
 During builds, the environment variables `VIAM_BUILD_OS` and `VIAM_BUILD_ARCH`
 are set to the target platform. See [Environment variables](#environment-variables).

--- a/docs/cli/build-and-deploy-modules.md
+++ b/docs/cli/build-and-deploy-modules.md
@@ -163,6 +163,12 @@ Build from a specific git ref:
 viam module build start --version=1.0.0 --ref=main
 ```
 
+Build from your local source directory without pushing to GitHub first:
+
+```sh {class="command-line" data-prompt="$"}
+viam module build start --version=1.0.0 --from-source --platforms=linux/amd64,linux/arm64 --wait
+```
+
 Build locally to test before pushing:
 
 ```sh {class="command-line" data-prompt="$"}

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -1911,6 +1911,9 @@ viam module build start --version "0.1.2"
 
 # initiate a cloud build for a private GitHub repo
 viam module build start --version "0.1.2" --token ghp_1234567890abcdefghijklmnopqrstuvwxyzABCD
+
+# build from local source without pushing to GitHub
+viam module build start --version "0.1.2" --from-source --platforms linux/amd64,linux/arm64 --wait
 ```
 
 <!-- prettier-ignore -->
@@ -1919,9 +1922,13 @@ viam module build start --version "0.1.2" --token ghp_1234567890abcdefghijklmnop
 | `--version` | The version of your module to set for this build. See [Using the `--version` argument](#using-the---version-argument). | **Required** |
 | `--module` | The path to the [`meta.json` file](/build-modules/module-reference/) for the module, if not in the current directory. | Optional |
 | `--platforms` | List of platforms to cloud build for. Default: `build.arch` in <file>meta.json</file>. | Optional |
-| `--ref` | Git reference to clone when building your module. This can be a branch name or a commit hash. Default: `main`. | Optional |
-| `--token` | GitHub token with repository **Contents** read access, and **Actions** read and write access. Required for private repos, not necessary for public repos. | Optional |
+| `--ref` | Git reference to clone when building your module. This can be a branch name or a commit hash. Default: `main`. Ignored when `--from-source` is set. | Optional |
+| `--token` | GitHub token with repository **Contents** read access, and **Actions** read and write access. Required for private repos, not necessary for public repos. Ignored when `--from-source` is set. | Optional |
 | `--workdir` | Use this to indicate that your <file>meta.json</file> is in a subdirectory of your repo. `--module` flag should be relative to this. Default: `.`. | Optional |
+| `--from-source` | Package your local source directory and upload it to the cloud builder instead of building from a git ref. `.gitignore` is honored when packaging. | Optional |
+| `--path` | Path to the local source directory to upload. Only used with `--from-source`. Default: `.`. | Optional |
+| `--wait` | Wait for the build to finish. Surfaces failed-platform logs and returns a non-zero exit code on failure. Only used with `--from-source`. | Optional |
+| `--no-progress` | Hide the progress spinner. Only used with `--from-source`. | Optional |
 
 ### `module build local`
 


### PR DESCRIPTION
> [!WARNING]
> **On hold until an RDK release.** `--from-source` merged to `rdk` `main` on 2026-07-01 (viamrobotics/rdk#6057) but is **not yet in a released `viam` CLI** — the latest release is v0.132.0 (2026-06-23), which predates the merge and does not contain the flag. Merging now would document a flag users on the current stable CLI cannot run. Hold until the flag ships in an RDK release (expected v0.133.0).

RDK #6057 adds a `--from-source` flag to `viam module build start` that packages local source and uploads it to the cloud builder. This bypasses the need for a GitHub repo or git push, making it easier to iterate during development.

New flags in `--from-source` mode:
- `--from-source`: enable source upload mode
- `--path`: path to the local source directory (default: `.`)
- `--wait`: wait for the build to finish and surface failure logs
- `--no-progress`: hide the progress spinner

## Source changes

- viamrobotics/rdk#6057: Add CLI commands to build/publish module in cloud from local source

## Docs changes

- `docs/cli/reference.md`: Added `--from-source`, `--path`, `--wait`, `--no-progress` flags to the `module build start` argument table. Added example command.
- `docs/cli/build-and-deploy-modules.md`: Added `--from-source` example to the Cloud builds section.
- `docs/build-modules/deploy-a-module.md`: Updated the cloud build intro to note that `--from-source` does not require a GitHub repo.
- `docs/build-modules/module-reference.md`: Updated the `build start` flags summary to include the new flags.

## How I found these

- Xref lookup: `cli-xref.md` maps `rdk/cli/` changes to CLI docs
- Grep matches: searched `module build start`, `--ref`, `cloud build` across entire docs repo; found 14 files referencing cloud builds, updated the 4 that describe `build start` flags or behavior

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFy4ubaHy4n3G9AXWJBi52)_
