### PR TITLE
[Hardware] Switch from Add Configuration Block to Add Block, and Create to Add to machine

### DIFF
--- a/docs/hardware/common-components/add-a-base.md
+++ b/docs/hardware/common-components/add-a-base.md
@@ -59,11 +59,11 @@ For bases not covered above, search for `base` in the [Viam registry](https://ap
 ### 2. Add a base component
 
 1. Click the **+** button.
-2. Select **Configuration block**.
+2. Select **Blocks**.
 3. Search for the base model that matches your hardware. For a
    differential-drive robot with left and right motors, search for
    **wheeled**.
-4. Name your base (for example, `my-base`) and click **Create**.
+4. Name your base (for example, `my-base`) and click **Add to machine**.
 
 ### 3. Configure base attributes
 

--- a/docs/hardware/common-components/add-a-board.md
+++ b/docs/hardware/common-components/add-a-board.md
@@ -62,13 +62,13 @@ Confirm it shows as **Live** in the upper left.
 ### 2. Add a board component
 
 1. Click the **+** button.
-2. Select **Configuration block**.
+2. Select **Blocks**.
 3. Search for the model that matches your hardware:
    - For a Raspberry Pi, search for **raspberry pi** and pick the model that matches your Pi version (for example, `viam:raspberry-pi:rpi5`).
    - For an NVIDIA Jetson, search for **jetson**.
    - For an Orange Pi, search for **orangepi**.
    - For an IO expander, search for it by chip name (for example, **pca9685**).
-4. Name your board (for example, `my-board`) and click **Create**.
+4. Name your board (for example, `my-board`) and click **Add to machine**.
 
 ### 3. Configure board attributes
 

--- a/docs/hardware/common-components/add-a-button.md
+++ b/docs/hardware/common-components/add-a-button.md
@@ -32,10 +32,10 @@ For hardware the built-in models don't cover, search for `button` in the [Viam r
 ### 1. Add a button component
 
 1. Click the **+** button.
-2. Select **Configuration block**.
+2. Select **Blocks**.
 3. Search for the model that matches your button hardware. Search by
    manufacturer name, chip, or device type.
-4. Name your button (for example, `my-button`) and click **Create**.
+4. Name your button (for example, `my-button`) and click **Add to machine**.
 
 ### 2. Configure button attributes
 

--- a/docs/hardware/common-components/add-a-camera.md
+++ b/docs/hardware/common-components/add-a-camera.md
@@ -56,12 +56,12 @@ If it shows as offline, verify that `viam-server` is running on your machine.
 ### 2. Add a camera component
 
 1. Click the **+** button.
-2. Select **Configuration block**.
+2. Select **Blocks**.
 3. Search for the model that matches your camera:
    - For a USB webcam or built-in laptop camera, search for **webcam**.
    - For an IP camera that supports RTSP, search for **rtsp** and pick one of the `viam:viamrtsp` models (`rtsp` autodetects codec; specific codecs like `rtsp-h264` or `rtsp-h265` are also available).
    - For an Intel RealSense depth camera, search for **realsense**.
-4. Name your camera (this guide uses `my-camera`) and click **Create**.
+4. Name your camera (this guide uses `my-camera`) and click **Add to machine**.
 
 {{< alert title="Finding your camera" color="tip" >}}
 

--- a/docs/hardware/common-components/add-a-gantry.md
+++ b/docs/hardware/common-components/add-a-gantry.md
@@ -62,13 +62,13 @@ For gantries not covered above, search for `gantry` in the [Viam registry](https
 ### 2. Add a gantry component
 
 1. Click the **+** button.
-2. Select **Configuration block**.
+2. Select **Blocks**.
 3. Search for the gantry model that matches your setup:
    - For a single linear rail driven by a motor, search for
      **single-axis**.
    - For a multi-axis system composed of multiple single-axis gantries,
      search for **multi-axis**.
-4. Name your gantry (for example, `my-gantry`) and click **Create**.
+4. Name your gantry (for example, `my-gantry`) and click **Add to machine**.
 
 ### 3. Configure gantry attributes
 

--- a/docs/hardware/common-components/add-a-generic.md
+++ b/docs/hardware/common-components/add-a-generic.md
@@ -44,10 +44,10 @@ For hardware the built-in models don't cover, search for `generic` in the [Viam 
 ### 1. Add a generic component
 
 1. Click the **+** button.
-2. Select **Configuration block**.
+2. Select **Blocks**.
 3. Search for the model that matches your hardware. Search by
    manufacturer name, chip, or device type.
-4. Name your component (for example, `my-device`) and click **Create**.
+4. Name your component (for example, `my-device`) and click **Add to machine**.
 
 If no model exists for your hardware, you can
 [write your own module](/build-modules/write-a-driver-module/) that implements

--- a/docs/hardware/common-components/add-a-gripper.md
+++ b/docs/hardware/common-components/add-a-gripper.md
@@ -49,10 +49,10 @@ For grippers not covered above, search for `gripper` in the [Viam registry](http
 ### 1. Add a gripper component
 
 1. Click the **+** button.
-2. Select **Configuration block**.
+2. Select **Blocks**.
 3. Search for the model that matches your gripper hardware. Search by
    manufacturer name or gripper type (for example, "gripper", "finger gripper", "vacuum").
-4. Name your gripper (for example, `my-gripper`) and click **Create**.
+4. Name your gripper (for example, `my-gripper`) and click **Add to machine**.
 
 ### 2. Configure gripper attributes
 

--- a/docs/hardware/common-components/add-a-motor.md
+++ b/docs/hardware/common-components/add-a-motor.md
@@ -61,7 +61,7 @@ For motors not covered above, search for `motor` in the [Viam registry](https://
 ### 2. Add a motor component
 
 1. Click the **+** button.
-2. Select **Configuration block**.
+2. Select **Blocks**.
 3. Search for the motor model that matches your hardware:
    - For a brushed DC motor controlled through a motor driver with GPIO
      pins, search for **gpio motor**.
@@ -69,7 +69,7 @@ For motors not covered above, search for `motor` in the [Viam registry](https://
      pins, search for **gpiostepper**.
    - For other motor types, search by your motor driver or manufacturer
      name.
-4. Name your motor (for example, `left-motor`) and click **Create**.
+4. Name your motor (for example, `left-motor`) and click **Add to machine**.
 
 ### 3. Configure motor attributes
 

--- a/docs/hardware/common-components/add-a-movement-sensor.md
+++ b/docs/hardware/common-components/add-a-movement-sensor.md
@@ -69,10 +69,10 @@ and velocity estimates without any additional sensors.
 #### 2. Add the movement sensor
 
 1. Click the **+** button.
-2. Select **Configuration block**.
+2. Select **Blocks**.
 3. Search for **wheeled-odometry**. This is the built-in model that
    computes position from wheel encoder data.
-4. Name it (for example, `odometry`) and click **Create**.
+4. Name it (for example, `odometry`) and click **Add to machine**.
 
 #### 3. Configure attributes
 
@@ -96,10 +96,10 @@ and velocity estimates without any additional sensors.
 #### 1. Add the component
 
 1. Click the **+** button.
-2. Select **Configuration block**.
+2. Select **Blocks**.
 3. Search for the model that matches your sensor hardware. Search by
    sensor name or chip (for example, **NMEA GPS**, **BNO055**, **MPU6050**).
-4. Name it and click **Create**.
+4. Name it and click **Add to machine**.
 5. Configure attributes per the model's documentation (typically I2C
    address or serial port).
 

--- a/docs/hardware/common-components/add-a-power-sensor.md
+++ b/docs/hardware/common-components/add-a-power-sensor.md
@@ -48,10 +48,10 @@ For power sensors not covered above (Renogy controllers, other chips), search fo
 ### 2. Add a power sensor component
 
 1. Click the **+** button.
-2. Select **Configuration block**.
+2. Select **Blocks**.
 3. Search for the power sensor model that matches your hardware. Search
    by chip name (for example, **ina219**, **ina226**).
-4. Name it (for example, `battery-monitor`) and click **Create**.
+4. Name it (for example, `battery-monitor`) and click **Add to machine**.
 
 ### 3. Configure attributes
 

--- a/docs/hardware/common-components/add-a-sensor.md
+++ b/docs/hardware/common-components/add-a-sensor.md
@@ -50,11 +50,11 @@ For sensors not covered above, search for `sensor` in the [Viam registry](https:
 ### 1. Add a sensor component
 
 1. Click the **+** button.
-2. Select **Configuration block**.
+2. Select **Blocks**.
 3. Search for the model that matches your sensor hardware. Search by
    sensor name or chip (for example, **DHT22**, **BME280**, **SHT31**). For I2C
    or serial sensors, you can also search by protocol or manufacturer.
-4. Name your sensor (for example, `temperature-sensor`) and click **Create**.
+4. Name your sensor (for example, `temperature-sensor`) and click **Add to machine**.
 
 If no model exists for your sensor, you can
 [write your own module](/build-modules/write-a-driver-module/) to add support.

--- a/docs/hardware/common-components/add-a-servo.md
+++ b/docs/hardware/common-components/add-a-servo.md
@@ -51,10 +51,10 @@ For servos not covered above, search for `servo` in the [Viam registry](https://
 ### 2. Add a servo component
 
 1. Click the **+** button.
-2. Select **Configuration block**.
+2. Select **Blocks**.
 3. For a standard hobby servo controlled by a PWM pin on your board,
    search for **gpio servo**.
-4. Name your servo (for example, `pan-servo`) and click **Create**.
+4. Name your servo (for example, `pan-servo`) and click **Add to machine**.
 
 ### 3. Configure servo attributes
 

--- a/docs/hardware/common-components/add-a-switch.md
+++ b/docs/hardware/common-components/add-a-switch.md
@@ -41,10 +41,10 @@ For hardware the built-in models don't cover, search for `switch` in the [Viam r
 ### 1. Add a switch component
 
 1. Click the **+** button.
-2. Select **Configuration block**.
+2. Select **Blocks**.
 3. Search for the model that matches your switch hardware. Search by
    manufacturer name, chip, or device type.
-4. Name your switch (for example, `my-switch`) and click **Create**.
+4. Name your switch (for example, `my-switch`) and click **Add to machine**.
 
 ### 2. Configure switch attributes
 

--- a/docs/hardware/common-components/add-an-arm.md
+++ b/docs/hardware/common-components/add-an-arm.md
@@ -52,11 +52,11 @@ For arms not covered above, search for `arm` in the [Viam registry](https://app.
 ### 1. Add an arm component
 
 1. Click the **+** button.
-2. Select **Configuration block**.
+2. Select **Blocks**.
 3. Search for the model that matches your arm manufacturer and model:
    - For a UFactory xArm, search for **xArm6** (or xArm5, xArm7, Lite6).
    - For a Universal Robots arm, search for **ur5e** (or ur3e, ur10e, ur16e).
-4. Name your arm (for example, `my-arm`) and click **Create**.
+4. Name your arm (for example, `my-arm`) and click **Add to machine**.
 
 ### 2. Configure arm attributes
 

--- a/docs/hardware/common-components/add-an-encoder.md
+++ b/docs/hardware/common-components/add-an-encoder.md
@@ -61,11 +61,11 @@ For encoders not covered above, search for `encoder` in the [Viam registry](http
 ### 2. Add an encoder component
 
 1. Click the **+** button.
-2. Select **Configuration block**.
+2. Select **Blocks**.
 3. Search for the encoder model that matches your hardware:
    - For a two-channel quadrature encoder, search for **incremental**.
    - For a single-channel encoder, search for **single encoder**.
-4. Name your encoder (for example, `left-encoder`) and click **Create**.
+4. Name your encoder (for example, `left-encoder`) and click **Add to machine**.
 
 ### 3. Configure encoder attributes
 

--- a/docs/hardware/common-components/add-an-input-controller.md
+++ b/docs/hardware/common-components/add-an-input-controller.md
@@ -39,10 +39,10 @@ For hardware the built-in models don't cover, search for `input controller` in t
 
 1. Plug your gamepad into the machine's USB port.
 2. Click the **+** button.
-3. Select **Configuration block**.
+3. Select **Blocks**.
 4. Search for **gamepad**. This is the built-in model for USB game
    controllers.
-5. Name it (for example, `my-gamepad`) and click **Create**.
+5. Name it (for example, `my-gamepad`) and click **Add to machine**.
 
 #### 2. Configure attributes
 
@@ -62,10 +62,10 @@ If you have multiple controllers, specify which one:
 #### 1. Add a webgamepad component
 
 1. Click the **+** button.
-2. Select **Configuration block**.
+2. Select **Blocks**.
 3. Search for **webgamepad**. This model provides browser-based
    controls in the Viam app.
-4. Name it (for example, `web-controller`) and click **Create**.
+4. Name it (for example, `web-controller`) and click **Add to machine**.
 
 No attributes needed. The web gamepad appears in the Viam app's CONTROL tab
 and works with browser-compatible game controllers or on-screen controls.
@@ -80,10 +80,10 @@ and works with browser-compatible game controllers or on-screen controls.
 #### 2. Add and configure
 
 1. Click the **+** button.
-2. Select **Configuration block**.
+2. Select **Blocks**.
 3. Search for **gpio input controller**. This model maps GPIO pins to
    controller buttons.
-4. Name it and click **Create**.
+4. Name it and click **Add to machine**.
 5. Configure the pins:
 
 ```json

--- a/docs/hardware/configure-hardware.md
+++ b/docs/hardware/configure-hardware.md
@@ -100,10 +100,10 @@ If it shows as offline, verify that `viam-server` is running on your machine.
 ### 2. Add the component
 
 1. Click the **+** button.
-2. Select **Configuration block**.
+2. Select **Blocks**.
 3. Search for the model that matches your hardware (for example, "webcam", "gpio
    motor", "xArm6"). The search covers all available models and fragments.
-4. Give your component a **name** and click **Create**. The name is how
+4. Give your component a **name** and click **Add to machine**. The name is how
    you reference it in code and configuration, so keep it short,
    descriptive, and unique on this machine.
 


### PR DESCRIPTION
## What

Updates the **hardware** add-component pages to the current Viam app UI wording. This is the first of a few section-scoped PRs migrating the whole docs site off the old add-component wording.

Two strings changed (verified live against a machine's CONFIGURE tab):

| Old | New |
|-----|-----|
| Select **Configuration block** (the + menu option) | Select **Blocks** |
| Name your X and click **Create** (confirm button) | ...and click **Add to machine** |

## Scope

17 files under `docs/hardware/` — the 16 `common-components/add-a-*.md` pages plus `configure-hardware.md`. 40 lines, a symmetric wording swap.

## Deliberately not changed

- `docs/hardware/machine-configuration.md` — its only "Configuration block" is the concept heading `## Configuration blocks` (describing the config JSON structure), **not** the + menu label, so it's left as-is.
- Only the **bolded menu label** `**Configuration block**` and the **component-naming** `and click **Create**` were touched. Non-component "Create" buttons (jobs, module resources, etc.) are out of scope and untouched.

## Follow-ups (same sweep, separate PRs)

tutorials, vision + reference, motion-planning, and the remainder (try / monitor / fleet / build-modules / train / data).

## Checks

prettier, markdownlint, and vale (error level) all pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)