### PR TITLE
Document the C++ cloud build image

### DIFF
--- a/docs/cli/build-and-deploy-modules.md
+++ b/docs/cli/build-and-deploy-modules.md
@@ -145,6 +145,12 @@ viam module upload --version=1.0.0 --platform=linux/arm64 dist/archive-arm64.tar
 
 For CI/CD workflows, use cloud builds to compile your module on Viam's build infrastructure.
 
+{{% alert title="C++ build environment" color="note" %}}
+On Linux, cloud builds compile C++ modules in a Debian-based environment, the same one that builds the Viam {{< glossary_tooltip term_id="rdk" text="RDK" >}}.
+To match this environment locally and add any libraries your module needs, install build dependencies with `apt-get` in your module's setup step.
+The [C++ example module](https://github.com/viamrobotics/module-example-cpp) follows this pattern in its `apt-setup.sh` script.
+{{% /alert %}}
+
 Start a cloud build:
 
 ```sh {class="command-line" data-prompt="$"}


### PR DESCRIPTION
Closes #5208.

Adds a small reference note to the **Cloud builds** section of `docs/cli/build-and-deploy-modules.md` documenting the environment Viam cloud build uses to compile C++ modules, and how a developer can match it locally.

## Image detail: documented conservatively (did not assert "Debian Bookworm")

The issue's premise is that C++ cloud builds run on a **Debian Bookworm** image. I could not confirm that exact codename from source, and one of the issue's own cited sources points the other way, so the note documents only the verifiable Debian fact:

- The authoritative source for what cloud build actually runs is the build action's "Environment and base image" section, which deliberately does **not** name a Debian version: Linux builds use "the same Debian layer that builds our golang RDK" (`viamrobotics/build-action` `README.md`). That layer is the `rdk-devenv` image, which upstream treats as a moving target (`.canon.yaml` `update_interval`), so pinning a codename in docs would go stale and be less accurate than the source's own contract.
- `viamrobotics/viam-cpp-sdk#548` generated the cloud-build lockfile from "the macos and **bookworm** jobs".
- But `viamrobotics/viam-cpp-sdk#616` (merged 2026-04-20, after the 2026-04-03 announcement) is titled "fix **bullseye** cloud build", and the SDK is published for both Debian Bullseye and Bookworm. So a single "Bookworm" assertion is contradicted by the source.
- The only artifact literally named "bookworm", `cli/module_generate/cpp-gen/Dockerfile.debian.bookworm`, is (per its README) the dev container for the stub-**generator tool** (`cl_gen`), not the module cloud-build image. This is a likely (inference, low confidence) origin of the issue's Bookworm claim.

The verified user-facing pattern is confirmed by the canonical `viamrobotics/module-example-cpp` example: its `meta.json` build `setup` runs `make setup` → `apt-setup.sh`, installing dependencies with `apt-get` on a Debian environment. The note points readers there.

## Placement

Additive note in the existing `## Cloud builds` section. No new page, no moves/renames/URL changes.

## Checks

- `prettier --write`: clean (unchanged).
- `markdownlint`: pass.
- `vale --minAlertLevel suggestion`: no errors/warnings on the added lines (only pre-existing suggestions elsewhere on the page); RDK abbreviation resolved with a glossary tooltip.
