### PR TITLE
Document motion service error for disconnected frame systems

### DIFF
--- a/docs/motion-planning/debug-motion-with-cli.md
+++ b/docs/motion-planning/debug-motion-with-cli.md
@@ -174,6 +174,37 @@ interpreted in an unexpected reference frame. Double-check the
 `reference_frame` on the target `PoseInFrame`: the same `(x, y, z)` in
 the arm's frame and in the world frame describes two different places.
 
+## Symptom: "Some frames are not linked to the world frame"
+
+The motion service refuses to plan if any frame in your configuration is
+not connected to the world frame through its parent chain. This happens
+when you rename a component without updating the `parent` field on
+components that were attached to it.
+
+### 1. Find the unlinked parts
+
+The error message lists which parts are unlinked. Run `print-config` to
+see each part's declared parent:
+
+```sh
+viam machines part motion print-config --part "my-machine-main"
+```
+
+Look for parts whose parent names do not match any other part in the
+output. A typo, a stale reference to a deleted or renamed component, or
+a circular reference all produce this error.
+
+### 2. Fix the parent references
+
+In the [Viam app](https://app.viam.com), open the **CONFIGURE** tab.
+Find each unlinked component's **Frame** configuration and correct the
+`parent` field so it references an existing component or `"world"`.
+
+### 3. Verify
+
+After saving the configuration, run `print-config` again and confirm
+every part traces back to the world frame. Then retry your motion call.
+
 ## Limitations
 
 - **Internal RPC is deprecated but the CLI output is not.**

--- a/docs/motion-planning/how-planning-works.md
+++ b/docs/motion-planning/how-planning-works.md
@@ -132,21 +132,29 @@ and may cause execution-time errors even after planning succeeds.
 The planner returns an error if it cannot find a path within the
 planning timeout (300 seconds by default). Common causes:
 
-1. **Constraints are too tight.** A linear or orientation tolerance below
+1. **Frames are not linked to the world frame.** If any configured frame
+   has a parent that does not exist or creates an orphaned subtree
+   disconnected from the world frame, the motion service returns an
+   error listing the unlinked parts. Fix the frame configuration so
+   every component traces back to the world frame through its parent
+   chain. This commonly happens when you rename a component (such as an
+   arm) without updating the `parent` field on components attached to
+   it (such as a gripper or camera).
+2. **Constraints are too tight.** A linear or orientation tolerance below
    a few millimeters or a few degrees can make the constrained space too
    small for the algorithm to explore. Start with larger tolerances and
    tighten only as needed.
-2. **Obstacles leave no room.** Oversized obstacle geometries close off
+3. **Obstacles leave no room.** Oversized obstacle geometries close off
    valid corridors. Try smaller geometries or remove temporarily to
    isolate the problem.
-3. **Joint limits are more restrictive than you expect.** Check the
+4. **Joint limits are more restrictive than you expect.** Check the
    kinematics file: the planner only explores configurations inside the
    declared limits.
-4. **The destination is inside an obstacle or outside the arm's reach.**
+5. **The destination is inside an obstacle or outside the arm's reach.**
    Use `GetEndPosition` on the arm to read its current pose, then try a
    simpler target close to the current position to isolate whether the
    planner works at all.
-5. **Multiple IK solutions exist but the one the planner picks is bad.**
+6. **Multiple IK solutions exist but the one the planner picks is bad.**
    The planner prefers the IK solution with the least joint travel, but
    when the fallback runs, cBiRRT returns the first feasible path it
    finds. For some Cartesian targets it routes through a wrist flip or


### PR DESCRIPTION
The motion service now rejects all planning requests (Move, MoveOnGlobe, MoveOnMap, etc.) when the machine's frame system has parts that are not connected to the world frame. Previously, orphaned frames were silently ignored, which could lead to collisions. This PR documents the new error so users can diagnose and fix it.

## Source changes

- viamrobotics/rdk#6240: Disallow motion service API calls when the frame system is disconnected. Adds `NewFromServiceMustBeConnected` which returns an error listing unlinked parts if any frame's parent chain does not reach the world frame.

## Docs changes

- `docs/motion-planning/how-planning-works.md`: Added "Frames are not linked to the world frame" as item 1 in the "When planning fails" list, with explanation and fix guidance.
- `docs/motion-planning/debug-motion-with-cli.md`: Added a new troubleshooting section for the specific error message, with steps to identify and fix unlinked frame parents.

## How I found these

- Xref lookup: `flows.md` lists motion planning behavioral paths; `maintenance.md` staleness table maps `rdk/services/motion/` changes to motion planning docs.
- Grep matches: searched for "frame system", "world frame", "disconnected", "orphan", "unlinked" across all docs. Found 62 pages referencing frame system, narrowed to the two most relevant for documenting this new error condition.

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJk1PPu5KzH57qUvND5bi)_