### PR TITLE
[Reference] Switch from Add Configuration Block to Add Block, and Create to Add to machine

### DIFF
--- a/docs/reference/components/camera/webcam.md
+++ b/docs/reference/components/camera/webcam.md
@@ -94,7 +94,7 @@ To add and use the service:
 1. Click the **+** icon next to your machine part in the left-hand menu and select **Service**.
 1. Search for `find-webcams` and select the `discovery / find-webcams:webcam-discovery` service.
 1. Click **Add module**.
-1. Enter a name or use the suggested name for your camera and click **Create**.
+1. Enter a name or use the suggested name for your camera and click **Add to machine**.
 1. Save your configuration, and wait a moment for the service to start.
 1. Click **Test** to see the available `video_path`s.
 1. Click the **Copy attributes** button for the camera you want to use.

--- a/docs/reference/device-setup/pumpkin.md
+++ b/docs/reference/device-setup/pumpkin.md
@@ -212,9 +212,9 @@ Configure your board as a [`customlinux`](https://app.viam.com/module/viam/custo
 {{% tab name="Config Builder" %}}
 
 Navigate to the **CONFIGURE** tab of your machine's page.
-Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Select the `board` type, then select the `customlinux` model.
-Enter a name or use the suggested name for your `customlinux` board and click **Create**.
+Enter a name or use the suggested name for your `customlinux` board and click **Add to machine**.
 
 [Example configuration for a pumpkin board using customlinux](https://github.com/viam-modules/customlinux/blob/main/README.md#example-configuration-for-a-pumpkin-board)
 

--- a/docs/reference/services/base-rc/_index.md
+++ b/docs/reference/services/base-rc/_index.md
@@ -49,9 +49,9 @@ Then, configure the service:
 {{% tab name="Builder" %}}
 
 Navigate to the **CONFIGURE** tab of your machine's page.
-Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Select the `base remote control` type.
-Enter a name or use the suggested name for your service and click **Create**.
+Enter a name or use the suggested name for your service and click **Add to machine**.
 
 In your base remote control service's configuration panel, copy and paste the following JSON object into the attributes field:
 

--- a/docs/reference/services/generic/fake.md
+++ b/docs/reference/services/generic/fake.md
@@ -19,9 +19,9 @@ Configure a `fake` generic service to test implementing a generic service on you
 {{% tab name="Config Builder" %}}
 
 Navigate to the **CONFIGURE** tab of your machine's page.
-Click the **+** button and select **Configuration block**.
+Click the **+** button and select **Blocks**.
 Select the `generic` type, then select the `fake` model.
-Enter a name or use the suggested name for your generic service and click **Create**.
+Enter a name or use the suggested name for your generic service and click **Add to machine**.
 
 ![An example configuration for a fake generic service.](/services/fake-generic-service-config.png)
 

--- a/docs/reference/services/vision/color_detector.md
+++ b/docs/reference/services/vision/color_detector.md
@@ -33,7 +33,7 @@ Object colors vary dramatically with lighting. Verify your target color value un
 {{% tab name="Builder" %}}
 
 1. Navigate to the **CONFIGURE** tab of your machine's page.
-2. Click the **+** icon next to your machine part and select **Configuration block**.
+2. Click the **+** icon next to your machine part and select **Blocks**.
 3. In the search field, type `color detector` and select the `vision/color_detector` result.
 4. Click **Add to machine**, enter a name, and click **Add to machine** again to confirm.
 5. Choose a color and a hue tolerance, then set a segment size in pixels.

--- a/docs/reference/services/vision/detections-to-segments.md
+++ b/docs/reference/services/vision/detections-to-segments.md
@@ -29,7 +29,7 @@ This model previously shipped with core RDK as `detector_3d_segmenter`. It now s
 ## Install the module
 
 1. In the Viam app, open your machine's **CONFIGURE** tab.
-2. Click the **+** icon next to your machine part and select **Configuration block**.
+2. Click the **+** icon next to your machine part and select **Blocks**.
 3. In the search field, type `detections-to-segments` and select the matching result.
 4. Click **Add to machine**, enter a name for the service, and click **Add to machine** again to confirm. The module is installed automatically.
 

--- a/docs/reference/services/vision/mlmodel.md
+++ b/docs/reference/services/vision/mlmodel.md
@@ -46,7 +46,7 @@ Configure an [ML model service](/vision/deploy-and-maintain/deploy-from-registry
 {{% tab name="Builder" %}}
 
 1. Navigate to the **CONFIGURE** tab of your machine's page.
-2. Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+2. Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 3. In the search field, type `vision` or `mlmodel` and select the `vision/mlmodel` result.
 4. Click **Add to machine**, enter a name for your service, and click **Add to machine** again to confirm.
 5. In the **ML MODEL** section, select the ML model service your model is deployed on.


### PR DESCRIPTION
## What

Reference section of the add-component wording sweep (see #5160 for hardware). Matches the current Viam app UI, verified live:

| Old | New |
|-----|-----|
| Select **Configuration block** | Select **Blocks** |
| ...and click **Create** | ...and click **Add to machine** |

## Scope

7 files under `docs/reference/`. All 4 "Create" edits are component/service add lines (webcam camera, pumpkin board, base-rc service, generic service). No job/dataset/module/trigger "Create" exists in this section, so nothing was excluded.

## Checks

prettier, markdownlint, vale (error level) all pass.

Part of the site-wide sweep. Tutorials are intentionally excluded (handled separately due to module/org/trigger "Create" flows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)