### PR TITLE
Update Windows native install to use one-liner command

### DIFF
--- a/docs/reference/viam-server.md
+++ b/docs/reference/viam-server.md
@@ -398,10 +398,12 @@ curl https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-serv
 {{% /tab %}}
 {{% tab name="Windows native" %}}
 
-To install `viam-agent` on native Windows, open **Command Prompt as administrator** and run the following command, replacing `<KEY_ID>`, `<KEY>`, and `<CONFIG_URL>` with the values from your machine's **CONNECT** tab in the [Viam app](https://app.viam.com):
+To install `viam-agent` on native Windows, open **Command Prompt as administrator** and run the following command.
+Replace `<KEY_ID>` and `<KEY>` with an [API key](/organization/api-keys/) that can access your machine, and `<PART_ID>` with your machine part's ID.
+To copy the part ID, click the **Live** / **Offline** status dropdown at the top of your machine's page, then click **Part ID**.
 
 ```bat {class="line-numbers linkable-line-numbers"}
-mkdir C:\etc 2>nul & curl -fsSL -H "key_id:<KEY_ID>" -H "key:<KEY>" "<CONFIG_URL>" -o C:\etc\viam.json && curl -fsSL "https://storage.googleapis.com/packages.viam.com/apps/viam-agent/viam-agent-stable-windows-x86_64.msi" -o "%TEMP%\viam-agent.msi" && msiexec /i "%TEMP%\viam-agent.msi" /qn /norestart
+mkdir C:\etc 2>nul & curl -fsSL -H "key_id:<KEY_ID>" -H "key:<KEY>" "https://app.viam.com/api/json1/config?id=<PART_ID>&client=true" -o C:\etc\viam.json && curl -fsSL "https://storage.googleapis.com/packages.viam.com/apps/viam-agent/viam-agent-stable-windows-x86_64.msi" -o "%TEMP%\viam-agent.msi" && msiexec /i "%TEMP%\viam-agent.msi" /qn /norestart
 ```
 
 This command fetches the machine configuration, downloads the installer, and installs `viam-agent` silently.

--- a/docs/reference/viam-server.md
+++ b/docs/reference/viam-server.md
@@ -398,7 +398,14 @@ curl https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-serv
 {{% /tab %}}
 {{% tab name="Windows native" %}}
 
-Manual installation is not available for native Windows; you must download the [Viam Agent installer](https://storage.googleapis.com/packages.viam.com/apps/viam-agent/viam-agent-stable-windows-x86_64.msi) and follow the on-screen instructions to complete the installation.
+To install `viam-agent` on native Windows, open **Command Prompt as administrator** and run the following command, replacing `<KEY_ID>`, `<KEY>`, and `<CONFIG_URL>` with the values from your machine's **CONNECT** tab in the [Viam app](https://app.viam.com):
+
+```bat {class="line-numbers linkable-line-numbers"}
+mkdir C:\etc 2>nul & curl -fsSL -H "key_id:<KEY_ID>" -H "key:<KEY>" "<CONFIG_URL>" -o C:\etc\viam.json && curl -fsSL "https://storage.googleapis.com/packages.viam.com/apps/viam-agent/viam-agent-stable-windows-x86_64.msi" -o "%TEMP%\viam-agent.msi" && msiexec /i "%TEMP%\viam-agent.msi" /qn /norestart
+```
+
+This command fetches the machine configuration, downloads the installer, and installs `viam-agent` silently.
+Use Cmd, not PowerShell.
 
 The `viam-agent` and `viam-server` binaries are installed at <FILE>C:\opt\viam\cache</FILE>.
 


### PR DESCRIPTION
The Viam app now generates a single Command Prompt one-liner for Windows viam-agent installation instead of directing users to download the MSI and click through the wizard (viamrobotics/app#12694, merged 2026-07-14).

The old docs said "download the Viam Agent installer and follow the on-screen instructions to complete the installation." The app UI no longer shows that flow — it now shows a single copy-paste command that fetches the machine config, downloads the MSI, and installs silently with `msiexec /qn /norestart`.

This PR updates `docs/reference/viam-server.md` to match the new app behavior: the Windows native tab now shows the one-liner command with placeholder credentials, matching the Linux install experience.

## Source changes

- viamrobotics/app#12694: Make the viam-agent Windows install instructions a one-liner

## Docs changes

- `docs/reference/viam-server.md`: Replace "download the installer and follow on-screen instructions" with the actual one-liner command (mkdir, curl config, curl MSI, msiexec silent install). Note that Command Prompt must be run as administrator, and Cmd (not PowerShell) must be used.

## How I found these

- Xref lookup: `maintenance.md` staleness detection table for `app/ui/src/` changes
- Grep matches: searched for `viam-agent-stable-windows`, `mkdir.*\\etc`, `Download.*installer`, `Command Prompt` across the entire docs repo. Only one page (`viam-server.md` line 401) referenced the old install flow.

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCPjBhmwapYtVuNM36gNp1)_