### PR TITLE
[Motion Planning] Switch from Add Configuration Block to Add Block, and Create to Add to machine

### DIFF
--- a/docs/motion-planning/obstacles/configure-workspace-obstacles.md
+++ b/docs/motion-planning/obstacles/configure-workspace-obstacles.md
@@ -33,7 +33,7 @@ The `erh:vmodutils:obstacle` module accepts a list of geometries under one compo
 ### 1. Add the obstacle component
 
 1. In the Viam app, open your machine's **CONFIGURE** tab.
-2. Click the **+** icon and select **Configuration block**.
+2. Click the **+** icon and select **Blocks**.
 3. Search for `obstacle` and click the **gripper/obstacle** result card for the `erh:vmodutils` module.
    The Viam app installs the `erh:vmodutils` module automatically.
 4. Click **Add to machine** on the detail page.
@@ -186,7 +186,7 @@ The component's frame positions the whole group.
 
 For a single primitive shape when you do not want to add the `erh:vmodutils` module, use a `generic`/`fake` component:
 
-1. Click the **+** icon and select **Configuration block**.
+1. Click the **+** icon and select **Blocks**.
 2. Search for `generic` and click the **generic/fake** result card. Click **Add to machine**.
 3. Name the component (for example, `table`) and click **Add to machine**.
 4. Click **Frame** on the new component card. Replace the JSON:
@@ -292,7 +292,7 @@ The motion planner should treat them as collision volume, but Viam has no compon
 
 Use the `generic`/`fake` pattern, parented to the moving component instead of `world`:
 
-1. Click the **+** icon and select **Configuration block**.
+1. Click the **+** icon and select **Blocks**.
 2. Search for `generic` and click the **generic/fake** result card. Click **Add to machine**.
 3. Name the component descriptively (for example, `arm-camera-mount`) and click **Add to machine**.
 4. Click **Frame** on the new component card. Set `parent` to the component the object attaches to (the arm's name for an end-effector mount, the gripper's name for a gripper attachment). Add a `geometry` field:

--- a/docs/motion-planning/quickstarts/frame-system.md
+++ b/docs/motion-planning/quickstarts/frame-system.md
@@ -37,9 +37,9 @@ world
 In the [Viam app](https://app.viam.com), go to your machine's
 **CONFIGURE** tab.
 
-1. Click **+** and add an **arm** component.
-2. Choose the **fake** model.
-3. Name it **my-arm**.
+1. Click **+** and select **Blocks**.
+2. Search for **arm** and choose the **arm/fake** component.
+3. Name it **my-arm** and click **Add to machine**.
 4. In the arm's attributes, set `arm-model` to `"ur5e"`.
 5. Click **Frame** on the arm's card. The Frame section is a JSON
    editor with no form, parent dropdown, or geometry-type picker.
@@ -60,9 +60,9 @@ Click **Save** in the top-right of the page (or press ⌘/Ctrl+S).
 
 ## 2. Add the gripper
 
-1. Click **+** and add a **gripper** component.
-2. Choose the **fake** model.
-3. Name it **my-gripper**.
+1. Click **+** and select **Blocks**.
+2. Search for **gripper** and choose the **gripper/fake** component.
+3. Name it **my-gripper** and click **Add to machine**.
 4. Click **Frame** on the gripper's card. Edit the JSON so the
    parent is the arm and the origin is offset 110 mm along the arm's
    z axis (the end of a typical gripper mount):
@@ -83,9 +83,9 @@ pose moves with the arm automatically.
 
 ## 3. Add the camera
 
-1. Click **+** and add a **camera** component.
-2. Choose the **fake** model.
-3. Name it **my-camera**.
+1. Click **+** and select **Blocks**.
+2. Search for **camera** and choose the **camera/fake** component.
+3. Name it **my-camera** and click **Add to machine**.
 4. Click **Frame** on the camera's card. Edit the JSON so the camera
    sits 30 mm to the side of the arm's end effector and 60 mm above it,
    tilted 30 degrees downward about the x axis:


### PR DESCRIPTION
## What

Motion Planning section of the add-component wording sweep, and the follow-up to #5158 (which fixed `first-arm.md`). Matches the current Viam app UI, verified live.

- **`configure-workspace-obstacles.md`** — `select **Configuration block**` → `select **Blocks**` (×3). Already used **Add to machine**.
- **`frame-system.md`** — rewrote the arm/gripper/camera add blocks from the old flow ("Click + and add an **arm** component / Choose the **fake** model / Name it") to the current Blocks flow:
  > 1. Click **+** and select **Blocks**.
  > 2. Search for **arm** and choose the **arm/fake** component.
  > 3. Name it **my-arm** and click **Add to machine**.

## Checks

prettier, markdownlint, vale (error level) all pass.

Part of the site-wide sweep (#5160 hardware, #5161 reference, #5162 vision, #5164 fleet/monitor/build-modules/train/data). Tutorials and Try Viam are intentionally excluded (module/org/trigger "Create" flows need per-line review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)