### PR TITLE
[Fleet, Monitor, Build Modules, Train, Data] Switch from Add Configuration Block to Add Block, and Create to Add to machine

### DIFF
--- a/docs/build-modules/deploy-a-module.md
+++ b/docs/build-modules/deploy-a-module.md
@@ -282,7 +282,7 @@ viam module upload --version=0.1.0 --platform=linux/amd64 dist/archive.tar.gz
 With your module in the registry, any machine in your org can use it (and any Viam user's machine, if the module is public).
 
 1. In the [Viam app](https://app.viam.com), open your machine's **CONFIGURE** tab.
-1. Click **+** and select **Configuration block**.
+1. Click **+** and select **Blocks**.
 1. Search for your module by name or browse the registry, then add it.
 1. Pick a model from your module and create an instance. Name the instance and configure its attributes:
 
@@ -379,7 +379,7 @@ This module implements the [Viam sensor API](https://docs.viam.com/reference/api
 With this model, you can gather temperature and humidity data from a custom HTTP endpoint.
 
 Navigate to the **CONFIGURE** tab of your machine's page.
-Click the **+** button, select **Configuration block**, then select the `sensor / my-sensor-module:my-sensor` model provided by the [`my-sensor-module` module](https://app.viam.com/module/my-org/my-sensor-module).
+Click the **+** button, select **Blocks**, then select the `sensor / my-sensor-module:my-sensor` model provided by the [`my-sensor-module` module](https://app.viam.com/module/my-org/my-sensor-module).
 Click **Add module**, enter a name for your sensor, and click **Create**.
 
 ## Models

--- a/docs/build-modules/deploy-a-module.md
+++ b/docs/build-modules/deploy-a-module.md
@@ -380,7 +380,7 @@ With this model, you can gather temperature and humidity data from a custom HTTP
 
 Navigate to the **CONFIGURE** tab of your machine's page.
 Click the **+** button, select **Blocks**, then select the `sensor / my-sensor-module:my-sensor` model provided by the [`my-sensor-module` module](https://app.viam.com/module/my-org/my-sensor-module).
-Click **Add module**, enter a name for your sensor, and click **Create**.
+Enter a name for your sensor and click **Add to machine**.
 
 ## Models
 

--- a/docs/build-modules/use-registry-modules.md
+++ b/docs/build-modules/use-registry-modules.md
@@ -51,7 +51,7 @@ This page exists in the build-modules section as a reminder: look first, build s
 Two paths:
 
 1. **Search the registry directly** at [app.viam.com/registry](https://app.viam.com/registry). Filter by type (Module, ML Model, or Training Script), by API (such as `rdk:service:vision` or `rdk:service:discovery`), or by keyword.
-2. **Search from your machine's CONFIGURE tab.** Click **+** then **Configuration block**. The model search shows registry modules alongside built-in models.
+2. **Search from your machine's CONFIGURE tab.** Click **+** then **Blocks**. The model search shows registry modules alongside built-in models.
 
 When you find a candidate, open its registry page and check:
 

--- a/docs/data/capture-sync/conditional-sync.md
+++ b/docs/data/capture-sync/conditional-sync.md
@@ -44,7 +44,7 @@ This example uses the [`sync-at-time/timesyncsensor`](https://app.viam.com/modul
 
 1. On your machine's **CONFIGURE** tab, click **+** next to your machine part and select **Component or service**.
 2. Search for **sync-at-time/timesyncsensor** and select the result.
-3. Click **Add module**, enter a name (for example, `timesensor`), and click **Create**.
+3. Enter a name (for example, `timesensor`) and click **Add to machine**.
 4. Configure the time window in the sensor's attributes:
 
    ```json

--- a/docs/data/data-management-tutorial.md
+++ b/docs/data/data-management-tutorial.md
@@ -27,9 +27,9 @@ We need a component that produces data. The built-in `sensor/fake` component ret
 
 1. Go to your machine's page in the Viam app.
 2. Click the **+** button in the left sidebar.
-3. Select **Configuration block**.
+3. Select **Blocks**.
 4. Search for **sensor/fake** and select the result.
-5. Name it `test-sensor` and click **Create**.
+5. Name it `test-sensor` and click **Add to machine**.
 6. Click **Save** in the upper right.
 
 Expand the **test** section on the sensor's component card. You should see `{"a": 1, "b": 2, "c": 3}` returned from `GetReadings`. This confirms the sensor is working.

--- a/docs/fleet/deploy-software.md
+++ b/docs/fleet/deploy-software.md
@@ -17,7 +17,7 @@ Deploy modules (hardware drivers, control logic, or other custom code) to one ma
 ## 1. Add the module to a fragment
 
 1. Navigate to your fragment's page at [app.viam.com/fragments](https://app.viam.com/fragments).
-1. Click **+** and select **Configuration block**.
+1. Click **+** and select **Blocks**.
 1. Search for your module in the registry and add it.
 1. Configure the module's attributes as needed.
 1. Click **Save**.
@@ -41,7 +41,7 @@ To control when updates are applied, configure a maintenance window. See [manage
 **Through the Viam app:**
 
 1. Navigate to each machine's **CONFIGURE** tab.
-1. Click **+** and select **Configuration block**.
+1. Click **+** and select **Blocks**.
 1. Search for your fragment and select it.
 1. Click **Add to machine**.
 1. Click **Add to machine** again to confirm, then **Save**.

--- a/docs/fleet/reuse-configuration.md
+++ b/docs/fleet/reuse-configuration.md
@@ -63,7 +63,7 @@ The CLI supports applying and removing fragments. Authoring fragments, setting v
 ### In the Viam app
 
 1. Navigate to your machine's **CONFIGURE** tab.
-1. Click **+** and select **Configuration block**.
+1. Click **+** and select **Blocks**.
 1. Search for your fragment by name and select it.
 1. Click **Add to machine**.
 1. Click **Add to machine** again to confirm.

--- a/docs/monitor/alert.md
+++ b/docs/monitor/alert.md
@@ -46,7 +46,7 @@ To monitor machine health metrics like CPU usage, memory, and temperature, add a
 {{< tabs >}}
 {{% tab name="Linux" %}}
 
-On your machine's **CONFIGURE** page, click the **+** icon next to your machine part and select **Configuration block**.
+On your machine's **CONFIGURE** page, click the **+** icon next to your machine part and select **Blocks**.
 Search for and add the `hwmonitor:cpu_monitor` model from the [`sbc-hwmonitor`](https://app.viam.com/module/rinzlerlabs/sbc-hwmonitor) module.
 
 You can add additional sensors for memory, temperature, and other metrics.

--- a/docs/monitor/custom-push-notifications.md
+++ b/docs/monitor/custom-push-notifications.md
@@ -130,7 +130,7 @@ To authorize a machine for your custom app:
 
 1. [Create a fragment](/hardware/fragments/#save-your-own-configurations) owned by the organization that uploaded the Firebase config.
    The fragment does not need to contain the trigger config; any fragment owned by that organization satisfies the check.
-1. On the machine's **CONFIGURE** tab, click **+**, select **Configuration block**, search for your fragment, and click **Add fragment**.
+1. On the machine's **CONFIGURE** tab, click **+**, select **Blocks**, search for your fragment, and click **Add fragment**.
 
 For cross-organization deployments, create the fragment in the Firebase-config-owning organization first, then import it on machines in any other organization.
 The check compares the fragment's owning organization, not the machine's.

--- a/docs/train/deploy-a-model.md
+++ b/docs/train/deploy-a-model.md
@@ -46,7 +46,7 @@ For hardware-specific alternatives (for example, `triton` for Nvidia GPU),
 see [Supported frameworks and hardware](/train/overview/#supported-frameworks-and-hardware).
 
 1. Navigate to your machine's **CONFIGURE** tab.
-2. Click **+** and select **Configuration block**.
+2. Click **+** and select **Blocks**.
 3. Search for the ML model service matching your framework (for example,
    `tflite_cpu`) and select the matching result.
 4. Click the block, then click **Add to machine**.
@@ -62,7 +62,7 @@ see [Supported frameworks and hardware](/train/overview/#supported-frameworks-an
 
 ### 2. Add the vision service
 
-1. Click **+** and select **Configuration block**.
+1. Click **+** and select **Blocks**.
 2. Search for `mlmodel` and find the **mlmodel** block (type: **VISION**,
    built-in).
 3. Click the block, then click **Add to machine**.


### PR DESCRIPTION
## What

Grouped update for the smaller main-site sections in the add-component wording sweep (see #5160 hardware, #5161 reference, #5162 vision). The + menu option is now **Blocks** (was **Configuration block**) and the confirm button is **Add to machine** (was **Create**), verified live.

## Scope

`fleet/`, `monitor/`, `build-modules/`, `train/`, `data/`. Menu label swapped everywhere; component/service "Create" → "Add to machine", including the two registry-module sensor adds (`deploy-a-module.md`, `conditional-sync.md`) — the module installs automatically, so the stale "Add module" step was dropped and the wording kept concise.

## Kept as "Create" (genuinely different flows, not + → Blocks)

- **Jobs:** `fleet/schedule-jobs.md`, `build-modules/write-a-logic-module.md`, `write-an-inline-module.md`
- **Triggers:** `monitor/alert.md` (×4), `data/trigger-on-data.md`
- **Datasets:** `train/create-a-dataset.md`

## Checks

prettier, markdownlint, vale (error level) all pass.
