### PR TITLE
[Try Viam] Switch from Add Configuration Block to Add Block, and Create to Add to machine

### DIFF
--- a/docs/try/part-1.md
+++ b/docs/try/part-1.md
@@ -67,7 +67,6 @@ In Viam, a **component** is any piece of hardware: cameras, motors, arms, sensor
 To add the camera component to your machine part:
 
 1. Click the **+** button and select **Blocks**
-2. Click **Camera**
 3. Search for `gz-camera`
 4. Select `gz-camera/rgb-camera`
 5. Click **Add Component**

--- a/docs/try/part-1.md
+++ b/docs/try/part-1.md
@@ -67,10 +67,10 @@ In Viam, a **component** is any piece of hardware: cameras, motors, arms, sensor
 To add the camera component to your machine part:
 
 1. Click the **+** button and select **Blocks**
-3. Search for `gz-camera`
-4. Select `gz-camera/rgb-camera`
-5. Click **Add Component**
-6. Enter `inspection-cam` for the name
+2. Search for `gz-camera`
+3. Select `gz-camera/rgb-camera`
+4. Click **Add Component**
+5. Enter `inspection-cam` for the name
 
 {{< expand "Why were two items added to my machine part?" >}}
 After adding the camera component, you will see two items appear under your machine part. One is the actual camera hardware (`inspection-cam`) that you will use through the Viam camera API. The other is the software module (`gz-camera`) that implements this API for the specific model of camera you are using. All components that are supported through modules available in the Viam registry will appear this way in the **CONFIGURE** tab. For built-in components, such as webcams, you will not also see a module appear in the configuration.

--- a/docs/try/part-1.md
+++ b/docs/try/part-1.md
@@ -69,7 +69,7 @@ To add the camera component to your machine part:
 1. Click the **+** button and select **Blocks**
 2. Search for `gz-camera`
 3. Select `gz-camera/rgb-camera`
-4. Click **Add Component**
+4. Click **Add to machine**
 5. Enter `inspection-cam` for the name
 
 {{< expand "Why were two items added to my machine part?" >}}
@@ -136,7 +136,7 @@ The `try-vision-pipeline` fragment includes an ML model service loaded with a ca
 1. Click **+** next to your machine name
 2. Select **Blocks**
 3. Search for `try-vision-pipeline`
-4. Select `try-vision-pipeline` and click **Add Fragment**
+4. Select `try-vision-pipeline` and click **Add to machine**
 
 ### Set the camera variable
 

--- a/docs/try/part-1.md
+++ b/docs/try/part-1.md
@@ -66,7 +66,7 @@ In Viam, a **component** is any piece of hardware: cameras, motors, arms, sensor
 
 To add the camera component to your machine part:
 
-1. Click the **+** button and select **Configuration block**
+1. Click the **+** button and select **Blocks**
 2. Click **Camera**
 3. Search for `gz-camera`
 4. Select `gz-camera/rgb-camera`
@@ -135,7 +135,7 @@ The `try-vision-pipeline` fragment includes an ML model service loaded with a ca
 ### Add the fragment
 
 1. Click **+** next to your machine name
-2. Select **Configuration block**
+2. Select **Blocks**
 3. Search for `try-vision-pipeline`
 4. Select `try-vision-pipeline` and click **Add Fragment**
 

--- a/docs/try/part-2.md
+++ b/docs/try/part-2.md
@@ -31,10 +31,10 @@ Data gets buffered locally, synced to the cloud at an interval you configure, an
 **Include the data service in your machine configuration:**
 
 1. Click **+** next to **inspection-station-1-main** in the **CONFIGURE** tab
-2. Click **Configuration block**
+2. Click **Blocks**
 3. Select **data_manager/builtin**
 4. Name it `data-service`
-5. Click **Create**
+5. Click **Add to machine**
 6. **Save** your updated machine configuration
 
 The default configuration options for the data service are correct for our application so we can move on to capturing data from the vision service.

--- a/docs/try/part-2.md
+++ b/docs/try/part-2.md
@@ -32,7 +32,7 @@ Data gets buffered locally, synced to the cloud at an interval you configure, an
 
 1. Click **+** next to **inspection-station-1-main** in the **CONFIGURE** tab
 2. Click **Blocks**
-3. Select **data_manager/builtin**
+3. Search for `data_manager` and select **data_manager/builtin**
 4. Name it `data-service`
 5. Click **Add to machine**
 6. **Save** your updated machine configuration

--- a/docs/try/part-4.md
+++ b/docs/try/part-4.md
@@ -212,10 +212,10 @@ viam module upload --version 0.0.1 --platform linux/arm64 --upload module.tar.gz
 
 1. In the Viam app, go to your machine's **Configure** tab
 2. Click **+** next to your machine part
-3. Select **Configuration block**
+3. Select **Blocks**
 4. Search for your model (for example, `your-namespace:inspection-module:inspector`)
 5. Name it `inspector-service`
-6. Click **Create**
+6. Click **Add to machine**
 
 When you add a service from the registry, the module that provides it is added automatically.
 


### PR DESCRIPTION
## What

Try Viam section of the add-component wording sweep (see #5160 hardware, #5161 reference, #5162 vision, #5164 misc, #5165 motion-planning). Matches the current Viam app UI, verified live.

| Old | New |
|-----|-----|
| Select/Click **Configuration block** | **Blocks** |
| Click **Create** | Click **Add to machine** |
| Click **Add Component** / **Add Fragment** | Click **Add to machine** |

## Scope

3 files (`part-1`, `part-2`, `part-4`). Menu label swapped (×4). Both "Create"s are service adds via the Blocks flow, so both become **Add to machine**:
- `part-2.md` — `data_manager/builtin` data service
- `part-4.md` — a registry inspector service (no separate "Add module" step; the module auto-installs when adding a registry service)

## Procedure changes (not just labels)

Two steps changed because the Blocks flow itself changed, verified against the live app:

- `part-1.md` — removed the **Click Camera** category step. The Blocks picker is now a flat, searchable list with no component-type submenu.
- `part-2.md` — added **Search for `data_manager`**, since the list is search-driven. `data_manager/builtin` is the top result.

Also corrected `part-1.md` to say **Add to machine** rather than **Add Component** / **Add Fragment**. The block detail pane shows one **Add to machine** button for every block type — component (`camera/webcam`), service (`data_manager/builtin`), and fragment (`try-vision-pipeline`) alike. "Add component" is the title of the naming dialog, not a button label. These were the last two `Add Component` / `Add Fragment` strings in `docs/`.

## Checks

prettier, markdownlint, vale (error level) all pass.

Tutorials remain excluded (their "Create" mix — orgs, triggers, modular resources — needs per-line review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
