### PR TITLE
Split alias reminder into unprivileged check + workflow_run commenter

### DIFF
--- a/.github/workflows/alias-check.yml
+++ b/.github/workflows/alias-check.yml
@@ -1,0 +1,37 @@
+name: Alias check
+
+# Unprivileged half of the alias reminder: runs fork code under plain
+# pull_request (no secrets, read-only token), records renamed .md files as an
+# artifact. alias-reminder.yml posts the PR comment from that artifact.
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  check:
+    name: Check for moved files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        # actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+      - name: Check for moved files
+        shell: pwsh
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          $diff = git diff -M --find-renames=10 --summary $env:BASE_SHA
+          $SourceDiff = $diff | Where-Object { $_ -match 'rename.*.md.*$' }
+          $SourceDiff | Set-Content files.txt
+          $env:PR_NUMBER | Set-Content pr-number.txt
+      - name: Upload results
+        # actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: alias-check-results
+          path: |
+            files.txt
+            pr-number.txt

--- a/.github/workflows/alias-reminder.yml
+++ b/.github/workflows/alias-reminder.yml
@@ -1,36 +1,56 @@
 name: Alias reminder
 
+# Privileged half of the alias reminder: alias-check.yml diffs the PR without
+# secrets and uploads its findings; this workflow only reads that artifact and
+# posts the sticky comment. Fork code never runs with secrets in scope.
 on:
-  pull_request_target:
-    branches: [ main ]
-    types: [ labeled, synchronize ]
+  workflow_run:
+    workflows: [ "Alias check" ]
+    types: [ completed ]
+
+permissions:
+  actions: read  # download the artifact from the triggering run
 
 jobs:
-    alias_reminder:
-        name: Check for moved files
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3
-              with:
-                  ref: ${{github.event.pull_request.head.sha}}
-                  fetch-depth: 0
-            - name: Check for moved files
-              shell: pwsh
-              id: check_files_moved
-              run: |
-                $diff = git diff -M --find-renames=10 --summary ${{github.event.pull_request.base.sha}}
-                $SourceDiff = $diff | Where-Object { $_ -match 'rename.*.md.*$' }
-                $HasDiff = $SourceDiff.Length -gt 0
-
-                Write-Host "::set-output name=files_moved::$HasDiff"
-                Write-Host "::set-output name=files::$SourceDiff"
-            - name: Comment on PR with changed files
-              if: steps.check_files_moved.outputs.files_moved == 'True'
-              uses: marocchino/sticky-pull-request-comment@v2.2.0
-              with:
-                recreate: true
-                message: |
-                  It looks like the following files may have been renamed. Please ensure you set all needed aliases:
-                  ${{ steps.check_files_moved.outputs.files }}
-                GITHUB_TOKEN: ${{ secrets.PR_TOKEN }}
+  comment:
+    name: Comment on PR with changed files
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download check results
+        # actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: alias-check-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Read results
+        id: results
+        shell: bash
+        # Artifact content is PR-author-controlled: take only digits for the PR
+        # number and fence the file list so names cannot inject markdown.
+        run: |
+          pr=$(tr -cd '0-9' < pr-number.txt)
+          if [ -z "$pr" ]; then
+            echo "no PR number in artifact; skipping"
+            exit 0
+          fi
+          echo "pr=$pr" >> "$GITHUB_OUTPUT"
+          if [ -s files.txt ]; then
+            echo "moved=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "It looks like the following files may have been renamed. Please ensure you set all needed aliases:"
+              echo '```'
+              cat files.txt
+              echo '```'
+            } > body.md
+          fi
+      - name: Comment on PR
+        if: steps.results.outputs.moved == 'true'
+        # marocchino/sticky-pull-request-comment@v3.0.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
+        with:
+          recreate: true
+          number: ${{ steps.results.outputs.pr }}
+          path: body.md
+          GITHUB_TOKEN: ${{ secrets.PR_TOKEN }}


### PR DESCRIPTION
alias-reminder.yml ran on every fork PR push under `pull_request_target` with no gate, holding repo secrets (including the org `PR_TOKEN`) while checking out the PR head. Nothing executed the fork code — the concrete exposure was only filename injection into the bot comment — but the workflow was one added build/lint step away from running untrusted code with secrets in scope, and it bypassed the `safe to build` gating the rest of the repo uses.

This splits it into the standard `workflow_run` pair:

- **alias-check.yml** (new, unprivileged): runs the rename diff under plain `pull_request`, where fork runs get no secrets and a read-only token, and uploads the result as an artifact.
- **alias-reminder.yml** (rewritten, privileged): triggers on `workflow_run`, downloads the artifact, and posts the sticky comment with `PR_TOKEN`. Artifact content is treated as untrusted: the PR number is reduced to digits and the file list is fenced in the comment body so names cannot inject markdown or workflow commands.

Behavior changes: the check now also runs on PR open (before it ran only on label/synchronize), the deprecated `::set-output` syntax is gone (it stopped working in mid-2023, so the comment may not have fired in a while — worth confirming), and actions are pinned to commit SHAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)