### PR TITLE
Document minimum viam-server version for modules

### DIFF
--- a/docs/build-modules/manage-modules.md
+++ b/docs/build-modules/manage-modules.md
@@ -21,7 +21,7 @@ date: "2024-06-30"
 cost: "0"
 ---
 
-After you [create and upload a module](/build-modules/write-a-driver-module/), you can release new versions, pin machines to a specific version, change visibility, deprecate, or delete the module.
+After you [create and upload a module](/build-modules/write-a-driver-module/), you can release new versions, pin machines to a specific version, set a minimum `viam-server` version, change visibility, deprecate, or delete the module.
 
 ## Update a module
 
@@ -322,6 +322,39 @@ To pin a machine to a specific version:
 1. Find the module in the configuration.
 1. Set the **Version** field to a specific version (for example, `0.1.0`).
 1. Click **Save**.
+
+## Set a minimum viam-server version
+
+Some module versions rely on `viam-server` features that older servers lack.
+To warn machine builders before they reach a runtime failure, set the minimum `viam-server` version your module needs.
+Machines running an older server then show a compatibility warning wherever your module is configured or added.
+
+This requirement is advisory: it warns machine builders while still allowing them to add and run the module.
+
+To set the minimum version (module owners only):
+
+1. Navigate to your module's page in the [registry](https://app.viam.com/registry).
+2. In the right-hand sidebar, click the pencil icon next to the minimum `viam-server` version.
+3. Enter the full version your module needs, in `x.y.z` form (for example, `0.62.0`).
+   The field requires a valid `x.y.z` version, so **Save** stays disabled until the value parses.
+4. Click **Save**.
+
+To clear the requirement, open the same field, remove the value, and save the empty input.
+
+The requirement is stamped onto your module's current latest version and applied to the versions you publish next.
+Each new version inherits the minimum in effect when you publish it, and you can change the minimum for that version afterward.
+Earlier versions keep the minimum they were stamped with.
+The **Version history** on your module's page shows the value each version carries, so you can see which versions require which server version.
+
+### Resolve a compatibility warning
+
+When a machine runs a `viam-server` older than a configured module requires, the machine builder sees a compatibility warning in two places:
+
+- On the configured module's card in the machine config, which compares the deployed version's requirement against the running server.
+- In the add-module search preview, which compares the module's current requirement against the running server.
+
+The warning names the version the module requires and the version the machine reports running.
+To resolve it, either upgrade `viam-server` on the machine to that version or newer, or [pin the module](#pin-a-module-to-a-specific-version) to a version whose requirement the machine already meets.
 
 ## Auto-detect models with `update-models`
 


### PR DESCRIPTION
Closes #5205.

Documents the new **minimum viam-server version for modules** feature (announced 2026-07-14) as additive edits to the module-owner how-to page.

## What changed

- `docs/build-modules/manage-modules.md`:
  - New `## Set a minimum viam-server version` section: how a module owner sets the minimum from the registry page (right-hand sidebar, pencil-icon edit modal, owners only), how the requirement is stamped per published version and inherited by future publishes, and how to clear it.
  - New `### Resolve a compatibility warning` subsection: where the advisory banner appears (configured module's card and the add-module search preview) and how a machine builder resolves it (upgrade `viam-server` or pin a compatible module version).
  - Intro sentence updated to list the new capability.

## Source

- viamrobotics/app#12725 — registry-page edit/display of min `viam-server` version.
- viamrobotics/app#12731 — machine-config compatibility banners.

## Notes for reviewers

- **UI-only, no `meta.json` field.** Neither source PR exposes a `meta.json` key or CLI flag; the setting writes through the existing `UpdateRegistryItem` flow from the registry page. The live schema at `https://dl.viam.dev/module.schema.json` has no min/server/version field. `docs/build-modules/module-reference.md` is intentionally left untouched.
- **Advisory only** — the banner warns; it does not block adding or running a module.
- Existing `docs/reference/viam-agent.md` "viam-server version" mentions are about the agent choosing a server binary, a different topic; there was no prior owner for this content.