### PR TITLE
Update manage-modules docs for module deprecation

### DIFF
--- a/docs/build-modules/manage-modules.md
+++ b/docs/build-modules/manage-modules.md
@@ -398,9 +398,9 @@ You can deprecate a module to signal that it should no longer be used.
 Deprecating a module:
 
 - Marks it with a **Deprecated** badge in the registry
-- Hides it from registry search results
+- Hides it from registry search results for users outside the owning organization
 - Prevents users from adding it to new machines
-- Does not affect machines that already use the module
+- Existing machines that already use the module will continue running it, but warnings will be shown on the config page
 
 To deprecate a module:
 

--- a/docs/build-modules/manage-modules.md
+++ b/docs/build-modules/manage-modules.md
@@ -6,7 +6,7 @@ weight: 32
 images: ["/registry/create-module.svg"]
 icon: true
 tags: ["modular resources", "components", "services", "registry"]
-description: "Update or delete your existing modules, or change their privacy settings."
+description: "Update, deprecate, or delete your existing modules, or change their privacy settings."
 aliases:
   - /operate/modules/advanced/manage-modules/
   - /use-cases/deploy-code/
@@ -21,7 +21,7 @@ date: "2024-06-30"
 cost: "0"
 ---
 
-After you [create and upload a module](/build-modules/write-a-driver-module/), you can release new versions, pin machines to a specific version, change visibility, or delete the module.
+After you [create and upload a module](/build-modules/write-a-driver-module/), you can release new versions, pin machines to a specific version, change visibility, deprecate, or delete the module.
 
 ## Update a module
 
@@ -391,6 +391,39 @@ viam module update
 {{% hiddencontent %}}
 If you don't see a private module of yours in the registry, make sure that you have the correct organization selected in the upper right corner of the page.
 {{% /hiddencontent %}}
+
+## Deprecate a module
+
+You can deprecate a module to signal that it should no longer be used.
+Deprecating a module:
+
+- Marks it with a **Deprecated** badge in the registry
+- Hides it from registry search results
+- Prevents users from adding it to new machines
+- Does not affect machines that already use the module
+
+To deprecate a module:
+
+1. Navigate to your module's page in the [registry](https://app.viam.com/registry).
+1. Click the **...** (menu) icon in the upper-right corner of the page.
+1. Click **Deprecate**.
+1. Optionally, enter a message for users (for example, "Use acme:sensor:v2 instead").
+1. Click **Deprecate** to confirm.
+
+To reverse the deprecation, open the same **...** menu and click **Undeprecate**.
+
+### Deprecate a single version
+
+You can deprecate individual versions instead of the entire module.
+This is useful when a specific release has a known issue but the module itself is still active.
+
+1. Navigate to your module's page in the [registry](https://app.viam.com/registry).
+1. Click **Show previous versions** under the **Latest version** heading.
+1. Click the **...** (menu) icon next to the version you want to deprecate.
+1. Click **Deprecate version**, optionally enter a message, and confirm.
+
+Deprecated versions appear with a strikethrough and a **Deprecated** badge.
+To reverse a version deprecation, click the **...** menu on the deprecated version and select **Undeprecate version**.
 
 ## Delete a module
 


### PR DESCRIPTION
Document the module deprecation and undeprecation workflow now that the feature is generally available to all users.

## Source changes

- viamrobotics/app#12612: Remove `ENABLE_MODULE_DEPRECATION` feature flag and its traces (APP-17068)
- viamrobotics/api#859: Add DeprecateRegistryItem, UndeprecateRegistryItem, DeprecateRegistryItemVersion, UndeprecateRegistryItemVersion RPCs
- viamrobotics/app#12264: Backend implementation of deprecation endpoints
- viamrobotics/app#12274: Frontend UI for module deprecation

## Docs changes

- `docs/build-modules/manage-modules.md`: Added "Deprecate a module" section covering whole-module and per-version deprecation workflows. Updated page description and intro sentence to mention deprecation. Placed between "Change module visibility" and "Delete a module" sections.

## How I found these

- Backlog item `api-1cb9083-deprecate-registry-item` was deferred until the feature flag was removed
- Today's diff of `app/data/feature_models.go` and `app/ui/src/lib/api/feature.ts` showed the `ENABLE_MODULE_DEPRECATION` flag removed
- Grep of entire docs repo confirmed zero existing references to module deprecation lifecycle

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01XnV5By1Zg9VWgxE4rpaMaR)_