### PR TITLE
Add tf:2.21 to supported training container versions

### DIFF
--- a/docs/train/custom-training-scripts.md
+++ b/docs/train/custom-training-scripts.md
@@ -282,7 +282,7 @@ Once a training script is in the registry, whether you uploaded it or are using 
 
 Every custom training job runs inside a Viam-hosted container on GPU-backed
 cloud infrastructure. Containers are based on Python 3.10 with TensorFlow
-pre-installed. The currently supported versions are `tf:2.16` and `tf:2.17`.
+pre-installed. The currently supported versions are `tf:2.16`, `tf:2.17`, and `tf:2.21`.
 To use a different framework (PyTorch, scikit-learn, or anything installable
 with pip), add it to the `install_requires` list in `setup.py`; Viam
 installs the packages in the container before running your script.


### PR DESCRIPTION
## Source changes

- viamrobotics/app#12592: Training OCI - adds TF 2.21 self-built container and container catalog system

## Docs changes

- `docs/train/custom-training-scripts.md`: Added `tf:2.21` to the list of supported container versions

## How I found these

- Container catalog code change detected in daily diff of viamrobotics/app
- Grep for "tf:2.16" and "tf:2.17" and "container" across all docs pages

---
Generated by daily docs change agent

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QSjgt2GsnUNHBC9DtXah88


---
_Generated by [Claude Code](https://claude.ai/code/session_01QSjgt2GsnUNHBC9DtXah88)_