### PR TITLE
Fix run-htmltest rate limiting (real htmltest keys)

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -3,10 +3,16 @@ EnforceHTTPS: true
 IgnoreEmptyHref: true
 IgnoreInternalEmptyHash: true
 IgnoreDirectoryMissingTrailingSlash: false
-# rate limiting settings
-MaxConcurrency: 1
-RequestDelay: 1000ms
-Timeout: 30s
+# Rate limiting. htmltest has no per-request delay option, and MaxConcurrency /
+# RequestDelay / Timeout are NOT valid htmltest keys -- they were silently
+# ignored, so external links were being checked at the default concurrency of
+# 16, hitting each domain with a burst of simultaneous requests. That is what
+# caused the transient 403/429/timeout failures on otherwise-valid links (for
+# example docs.flutter.dev, apps.apple.com, ri.cmu.edu). Limit HTTP concurrency
+# to 1 so external links are checked one at a time and no single domain is hit
+# in a burst.
+HTTPConcurrencyLimit: 1
+ExternalTimeout: 30
 IgnoreURLs:
   # Valid links that automated checkers cannot verify: pkg.go.dev rate-limits
   # requests (HTTP 429); analog.com, fandom.com, cloud.google.com, and ebay.com


### PR DESCRIPTION
After #5137 (broken links) and #5138 (generator links), the remaining run-htmltest failures were **transient**: every URL resolves 200 in a browser, and the failing set drifted run to run (docs.flutter.dev, apps.apple.com, ri.cmu.edu, ologicinc.com, ...).

## Root cause
`.htmltest.yml` had `MaxConcurrency`, `RequestDelay`, and `Timeout` — **none of which are valid htmltest options** (not in the v0.17.0 `Options` struct). They were silently ignored, so external links were checked at the default `HTTPConcurrencyLimit` of **16**, hitting each domain with a burst of simultaneous requests. Those sites rate-limit/block bursts (403/429/timeout).

## Fix
htmltest has **no per-request delay** option, so the only lever is concurrency: set the real key `HTTPConcurrencyLimit: 1` (check external links one at a time — no simultaneous per-domain burst) and `ExternalTimeout: 30`. This addresses the flakiness at the source instead of ignoring valid links.

## Caveat
Concurrency:1 prevents *simultaneous* bursts but is not a literal per-domain delay (htmltest can't do that). Verifying with repeated dispatches that the external error count holds at ~0 and runtime stays acceptable.

Refs #5127

🤖 Generated with [Claude Code](https://claude.com/claude-code)