### PR TITLE
Retry each code sample once on failure to absorb transient backend errors

### DIFF
--- a/.github/workflows/test-code-snippets.yml
+++ b/.github/workflows/test-code-snippets.yml
@@ -84,6 +84,16 @@ jobs:
         passed_files_py=0
         failed_files_py=0
 
+        # Run a sample, retrying once after a delay. The live backend
+        # intermittently returns transient errors (gRPC INTERNAL,
+        # DEADLINE_EXCEEDED) that clear within seconds.
+        run_sample() {
+          if "$@"; then return 0; fi
+          echo "⚠️ Failed, retrying once in 30s in case the error is transient..."
+          sleep 30
+          "$@"
+        }
+
         echo "Starting to test Python code samples..."
         echo "========================================"
 
@@ -91,8 +101,8 @@ jobs:
           echo "Testing: $file"
           total_files_py=$((total_files_py + 1))
 
-          # Run the test with environment variables explicitly passed
-          if VIAM_API_KEY="$VIAM_API_KEY" VIAM_API_KEY_ID="$VIAM_API_KEY_ID" TEST_ORG_ID="$TEST_ORG_ID" VIAM_API_KEY_DATA_REGIONS="$VIAM_API_KEY_DATA_REGIONS" VIAM_API_KEY_ID_DATA_REGIONS="$VIAM_API_KEY_ID_DATA_REGIONS" python "$file"; then
+          # Credentials come from this step's env block.
+          if run_sample python "$file"; then
             passed_files_py=$((passed_files_py + 1))
             echo "✅ PASSED: $file"
           else
@@ -150,6 +160,16 @@ jobs:
         passed_files_go=0
         failed_files_go=0
 
+        # Run a sample, retrying once after a delay. The live backend
+        # intermittently returns transient errors (gRPC INTERNAL,
+        # DEADLINE_EXCEEDED) that clear within seconds.
+        run_sample() {
+          if "$@"; then return 0; fi
+          echo "⚠️ Failed, retrying once in 30s in case the error is transient..."
+          sleep 30
+          "$@"
+        }
+
         echo "Starting to test Go code samples..."
         echo "========================================"
 
@@ -166,7 +186,8 @@ jobs:
 
           # Check if directory exists before changing to it
           if [ -d "$file_dir" ]; then
-            if (cd "$file_dir" && VIAM_API_KEY="$VIAM_API_KEY" VIAM_API_KEY_ID="$VIAM_API_KEY_ID" TEST_ORG_ID="$TEST_ORG_ID" go run "$file_name"); then
+            # Credentials come from this step's env block.
+            if (cd "$file_dir" && run_sample go run "$file_name"); then
               passed_files_go=$((passed_files_go + 1))
               echo "✅ PASSED: $file"
             else
@@ -229,6 +250,16 @@ jobs:
         passed_files_ts=0
         failed_files_ts=0
 
+        # Run a sample, retrying once after a delay. The live backend
+        # intermittently returns transient errors (gRPC INTERNAL,
+        # DEADLINE_EXCEEDED) that clear within seconds.
+        run_sample() {
+          if "$@"; then return 0; fi
+          echo "⚠️ Failed, retrying once in 30s in case the error is transient..."
+          sleep 30
+          "$@"
+        }
+
         echo "Starting to test TypeScript code samples..."
         echo "========================================"
 
@@ -236,8 +267,8 @@ jobs:
           echo "Testing: $file"
           total_files_ts=$((total_files_ts + 1))
 
-          # Run the test with environment variables explicitly passed
-          if VIAM_API_KEY="$VIAM_API_KEY" VIAM_API_KEY_ID="$VIAM_API_KEY_ID" TEST_ORG_ID="$TEST_ORG_ID" VIAM_API_KEY_DATA_REGIONS="$VIAM_API_KEY_DATA_REGIONS" VIAM_API_KEY_ID_DATA_REGIONS="$VIAM_API_KEY_ID_DATA_REGIONS" node "$file"; then
+          # Credentials come from this step's env block.
+          if run_sample node "$file"; then
             passed_files_ts=$((passed_files_ts + 1))
             echo "✅ PASSED: $file"
           else


### PR DESCRIPTION
## Problem

Every **Test Code Samples** failure since the sample-bug fixes in #5120 (7/1) has been a transient backend error, not a code bug — triage across the failing runs in #5119:

- gRPC `INTERNAL` on `DeleteDataPipeline` (`pipeline-delete.py`/`.go`, `pipeline-list.py` teardown, `pipeline-create.go` cleanup) — hit 6 of 8 runs on 7/13
- `DEADLINE_EXCEEDED` on the shared `data-query` SQL query (once taking out all three language variants in the same run)
- brief test-machine connection drops

These clear within seconds: in run 29241295626, the pipeline orphaned by a failed delete was successfully deleted by the next sample's setup cleanup 3 seconds later.

## Fix

Run each failed sample a second time after a 30-second delay before counting it as failed, in all three language steps. Only persistent failures fail the job. Samples are already re-runnable by design (the suite runs weekly and on every push, and each sample cleans up prior state on entry), so a retry is equivalent to the next scheduled run.

Also drops the redundant inline `VAR="$VAR"` prefixes on the run commands: each step's `env:` block already exports a superset of those variables to every process in the step.

## Validation (8 dispatched runs on 7/13)

- **The retry works:** across three dispatches of this branch it absorbed three would-be job failures (`pipeline-delete.py`, `pipeline-list.py`, `pipeline-create.go` — each failed once, passed 30s later), while two plain-main control dispatches failed outright on the same `INTERNAL` error.
- **The TS connect failures seen during validation are unrelated to this change:** they initially looked branch-correlated, but bisection (TS step byte-identical to main still failed) and finally a dispatch of unmodified main (run 29266526730) reproduced them. They are a flapping backend incident in the TS cloud-WebRTC dial path, tracked on #5119; Go/Python samples are immune because they reach the runner-local server via mDNS.

## What this does not fix

Failures that persist longer than the 30s retry window — the flapping TS WebRTC incident, extended test-machine outages, and the late-afternoon persistent `DeleteDataPipeline` errors — still fail the job. Those are backend/infra issues tracked on #5119.

Tracking issue: #5119

🤖 Generated with [Claude Code](https://claude.com/claude-code)
