### PR TITLE
Add brew trust to the brew install commands outside the shared CLI include

### DIFF
--- a/docs/reference/viam-server.md
+++ b/docs/reference/viam-server.md
@@ -379,7 +379,7 @@ The `viam-agent` and `viam-server` binaries are installed at <FILE>/opt/viam/bin
 {{% tab name="macOS" %}}
 
 ```bash {class="line-numbers linkable-line-numbers"}
-brew tap viamrobotics/brews && brew install viam-server
+brew tap viamrobotics/brews && brew trust viamrobotics/brews && brew install viam-server
 ```
 
 The `viam-server` binary is installed at <FILE>/opt/homebrew/bin/viam-server</FILE>.

--- a/docs/try/part-3.md
+++ b/docs/try/part-3.md
@@ -46,6 +46,7 @@ The Viam CLI is used for authentication, module generation, and deployment.
 
 ```bash
 brew tap viamrobotics/brews
+brew trust viamrobotics/brews
 brew install viam
 ```
 


### PR DESCRIPTION
## What

Adds `brew trust viamrobotics/brews` to the two brew install command blocks that live outside the shared CLI install include:

- `docs/try/part-3.md`: the macOS tab inlines its own copy of the CLI install commands instead of reading `static/include/how-to/install-cli.md`.
- `docs/reference/viam-server.md`: the macOS `viam-server` one-liner uses the same tap, so it hits the same trust gate. It becomes `brew tap viamrobotics/brews && brew trust viamrobotics/brews && brew install viam-server`.

## Why

Homebrew 6.0 made [tap trust](https://docs.brew.sh/Tap-Trust) mandatory: formulae from a third-party tap refuse to load until the user trusts the tap, so the documented tap-then-install sequence fails with `Refusing to load formula viamrobotics/brews/viam from untrusted tap`. Trusting only the formula also fails, because the `viam` formula depends on `nlopt-static` from the same tap. Full failure log and affected-page inventory: #5215.

## Relationship to #5214

#5214 (nathartman) fixes the shared include, which covers the CLI overview page and the four other pages that embed it. This PR covers the two remaining brew blocks that bypass the include. Together the two PRs close #5215; neither is complete alone.

Part of #5215.

## Verification

prettier, markdownlint, vale (0 errors), and `make build-prod` all pass.
