### PR TITLE
[Vision] Switch from Add Configuration Block to Add Block

### DIFF
--- a/docs/vision/3d-vision/segment-3d.md
+++ b/docs/vision/3d-vision/segment-3d.md
@@ -53,7 +53,7 @@ Name the detector something memorable, for example `person_detector` or `red_blo
 ## 3. Add the detections-to-segments module
 
 1. Open the **CONFIGURE** tab in the Viam app.
-2. Click the **+** icon and select **Configuration block**.
+2. Click the **+** icon and select **Blocks**.
 3. In the search field, type `detections-to-segments` and select the matching result.
 4. Click **Add to machine**, give the service a name (for example, `my_segmenter`), and click **Add to machine** again to confirm. The module is installed automatically.
 

--- a/docs/vision/configure.md
+++ b/docs/vision/configure.md
@@ -36,7 +36,7 @@ Three resources (camera, vision service, ML model service) plus the model file i
 The ML model service matches your model file's framework. For most tasks, `tflite_cpu` is the right starting point: it runs on almost any CPU and keeps hardware costs down. When you need GPU acceleration (larger models, higher frame rates, Nvidia Jetson hardware), use [`triton`](https://app.viam.com/module/viam/mlmodelservice-triton-jetpack) instead. The framework-support table in [Deploy a model from the registry](/vision/deploy-and-maintain/deploy-from-registry/#model-framework-support) lists which implementations support which frameworks and hardware paths.
 
 1. Navigate to the **CONFIGURE** tab of your machine in the Viam app.
-2. Click the **+** icon next to your machine part and select **Configuration block**.
+2. Click the **+** icon next to your machine part and select **Blocks**.
 3. In the search field, type `tflite_cpu` (or the service matching your model format) and select the matching result. For other frameworks, see the [framework table](/vision/deploy-and-maintain/deploy-from-registry/#model-framework-support).
 4. Click **Add to machine**, name the service `my-ml-model`, and click **Add to machine** again to confirm.
 
@@ -116,7 +116,7 @@ For more on the deployment flow, see [Deploy a model from the registry](/vision/
 
 ## 3. Add a vision service
 
-1. Click the **+** icon and select **Configuration block**.
+1. Click the **+** icon and select **Blocks**.
 2. In the search field, type `vision` or `mlmodel` and select the `vision/mlmodel` result.
 3. Click **Add to machine**, name the service `my-detector`, and click **Add to machine** again to confirm.
 

--- a/docs/vision/deploy-and-maintain/deploy-custom-model.md
+++ b/docs/vision/deploy-and-maintain/deploy-custom-model.md
@@ -75,7 +75,7 @@ The model is now available in your organization. You can change visibility betwe
 On the machine you want the model to run on:
 
 1. Open the **CONFIGURE** tab.
-2. Click the **+** icon and select **Configuration block**.
+2. Click the **+** icon and select **Blocks**.
 3. In the search field, type the ML model service name matching your model's framework (for example, `tflite_cpu` for TFLite models) and select the matching result.
 4. Click **Add to machine**, name the service (for example, `my-ml-model`), and click **Add to machine** again to confirm.
 5. In the ML model service panel, click **Select model** and pick the model you just uploaded. Choose a version (or **Latest** during development).

--- a/docs/vision/deploy-and-maintain/deploy-from-registry.md
+++ b/docs/vision/deploy-and-maintain/deploy-from-registry.md
@@ -60,7 +60,7 @@ For ML model services that support GPUs (like [Triton on Jetson](https://github.
 The ML model service loads the model file and exposes it for inference. It does not interpret the output; that is the vision service's job.
 
 1. Open your machine in the Viam app and go to the **CONFIGURE** tab.
-2. Click the **+** icon next to your machine part and select **Configuration block**.
+2. Click the **+** icon next to your machine part and select **Blocks**.
 3. In the search field, type the ML model service name (for example, `tflite_cpu` for TFLite models) and select the matching result.
 4. Click **Add to machine**, give it a name (for example, `my-ml-model`), and click **Add to machine** again to confirm.
 
@@ -82,7 +82,7 @@ Save the configuration. `viam-server` downloads the model package to the machine
 
 The ML model service is a building block. To get detections, classifications, or point cloud objects from your code, add a vision service that wraps it.
 
-1. Click the **+** icon and select **Configuration block**.
+1. Click the **+** icon and select **Blocks**.
 2. In the search field, type `vision` or `mlmodel` and select the `vision/mlmodel` result.
 3. Click **Add to machine**, name the service (for example, `my-detector`), and click **Add to machine** again to confirm.
 4. In the vision service panel's **ML MODEL** section, select the ML model service from step 3.

--- a/docs/vision/object-detection/alert-on-detections.md
+++ b/docs/vision/object-detection/alert-on-detections.md
@@ -47,7 +47,7 @@ Triggers support a configurable alert frequency to prevent alert fatigue. For ex
 Add the filtered camera module to your machine:
 
 1. Navigate to your machine's **CONFIGURE** tab.
-2. Click **+** and select **Configuration block**.
+2. Click **+** and select **Blocks**.
 3. In the search field, type `filtered-camera` and select the matching result.
 4. Click **Add to machine**, name the component `objectfilter-cam`, and click **Add to machine** again to confirm. The module is installed automatically.
 5. Add configuration attributes:
@@ -104,7 +104,7 @@ To verify your confidence threshold, expand the **TEST** panel on your vision se
 
 Add the data management service to capture and sync filtered images:
 
-1. Click **+** and select **Configuration block**.
+1. Click **+** and select **Blocks**.
 2. In the search field, type `data management` and select `data_manager/builtin` from the results.
 3. Click **Add to machine**, name the service `data-manager`, and click **Add to machine** again to confirm.
 4. Leave the default attributes and click **Save**.

--- a/docs/vision/object-detection/detect-by-color.md
+++ b/docs/vision/object-detection/detect-by-color.md
@@ -55,7 +55,7 @@ The practical approach:
 ## 2. Add the color_detector vision service
 
 1. Open the **CONFIGURE** tab in the Viam app.
-2. Click the **+** icon and select **Configuration block**.
+2. Click the **+** icon and select **Blocks**.
 3. In the search field, type `color detector` and select the `vision/color_detector` result.
 4. Click **Add to machine**, name the service (for example, `red_detector`), and click **Add to machine** again to confirm.
 

--- a/docs/vision/object-detection/track.md
+++ b/docs/vision/object-detection/track.md
@@ -41,7 +41,7 @@ For example, the first person detected becomes `person_0_20250413_143052`. The `
 
 ### 1. Add the object-tracker vision service
 
-1. Click **+** and select **Configuration block**.
+1. Click **+** and select **Blocks**.
 2. In the search field, type `object-tracker` and select the `viam:vision:object-tracker` result (the card shows the module name and model name; the badge says `VISION`).
 3. Click **Add to machine**, name the service (for example, `my-tracker`), and click **Add to machine** again to confirm. The module is installed automatically.
 


### PR DESCRIPTION
## What

Vision section of the add-component wording sweep (see #5160 hardware, #5161 reference). The + menu option is now **Blocks** (was **Configuration block**), verified live.

## Scope

7 files under `docs/vision/`, menu label only.

**Not changed:** `alert-on-detections.md:124` — that "Create" confirms a **Trigger** (added via `+` → **Trigger**, a different menu path), not a component, so it correctly stays **Create**. No component-add "Create" exists in this section.

## Checks

prettier, markdownlint, vale (error level) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)