### PR TITLE
[Claude CI Failure] Fix TypeScript SDK coverage parser crash on non-element ul children

### DIFF
--- a/.github/workflows/parse_typescript.py
+++ b/.github/workflows/parse_typescript.py
@@ -138,7 +138,7 @@ class TypeScriptParser:
                 param_object = {}
                 if method.find('div', class_="tsd-parameters"):
                     parameters = method.find('div', class_="tsd-parameters")
-                    parameter_list = parameters.find('ul', class_="tsd-parameter-list").children
+                    parameter_list = parameters.find('ul', class_="tsd-parameter-list").find_all('li', recursive=False)
 
                     for param in parameter_list:
                         param_name = param.find('span', class_="tsd-kind-parameter").text


### PR DESCRIPTION
## What

The **SDK method coverage** job (`check-methods.yml`, issue #5142) has been crashing since run [29912891858](https://github.com/viamrobotics/docs/actions/runs/29912891858) (2026-07-22) with:

```
File ".../parse_typescript.py", line 144, in parse
    param_name = param.find('span', class_="tsd-kind-parameter").text
TypeError: find() takes no keyword arguments
```

`.github/workflows/parse_typescript.py:141` built `parameter_list` from `parameters.find('ul', class_="tsd-parameter-list").children`, which iterates **all** child nodes of the `<ul>`, including whitespace-only `NavigableString` text nodes between `<li>` elements — not just the `<li>` tags. When one of those text nodes reaches `param.find('span', class_=...)`, it resolves to Python's built-in `str.find()` (which doesn't accept keyword arguments) instead of `Tag.find()`, raising the `TypeError` and crashing the entire coverage script before it can check any TypeScript SDK methods.

## Root cause verification

I ruled out the dependency-drift theory before fixing anything:

- Run [29408480993](https://github.com/viamrobotics/docs/actions/runs/29408480993) (2026-07-15) installed the **exact same** `beautifulsoup4==4.15.0` (confirmed via job logs: `Successfully installed argparse-1.4.0 beautifulsoup4-4.15.0 markdownify-1.2.3 ...`) and completed the full TypeScript parse successfully (only failing afterward on the pre-existing "unused SDK method" warnings backlog tracked separately in #5142).
- So the crash isn't from an unpinned-dependency version bump — it's this pre-existing fragility in `parse_typescript.py`, most likely triggered by an incidental whitespace change in the upstream `ts.viam.dev` (typedoc-generated) HTML between 7/15 and 7/22.

## Fix

Changed `.children` to `.find_all('li', recursive=False)` (`parse_typescript.py:141`) so only `<li>` element children are iterated, matching the original code's intent without picking up incidental whitespace text nodes. Verified locally against mock HTML containing both `<li>` elements and whitespace between them — the fix correctly returns only the 2 `<li>` elements where `.children` would have yielded whitespace `NavigableString`s too.

## Out of scope

This fixes the **crash** so the coverage script can run to completion again. It does **not** fix the underlying "unused SDK method" warnings backlog (~110 warnings) that the job has been failing on since before this crash — that's a domain-owner CSV-mapping decision already being chipped away at by #5184, #5186, #5187, and #5193. Since the job will likely still fail on those warnings after this crash fix, using `Refs #5142` rather than `Fixes #5142`.

## Verification

- `python3 -m py_compile .github/workflows/parse_typescript.py` — passes
- Local reproduction with mock HTML (`<ul class="tsd-parameter-list">` containing `<li>` elements separated by whitespace) confirms `find_all('li', recursive=False)` returns only the element children
- This file isn't covered by the docs `prettier`/`markdownlint`/`vale` pre-PR checks (those target `docs/**/*.md`) or by `python-lint.yml` (that lints Python *snippets embedded in markdown*, not `.github/workflows/*.py` scripts) — no formal linter governs this file
- Full `make coveragetest` couldn't be run end-to-end in this sandbox (network policy blocks `ts.viam.dev`)

Refs #5142

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmzC5WSPTNL1QhSswUW6Gf)_