### PR TITLE
Stop SDK-coverage check crashing on inherited methods (#5126)

### DIFF
--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -857,6 +857,23 @@ def write_markdown(type, names, methods):
                     flutter_method_name = row.split(',')[5].rstrip()
                     typescript_method_name = row.split(',')[6].rstrip()
 
+                    ## A proto RPC can map to an SDK method that the SDK's own
+                    ## resource doc page does not surface -- for example gripper's
+                    ## CurrentInputs/GoToInputs, which are inherited via
+                    ## framesystem.InputEnabled and documented on that interface's
+                    ## page, not the gripper page. If the scraper did not find the
+                    ## mapped method for a given SDK, treat that SDK as not having
+                    ## it so the proto still documents in the SDKs that do surface
+                    ## it, instead of raising a KeyError.
+                    if py_method_name and "python" in sdks and py_method_name not in methods['python'][type].get(resource, {}):
+                        py_method_name = ''
+                    if go_method_name and "go" in sdks and go_method_name not in methods['go'][type].get(resource, {}):
+                        go_method_name = ''
+                    if flutter_method_name and "flutter" in sdks and flutter_method_name not in methods['flutter'][type].get(resource, {}):
+                        flutter_method_name = ''
+                    if typescript_method_name and "typescript" in sdks and typescript_method_name not in methods['typescript'][type].get(resource, {}):
+                        typescript_method_name = ''
+
                     if py_method_name and "python" in sdks:
                         methods['python'][type][resource][py_method_name]["used"] = True
                     if go_method_name and "go" in sdks:


### PR DESCRIPTION
`make coveragetest` crashed with `KeyError: 'CurrentInputs'` in `write_markdown`. A proto RPC can map to an SDK method that the SDK's own resource doc page doesn't surface: gripper gained `GetCurrentInputs`/`GoToInputs` (real proto RPCs, **already documented** in the Python/TS references), but in **Go** they're inherited via `framesystem.InputEnabled` and rendered on that interface's page — not gripper's — so the per-resource Go scrape doesn't find them, and the unguarded `methods['go'][type][resource][go_method_name]` access raised `KeyError`. (Arm never crashed because it has no CSV rows for these.)

## Fix
Guard the mapped-method lookup: if a scraper didn't find the mapped method for a given SDK, treat that SDK as not having it, so the proto still documents in the SDKs that do surface it instead of crashing. Verified locally: the generator completes for gripper and the coverage check runs to completion.

## Honest scope (this does NOT by itself close #5126)
- **Crash fixed; check functional again.** With the crash gone, the coverage check now surfaces pre-existing gaps it had been *masking* (e.g. `get_status` unused across components) and exits 1 on them. So check-methods is still red — but for real, reported reasons, not a crash. Closing #5126 means a document-vs-ignore decision on each remaining gap (assessed separately).
- **Go gripper Inputs:** documented only where the SDKs surface them per-resource (Python/TS, which already existed). Go's inherited Inputs are not added here; documenting them too would require teaching the Go scraper to follow the embedded `framesystem.InputEnabled` interface — a larger change to decide on.

Refs #5126

🤖 Generated with [Claude Code](https://claude.com/claude-code)