### PR TITLE
Add nightly docs.viam.com link checker across Viam source repos

### DIFF
--- a/.github/actions/report-ci-failure/action.yml
+++ b/.github/actions/report-ci-failure/action.yml
@@ -13,6 +13,13 @@ inputs:
     description: Label applied to the tracking issue.
     required: false
     default: ci-failure
+  details:
+    description: >-
+      Optional extra markdown appended to the issue body (on create) and to the
+      repeat-failure comment. Use it to carry specific findings (e.g. the list
+      of broken links) so a triage routine can act without re-running the job.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -23,6 +30,7 @@ runs:
         GH_TOKEN: ${{ github.token }}
         JOB_NAME: ${{ inputs.job-name }}
         ISSUE_LABEL: ${{ inputs.label }}
+        DETAILS: ${{ inputs.details }}
       run: |
         set -euo pipefail
 
@@ -46,9 +54,13 @@ runs:
 
         if [ -n "${existing}" ]; then
           echo "Existing issue #${existing} found; adding a comment."
+          comment="$(printf '%s\n' "Job **${JOB_NAME}** failed again. Run: ${run_url}")"
+          if [ -n "${DETAILS}" ]; then
+            comment="$(printf '%s\n\n%s\n' "${comment}" "${DETAILS}")"
+          fi
           gh issue comment "${existing}" \
             --repo "${GITHUB_REPOSITORY}" \
-            --body "Job **${JOB_NAME}** failed again. Run: ${run_url}"
+            --body "${comment}"
         else
           echo "No open issue found; creating one."
           body="$(printf '%s\n' \
@@ -61,6 +73,9 @@ runs:
             "comment on this issue explaining what is needed. This issue is" \
             "created automatically on failure and reused (commented on) for" \
             "repeat failures.")"
+          if [ -n "${DETAILS}" ]; then
+            body="$(printf '%s\n\n%s\n' "${body}" "${DETAILS}")"
+          fi
           gh issue create \
             --repo "${GITHUB_REPOSITORY}" \
             --title "${title}" \

--- a/.github/workflows/check-org-docs-links.md
+++ b/.github/workflows/check-org-docs-links.md
@@ -7,9 +7,9 @@ tokenless. The **private `app` repo** needs a read token; without it the job
 scans the other repos and logs a warning (it does **not** fail).
 
 Provide the token as the repository secret **`ORG_REPO_READ_TOKEN`**. Two ways to
-create one — a fine-grained PAT is simplest.
+create one. A fine-grained PAT is simplest.
 
-## Option A — fine-grained personal access token (recommended)
+## Option A: fine-grained personal access token (recommended)
 
 1. GitHub → **Settings → Developer settings → Fine-grained personal access
    tokens → Generate new token**.
@@ -18,8 +18,8 @@ create one — a fine-grained PAT is simplest.
    any other private repos you later add to the scan).
 4. **Permissions:** Repository permissions → **Contents: Read-only**. Nothing
    else is needed (the job only clones).
-5. **Expiration:** pick a policy your org allows (e.g. 90 days) and set a
-   calendar reminder to rotate — an expired token silently drops `app` from the
+5. **Expiration:** pick a policy your org allows (for example, 90 days) and set a
+   calendar reminder to rotate. An expired token silently drops `app` from the
    scan (the job warns, doesn't fail).
 6. Generate. If the org requires approval for fine-grained tokens, an org owner
    approves the request before it works.
@@ -28,11 +28,11 @@ Ideally create the token from a **service/bot account** with read access to
 `app`, not a personal account, so the scan does not depend on one person's
 membership.
 
-## Option B — GitHub App installation token
+## Option B: GitHub App installation token
 
 If the org prefers Apps over PATs: install (or reuse) a GitHub App with
-**Contents: Read** on `app`, mint an installation token in the workflow (e.g.
-`actions/create-github-app-token`), and pass it in place of the PAT. This adds a
+**Contents: Read** on `app`, mint an installation token in the workflow (for
+example, `actions/create-github-app-token`), and pass it in place of the PAT. This adds a
 step to the workflow but avoids PAT expiry/rotation.
 
 ## Add the secret

--- a/.github/workflows/check-org-docs-links.md
+++ b/.github/workflows/check-org-docs-links.md
@@ -1,0 +1,57 @@
+# `ORG_REPO_READ_TOKEN` setup for the org docs-link check
+
+The nightly [`check-org-docs-links.yml`](./check-org-docs-links.yml) job clones
+each target repo and scans it for `docs.viam.com` links. Public repos (`rdk`,
+`api`, `viam-python-sdk`, `viam-typescript-sdk`, `viam-flutter-sdk`) clone
+tokenless. The **private `app` repo** needs a read token; without it the job
+scans the other repos and logs a warning (it does **not** fail).
+
+Provide the token as the repository secret **`ORG_REPO_READ_TOKEN`**. Two ways to
+create one — a fine-grained PAT is simplest.
+
+## Option A — fine-grained personal access token (recommended)
+
+1. GitHub → **Settings → Developer settings → Fine-grained personal access
+   tokens → Generate new token**.
+2. **Resource owner:** `viamrobotics`.
+3. **Repository access:** *Only select repositories* → `viamrobotics/app` (add
+   any other private repos you later add to the scan).
+4. **Permissions:** Repository permissions → **Contents: Read-only**. Nothing
+   else is needed (the job only clones).
+5. **Expiration:** pick a policy your org allows (e.g. 90 days) and set a
+   calendar reminder to rotate — an expired token silently drops `app` from the
+   scan (the job warns, doesn't fail).
+6. Generate. If the org requires approval for fine-grained tokens, an org owner
+   approves the request before it works.
+
+Ideally create the token from a **service/bot account** with read access to
+`app`, not a personal account, so the scan does not depend on one person's
+membership.
+
+## Option B — GitHub App installation token
+
+If the org prefers Apps over PATs: install (or reuse) a GitHub App with
+**Contents: Read** on `app`, mint an installation token in the workflow (e.g.
+`actions/create-github-app-token`), and pass it in place of the PAT. This adds a
+step to the workflow but avoids PAT expiry/rotation.
+
+## Add the secret
+
+Repo → **Settings → Secrets and variables → Actions → New repository secret**:
+
+- **Name:** `ORG_REPO_READ_TOKEN`
+- **Value:** the token from Option A or B
+
+The workflow uses it only for the private clone:
+
+```bash
+git clone --filter=blob:none --depth 1 \
+  "https://x-access-token:${ORG_REPO_READ_TOKEN}@github.com/viamrobotics/app.git" \
+  repos/app
+```
+
+## Verify
+
+Run the workflow manually (**Actions → Org docs-link check → Run workflow**) and
+confirm the log shows `Cloning private app ...` rather than the
+`ORG_REPO_READ_TOKEN not set; skipping private 'app' repo.` warning.

--- a/.github/workflows/check-org-docs-links.yml
+++ b/.github/workflows/check-org-docs-links.yml
@@ -1,0 +1,105 @@
+name: Org docs-link check
+
+# Nightly: scan Viam's source repos for docs.viam.com links and verify each is
+# working (not 404) and canonical (not a stale alias/redirect; anchors resolve).
+# Findings open/update a single deduplicated issue for the CI-failure triage
+# routine (or a maintainer) to act on. See check_org_docs_links.py.
+
+on:
+  schedule:
+    # 07:00 UTC daily (staggered off the other scheduled jobs).
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    # Let the reporting step run even when the check step exits non-zero.
+    continue-on-error: true
+
+    steps:
+      - name: Check out docs
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install requests
+
+      - name: Clone target repos
+        # Public repos clone tokenless. The private 'app' repo needs a read
+        # token (fine-grained PAT / App installation token) in the
+        # ORG_REPO_READ_TOKEN secret; if it is absent we scan the rest and warn.
+        # The scanned set is duplicated in check_org_docs_links.py (DEFAULT_REPOS);
+        # keep the two in sync. The checker skips any repo whose clone is missing.
+        env:
+          APP_TOKEN: ${{ secrets.ORG_REPO_READ_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p repos
+          for repo in rdk api viam-python-sdk viam-typescript-sdk viam-flutter-sdk; do
+            echo "Cloning ${repo} ..."
+            git clone --filter=blob:none --depth 1 \
+              "https://github.com/viamrobotics/${repo}.git" "repos/${repo}"
+          done
+          if [ -n "${APP_TOKEN}" ]; then
+            echo "Cloning private app ..."
+            git clone --filter=blob:none --depth 1 \
+              "https://x-access-token:${APP_TOKEN}@github.com/viamrobotics/app.git" \
+              "repos/app"
+          else
+            echo "::warning::ORG_REPO_READ_TOKEN not set; skipping private 'app' repo."
+          fi
+
+      - name: Check docs links
+        id: check
+        run: |
+          python .github/workflows/check_org_docs_links.py \
+            --base-dir repos --out link-findings.md
+
+      - name: Upload findings artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: link-findings
+          path: link-findings.md
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Prepare findings body
+        if: failure()
+        id: findings
+        env:
+          # GitHub issue bodies cap at 65536 chars; leave headroom for the
+          # action's own boilerplate and truncate to the full artifact.
+          MAX_BYTES: "58000"
+        run: |
+          {
+            echo 'body<<FINDINGS_EOF'
+            if [ -s link-findings.md ]; then
+              size=$(wc -c < link-findings.md)
+              if [ "${size}" -gt "${MAX_BYTES}" ]; then
+                head -c "${MAX_BYTES}" link-findings.md
+                run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+                printf '\n\n_...truncated (%s chars). Full list in the `link-findings` artifact: %s_\n' \
+                  "${size}" "${run_url}"
+              else
+                cat link-findings.md
+              fi
+            else
+              echo "The link checker failed before producing a findings file."
+              echo "See the run log for the error."
+            fi
+            echo 'FINDINGS_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Report failure
+        if: failure()
+        uses: ./.github/actions/report-ci-failure
+        with:
+          job-name: Org docs links
+          details: ${{ steps.findings.outputs.body }}

--- a/.github/workflows/check_org_docs_links.py
+++ b/.github/workflows/check_org_docs_links.py
@@ -138,6 +138,29 @@ def same_page(a, b):
     )
 
 
+# Landing pages that mean "the specific page is gone" -- a redirect here is a
+# dead end, not a useful canonicalization, so treat it as broken.
+GENERIC_LANDINGS = {
+    "/", "/reference/", "/reference/apis/", "/reference/overview/",
+}
+
+
+def is_dead_end(orig, final):
+    """True if `orig` redirects to a generic index or an ancestor of itself.
+
+    Distinguishes a real move (``/services/motion/`` -> ``/reference/services/
+    motion/``, same topic) from a page that was removed and now dumps the
+    visitor on an index (``/reference/apis/services/slam/`` -> ``/reference/
+    apis/``). The latter should be reported as broken.
+    """
+    op = urlsplit(orig).path.rstrip("/") + "/"
+    fp = urlsplit(final).path.rstrip("/") + "/"
+    if fp in GENERIC_LANDINGS:
+        return True
+    # Final is a strict ancestor of the original path (specificity collapsed).
+    return op.startswith(fp) and fp != op
+
+
 def resolve(url, session, retries=1, max_hops=6):
     """Follow HTTP 3xx and Hugo meta-refresh aliases to the final page.
 
@@ -202,7 +225,10 @@ def classify(url, session, delay):
     fragment = urlsplit(url).fragment
 
     if not same_page(url, final_url):
-        # Report only the move; the canonical target is the actionable fix. Any
+        if is_dead_end(url, final_url):
+            # Redirects to a generic index / ancestor: the specific page is gone.
+            return "broken", f"page removed; redirects to index {final_url}"
+        # A real move. Report only the move; the canonical target is the fix. Any
         # missing anchor on the target surfaces as its own broken-anchor finding
         # once the source is repointed to the canonical URL.
         return "stale-redirect", final_url

--- a/.github/workflows/check_org_docs_links.py
+++ b/.github/workflows/check_org_docs_links.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Scan Viam source repos for docs.viam.com links and verify them.
+
+Walks one or more repository clones, extracts every ``docs.viam.com`` URL from
+text files (regardless of context -- godoc comments, error/CLI strings,
+markdown, docstrings), and checks each unique URL against the live docs site:
+
+* 4xx / 5xx / connection error  -> ``broken``
+* 3xx redirect                  -> ``stale-redirect`` (records the canonical
+                                   target so the source link can be updated)
+* 2xx with a ``#fragment`` whose ``id`` is absent on the page -> ``broken-anchor``
+
+Findings are written as a grouped markdown report. The script exits non-zero
+when there are findings so the workflow's ``if: failure()`` reporting step fires.
+
+Every URL targets a single host (docs.viam.com), so requests are **serialized**
+with a small delay and one retry on transient 429/5xx -- a burst against one
+host is what caused the historical htmltest 403/429/timeout flakiness.
+"""
+
+import argparse
+import os
+import re
+import sys
+import time
+from urllib.parse import urljoin, urlsplit
+
+import requests
+
+# Repositories to scan. Public repos clone tokenless; private repos (app) need a
+# read token supplied at clone time by the workflow. Extend this list to cover
+# more repos (e.g. viam-cli, micro-server).
+DEFAULT_REPOS = [
+    "rdk",
+    "app",
+    "api",
+    "viam-python-sdk",
+    "viam-typescript-sdk",
+    "viam-flutter-sdk",
+]
+
+# Match a docs.viam.com URL, stopping at whitespace or characters that commonly
+# delimit a URL in code/markdown (quotes, backticks, brackets, parens, angle
+# brackets, pipes, backslashes).
+URL_RE = re.compile(r"""https?://docs\.viam\.com/[^\s"'`)>\]}|\\]*""")
+
+# File extensions worth scanning for embedded links.
+TEXT_EXT = {
+    ".go", ".md", ".mdx", ".txt", ".py", ".ts", ".tsx", ".js", ".jsx",
+    ".dart", ".rst", ".proto", ".yaml", ".yml", ".json", ".html", ".sh",
+    ".java", ".kt", ".swift", ".rs", ".c", ".cc", ".cpp", ".h",
+}
+
+# Directories that never contain first-party source worth checking.
+SKIP_DIRS = {
+    ".git", "node_modules", "vendor", "dist", "build", "out",
+    ".venv", "venv", "__pycache__", "gen", "bin", "target",
+}
+
+USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/124.0 Safari/537.36 viam-docs-link-checker"
+)
+
+# Trailing characters to strip from a captured URL (sentence/markdown punctuation
+# the greedy match may absorb).
+TRAILING = ".,;:!?"
+
+
+def strip_url(url):
+    """Trim trailing punctuation a greedy match may have absorbed."""
+    return url.rstrip(TRAILING)
+
+
+def extract(base_dir, repos):
+    """Return ``{url: sorted[list of 'repo/relpath:lineno']}`` across repos."""
+    locations = {}
+    for repo in repos:
+        repo_root = os.path.join(base_dir, repo)
+        if not os.path.isdir(repo_root):
+            print(f"  ! skipping {repo}: clone not found at {repo_root}", file=sys.stderr)
+            continue
+        for dirpath, dirnames, filenames in os.walk(repo_root):
+            dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+            for name in filenames:
+                if os.path.splitext(name)[1].lower() not in TEXT_EXT:
+                    continue
+                path = os.path.join(dirpath, name)
+                rel = os.path.relpath(path, repo_root)
+                try:
+                    with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+                        for lineno, line in enumerate(fh, 1):
+                            if "docs.viam.com" not in line:
+                                continue
+                            for match in URL_RE.findall(line):
+                                url = strip_url(match)
+                                locations.setdefault(url, set()).add(
+                                    f"{repo}/{rel}:{lineno}"
+                                )
+                except OSError as exc:
+                    print(f"  ! read error {rel}: {exc}", file=sys.stderr)
+    return {u: sorted(locs) for u, locs in locations.items()}
+
+
+# Hugo emits page aliases as an HTML stub that meta-refreshes to the canonical
+# URL -- an HTTP 200, NOT a 3xx. Detect it so an aliased link is treated as a
+# (stale) redirect rather than a live page with missing anchors.
+META_REFRESH_RE = re.compile(
+    r"""<meta[^>]+http-equiv=["']?refresh["']?[^>]+content=["'][^"']*url=([^"'\s]+)""",
+    re.IGNORECASE,
+)
+
+
+def anchor_present(html, fragment):
+    """True if an ``id``/``name`` matches the fragment (Hugo slug).
+
+    docs.viam.com renders anchors with **unquoted** attributes (e.g.
+    ``id=move``), so match quoted and unquoted forms, ending on a delimiter so
+    ``move`` does not spuriously match ``moveonglobe``.
+    """
+    frag = fragment.strip()
+    if not frag:
+        return True
+    pat = re.compile(
+        r"""(?:id|name)\s*=\s*["']?""" + re.escape(frag) + r"""(?=["'\s/>])""",
+        re.IGNORECASE,
+    )
+    return bool(pat.search(html))
+
+
+def same_page(a, b):
+    """True if two URLs point at the same page (ignore fragment/query, //-slash)."""
+    pa, pb = urlsplit(a), urlsplit(b)
+    return (
+        pa.scheme == pb.scheme
+        and pa.netloc == pb.netloc
+        and pa.path.rstrip("/") == pb.path.rstrip("/")
+    )
+
+
+def resolve(url, session, retries=1, max_hops=6):
+    """Follow HTTP 3xx and Hugo meta-refresh aliases to the final page.
+
+    Returns ``(final_url, status, html)``. ``status`` is the last HTTP status;
+    ``html`` is the final page body (empty on error).
+    """
+    current = url
+    seen = set()
+    for _ in range(max_hops):
+        if current in seen:
+            break
+        seen.add(current)
+
+        attempt = 0
+        while True:
+            try:
+                resp = session.get(current, allow_redirects=False, timeout=30)
+            except requests.RequestException as exc:
+                if attempt < retries:
+                    attempt += 1
+                    time.sleep(2)
+                    continue
+                return current, 0, ""
+            code = resp.status_code
+            if code == 429 or 500 <= code < 600:
+                if attempt < retries:
+                    attempt += 1
+                    time.sleep(2)
+                    continue
+            break
+
+        if 300 <= code < 400:
+            location = resp.headers.get("Location")
+            if not location:
+                return current, code, resp.text
+            current = urljoin(current, location)
+            continue
+
+        if code >= 400:
+            return current, code, resp.text
+
+        # 2xx: a meta-refresh body means this is an alias stub -> keep following.
+        match = META_REFRESH_RE.search(resp.text)
+        if match:
+            current = urljoin(current, match.group(1).strip())
+            continue
+
+        return current, code, resp.text
+
+    return current, 0, ""
+
+
+def classify(url, session, delay):
+    """Return ``(label, detail)`` for one URL, following aliases/redirects."""
+    final_url, status, html = resolve(url, session)
+
+    if status == 0:
+        return "broken", "unreachable / redirect loop"
+    if status >= 400:
+        return "broken", f"HTTP {status} (final: {final_url})"
+
+    fragment = urlsplit(url).fragment
+
+    if not same_page(url, final_url):
+        # Report only the move; the canonical target is the actionable fix. Any
+        # missing anchor on the target surfaces as its own broken-anchor finding
+        # once the source is repointed to the canonical URL.
+        return "stale-redirect", final_url
+
+    if fragment and not anchor_present(html, fragment):
+        return "broken-anchor", f"missing #{fragment}"
+    return "ok", f"HTTP {status}"
+
+
+def rewrite_rule(orig_url, final_url):
+    """Describe the path change between two URLs as a ``(from, to)`` substring
+    rule, so links that moved the same way group together.
+
+    e.g. ``/dev/reference/apis/services/motion/`` -> ``/reference/apis/services/
+    motion/`` yields ``("dev/", "")`` -- the systematic prefix change shared by
+    every ``/dev/reference/`` link.
+    """
+    a = urlsplit(orig_url).path.strip("/").split("/")
+    b = urlsplit(final_url).path.strip("/").split("/")
+    i = 0
+    while i < min(len(a), len(b)) and a[i] == b[i]:
+        i += 1
+    j = 0
+    while j < min(len(a) - i, len(b) - i) and a[-1 - j] == b[-1 - j]:
+        j += 1
+    frm = "/".join(a[i:len(a) - j])
+    to = "/".join(b[i:len(b) - j])
+    return frm, to
+
+
+def build_report(findings, url_locations):
+    """Render grouped, summarized markdown for ``{label: [(url, detail)]}``."""
+    n_broken = len(findings.get("broken", []))
+    n_stale = len(findings.get("stale-redirect", []))
+    n_anchor = len(findings.get("broken-anchor", []))
+    total = n_broken + n_stale + n_anchor
+
+    lines = ["## docs.viam.com link check findings", ""]
+    lines.append(
+        f"Found **{total}** link problem(s): "
+        f"**{n_broken}** broken, **{n_stale}** stale redirect(s), "
+        f"**{n_anchor}** broken anchor(s)."
+    )
+    lines.append("")
+
+    # Broken links -- unambiguous, highest priority; flat list.
+    if n_broken:
+        lines.append(f"### Broken links (4xx / 5xx / unreachable) — {n_broken}")
+        lines.append("")
+        for url, detail in sorted(findings["broken"]):
+            lines.append(f"- `{url}` — {detail}")
+            for loc in url_locations[url]:
+                lines.append(f"  - `{loc}`")
+        lines.append("")
+
+    # Stale redirects -- grouped by the shared path-rewrite so a bulk fix is
+    # obvious (e.g. "dev/ -> '' (204 links)").
+    if n_stale:
+        lines.append(
+            f"### Stale redirects (works via alias, not canonical) — {n_stale}"
+        )
+        lines.append("")
+        groups = {}
+        for url, final_url in findings["stale-redirect"]:
+            frm, to = rewrite_rule(url, final_url)
+            groups.setdefault((frm, to), []).append((url, final_url))
+        for (frm, to), items in sorted(groups.items(), key=lambda kv: -len(kv[1])):
+            frm_disp = frm or "∅"
+            to_disp = to or "∅"
+            lines.append(
+                f"#### Replace `{frm_disp}` → `{to_disp}` — {len(items)} link(s)"
+            )
+            lines.append("")
+            for url, final_url in sorted(items):
+                loc_count = len(url_locations[url])
+                lines.append(
+                    f"- `{url}` → `{final_url}` "
+                    f"({loc_count} source location(s))"
+                )
+                for loc in url_locations[url]:
+                    lines.append(f"  - `{loc}`")
+            lines.append("")
+
+    # Broken anchors -- lower-confidence tier (rendering-dependent); flat list.
+    if n_anchor:
+        lines.append(
+            f"### Broken anchors (page exists, #fragment absent) — {n_anchor}"
+        )
+        lines.append("")
+        lines.append(
+            "_Lower confidence: anchor rendering varies by page; verify before "
+            "acting._"
+        )
+        lines.append("")
+        for url, detail in sorted(findings["broken-anchor"]):
+            lines.append(f"- `{url}` — {detail}")
+            for loc in url_locations[url]:
+                lines.append(f"  - `{loc}`")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-dir", default="repos",
+        help="Directory containing the repo clones (default: repos).",
+    )
+    parser.add_argument(
+        "--repos", nargs="*", default=None,
+        help="Override the repo list (default: the built-in DEFAULT_REPOS).",
+    )
+    parser.add_argument(
+        "--out", default="link-findings.md",
+        help="Path to write the findings markdown report.",
+    )
+    parser.add_argument(
+        "--delay", type=float, default=0.3,
+        help="Seconds to sleep between requests (single-host rate limiting).",
+    )
+    args = parser.parse_args()
+
+    repos = args.repos if args.repos else DEFAULT_REPOS
+
+    print(f"Extracting docs.viam.com links from: {', '.join(repos)}")
+    url_locations = extract(args.base_dir, repos)
+    print(f"Found {len(url_locations)} unique docs.viam.com URL(s).")
+
+    session = requests.Session()
+    session.headers["User-Agent"] = USER_AGENT
+
+    findings = {}
+    ok = 0
+    for i, url in enumerate(sorted(url_locations), 1):
+        time.sleep(args.delay)
+        label, detail = classify(url, session, args.delay)
+        if label == "ok":
+            ok += 1
+        else:
+            findings.setdefault(label, []).append((url, detail))
+            print(f"  [{label}] {url}  ({detail})")
+        if i % 25 == 0:
+            print(f"  ...checked {i}/{len(url_locations)}")
+
+    total_findings = sum(len(v) for v in findings.values())
+    print(f"\nDone: {ok} ok, {total_findings} problem(s).")
+
+    report = build_report(findings, url_locations) if total_findings else ""
+    if report:
+        with open(args.out, "w", encoding="utf-8") as fh:
+            fh.write(report)
+        print(f"Wrote findings to {args.out}")
+
+    # Emit a workflow output flag when running in GitHub Actions.
+    gh_out = os.environ.get("GITHUB_OUTPUT")
+    if gh_out:
+        with open(gh_out, "a", encoding="utf-8") as fh:
+            fh.write(f"findings={'true' if total_findings else 'false'}\n")
+
+    # Non-zero exit on findings so the workflow's if: failure() reporting fires.
+    return 1 if total_findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds a **nightly job that scans Viam source repos for `docs.viam.com` links and verifies them** against the live docs site. Findings open a single deduplicated `ci-failure` issue for the existing CI-failure triage routine.

Scanned repos (configurable): `rdk`, `app` (private, via token), `api`, `viam-python-sdk`, `viam-typescript-sdk`, `viam-flutter-sdk`.

## How it works

- **`check_org_docs_links.py`** greps every `docs.viam.com` URL out of the source across all contexts (godoc comments, error/CLI strings, markdown, docstrings) and checks each unique URL:
  - **broken** — 4xx/5xx/unreachable
  - **stale redirect** — resolves to a different canonical URL. Follows both HTTP 3xx and **Hugo meta-refresh alias stubs** (docs.viam.com serves aliases as HTTP 200 + a `<meta http-equiv=refresh>` body, not a 3xx), and matches **unquoted** anchor ids.
  - **broken anchor** — page exists but the `#fragment` is absent (lower-confidence tier; anchor rendering varies by page)
  - Single-host requests are serialized with a small delay + one retry (the same lesson as the htmltest fix — bursting one host causes 403/429/timeout flakiness).
- Findings are written **grouped by shared path-rewrite rule** (e.g. `dev/` → `∅` — N links) so bulk fixes are obvious; the full report is uploaded as an artifact and summarized in the issue (with truncation for the 65 KB issue-body cap).
- Reuses `report-ci-failure` (new optional `details` input carries the findings into the issue body).

## Notes / follow-ups (not in this PR)

- **`ORG_REPO_READ_TOKEN` secret** — needed to clone the private `app` repo; without it the job scans the other repos and warns.
- **Bulk `/dev/reference/` → `/reference/` fix in the source repos** should land first — the docs site recently moved `/dev/reference/…` → `/reference/…`, so ~200 RDK godoc links currently trail it. An RDK bulk-fix PR is being prepared separately.
- RDK's old `linkcheck.yml` (weekly doc2go+htmltest into dead Jira, failing unseen since April) can be retired once this covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
