### PR TITLE
RSDK-14255: Remove AppImage/manual install-method step for 64-bit Linux setup

### DIFF
--- a/static/include/install/install-linux-aarch.md
+++ b/static/include/install/install-linux-aarch.md
@@ -13,10 +13,7 @@ Install `viam-server` on the computer or single-board computer (SBC) that is dir
 
 1. Select **Linux / Aarch64**.
 
-1. Select your installation method:
-
-   - `viam-agent` (recommended): installs viam-agent, which will automatically install (and update) viam-server **and** provide additional functionality such as [provisioning](/fleet/provision-devices/) and operating system update configuration.
-   - `manual`: installs only `viam-server` on your machine.
+   Viam installs [`viam-agent`](/reference/viam-agent/), which installs and automatically updates `viam-server` **and** provides additional functionality such as [provisioning](/fleet/provision-devices/) and operating system update configuration.
 
 1. Follow the instructions on the page to install `viam-server` and connect it to the cloud with your machine’s unique credentials.
 

--- a/static/include/install/install-linux.md
+++ b/static/include/install/install-linux.md
@@ -15,10 +15,7 @@ Install `viam-server` on the computer or single-board computer (SBC) that is dir
 
    On most Linux operating systems, you can run `uname -m` to confirm your computer's architecture.
 
-   If you selected **Linux / Aarch 64** or **Linux / x86** also select your installation method:
-
-   - `viam-agent` (recommended): installs viam-agent, which will automatically install (and update) viam-server **and** provide additional functionality such as [provisioning](/fleet/provision-devices/) and operating system update configuration.
-   - `manual`: installs only `viam-server` on your machine.
+   For **Linux / Aarch64** and **Linux / x86_64**, Viam installs [`viam-agent`](/reference/viam-agent/), which installs and automatically updates `viam-server` **and** provides additional functionality such as [provisioning](/fleet/provision-devices/) and operating system update configuration.
 
 1. Follow the instructions on the page to install `viam-server` and connect it to the cloud with your machine’s unique credentials.
 


### PR DESCRIPTION
## What

Updates the Linux setup instructions to match [viamrobotics/app#12758](https://github.com/viamrobotics/app/pull/12758) ([RSDK-14255](https://viam.atlassian.net/browse/RSDK-14255)), which removes the **AppImage** ("manual") install option for the two **64-bit Linux** platforms (`Linux / Aarch64` and `Linux / x86_64`) on the machine setup page. `viam-agent` is now the only, forced install path for those platforms.

After that change, **every** platform in the setup UI has exactly one install option (aarch64/x86_64 → viam-agent; armv7l/Mac/Windows → manual), so the **"Installation method" dropdown no longer renders for anyone**. The docs still instructed users to pick viam-agent vs. manual for 64-bit Linux, which no longer exists.

## Changes

- `static/include/install/install-linux.md` — removed the "also select your installation method (viam-agent / manual)" sub-step; now states that Viam installs `viam-agent` for Aarch64 and x86_64. (Also drops the stale `Aarch 64`/`x86` typos.)
- `static/include/install/install-linux-aarch.md` — removed the "Select your installation method" step; Aarch64 now installs `viam-agent` directly.

Both files render on the "Set up a computer or SBC" install flow and in device-setup guides that `readfile` these includes.

## Deliberately NOT changed (flagging for review)

- **`docs/reference/viam-server.md`** — the "Install `viam-server` without the web UI" section still documents an **"Install manually" AppImage tab for Linux (Aarch64/x86_64)**. app#12758 is frontend-only and the manual `curl … --aix-install` CLI path still works (RDK still builds/publishes AppImages), so these are intentionally left. They should be revisited when the RDK-side AppImage build/publish is removed.
- **`static/include/install/architectures.md`** — the AppImage `curl … --aix-install` snippet for 64-bit; now unreachable from the setup flow but still valid for the CLI path / Armv7l. Left for the same follow-up.
- **`docs/monitor/common-errors.md`** (FUSE / `libfuse.so.2`) and the aarch64 device-setup guides' AppImage `wget` fallbacks — still relevant while AppImage exists for Armv7l and the manual CLI path; part of the broader AppImage-deprecation cleanup, not this step.

## Scope

64-bit Linux setup instructions only. Armv7l (32-bit ARM), Mac, Windows, and WSL are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSDK-14255]: https://viam.atlassian.net/browse/RSDK-14255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ