### PR TITLE
Add --collect-all viam to PyInstaller build commands

### DIFF
--- a/docs/build-modules/manage-modules.md
+++ b/docs/build-modules/manage-modules.md
@@ -176,7 +176,7 @@ if ! $PYTHON -m pip install pyinstaller -Uqq; then
     exit 1
 fi
 
-$PYTHON -m PyInstaller --onefile --hidden-import="googleapiclient" src/main.py
+$PYTHON -m PyInstaller --onefile --collect-all viam --hidden-import="googleapiclient" src/main.py
 tar -czvf dist/archive.tar.gz ./dist/main
 ```
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -2135,7 +2135,7 @@ pip3 install -r requirements.txt
 ```sh {class="line-numbers linkable-line-numbers"}
 #!/bin/bash
 pip3 install -r requirements.txt
-python3 -m PyInstaller --onefile --hidden-import="googleapiclient" src/main.py
+python3 -m PyInstaller --onefile --collect-all viam --hidden-import="googleapiclient" src/main.py
 tar -czvf dist/archive.tar.gz <PATH-TO-EXECUTABLE>
 ```
 
@@ -2162,7 +2162,7 @@ fi
 python3 -m venv .venv
 . .venv/bin/activate
 pip3 install -r requirements.txt
-python3 -m PyInstaller --onefile --hidden-import="googleapiclient" src/main.py
+python3 -m PyInstaller --onefile --collect-all viam --hidden-import="googleapiclient" src/main.py
 tar -czvf dist/archive.tar.gz <PATH-TO-EXECUTABLE>
 ```
 
@@ -2196,7 +2196,7 @@ sudo apt-get install -y python3-venv
 python3 -m venv .venv
 . .venv/bin/activate
 pip3 install -r requirements.txt
-python3 -m PyInstaller --onefile --hidden-import="googleapiclient" src/main.py
+python3 -m PyInstaller --onefile --collect-all viam --hidden-import="googleapiclient" src/main.py
 tar -czvf dist/archive.tar.gz <PATH-TO-EXECUTABLE>
 ```
 
@@ -2212,7 +2212,7 @@ brew install python3-venv
 python3 -m venv .venv
 . .venv/bin/activate
 pip3 install -r requirements.txt
-python3 -m PyInstaller --onefile --hidden-import="googleapiclient" src/main.py
+python3 -m PyInstaller --onefile --collect-all viam --hidden-import="googleapiclient" src/main.py
 tar -czvf dist/archive.tar.gz <PATH-TO-EXECUTABLE>
 ```
 


### PR DESCRIPTION
The inline module code template in the Viam app was updated (viamrobotics/app#12689) to add `--collect-all viam` to the PyInstaller command. Without this flag, PyInstaller can miss Viam SDK subpackages with complex import structures, causing runtime `ImportError`s when the built module runs.

The docs show the PyInstaller command in 5 places across 2 files, all missing the new flag. This PR adds it to all instances.

## Source changes

- viamrobotics/app#12689: fix(inline-module/code-template): add --collect-all viam to PyInstaller call

## Docs changes

- `docs/build-modules/manage-modules.md`: Added `--collect-all viam` to the example `build.sh` PyInstaller command
- `docs/cli/reference.md`: Added `--collect-all viam` to all 4 example `build.sh` PyInstaller commands (with setup.sh, without setup.sh, linux/arm64, darwin/arm64)

## How I found these

- Grep matches: searched for `PyInstaller --onefile` across the entire docs repo, found 5 instances

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_017nxAcukEvUrm3YXCsU23KC)_