### PR TITLE
Update liveness trigger docs: no cooldown for part online/offline

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -1528,7 +1528,8 @@ Add a trigger to a machine part. Run without `--config` to use an interactive fo
 
 Trigger configs support the following event types:
 
-- `part_online`: liveness check.
+- `part_online`: fires on each online state transition.
+- `part_offline`: fires on each offline state transition.
 - `part_data_ingested`: fires when data of the specified types is ingested.
 - `conditional_data_ingested`: fires when data ingested by a specific data capture method matches a condition.
 - `conditional_logs_ingested`: fires when logs at the specified levels are ingested.
@@ -1544,7 +1545,7 @@ viam machines part add-trigger --part=<part id>
 
 # add a trigger from inline JSON
 viam machines part add-trigger --part=<part id> \
-    --config '{"name":"my-online-trigger","event":{"type":"part_online"},"notifications":[{"type":"email","value":"user@example.com","seconds_between_notifications":60}]}'
+    --config '{"name":"my-online-trigger","event":{"type":"part_online"},"notifications":[{"type":"email","value":"user@example.com"}]}'
 
 # add a trigger from a JSON file
 viam machines part add-trigger --part=<part id> --config ./trigger.json

--- a/docs/data/trigger-on-data.md
+++ b/docs/data/trigger-on-data.md
@@ -165,7 +165,9 @@ For the full header and body reference, see [Webhook attributes](/reference/trig
 
 ## Notification interval
 
-The `seconds_between_notifications` field sets the minimum time between notifications for the same trigger. If a trigger fires more frequently than this interval, additional notifications are suppressed until the interval has elapsed. To avoid floods of notifications, set the interval to a value appropriate for your use case (for example, 3600 to allow at most one alert per hour). For `conditional_logs_ingested` triggers, the check interval is always one hour regardless of this setting.
+The `seconds_between_notifications` field sets the minimum time between notifications for data triggers (`part_data_ingested` and `conditional_data_ingested`). If a trigger fires more frequently than this interval, additional notifications are suppressed until the interval has elapsed. To avoid floods of notifications, set the interval to a value appropriate for your use case (for example, 3600 to allow at most one alert per hour).
+
+This field is ignored for `part_online` and `part_offline` triggers, which fire on every state transition. It is also ignored for `conditional_logs_ingested` triggers, where the check interval is always one hour.
 
 ## Machine telemetry triggers
 

--- a/docs/monitor/alert.md
+++ b/docs/monitor/alert.md
@@ -234,7 +234,7 @@ The notification interval for log triggers is always one hour.
    Click **+** in the left sidebar and select **Trigger**.
 1. Enter a name and click **Create**.
 1. Select **Part is online** as the trigger **Type**.
-1. Add notification methods and set the alert frequency.
+1. Add notification methods.
 1. Click **Save**.
 
 {{% /tab %}}
@@ -250,13 +250,14 @@ The notification interval for log triggers is always one hour.
     "notifications": [
       {
         "type": "email",
-        "value": "you@example.com",
-        "seconds_between_notifications": 600
+        "value": "you@example.com"
       }
     ]
   }
 ]
 ```
+
+Part online triggers fire on every state transition, so you receive a notification each time the part comes online.
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -270,7 +271,7 @@ The notification interval for log triggers is always one hour.
    Click **+** in the left sidebar and select **Trigger**.
 1. Enter a name and click **Create**.
 1. Select **Part is offline** as the trigger **Type**.
-1. Add notification methods and set the alert frequency.
+1. Add notification methods.
 1. Click **Save**.
 
 {{% /tab %}}
@@ -286,13 +287,14 @@ The notification interval for log triggers is always one hour.
     "notifications": [
       {
         "type": "email",
-        "value": "you@example.com",
-        "seconds_between_notifications": 300
+        "value": "you@example.com"
       }
     ]
   }
 ]
 ```
+
+Part offline triggers fire on every state transition, so you receive a notification each time the part goes offline.
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -302,16 +304,19 @@ This prevents false alerts from brief network interruptions.
 
 ## Manage alert frequency
 
-Every notification method has a `seconds_between_notifications` setting that controls the minimum time between consecutive alerts.
+For data and conditional triggers, each notification method has a `seconds_between_notifications` setting that controls the minimum time between consecutive alerts.
 If a trigger fires more frequently than this interval, Viam suppresses the extra notifications.
 
 Set this value based on how quickly you need to respond:
 
-- **Critical alerts** (machine offline, safety thresholds): 60-300 seconds
+- **Safety thresholds**: 60-300 seconds
 - **Operational alerts** (elevated CPU, low battery): 300-600 seconds
 - **Informational alerts** (data sync confirmations): 3600 seconds or more
 
 Starting with a longer interval and shortening it as needed is better than starting short and dealing with notification noise.
+
+Part online and part offline triggers do not use this setting.
+They fire on every state transition, so you receive a notification each time the machine comes online or goes offline.
 
 ## Use the CLI
 

--- a/docs/reference/triggers.md
+++ b/docs/reference/triggers.md
@@ -38,13 +38,15 @@ The following template demonstrates the structure of a JSON configuration for a 
      "notifications": [
       {
         "type": "<webhook|email|push>",
-        "value": "<webhook URL, email address, or all_machine_owners>",
-        "seconds_between_notifications": <number of seconds>
+        "value": "<webhook URL, email address, or all_machine_owners>"
       }
      ]
   }
 ]
 ```
+
+Part status triggers fire on every state transition.
+Viam sends a notification each time the part comes online or goes offline, with no cooldown interval between notifications.
 
 ### Data sync trigger template
 
@@ -137,7 +139,7 @@ Triggers support the following attributes:
 | ---- | ---- | --------- | ----------- |
 | `name` | string | **Required** | The name of the trigger |
 | `event` | object | **Required** | The trigger event object, which contains the following fields: <ul><li>`type`: The type of the event to trigger on. Options: <ul><li>`part_data_ingested`: fire when data syncs</li> <li>`conditional_data_ingested`: fire when data that meets a certain condition syncs</li> <li>`part_online`: fire when the part is online</li> <li>`part_offline`: fire when the part is offline</li> <li>`conditional_logs_ingested`: check every hour and fire if logs of the specified log level are present</li></ul></li><li>`data_types`: Required with `type` `part_data_ingested`. An array of data types that trigger the event. Options: `binary`, `tabular`, `file`, `unspecified`. </li><li> `conditional`: Required when `type` is `conditional_data_ingested`. For more information about this field, see [Conditional attributes](/reference/triggers/#conditional-attributes). </li><li> `log_levels`: Required when `type` is `conditional_logs_ingested`. An array of log levels. Options: `error`, `warn`, `info`. </li></ul> |
-| `notifications` | object | **Required** | The notifications object, which contains the following fields: <ul><li>`type`: The type of the notification. Options: `webhook`, `email`, `push`</li><li>`value`: The URL to send the request to, the email address to notify, or `all_machine_owners` to notify all machine owners.</li><li>`seconds_between_notifications`: The interval between notifications in seconds. This field is ignored for event type `conditional_logs_ingested` where the interval is always one hour.</li><li>`application`: Required when `type` is `push`. The application ID for push notifications. Use `com.viam.viammobile` for the Viam mobile app, or provide your own custom application ID. To use a custom application ID, you must first upload your Firebase credentials to Viam with the [`organizations firebase-config set`](/cli/reference/#organizations-firebase-config-set) CLI command. For the full setup flow, see [Set up custom push notifications](/monitor/custom-push-notifications/).</li></ul> For more information on webhooks, see [Webhook attributes](#webhook-attributes). For push notifications, the recipient specified in `value` must be a machine owner or operator, and the recipient must have accepted push notification permissions for the application. |
+| `notifications` | object | **Required** | The notifications object, which contains the following fields: <ul><li>`type`: The type of the notification. Options: `webhook`, `email`, `push`</li><li>`value`: The URL to send the request to, the email address to notify, or `all_machine_owners` to notify all machine owners.</li><li>`seconds_between_notifications`: The interval between notifications in seconds. This field is ignored for `part_online` and `part_offline` triggers, which fire on every state transition. It is also ignored for `conditional_logs_ingested` triggers, where the check interval is always one hour.</li><li>`application`: Required when `type` is `push`. The application ID for push notifications. Use `com.viam.viammobile` for the Viam mobile app, or provide your own custom application ID. To use a custom application ID, you must first upload your Firebase credentials to Viam with the [`organizations firebase-config set`](/cli/reference/#organizations-firebase-config-set) CLI command. For the full setup flow, see [Set up custom push notifications](/monitor/custom-push-notifications/).</li></ul> For more information on webhooks, see [Webhook attributes](#webhook-attributes). For push notifications, the recipient specified in `value` must be a machine owner or operator, and the recipient must have accepted push notification permissions for the application. |
 | `notes` | string | Optional | Descriptive text to document the purpose, configuration details, or other important information about this trigger. |
 
 ## Conditional attributes

--- a/docs/reference/triggers.md
+++ b/docs/reference/triggers.md
@@ -46,7 +46,7 @@ The following template demonstrates the structure of a JSON configuration for a 
 ```
 
 Part status triggers fire on every state transition.
-Viam sends a notification each time the part comes online or goes offline, with no cooldown interval between notifications.
+Viam sends a notification each time the part comes online or goes offline.
 
 ### Data sync trigger template
 


### PR DESCRIPTION
Part online and part offline triggers now fire on every state transition with no cooldown interval. The `ENABLE_LIVENESS_TRIGGER_STATE_TRANSITION_NOTIFICATIONS` feature flag was removed in [app#12683](https://github.com/viamrobotics/app/pull/12683), making event-based liveness notifications the default behavior.

## Source changes

- viamrobotics/app#12683: Remove the `ENABLE_LIVENESS_TRIGGER_STATE_TRANSITION_NOTIFICATIONS` feature flag — liveness triggers are now always event-based with no cooldown

## Docs changes

- `docs/reference/triggers.md`: Removed `seconds_between_notifications` from the part status trigger template; added note that part status triggers fire on every state transition. Updated the attributes table to note the field is ignored for `part_online` and `part_offline`.
- `docs/monitor/alert.md`: Removed `seconds_between_notifications` from part online and part offline JSON examples; removed "set the alert frequency" from builder mode instructions (the UI hides the cooldown field for liveness triggers); updated "Manage alert frequency" section to clarify it applies to data triggers, not liveness triggers.
- `docs/data/trigger-on-data.md`: Updated the notification interval section to note `seconds_between_notifications` is ignored for liveness triggers.
- `docs/cli/reference.md`: Added `part_offline` to the event type list; removed `seconds_between_notifications` from the `part_online` CLI example.

## How I found these

- Grep matches: searched for `seconds_between_notifications`, `part_online`, `part_offline`, `liveness`, `cooldown`, and `state transition` across the entire docs repo. Found references in 5 files; 4 required updates.

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLP3YPPgRvxxiFZHrtWE1d)_