### PR TITLE
[Tutorials] Switch from Add Configuration Block to Add Block, and Create to Add to machine

### DIFF
--- a/docs/tutorials/configure/configure-rover.md
+++ b/docs/tutorials/configure/configure-rover.md
@@ -54,9 +54,9 @@ In the following, you can see two popular examples with components that are pres
 
 The first component you will add is the [board](/reference/components/board/) which represents the Raspberry Pi to which the other components are wired.
 
-Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Select the `board` type, then select the `viam:raspberry-pi:rpi` model.
-Enter `local` as the name and click **Create**.
+Enter `local` as the name and click **Add to machine**.
 You can use a different name but will then need to adjust the name in the following steps to the name you choose.
 
 ![An example board configuration in the app builder UI. The name (local), type (board) and model (pi) are shown. No other attributes are configured.](/components/board/pi-ui-config.png)
@@ -84,9 +84,9 @@ Start with the right encoder:
 
 #### Right encoder
 
-Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Select the `encoder` type, then select the `AMS-AS5048` model.
-Enter `renc` as the name and click **Create**.
+Enter `renc` as the name and click **Add to machine**.
 
 Click the **board** dropdown list and select the name of your board, `local`.
 
@@ -94,9 +94,9 @@ In the **i2c bus** field type `1`, and in the **i2c address** field type `65`.
 
 #### Left encoder
 
-Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Select the `encoder` type, then select the `AMS-AS5048` model.
-Enter `lenc` as the name for your encoder and click **Create**.
+Enter `lenc` as the name for your encoder and click **Add to machine**.
 
 Click the **board** dropdown list and select the name of your board, `local`.
 
@@ -157,9 +157,9 @@ Start with the right motor:
 
 #### Right motor
 
-Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Select the `motor` type, then select the `gpio` model.
-Enter `right` as the name or use the suggested name for your motor and click **Create**.
+Enter `right` as the name or use the suggested name for your motor and click **Add to machine**.
 
 Then from the **Board** dropdown, select `local`, the Raspberry Pi the motor is wired to.
 
@@ -176,9 +176,9 @@ Next, describe how the motor is wired to the Pi:
 
 #### Left motor
 
-Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Select the `motor` type, then select the `gpio` model.
-Enter `left` as the name or use the suggested name for your motor and click **Create**.
+Enter `left` as the name or use the suggested name for your motor and click **Add to machine**.
 
 Then select `local` from the **Board** dropdown to choose the Raspberry Pi the motor is wired to.
 
@@ -244,9 +244,9 @@ Start with the right set of wheels.
 
 #### Right motor
 
-Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Select the `motor` type, then select the `gpio` model.
-Enter `right` as the name or use the suggested name for your motor and click **Create**.
+Enter `right` as the name or use the suggested name for your motor and click **Add to machine**.
 
 ![G P I O motor config in the builder UI with the In1 and In2 pins configured and the PWM pin field left blank.](/components/motor/gpio-config-ui.png)
 
@@ -267,9 +267,9 @@ You can ignore the other optional attributes.
 
 #### Left motor
 
-Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Select the `motor` type, then select the `gpio` model.
-Enter `left` as the name or use the suggested name for your motor and click **Create**.
+Enter `left` as the name or use the suggested name for your motor and click **Add to machine**.
 
 Click the **Board** dropdown and select `local` as the board the motor driver is wired to.
 Next, configure the **Component Pin Assignment** section to represent how the motor is wired to the board.
@@ -336,9 +336,9 @@ Optionally, add a camera to your rover.
 {{< tabs name="Configure a Webcam" >}}
 {{% tab name="Config Builder" %}}
 
-Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Select the `camera` type, then select the `webcam` model.
-Enter a name or use the suggested name for your camera and click **Create**.
+Enter a name or use the suggested name for your camera and click **Add to machine**.
 
 {{< imgproc src="/components/camera/configure-webcam.png" alt="Configuration of a webcam camera." resize="1200x" style="width=600x" >}}
 
@@ -364,16 +364,16 @@ If this doesn't work when you test your camera later, you can try a different vi
 
 If your rover has its camera mounted on a pair of [servos](/reference/components/servo/), like the Yahboom rover, you can use these to control the pan and tilt of the camera.
 
-Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Select the `servo` type, then select the `viam:raspberry-pi:pi-servo` model.
-Enter `pan` as the name and click **Create**.
+Enter `pan` as the name and click **Add to machine**.
 
 Set `Depends On` to `local`, and `pin` to the pin the servo is wired to (`23` for the Yahboom rover).
 
 Finally, add the tilt `servo` as well.
-Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Select the `servo` type, then select the `viam:raspberry-pi:pi-servo` model.
-Enter `tilt` as the name and click **Create**.
+Enter `tilt` as the name and click **Add to machine**.
 
 Set `Depends On` to `local`, and `pin` to the pin the servo is wired to (`21` for the Yahboom rover).
 
@@ -394,9 +394,9 @@ If your rover is not supported out of the box, follow the [Create a Modular Reso
 {{< tabs name="Configure a Wheeled Base" >}}
 {{% tab name="Config Builder" %}}
 
-Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Select the `base` type, then select the `wheeled` model.
-Enter a name or use the suggested name for your base and click **Create**.
+Enter a name or use the suggested name for your base and click **Add to machine**.
 
 {{< tabs >}}
 {{% tab name="SCUTTLE" %}}

--- a/docs/tutorials/configure/pet-photographer.md
+++ b/docs/tutorials/configure/pet-photographer.md
@@ -824,7 +824,7 @@ To enable data capture on your machine, add and configure the [data management s
 1. Choose `data management` as the type.
 1. Enter a name or use the suggested name for your instance of the data manager.
    This tutorial uses the name 'dm' in all example code.
-1. Click **Create**.
+1. Click **Add to machine**.
    On the panel that appears, you can manage the capturing and syncing functions individually.
    By default, the data management service captures data every 0.1 minutes to the <file>~/.viam/capture</file> directory.
    Leave the default settings as they are.
@@ -868,7 +868,7 @@ If you have a different item you want to use, or want to match to a color that m
 1. Select the `vision` type, then select the `color detector` model.
 1. Enter a name or use the suggested name for your color detector.
    This tutorial uses the name 'my_color_detector' in all example code.
-1. click **Create**.
+1. click **Add to machine**.
 1. In the vision service's **Attributes** section, click the color selection box to set the color to detect.
    For this tutorial, set the color to `#43A1D0` or `rgb(67, 161, 208)`.
    Alternatively, you can provide the color of your pet, or use a different brightly-colored collar or ribbon.
@@ -917,7 +917,7 @@ If you haven't already, add a [camera](/reference/components/camera/) component 
    Start typing "webcam" and select **camera / webcam**.
    Enter a name or use the suggested name for your camera.
    This tutorial uses the name 'cam' in all example code.
-   Click **Create**.
+   Click **Add to machine**.
 
 1. Leave the **video_path** blank and the camera will use the default video path for your machine.
    If this doesn't work when you test your camera later, you can try a different video path by following the prompt in the camera's configuration panel.

--- a/docs/tutorials/configure/pet-photographer.md
+++ b/docs/tutorials/configure/pet-photographer.md
@@ -820,7 +820,7 @@ To enable data capture on your machine, add and configure the [data management s
 {{< tabs >}}
 {{% tab name="Config Builder" %}}
 
-1. On the **CONFIGURE** tab, click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+1. On the **CONFIGURE** tab, click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 1. Choose `data management` as the type.
 1. Enter a name or use the suggested name for your instance of the data manager.
    This tutorial uses the name 'dm' in all example code.
@@ -864,7 +864,7 @@ If you have a different item you want to use, or want to match to a color that m
 {{% tab name="Config Builder" %}}
 
 1. Navigate to the **CONFIGURE** tab of your machine's page.
-1. Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+1. Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 1. Select the `vision` type, then select the `color detector` model.
 1. Enter a name or use the suggested name for your color detector.
    This tutorial uses the name 'my_color_detector' in all example code.
@@ -913,7 +913,7 @@ With the vision and data management services configured, you can now configure y
 
 If you haven't already, add a [camera](/reference/components/camera/) component to your smart machine:
 
-1. On the **CONFIGURE** tab, click the **+** (Create) button next to your main part in the left-hand menu and select **Configuration block**.
+1. On the **CONFIGURE** tab, click the **+** (Create) button next to your main part in the left-hand menu and select **Blocks**.
    Start typing "webcam" and select **camera / webcam**.
    Enter a name or use the suggested name for your camera.
    This tutorial uses the name 'cam' in all example code.

--- a/docs/tutorials/control/air-quality-fleet.md
+++ b/docs/tutorials/control/air-quality-fleet.md
@@ -111,9 +111,9 @@ When your machine shows as connected, continue to the next step.
 {{< table >}}
 {{% tablestep start=1 %}}
 
-Navigate to the **CONFIGURE** tab of the machine, click the **+** button and select **Configuration block**.
+Navigate to the **CONFIGURE** tab of the machine, click the **+** button and select **Blocks**.
 Click **sensor**, then search for `sds011` and add the **sds001:v1** {{< glossary_tooltip term_id="module" text="module" >}}.
-Name the sensor `PM_sensor` and click **Create**.
+Name the sensor `PM_sensor` and click **Add to machine**.
 
 {{<imgproc src="/tutorials/air-quality-fleet/add-sensor-module.png" resize="700x" declaredimensions=true alt="The Add Module button that appears after you click the model name." style="width:400px" class="imgzoom shadow">}}
 

--- a/docs/tutorials/control/gamepad.md
+++ b/docs/tutorials/control/gamepad.md
@@ -90,7 +90,7 @@ Go to your rover's **CONFIGURE** tab.
 
 Configure a [gamepad](/reference/components/input-controller/gamepad/):
 
-Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Search for `gamepad`, then select the official `input_controller/gamepad` block from `viam-server`.
 Click **Add to machine**, enter a name (or use the suggested name) for your input controller, then click **Add to machine** to confirm.
 
@@ -128,7 +128,7 @@ To link the controller's input to the base functionality, you need to configure 
 {{< tabs >}}
 {{% tab name="Config Builder" %}}
 
-Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Search for 'base_remote_control' and select the official `base_remote_control/builtin` block from `viam-server`.
 Click **Add to machine**, enter a name (or use the suggested name) for your service, then click **Add to machine** to confirm.
 

--- a/docs/tutorials/control/gamepad.md
+++ b/docs/tutorials/control/gamepad.md
@@ -92,7 +92,7 @@ Configure a [gamepad](/reference/components/input-controller/gamepad/):
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Search for `gamepad`, then select the official `input_controller/gamepad` block from `viam-server`.
-Click **Add to machine**, enter a name (or use the suggested name) for your input controller, then click **Add to machine** to confirm.
+Enter a name (or use the suggested name) for your input controller and click **Add to machine**.
 
 Once added, you can set the `auto_reconnect` attribute to `true`. You'll find it by clicking `Show 2 optional` in the Attributes section. Don't forget to Save!
 
@@ -130,7 +130,7 @@ To link the controller's input to the base functionality, you need to configure 
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Search for 'base_remote_control' and select the official `base_remote_control/builtin` block from `viam-server`.
-Click **Add to machine**, enter a name (or use the suggested name) for your service, then click **Add to machine** to confirm.
+Enter a name (or use the suggested name) for your service and click **Add to machine**.
 
 In your base remote control service's configuration panel, copy and paste the following JSON object into the attributes field:
 

--- a/docs/tutorials/get-started/blink-an-led.md
+++ b/docs/tutorials/get-started/blink-an-led.md
@@ -136,10 +136,10 @@ Go to [Viam](https://app.viam.com/) and navigate to your new machine's **CONFIGU
 {{% tab name="Config Builder" %}}
 
 Add a [_board component_](/reference/components/board/) to represent your single-board computer, which in this case is the Raspberry Pi.
-To create the new component, click the **+** icon next to your machine {{< glossary_tooltip term_id="part" text="part" >}} in the left-hand menu and select **Configuration block**.
+To create the new component, click the **+** icon next to your machine {{< glossary_tooltip term_id="part" text="part" >}} in the left-hand menu and select **Blocks**.
 Select the `board` type, then select the `viam:raspberry-pi:rpi` model if you are using a Raspberry Pi 4, Raspberry Pi 3 or Raspberry Pi Zero 2 W.
 If you are using a Raspberry Pi 5, use the `pi5` model.
-Enter a name or use the suggested name for your board and click **Create**.
+Enter a name or use the suggested name for your board and click **Add to machine**.
 We used the name `"local"`.
 
 Your board component panel will look like this:

--- a/docs/tutorials/get-started/servo-mousemover.md
+++ b/docs/tutorials/get-started/servo-mousemover.md
@@ -171,11 +171,11 @@ Navigate to the **CONFIGURE** tab.
 Create a [board component](/reference/components/board/):
 
 1. Navigate to the **CONFIGURE** tab of your machine's page.
-1. Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+1. Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 1. Select the `board` type, then select the `viam:raspberry-pi:rpi` model if you are using a Raspberry Pi 4, Raspberry Pi 3 or Raspberry Pi Zero 2 W.
    If you are using a Raspberry Pi 5, use the `pi5` model instead.
 
-1. Enter the name `local` for your board and click **Create**.
+1. Enter the name `local` for your board and click **Add to machine**.
 
 {{% alert title="Tip" color="tip" %}}
 You can name the board whatever you want, but if you change the name you must update the references to the board in the code we use later.
@@ -188,9 +188,9 @@ Create a [servo component](/reference/components/servo/):
 1. Navigate to the **CONFIGURE** tab of your machine's page.
 1. Click the **+** icon next to your machine part in the left-hand menu and select **Component**.
 1. Select the `servo` type, then select the `viam:raspberry-pi:pi-servo` model.
-1. Enter the name `fs90f` for your servo and click **Create**.
+1. Enter the name `fs90f` for your servo and click **Add to machine**.
 
-After clicking **Create**, you see where you can put in attributes for the servo.
+After clicking **Add to machine**, you see where you can put in attributes for the servo.
 This is where you tell Viam which hardware pin to use to control the servo.
 
 - For `"pin"` use `12` - this is the pin you attached the PWM (Pulse Width Modulation) jumper wire to.

--- a/docs/tutorials/projects/claw-game.md
+++ b/docs/tutorials/projects/claw-game.md
@@ -170,7 +170,7 @@ Click the **Create component** button in the lower-left corner.
 
 Add your [board](/reference/components/board/) with type `board` and model `viam:raspberry-pi:rpi` if you are using a Raspberry Pi 4, Raspberry Pi 3 or Raspberry Pi Zero 2 W.
 If you are using a Raspberry Pi 5, use the `pi5` model.
-Name your board `myBoard` and click **Create**.
+Name your board `myBoard` and click **Add to machine**.
 
 ![Create component panel, with the name attribute filled as myBoard, type attribute filled as board and model attribute filled as pi.](/tutorials/claw-game/app-component-myboard.png)
 
@@ -213,10 +213,10 @@ Use the parts dropdown menu to navigate to the `planning` sub-part.
 {{< tabs >}}
 {{% tab name="Builder UI" %}}
 
-Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 
 Select type `arm`, and model `viam:ufactory:xArm6`.
-Name it `myArm` and click **Create**.
+Name it `myArm` and click **Add to machine**.
 
 Configure the arm component with the arm's IP address in the `host` field.
 Our arm's address was `10.1.1.26`, but you should use the IP address for your arm.
@@ -277,7 +277,7 @@ Click **Save config** in the bottom left corner of the screen.
 
 Click **Create component** and add your [gripper](/reference/components/gripper/).
 Choose type `gripper` and model `fake`.
-Name it `gripper` and click **Create**.
+Name it `gripper` and click **Add to machine**.
 
 ![Create component panel, with the name attribute filled as gripper, type attribute filled as gripper and model attribute filled as fake. In the Frame section, there is a myArm parent in the frame.](/tutorials/claw-game/app-gripper.png)
 

--- a/docs/tutorials/projects/helmet.md
+++ b/docs/tutorials/projects/helmet.md
@@ -86,7 +86,7 @@ Configure your [webcam](/reference/components/camera/webcam/) so that your machi
 1. Navigate to your machine's page.
    Check that the part status dropdown in the upper left of the page, next to your machine's name, reads "Live"; this indicates that your machine is turned on and that its instance of `viam-server` is in contact with Viam.
 
-2. Click the **+** (Create) button next to your main part in the left-hand menu and select **Configuration block**.
+2. Click the **+** (Create) button next to your main part in the left-hand menu and select **Blocks**.
    Start typing "webcam" and select **camera / webcam**.
    Give your camera a name.
    This tutorial uses the name `my_webcam` in all example code.
@@ -113,11 +113,11 @@ The [YOLOv8 module](https://github.com/viam-labs/YOLOv8) enables you to use any 
 
 1. Navigate to your machine's **CONFIGURE** tab.
 
-2. Click the **+** (Create) button next to your main part in the left-hand menu and select **Configuration block**.
+2. Click the **+** (Create) button next to your main part in the left-hand menu and select **Blocks**.
    Start typing `yolo` and select **vision / yolov8** from the registry options.
    Click **Add module**.
 
-3. Give your vision service a name, for example `yolo`, and click **Create**.
+3. Give your vision service a name, for example `yolo`, and click **Add to machine**.
 
 4. In the attributes field of your new vision service, paste the following JSON:
 
@@ -145,11 +145,11 @@ This module also filters the output so that later, when you configure data manag
 
 1. Navigate to your machine's **CONFIGURE** tab.
 
-2. Click the **+** (Create) button next to your main part in the left-hand menu and select **Configuration block**.
+2. Click the **+** (Create) button next to your main part in the left-hand menu and select **Blocks**.
    Start typing `objectfilter` and select **camera / objectfilter** from the results.
    Click **Add module**.
 
-3. Name your filtering camera something like `objectfilter-cam` and click **Create**.
+3. Name your filtering camera something like `objectfilter-cam` and click **Add to machine**.
 
 4. Paste the following into the attributes field:
 
@@ -204,9 +204,9 @@ Configure data capture on the `objectfilter` camera to capture images of people 
 
    Navigate to your machine's **CONFIGURE** tab.
 
-   Click the **+** (Create) button next to your main part in the left-hand menu and select **Configuration block**.
+   Click the **+** (Create) button next to your main part in the left-hand menu and select **Blocks**.
    Type "data" and click **data management / RDK**.
-   Name your data management service `data-manager` and click **Create**.
+   Name your data management service `data-manager` and click **Add to machine**.
 
    Leave all the default data service attributes as they are and click **Save** in the top right corner of the screen to save your changes.
 

--- a/docs/tutorials/projects/helmet.md
+++ b/docs/tutorials/projects/helmet.md
@@ -90,7 +90,7 @@ Configure your [webcam](/reference/components/camera/webcam/) so that your machi
    Start typing "webcam" and select **camera / webcam**.
    Give your camera a name.
    This tutorial uses the name `my_webcam` in all example code.
-   Click **Create**.
+   Click **Add to machine**.
 
 3. Leave the **video_path** blank and the camera will use the default video path for your machine.
    If this doesn't work when you test your camera later, you can try a different video path by following the prompt on the camera's configuration panel.

--- a/docs/tutorials/projects/integrating-viam-with-openai.md
+++ b/docs/tutorials/projects/integrating-viam-with-openai.md
@@ -251,7 +251,7 @@ To configure an ML model service:
 - Select the **CONFIGURE** tab.
 - Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 - Select the `ML model` type, then select the `TFLite CPU` model.
-- Enter the name `stuff_detector` for your service, click **Add module** and click **Create**.
+- Enter the name `stuff_detector` for your service and click **Add to machine**.
 
 Your robot registers this as a machine learning model and makes it available for use.
 

--- a/docs/tutorials/projects/integrating-viam-with-openai.md
+++ b/docs/tutorials/projects/integrating-viam-with-openai.md
@@ -213,9 +213,9 @@ Now, configure your rover to:
 
 To configure your [servo](/reference/components/servo/), go to your rover's **CONFIGURE** tab.
 
-- Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+- Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 - Select the `servo` type, then select the `viam:raspberry-pi:pi-servo` model.
-- Enter the name `servo1` for your servo and click **Create**.
+- Enter the name `servo1` for your servo and click **Add to machine**.
 
 Now, in the panel for `servo1`, add the following attribute configuration:
 
@@ -249,7 +249,7 @@ This model can detect a variety of objects, which you can find in the provided <
 To configure an ML model service:
 
 - Select the **CONFIGURE** tab.
-- Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+- Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 - Select the `ML model` type, then select the `TFLite CPU` model.
 - Enter the name `stuff_detector` for your service, click **Add module** and click **Create**.
 
@@ -261,9 +261,9 @@ Click **Select model**, then select the `viam-labs:EfficientDet-COCO` model from
 Now, create a vision service to visualize your ML model:
 
 - Select the **CONFIGURE** tab.
-- Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+- Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 - Select the `vision` type, then select the `ML model` model.
-- Enter the name `mlmodel` for your service and click **Create**.
+- Enter the name `mlmodel` for your service and click **Add to machine**.
 
 Your companion robot will use this to interface with the machine learning model allowing you to - well, detect stuff!
 

--- a/docs/tutorials/projects/make-a-plant-watering-robot.md
+++ b/docs/tutorials/projects/make-a-plant-watering-robot.md
@@ -224,9 +224,9 @@ First, add your machine as a [board component](/reference/components/board/):
 {{< tabs name="Configure a Raspberry Pi Board" >}}
 {{% tab name="Config Builder" %}}
 
-Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Select the `board` type, then select the appropriate `viam:raspberry-pi:pi` model (for example, `viam:raspberry-pi:pi4` for Raspberry Pi 4).
-Enter a name for your board and click **Create**.
+Enter a name for your board and click **Add to machine**.
 This tutorial uses the name `local`.
 
 ![Creation of a board.](/tutorials/plant-watering-pi/pi-board-config-builder.png)
@@ -269,7 +269,7 @@ You can add a module from the Viam Registry directly from your machine's **CONFI
 To add the [mcp300x-adc-sensor](https://github.com/viam-labs/mcp300x-adc-sensor) module to your machine, follow these steps:
 
 1. Go to your machine's **CONFIGURE** tab.
-   Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+   Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 1. Search for `mcp300x` and select `sensor / mcp300x`.
    Click **Add module**.
 1. Give your module a name of your choice. We used the name `sensor`.

--- a/docs/tutorials/projects/send-security-photo.md
+++ b/docs/tutorials/projects/send-security-photo.md
@@ -61,7 +61,7 @@ Configure your [webcam](/reference/components/camera/webcam/) so that your machi
 1. Navigate to your machine's page.
    Check that the part status dropdown in the upper left of the page, next to your machine's name, reads "Live"; this indicates that your machine is turned on and that its instance of `viam-server` is in contact with Viam.
 
-2. Click the **+** (Create) button next to your main part in the left-hand menu and select **Configuration block**.
+2. Click the **+** (Create) button next to your main part in the left-hand menu and select **Blocks**.
    Start typing "webcam" and select **camera / webcam**.
    Give your camera a name.
    This tutorial uses the name `cam` in all example code.
@@ -93,7 +93,7 @@ If you want to train your own model instead, follow the instructions to [train a
 
    Navigate to your machine's **CONFIGURE** tab.
 
-   Click the **+** (Create) button next to your main part in the left-hand menu and select **Configuration block**.
+   Click the **+** (Create) button next to your main part in the left-hand menu and select **Blocks**.
    Start typing `ML model` and select **ML model / TFLite CPU** from the builtin options.
 
    Enter `people` as the name, click **Add Module**, then click **Create**.
@@ -107,7 +107,7 @@ If you want to train your own model instead, follow the instructions to [train a
 
 1. **Configure an mlmodel detector** [vision service](/reference/services/vision/)
 
-   Click the **+** (Create) button next to your main part in the left-hand menu and select **Configuration block**.
+   Click the **+** (Create) button next to your main part in the left-hand menu and select **Blocks**.
    Start typing `ML model` and select **vision / ML model** from the builtin options.
 
    Enter `myPeopleDetector` as the name, then click **Create**.

--- a/docs/tutorials/projects/send-security-photo.md
+++ b/docs/tutorials/projects/send-security-photo.md
@@ -65,7 +65,7 @@ Configure your [webcam](/reference/components/camera/webcam/) so that your machi
    Start typing "webcam" and select **camera / webcam**.
    Give your camera a name.
    This tutorial uses the name `cam` in all example code.
-   Click **Create**.
+   Click **Add to machine**.
 
 3. Leave the **video_path** blank and the camera will use the default video path for your machine.
    If this doesn't work when you test your camera later, you can try a different video path by following the prompt in the camera's configuration panel.
@@ -96,7 +96,7 @@ If you want to train your own model instead, follow the instructions to [train a
    Click the **+** (Create) button next to your main part in the left-hand menu and select **Blocks**.
    Start typing `ML model` and select **ML model / TFLite CPU** from the builtin options.
 
-   Enter `people` as the name, click **Add Module**, then click **Create**.
+   Enter `people` as the name, then click **Add to machine**.
 
    In the new ML Model service panel, configure your service.
 
@@ -110,7 +110,7 @@ If you want to train your own model instead, follow the instructions to [train a
    Click the **+** (Create) button next to your main part in the left-hand menu and select **Blocks**.
    Start typing `ML model` and select **vision / ML model** from the builtin options.
 
-   Enter `myPeopleDetector` as the name, then click **Create**.
+   Enter `myPeopleDetector` as the name, then click **Add to machine**.
 
    In the new vision service panel, configure your service.
 

--- a/docs/tutorials/projects/verification-system.md
+++ b/docs/tutorials/projects/verification-system.md
@@ -63,9 +63,9 @@ Navigate to the **CONFIGURE** tab of your machine's page.
 {{% tablestep start=1 %}}
 **Configure the camera you want to use for your security system.**
 
-Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Select the `camera` type, then select the `webcam` model or another model if you are using a different camera.
-Enter the name `my_webcam` for your camera and click **Create**.
+Enter the name `my_webcam` for your camera and click **Add to machine**.
 
 {{% /tablestep %}}
 {{% tablestep %}}
@@ -94,9 +94,9 @@ If you wish to train your own ML model, see [Train a TF or TFLite model](/train/
 
 To run the machine learning model on your machine, use the [ML model service](/vision/configure/):
 
-1. On your machine's **CONFIGURE** tab, click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+1. On your machine's **CONFIGURE** tab, click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 1. Select type `ML model`, then select model `TFLite CPU`.
-1. Enter `persondetect` as the name for your ML model service, then click **Create**.
+1. Enter `persondetect` as the name for your ML model service, then click **Add to machine**.
 1. On the ML model service panel, select **Deploy model on machine** for the **Deployment** field.
 1. Click **Select model**, then select the **EfficientDet-COCO** model by **viam-labs** from the **Registry** tab of the modal that appears.
 1. Add the `vision / ML model` vision service to your machine and name it `person-detector`.

--- a/docs/tutorials/services/color-detection-scuttle.md
+++ b/docs/tutorials/services/color-detection-scuttle.md
@@ -74,9 +74,9 @@ To create a [color detector vision service](/reference/apis/services/vision/#det
 {{% tab name="Builder" %}}
 
 Navigate to your machine's **CONFIGURE** tab.
-Click the **+** (Create) icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** (Create) icon next to your machine part in the left-hand menu and select **Blocks**.
 Select the `vision` type, then select the `color detector` model.
-Enter `my_color_detector` as the name for your service and click **Create**.
+Enter `my_color_detector` as the name for your service and click **Add to machine**.
 
 In your vision service's panel, set the following **Attributes**:
 

--- a/docs/tutorials/services/constrain-motion.md
+++ b/docs/tutorials/services/constrain-motion.md
@@ -158,9 +158,9 @@ Since this tutorial gets a bit more complicated than the last, let's configure a
 This configured table won't be taken into account by the motion service, but it's useful to be able to see it.
 
 Navigate to the **CONFIGURE** tab of your machine's page.
-Click the **+** icon next to your machine part in the left-hand menu and select **Configuration block**.
+Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
 Select the `generic` type, then select the `fake` model.
-Enter the name `"table"` for your movement sensor and click **Create**.
+Enter the name `"table"` for your movement sensor and click **Add to machine**.
 
 Select the **Frame** mode on the **CONFIGURE** tab.
 Click **table** on the left menu.

--- a/docs/tutorials/services/plan-motion-with-arm-gripper.md
+++ b/docs/tutorials/services/plan-motion-with-arm-gripper.md
@@ -198,10 +198,9 @@ This is possible because the motion service considers other components of the ro
 We need to do several things to prepare a new gripper component for motion.
 
 1. Go back to your machine configuration on [Viam](https://app.viam.com).
-2. Navigate to the **Components** tab and click **Create component** in the lower-left corner to add a new gripper component to your robot:
-   - Select `gripper` for the type and `fake` for the model.
-   - Enter `gripper-1` for the name of your gripper component.
-   - Click **Create**.
+2. On the **CONFIGURE** tab, click the **+** icon and select **Blocks** to add a new gripper component to your robot:
+   - Search for and select the `gripper / fake` model.
+   - Name the component `gripper-1` and click **Add to machine**.
 3. Add a **Frame** to the gripper component:
    - Set the parent as `arm-1`.
    - Set the translation as something small in the +Z direction, such as `90` millimeters.


### PR DESCRIPTION
## What

Tutorials section of the add-component wording sweep (see #5160 Hardware, #5161 Reference, #5162 Vision, #5164 Fleet/Monitor/…, #5165 Motion Planning, #5166 Try Viam). Matches the current Viam app UI, verified live.

| Old | New |
|-----|-----|
| Select **Configuration block** | Select **Blocks** |
| ...click **Create** (component/service add) | ...click **Add to machine** |

## Scope

Menu label swapped in all files. Component/service "Create" → "Add to machine" across the tutorials — component adds (motors, encoders, boards, cameras, sensors, servos, arms, grippers) and service adds (vision, data-manager, ML model), including registry-module services (stale "Add module" step dropped; module installs automatically). Kept concise: correct button name, no added name/reclick/save verbosity.

Also fixed two outdated flows in this section:
- `plan-motion-with-arm-gripper.md` — replaced the old "Components tab → Create component" UI with the current + → Blocks → Add to machine flow.
- `gamepad.md` — trimmed the verbose two-click phrasing to the concise single "Add to machine".

## Kept as "Create" (not a + → Blocks add)

- **Org creation:** `air-quality-fleet.md`
- **Trigger creation:** `helmet.md`
- **Local-module upload + its "Create" menu:** `pet-photographer.md`, `controlling-an-intermode-rover-canbus.md`, `make-a-plant-watering-robot.md`

## Checks

prettier, markdownlint, vale (error level) all pass.
