### PR TITLE
CLI install: add brew trust step for third-party tap

### DIFF
--- a/docs/reference/viam-server.md
+++ b/docs/reference/viam-server.md
@@ -379,7 +379,7 @@ The `viam-agent` and `viam-server` binaries are installed at <FILE>/opt/viam/bin
 {{% tab name="macOS" %}}
 
 ```bash {class="line-numbers linkable-line-numbers"}
-brew tap viamrobotics/brews && brew install viam-server
+brew tap viamrobotics/brews && brew trust viamrobotics/brews && brew install viam-server
 ```
 
 The `viam-server` binary is installed at <FILE>/opt/homebrew/bin/viam-server</FILE>.

--- a/docs/try/part-3.md
+++ b/docs/try/part-3.md
@@ -46,6 +46,7 @@ The Viam CLI is used for authentication, module generation, and deployment.
 
 ```bash
 brew tap viamrobotics/brews
+brew trust viamrobotics/brews
 brew install viam
 ```
 

--- a/static/include/how-to/install-cli.md
+++ b/static/include/how-to/install-cli.md
@@ -5,6 +5,7 @@ To download the Viam CLI on a macOS computer, install [brew](https://brew.sh/) a
 
 ```sh {class="command-line" data-prompt="$"}
 brew tap viamrobotics/brews
+brew trust viamrobotics/brews
 brew install viam
 ```
 
@@ -32,6 +33,7 @@ You can also install the Viam CLI using [brew](https://brew.sh/) on Linux `amd64
 
 ```sh {class="command-line" data-prompt="$"}
 brew tap viamrobotics/brews
+brew trust viamrobotics/brews
 brew install viam
 ```
 


### PR DESCRIPTION
## What

Adds `brew trust viamrobotics/brews` to the Homebrew install steps in the shared CLI install include (`static/include/how-to/install-cli.md`), which renders on the [CLI overview page](/cli/overview/) and every other page that reads it.

## Why

Homebrew now requires third-party taps to be explicitly trusted before any of their formulae will load. The currently-documented sequence:

```sh
brew tap viamrobotics/brews
brew install viam
```

fails on an up-to-date Homebrew with:

```
Error: Refusing to load formula viamrobotics/brews/viam from untrusted tap viamrobotics/brews.
```

Trusting only the `viam` formula (`brew trust --formula viamrobotics/brews/viam`, which the error message suggests) is not enough — the install still fails on a dependency pulled from the same tap. Trusting the whole tap is what works.

## Change

Insert `brew trust viamrobotics/brews` between the tap and install steps, in both Homebrew blocks (the **macOS** tab and the **Linux x86_64** tab):

```sh
brew tap viamrobotics/brews
brew trust viamrobotics/brews
brew install viam
```

The Linux `curl`, Windows, and source-build tabs are unaffected.

## Notes

- Draft — flagging for docs-team review of wording/placement.
- Editing the shared include is the single-source fix; no per-page edits needed.
- Verified against a real failed-then-fixed install on macOS (Homebrew tap-trust gate).
