### PR TITLE
[Tutorials] Apply post-merge review suggestions (Blocks search flow + model IDs)

### DIFF
--- a/docs/tutorials/configure/configure-rover.md
+++ b/docs/tutorials/configure/configure-rover.md
@@ -55,7 +55,7 @@ In the following, you can see two popular examples with components that are pres
 The first component you will add is the [board](/reference/components/board/) which represents the Raspberry Pi to which the other components are wired.
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Search for `board`, then select the `raspberry-pi/rpi` model.
+Search for `raspberry pi`, then select the `raspberry-pi/rpi` block.
 Enter `local` as the name and click **Add to machine**.
 You can use a different name but will then need to adjust the name in the following steps to the name you choose.
 
@@ -85,7 +85,7 @@ Start with the right encoder:
 #### Right encoder
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Search for `encoder`, then select the `ams/as5048` model.
+Search for `as5048`, then select the `ams/as5048` block.
 Enter `renc` as the name and click **Add to machine**.
 
 Click the **board** dropdown list and select the name of your board, `local`.
@@ -95,7 +95,7 @@ In the **i2c bus** field type `1`, and in the **i2c address** field type `65`.
 #### Left encoder
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Search for `encoder`, then select the `ams/as5048` model.
+Search for `as5048`, then select the `ams/as5048` block.
 Enter `lenc` as the name for your encoder and click **Add to machine**.
 
 Click the **board** dropdown list and select the name of your board, `local`.
@@ -158,7 +158,7 @@ Start with the right motor:
 #### Right motor
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Search for `motor`, then select the `motor/gpio` model.
+Search for `gpio`, then select the `motor/gpio` block.
 Enter `right` as the name or use the suggested name for your motor and click **Add to machine**.
 
 Then from the **Board** dropdown, select `local`, the Raspberry Pi the motor is wired to.
@@ -177,7 +177,7 @@ Next, describe how the motor is wired to the Pi:
 #### Left motor
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Search for `motor`, then select the `motor/gpio` model.
+Search for `gpio`, then select the `motor/gpio` block.
 Enter `left` as the name or use the suggested name for your motor and click **Add to machine**.
 
 Then select `local` from the **Board** dropdown to choose the Raspberry Pi the motor is wired to.
@@ -245,7 +245,7 @@ Start with the right set of wheels.
 #### Right motor
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Search for `motor`, then select the `motor/gpio` model.
+Search for `gpio`, then select the `motor/gpio` block.
 Enter `right` as the name or use the suggested name for your motor and click **Add to machine**.
 
 ![G P I O motor config in the builder UI with the In1 and In2 pins configured and the PWM pin field left blank.](/components/motor/gpio-config-ui.png)
@@ -268,7 +268,7 @@ You can ignore the other optional attributes.
 #### Left motor
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Search for `motor`, then select the `motor/gpio` model.
+Search for `gpio`, then select the `motor/gpio` block.
 Enter `left` as the name or use the suggested name for your motor and click **Add to machine**.
 
 Click the **Board** dropdown and select `local` as the board the motor driver is wired to.
@@ -337,7 +337,7 @@ Optionally, add a camera to your rover.
 {{% tab name="Config Builder" %}}
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Search for `camera`, then select the `camera/webcam` model.
+Search for `webcam`, then select the `camera/webcam` block.
 Enter a name or use the suggested name for your camera and click **Add to machine**.
 
 {{< imgproc src="/components/camera/configure-webcam.png" alt="Configuration of a webcam camera." resize="1200x" style="width=600x" >}}
@@ -365,14 +365,14 @@ If this doesn't work when you test your camera later, you can try a different vi
 If your rover has its camera mounted on a pair of [servos](/reference/components/servo/), like the Yahboom rover, you can use these to control the pan and tilt of the camera.
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Search for `servo`, then select the `raspberry-pi/rpi-servo` model.
+Search for `rpi-servo`, then select the `raspberry-pi/rpi-servo` block.
 Enter `pan` as the name and click **Add to machine**.
 
 Set `Depends On` to `local`, and `pin` to the pin the servo is wired to (`23` for the Yahboom rover).
 
 Finally, add the tilt `servo` as well.
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Search for `servo`, then select the `raspberry-pi/rpi-servo` model.
+Search for `rpi-servo`, then select the `raspberry-pi/rpi-servo` block.
 Enter `tilt` as the name and click **Add to machine**.
 
 Set `Depends On` to `local`, and `pin` to the pin the servo is wired to (`21` for the Yahboom rover).
@@ -395,7 +395,7 @@ If your rover is not supported out of the box, follow the [Create a Modular Reso
 {{% tab name="Config Builder" %}}
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Search for `base`, then select the `base/wheeled` model.
+Search for `wheeled`, then select the `base/wheeled` block.
 Enter a name or use the suggested name for your base and click **Add to machine**.
 
 {{< tabs >}}

--- a/docs/tutorials/configure/configure-rover.md
+++ b/docs/tutorials/configure/configure-rover.md
@@ -365,14 +365,14 @@ If this doesn't work when you test your camera later, you can try a different vi
 If your rover has its camera mounted on a pair of [servos](/reference/components/servo/), like the Yahboom rover, you can use these to control the pan and tilt of the camera.
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Select the `servo` type, then select the `viam:raspberry-pi:pi-servo` model.
+Search for `servo`, then select the `raspberry-pi/rpi-servo` model.
 Enter `pan` as the name and click **Add to machine**.
 
 Set `Depends On` to `local`, and `pin` to the pin the servo is wired to (`23` for the Yahboom rover).
 
 Finally, add the tilt `servo` as well.
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Select the `servo` type, then select the `viam:raspberry-pi:pi-servo` model.
+Search for `servo`, then select the `raspberry-pi/rpi-servo` model.
 Enter `tilt` as the name and click **Add to machine**.
 
 Set `Depends On` to `local`, and `pin` to the pin the servo is wired to (`21` for the Yahboom rover).
@@ -395,7 +395,7 @@ If your rover is not supported out of the box, follow the [Create a Modular Reso
 {{% tab name="Config Builder" %}}
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Select the `base` type, then select the `wheeled` model.
+Search for `base`, then select the `base/wheeled` model.
 Enter a name or use the suggested name for your base and click **Add to machine**.
 
 {{< tabs >}}

--- a/docs/tutorials/configure/configure-rover.md
+++ b/docs/tutorials/configure/configure-rover.md
@@ -55,7 +55,7 @@ In the following, you can see two popular examples with components that are pres
 The first component you will add is the [board](/reference/components/board/) which represents the Raspberry Pi to which the other components are wired.
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Select the `board` type, then select the `viam:raspberry-pi:rpi` model.
+Search for `board`, then select the `raspberry-pi/rpi` model.
 Enter `local` as the name and click **Add to machine**.
 You can use a different name but will then need to adjust the name in the following steps to the name you choose.
 
@@ -85,7 +85,7 @@ Start with the right encoder:
 #### Right encoder
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Select the `encoder` type, then select the `AMS-AS5048` model.
+Search for `encoder`, then select the `ams/as5048` model.
 Enter `renc` as the name and click **Add to machine**.
 
 Click the **board** dropdown list and select the name of your board, `local`.
@@ -95,7 +95,7 @@ In the **i2c bus** field type `1`, and in the **i2c address** field type `65`.
 #### Left encoder
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Select the `encoder` type, then select the `AMS-AS5048` model.
+Search for `encoder`, then select the `ams/as5048` model.
 Enter `lenc` as the name for your encoder and click **Add to machine**.
 
 Click the **board** dropdown list and select the name of your board, `local`.
@@ -158,7 +158,7 @@ Start with the right motor:
 #### Right motor
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Select the `motor` type, then select the `gpio` model.
+Search for `motor`, then select the `motor/gpio` model.
 Enter `right` as the name or use the suggested name for your motor and click **Add to machine**.
 
 Then from the **Board** dropdown, select `local`, the Raspberry Pi the motor is wired to.
@@ -177,7 +177,7 @@ Next, describe how the motor is wired to the Pi:
 #### Left motor
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Select the `motor` type, then select the `gpio` model.
+Search for `motor`, then select the `motor/gpio` model.
 Enter `left` as the name or use the suggested name for your motor and click **Add to machine**.
 
 Then select `local` from the **Board** dropdown to choose the Raspberry Pi the motor is wired to.
@@ -245,7 +245,7 @@ Start with the right set of wheels.
 #### Right motor
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Select the `motor` type, then select the `gpio` model.
+Search for `motor`, then select the `motor/gpio` model.
 Enter `right` as the name or use the suggested name for your motor and click **Add to machine**.
 
 ![G P I O motor config in the builder UI with the In1 and In2 pins configured and the PWM pin field left blank.](/components/motor/gpio-config-ui.png)
@@ -268,7 +268,7 @@ You can ignore the other optional attributes.
 #### Left motor
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Select the `motor` type, then select the `gpio` model.
+Search for `motor`, then select the `motor/gpio` model.
 Enter `left` as the name or use the suggested name for your motor and click **Add to machine**.
 
 Click the **Board** dropdown and select `local` as the board the motor driver is wired to.
@@ -337,7 +337,7 @@ Optionally, add a camera to your rover.
 {{% tab name="Config Builder" %}}
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Select the `camera` type, then select the `webcam` model.
+Search for `camera`, then select the `camera/webcam` model.
 Enter a name or use the suggested name for your camera and click **Add to machine**.
 
 {{< imgproc src="/components/camera/configure-webcam.png" alt="Configuration of a webcam camera." resize="1200x" style="width=600x" >}}

--- a/docs/tutorials/configure/pet-photographer.md
+++ b/docs/tutorials/configure/pet-photographer.md
@@ -865,7 +865,7 @@ If you have a different item you want to use, or want to match to a color that m
 
 1. Navigate to the **CONFIGURE** tab of your machine's page.
 1. Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-1. Select the `vision` type, then select the `color detector` model.
+1. Search for `vision`, then select the `vision/color_detector` model.
 1. Enter a name or use the suggested name for your color detector.
    This tutorial uses the name 'my_color_detector' in all example code.
 1. click **Add to machine**.

--- a/docs/tutorials/configure/pet-photographer.md
+++ b/docs/tutorials/configure/pet-photographer.md
@@ -821,7 +821,7 @@ To enable data capture on your machine, add and configure the [data management s
 {{% tab name="Config Builder" %}}
 
 1. On the **CONFIGURE** tab, click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-1. Choose `data management` as the type.
+1. Choose `data_manager/builtin` as the type.
 1. Enter a name or use the suggested name for your instance of the data manager.
    This tutorial uses the name 'dm' in all example code.
 1. Click **Add to machine**.

--- a/docs/tutorials/configure/pet-photographer.md
+++ b/docs/tutorials/configure/pet-photographer.md
@@ -821,7 +821,7 @@ To enable data capture on your machine, add and configure the [data management s
 {{% tab name="Config Builder" %}}
 
 1. On the **CONFIGURE** tab, click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-1. Choose `data_manager/builtin` as the type.
+1. Search for `data management`, then select the `data_manager/builtin` block.
 1. Enter a name or use the suggested name for your instance of the data manager.
    This tutorial uses the name 'dm' in all example code.
 1. Click **Add to machine**.
@@ -865,7 +865,7 @@ If you have a different item you want to use, or want to match to a color that m
 
 1. Navigate to the **CONFIGURE** tab of your machine's page.
 1. Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-1. Search for `vision`, then select the `vision/color_detector` model.
+1. Search for `color detector`, then select the `vision/color_detector` block.
 1. Enter a name or use the suggested name for your color detector.
    This tutorial uses the name 'my_color_detector' in all example code.
 1. click **Add to machine**.

--- a/docs/tutorials/get-started/blink-an-led.md
+++ b/docs/tutorials/get-started/blink-an-led.md
@@ -137,8 +137,8 @@ Go to [Viam](https://app.viam.com/) and navigate to your new machine's **CONFIGU
 
 Add a [_board component_](/reference/components/board/) to represent your single-board computer, which in this case is the Raspberry Pi.
 To create the new component, click the **+** icon next to your machine {{< glossary_tooltip term_id="part" text="part" >}} in the left-hand menu and select **Blocks**.
-Search for `board`, then select the `raspberry-pi/rpi` model if you are using a Raspberry Pi 4, Raspberry Pi 3 or Raspberry Pi Zero 2 W.
-If you are using a Raspberry Pi 5, use the `pi5` model.
+Search for `raspberry pi`, then select the `raspberry-pi/rpi` block if you are using a Raspberry Pi 4, Raspberry Pi 3 or Raspberry Pi Zero 2 W.
+If you are using a Raspberry Pi 5, use the `raspberry-pi/rpi5` block.
 Enter a name or use the suggested name for your board and click **Add to machine**.
 We used the name `"local"`.
 

--- a/docs/tutorials/get-started/blink-an-led.md
+++ b/docs/tutorials/get-started/blink-an-led.md
@@ -137,7 +137,7 @@ Go to [Viam](https://app.viam.com/) and navigate to your new machine's **CONFIGU
 
 Add a [_board component_](/reference/components/board/) to represent your single-board computer, which in this case is the Raspberry Pi.
 To create the new component, click the **+** icon next to your machine {{< glossary_tooltip term_id="part" text="part" >}} in the left-hand menu and select **Blocks**.
-Select the `board` type, then select the `viam:raspberry-pi:rpi` model if you are using a Raspberry Pi 4, Raspberry Pi 3 or Raspberry Pi Zero 2 W.
+Search for `board`, then select the `raspberry-pi/rpi` model if you are using a Raspberry Pi 4, Raspberry Pi 3 or Raspberry Pi Zero 2 W.
 If you are using a Raspberry Pi 5, use the `pi5` model.
 Enter a name or use the suggested name for your board and click **Add to machine**.
 We used the name `"local"`.

--- a/docs/tutorials/get-started/servo-mousemover.md
+++ b/docs/tutorials/get-started/servo-mousemover.md
@@ -172,8 +172,8 @@ Create a [board component](/reference/components/board/):
 
 1. Navigate to the **CONFIGURE** tab of your machine's page.
 1. Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-1. Search for `board`, then select the `raspberry-pi/rpi` model if you are using a Raspberry Pi 4, Raspberry Pi 3 or Raspberry Pi Zero 2 W.
-   If you are using a Raspberry Pi 5, use the `pi5` model instead.
+1. Search for `raspberry pi`, then select the `raspberry-pi/rpi` block if you are using a Raspberry Pi 4, Raspberry Pi 3 or Raspberry Pi Zero 2 W.
+   If you are using a Raspberry Pi 5, use the `raspberry-pi/rpi5` block instead.
 
 1. Enter the name `local` for your board and click **Add to machine**.
 
@@ -186,8 +186,8 @@ You can name the board whatever you want, but if you change the name you must up
 Create a [servo component](/reference/components/servo/):
 
 1. Navigate to the **CONFIGURE** tab of your machine's page.
-1. Click the **+** icon next to your machine part in the left-hand menu and select **Component**.
-1. Search for `servo`, then select the `raspberry-pi/rpi-servo` model.
+1. Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
+1. Search for `rpi-servo`, then select the `raspberry-pi/rpi-servo` block.
 1. Enter the name `fs90f` for your servo and click **Add to machine**.
 
 After clicking **Add to machine**, you see where you can put in attributes for the servo.

--- a/docs/tutorials/get-started/servo-mousemover.md
+++ b/docs/tutorials/get-started/servo-mousemover.md
@@ -172,7 +172,7 @@ Create a [board component](/reference/components/board/):
 
 1. Navigate to the **CONFIGURE** tab of your machine's page.
 1. Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-1. Select the `board` type, then select the `viam:raspberry-pi:rpi` model if you are using a Raspberry Pi 4, Raspberry Pi 3 or Raspberry Pi Zero 2 W.
+1. Search for `board`, then select the `raspberry-pi/rpi` model if you are using a Raspberry Pi 4, Raspberry Pi 3 or Raspberry Pi Zero 2 W.
    If you are using a Raspberry Pi 5, use the `pi5` model instead.
 
 1. Enter the name `local` for your board and click **Add to machine**.
@@ -187,7 +187,7 @@ Create a [servo component](/reference/components/servo/):
 
 1. Navigate to the **CONFIGURE** tab of your machine's page.
 1. Click the **+** icon next to your machine part in the left-hand menu and select **Component**.
-1. Select the `servo` type, then select the `viam:raspberry-pi:pi-servo` model.
+1. Search for `servo`, then select the `raspberry-pi/rpi-servo` model.
 1. Enter the name `fs90f` for your servo and click **Add to machine**.
 
 After clicking **Add to machine**, you see where you can put in attributes for the servo.

--- a/docs/tutorials/projects/integrating-viam-with-openai.md
+++ b/docs/tutorials/projects/integrating-viam-with-openai.md
@@ -214,7 +214,7 @@ Now, configure your rover to:
 To configure your [servo](/reference/components/servo/), go to your rover's **CONFIGURE** tab.
 
 - Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-- Select the `servo` type, then select the `viam:raspberry-pi:pi-servo` model.
+- Search for `servo`, then select the `raspberry-pi/rpi-servo` model.
 - Enter the name `servo1` for your servo and click **Add to machine**.
 
 Now, in the panel for `servo1`, add the following attribute configuration:

--- a/docs/tutorials/projects/integrating-viam-with-openai.md
+++ b/docs/tutorials/projects/integrating-viam-with-openai.md
@@ -214,7 +214,7 @@ Now, configure your rover to:
 To configure your [servo](/reference/components/servo/), go to your rover's **CONFIGURE** tab.
 
 - Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-- Search for `servo`, then select the `raspberry-pi/rpi-servo` model.
+- Search for `rpi-servo`, then select the `raspberry-pi/rpi-servo` block.
 - Enter the name `servo1` for your servo and click **Add to machine**.
 
 Now, in the panel for `servo1`, add the following attribute configuration:
@@ -250,7 +250,7 @@ To configure an ML model service:
 
 - Select the **CONFIGURE** tab.
 - Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-- Select the `ML model` type, then select the `TFLite CPU` model.
+- Search for `tflite`, then select the `tflite_cpu/tflite_cpu` block.
 - Enter the name `stuff_detector` for your service and click **Add to machine**.
 
 Your robot registers this as a machine learning model and makes it available for use.
@@ -262,7 +262,7 @@ Now, create a vision service to visualize your ML model:
 
 - Select the **CONFIGURE** tab.
 - Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-- Select the `vision` type, then select the `ML model` model.
+- Search for `mlmodel`, then select the `vision/mlmodel` block.
 - Enter the name `mlmodel` for your service and click **Add to machine**.
 
 Your companion robot will use this to interface with the machine learning model allowing you to - well, detect stuff!

--- a/docs/tutorials/projects/make-a-plant-watering-robot.md
+++ b/docs/tutorials/projects/make-a-plant-watering-robot.md
@@ -225,7 +225,7 @@ First, add your machine as a [board component](/reference/components/board/):
 {{% tab name="Config Builder" %}}
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Select the `board` type, then select the appropriate `viam:raspberry-pi:pi` model (for example, `viam:raspberry-pi:pi4` for Raspberry Pi 4).
+Search for `raspberry pi`, then select the block that matches your Pi (for example, `raspberry-pi/rpi4` for a Raspberry Pi 4).
 Enter a name for your board and click **Add to machine**.
 This tutorial uses the name `local`.
 

--- a/docs/tutorials/projects/verification-system.md
+++ b/docs/tutorials/projects/verification-system.md
@@ -64,7 +64,7 @@ Navigate to the **CONFIGURE** tab of your machine's page.
 **Configure the camera you want to use for your security system.**
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Search for `camera`, then select the `camera/webcam` model or another model if you are using a different camera.
+Search for `webcam`, then select the `camera/webcam` block, or another model if you are using a different camera.
 Enter the name `my_webcam` for your camera and click **Add to machine**.
 
 {{% /tablestep %}}

--- a/docs/tutorials/projects/verification-system.md
+++ b/docs/tutorials/projects/verification-system.md
@@ -64,7 +64,7 @@ Navigate to the **CONFIGURE** tab of your machine's page.
 **Configure the camera you want to use for your security system.**
 
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Select the `camera` type, then select the `webcam` model or another model if you are using a different camera.
+Search for `camera`, then select the `camera/webcam` model or another model if you are using a different camera.
 Enter the name `my_webcam` for your camera and click **Add to machine**.
 
 {{% /tablestep %}}

--- a/docs/tutorials/services/color-detection-scuttle.md
+++ b/docs/tutorials/services/color-detection-scuttle.md
@@ -75,7 +75,7 @@ To create a [color detector vision service](/reference/apis/services/vision/#det
 
 Navigate to your machine's **CONFIGURE** tab.
 Click the **+** (Create) icon next to your machine part in the left-hand menu and select **Blocks**.
-Select the `vision` type, then select the `color detector` model.
+Search for `vision`, then select the `vision/color_detector` model.
 Enter `my_color_detector` as the name for your service and click **Add to machine**.
 
 In your vision service's panel, set the following **Attributes**:

--- a/docs/tutorials/services/color-detection-scuttle.md
+++ b/docs/tutorials/services/color-detection-scuttle.md
@@ -75,7 +75,7 @@ To create a [color detector vision service](/reference/apis/services/vision/#det
 
 Navigate to your machine's **CONFIGURE** tab.
 Click the **+** (Create) icon next to your machine part in the left-hand menu and select **Blocks**.
-Search for `vision`, then select the `vision/color_detector` model.
+Search for `color detector`, then select the `vision/color_detector` block.
 Enter `my_color_detector` as the name for your service and click **Add to machine**.
 
 In your vision service's panel, set the following **Attributes**:

--- a/docs/tutorials/services/constrain-motion.md
+++ b/docs/tutorials/services/constrain-motion.md
@@ -159,7 +159,7 @@ This configured table won't be taken into account by the motion service, but it'
 
 Navigate to the **CONFIGURE** tab of your machine's page.
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Select the `generic` type, then select the `fake` model.
+Search for `generic`, then select the `generic/fake` model.
 Enter the name `"table"` for your movement sensor and click **Add to machine**.
 
 Select the **Frame** mode on the **CONFIGURE** tab.

--- a/docs/tutorials/services/constrain-motion.md
+++ b/docs/tutorials/services/constrain-motion.md
@@ -159,7 +159,7 @@ This configured table won't be taken into account by the motion service, but it'
 
 Navigate to the **CONFIGURE** tab of your machine's page.
 Click the **+** icon next to your machine part in the left-hand menu and select **Blocks**.
-Search for `generic`, then select the `generic/fake` model.
+Search for `generic/fake`, then select the matching block.
 Enter the name `"table"` for your movement sensor and click **Add to machine**.
 
 Select the **Frame** mode on the **CONFIGURE** tab.


### PR DESCRIPTION
## What

Started as @HipsterBrown's 4 inline suggestions from #5167 (which merged before they were applied), then extended to the **whole pattern** at his request: the tutorials still used the old "**Select** the `X` **type**, then select the `Y` model" phrasing (pre-Blocks type dropdown) with outdated model IDs. This switches them to the Blocks **search** flow with correct IDs.

## Verified against the live app

Every block below was confirmed in the **Configuration Blocks** dialog in app.viam.com, not inferred from other docs pages. That mattered — the two ID schemes are indistinguishable in prose:

- **Registry modules** display as `module/model`: `raspberry-pi/rpi`, `raspberry-pi/rpi-servo`, `ams/as5048`, `tflite_cpu/tflite_cpu`
- **Builtins** display as `api/model` and are marked "Included in `viam-server`": `motor/gpio`, `camera/webcam`, `base/wheeled`, `generic/fake`, `vision/color_detector`, `vision/mlmodel`, `data_manager/builtin`

## Search terms, not API names

The Blocks search matches model and module names — **not** API names. Searching `board` returns four `fake-modules-go/*` results before `raspberry-pi/rpi4`; searching `vision` never surfaces `vision/color_detector`. So each step now searches a term that puts the intended block first:

| Block | Search term |
|---|---|
| `raspberry-pi/rpi`, `raspberry-pi/rpi4`, `raspberry-pi/rpi5` | `raspberry pi` |
| `raspberry-pi/rpi-servo` | `rpi-servo` |
| `ams/as5048` | `as5048` |
| `motor/gpio` | `gpio` |
| `camera/webcam` | `webcam` |
| `base/wheeled` | `wheeled` |
| `vision/color_detector` | `color detector` |
| `data_manager/builtin` | `data management` |

This matches the guidance already in `hardware/configure-hardware.md` and `hardware/common-components/add-a-board.md` ("search for **raspberry pi**").

## Previously held — now resolved

@HipsterBrown, the three IDs I was holding for you are confirmed against the app; no input needed:

- `integrating-viam-with-openai.md:253` — **`tflite_cpu/tflite_cpu`** (I had guessed `mlmodel/tflite_cpu`; wrong)
- `integrating-viam-with-openai.md:265` — **`vision/mlmodel`**
- `make-a-plant-watering-robot.md:228` — **`raspberry-pi/rpi4`**

## Also in this PR

- `pet-photographer.md` — the data manager step still read "Choose `data_manager/builtin` as the type" (a model ID called a type, no search step).
- `blink-an-led.md`, `servo-mousemover.md` — bare `pi5` → `raspberry-pi/rpi5`.
- `servo-mousemover.md` — one step still said select **Component** instead of **Blocks**.
- Cards are **blocks**, not models, matching `control/gamepad.md`.

**Not touched:** `pet-photographer.md:934` "Select the `camera` type from the dropdown" — that's the local-module Create menu (a config-field dropdown), not an add-block step.

## Follow-ups (tracked separately, not this PR)

Tracked in #5175:

- Stale `"model": "pi"` in raw-JSON tabs across 11 files, plus the `pi-ui-config.png` screenshot and its alt text.
- `constrain-motion.md:163` calls a `generic` component "your movement sensor".
- **Question for @HipsterBrown:** is `raspberry-pi/rpi` still right for a Pi 4? The app shows `rpi` at 221 uses vs `rpi4` at 24,487, and `rpi-servo`'s own description says a Pi 5 needs `servo/gpio` instead. The answer determines what those 11 JSON blocks should say.

## Checks

prettier, markdownlint, vale (error level) all pass.
