### PR TITLE
Fix "Move your first arm" quickstart: new add-component flow and missing frame step

### DIFF
--- a/docs/motion-planning/quickstarts/first-arm.md
+++ b/docs/motion-planning/quickstarts/first-arm.md
@@ -117,8 +117,7 @@ executes it, plus a verification read after the motion completes.
 Add the arm to the frame system so the motion service can plan
 its movements. On the arm's card, click **Frame**. The default values
 (parent `world`, zero translation and rotation) place the arm's base
-at the world origin, which is correct for this tutorial, so you don't need to
-change anything:
+at the world origin, so you don't need to change anything:
 
 ```json
 {

--- a/docs/motion-planning/quickstarts/first-arm.md
+++ b/docs/motion-planning/quickstarts/first-arm.md
@@ -7,8 +7,8 @@ type: "docs"
 description: "From zero to an arm moving under motion service control, using a fake arm that runs on any machine."
 ---
 
-In this quickstart we will configure a fake arm with UR5e kinematics,
-connect to it from Python, and call the motion service to drive the
+This quickstart configures a fake arm with UR5e kinematics,
+connects to it from Python, and calls the motion service to drive the
 arm's end effector to a target pose. The whole thing runs on any
 machine that has `viam-server`; no physical arm required. When you
 have a real UR5e (or any other arm with a Viam module) later, the only
@@ -117,7 +117,7 @@ executes it, plus a verification read after the motion completes.
 Add the arm to the frame system so the motion service can plan
 its movements. On the arm's card, click **Frame**. The default values
 (parent `world`, zero translation and rotation) place the arm's base
-at the world origin, which is what we want here, so you don't need to
+at the world origin, which is correct for this tutorial, so you don't need to
 change anything:
 
 ```json

--- a/docs/motion-planning/quickstarts/first-arm.md
+++ b/docs/motion-planning/quickstarts/first-arm.md
@@ -37,11 +37,11 @@ an existing one that has `viam-server` running. Go to its
 
 ## 2. Add the fake arm component
 
-1. Click **+** and choose **Component**.
-2. Select **arm**.
-3. Choose the **fake** model.
+1. Click **+** and choose **Blocks**.
+2. Search for **arm**.
+3. Choose the **arm/fake** component.
 4. Name the component **my-arm**.
-5. Click **Create**.
+5. Click **Add to machine**.
 
 In the arm's configuration card, set the `arm-model` attribute to
 `"ur5e"` so the fake arm exposes UR5e kinematics:
@@ -113,6 +113,26 @@ What matters is that the arm responds and returns a pose.
 You now have a script that connects to the machine and reads the arm's
 pose. Next you will add the motion service call that plans a path and
 executes it, plus a verification read after the motion completes.
+
+Add the arm to the frame system so the motion service can plan
+its movements. On the arm's card, click **Frame**. The default values
+(parent `world`, zero translation and rotation) place the arm's base
+at the world origin, which is what we want here, so you don't need to
+change anything:
+
+```json
+{
+  "parent": "world",
+  "translation": { "x": 0, "y": 0, "z": 0 },
+  "orientation": {
+    "type": "ov_degrees",
+    "value": { "x": 0, "y": 0, "z": 1, "th": 0 }
+  }
+}
+```
+
+Click **Save** again.
+
 Replace the `main` function with:
 
 ```python


### PR DESCRIPTION
# Fix "Move your first arm" quickstart: new add-component flow and missing frame step

## What changed

Walked through the [Move your first arm quickstart](https://docs.viam.com/motion-planning/quickstarts/first-arm/) end to end against a live machine and fixed two issues that prevent readers from completing it as written.

### 1. Updated the add-component steps to the current app UI (section 2)

The **+** menu on the **CONFIGURE** tab no longer has a **Component** option. Components are now added via **Blocks**, which opens a searchable model browser with an **Add to machine** button:

- ~~Click **+** and choose **Component** → Select **arm** → Choose the **fake** model → **Create**~~
- Click **+** and choose **Blocks** → search **arm** → choose **arm/fake** → **Add to machine**

### 2. Added the missing frame-system step (section 4)

The tutorial never told readers to add a frame to the arm. Without one, the arm isn't part of the frame system, so reading the pose in section 3 works but the `motion_service.move()` call fails with:

```
component named my-arm not found in robot frame system
```

Section 4 now has readers click **Frame** on the arm's card before running the motion code. The default values (parent `world`, zero translation and rotation) are correct for this tutorial, so it's a click-and-save step; the JSON is shown for reference.

## Testing

- Followed the quickstart from scratch in the app (fake arm on `darwin/arm64`) and ran `first_arm.py` at each stage.
- Confirmed the failure mode: without the frame, `move` fails with the error above; after adding it, the motion completes and the verification read shows the end effector moved +100 mm in X.
- `make serve-dev` renders the page correctly.
