### PR TITLE
Ignore wiki.ros.org in htmltest external link check

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -15,10 +15,11 @@ HTTPConcurrencyLimit: 1
 ExternalTimeout: 30
 IgnoreURLs:
   # Valid links that automated checkers cannot verify: pkg.go.dev rate-limits
-  # requests (HTTP 429); analog.com, fandom.com, cloud.google.com, and ebay.com
-  # block non-browser clients (HTTP 403); jordanorelli.com intermittently drops
-  # connections (EOF).
+  # requests (HTTP 429); analog.com, fandom.com, cloud.google.com, ebay.com, and
+  # wiki.ros.org block non-browser clients (HTTP 403 / bot-detection); jordanorelli.com
+  # intermittently drops connections (EOF).
   - "pkg.go.dev"
+  - "wiki.ros.org"
   - "analog.com"
   - "fandom.com"
   - "cloud.google.com"


### PR DESCRIPTION
## Summary

The scheduled `run-htmltest-external` job (issue #5151) fails on `https://wiki.ros.org/xacro`. The page is live and valid, but `wiki.ros.org` uses bot-detection that blocks non-browser clients, so htmltest cannot verify it (times out / 403s under our 30s `ExternalTimeout`).

This is the only `ros.org` link in the docs (referenced once, in `docs/cli/build-and-deploy-modules.md`). Adding it to `IgnoreURLs` alongside the other hosts that block automated checkers (`analog.com`, `ebay.com`, `cloud.google.com`, etc.) resolves the recurring failure.

## Context

After the 2026-07-02 rate-limiting fixes (#5137, #5141: `HTTPConcurrencyLimit: 1` + `pkg.go.dev` ignore), the 2026-07-07 scheduled run dropped from 326 errors to a single one: this `wiki.ros.org/xacro` block. This PR clears that last case.

Fixes #5151