### PR TITLE
[Claude CI Failure] Fix broken /dev/reference/apis/* redirects for removed/renamed API pages

### DIFF
--- a/docs/reference/apis/_index.md
+++ b/docs/reference/apis/_index.md
@@ -11,11 +11,6 @@ aliases:
   - /program/apis/
   - /build/program/apis/
   - /appendix/apis/
-  - /reference/apis/services/SLAM/
-  - /reference/apis/services/slam/
-  - /dev/reference/apis/services/SLAM/
-  - /dev/reference/apis/services/slam/
-  - /appendix/apis/services/slam/
 no_list: true
 date: "2024-10-01"
 # updated: ""  # When the content was last entirely checked

--- a/netlify.toml
+++ b/netlify.toml
@@ -298,6 +298,18 @@
   status = 301
 
 [[redirects]]
+  from = "/dev/reference/apis/services/slam/*"
+  to = "/motion-planning/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/dev/reference/apis/services/SLAM/*"
+  to = "/motion-planning/"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/dev/reference/apis/*"
   to = "/reference/apis/:splat"
   status = 301
@@ -562,6 +574,12 @@
 
 [[redirects]]
   from = "/reference/apis/services/slam/*"
+  to = "/motion-planning/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/reference/apis/services/SLAM/*"
   to = "/motion-planning/"
   status = 301
   force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -293,8 +293,13 @@
   status = 301
 
 [[redirects]]
+  from = "/dev/reference/apis/components/encode/*"
+  to = "/reference/apis/components/encoder/:splat"
+  status = 301
+
+[[redirects]]
   from = "/dev/reference/apis/*"
-  to = "/reference/apis/"
+  to = "/reference/apis/:splat"
   status = 301
 
 [[redirects]]
@@ -548,6 +553,24 @@
   from = "/mobility/slam/*"
   to = "/motion-planning/"
   status = 301
+
+[[redirects]]
+  from = "/reference/apis/services/slam/*"
+  to = "/motion-planning/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/reference/services/slam/*"
+  to = "/motion-planning/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/appendix/apis/services/slam/*"
+  to = "/motion-planning/"
+  status = 301
+  force = true
 
 # Old IA paths from previous site versions
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -328,6 +328,12 @@
   status = 301
 
 [[redirects]]
+  from = "/reference/services/slam/*"
+  to = "/motion-planning/"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/reference/services/*"
   to = "/reference/"
   status = 301
@@ -556,12 +562,6 @@
 
 [[redirects]]
   from = "/reference/apis/services/slam/*"
-  to = "/motion-planning/"
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "/reference/services/slam/*"
   to = "/motion-planning/"
   status = 301
   force = true


### PR DESCRIPTION
## What

The **Org docs-link check** job (`check-org-docs-links.yml`, issue #5170) scans `rdk`, `app`, `api`, `viam-python-sdk`, `viam-typescript-sdk`, and `viam-flutter-sdk` for `docs.viam.com` links and classifies each as broken / stale-redirect / broken-anchor. The latest run ([30193440177](https://github.com/viamrobotics/docs/actions/runs/30193440177), 2026-07-26) found **368** problems: **30 broken**, 321 stale-redirect, 17 broken-anchor.

I pulled the complete findings (job log + live per-URL classification output, not just the truncated issue-body summary) and root-caused all 30 "broken" entries to two bugs entirely on the docs.viam.com side:

1. **`/dev/reference/apis/*` → `/reference/apis/` redirect was missing `:splat`.** Every sub-path collapsed to the bare `/reference/apis/` index instead of the specific page. `components/generic`, `components/input-controller`, and `services/vision` all still exist as real pages (`docs/reference/apis/components/generic.md`, `input-controller.md`, `docs/reference/apis/services/vision.md`) — they just never got a working redirect. This alone accounts for 18 of the 30 broken findings.
2. **Removed SLAM API pages' aliases pointed at the same dead-end index**, instead of the motion-planning replacement content, unlike the existing SLAM redirect convention already present in `netlify.toml` for other removed SLAM URLs (`/operate/reference/services/slam/*`, `/services/slam/*`, `/mobility/slam/*` → `/motion-planning/`). Accounts for 11 of the 30.
3. **The `encode` component was renamed to `encoder`** with no redirect for the old slug (`viam-flutter-sdk/lib/src/components/encoder/encoder.dart:82` still links to `/dev/.../components/encode/`). Accounts for the last 1 of the 30.

## Fix (fixes 30 of 30 broken-link findings)

- `netlify.toml`: restore `:splat` on the `/dev/reference/apis/*` redirect.
- `netlify.toml`: add a redirect for the `encode` → `encoder` rename.
- `netlify.toml`: add 3 new SLAM redirects (`/reference/apis/services/slam/*`, `/reference/services/slam/*`, `/appendix/apis/services/slam/*` → `/motion-planning/`), matching the existing convention for other removed SLAM URLs in the same file.
- `docs/reference/apis/_index.md`: remove the now-redundant SLAM aliases that were producing the dead-end redirect (superseded by the netlify redirects above, which point at the correct destination instead of the generic index).

## Out of scope (left unchanged, with counts)

- **321 stale-redirect findings**: these already resolve correctly (e.g. `/dev/reference/apis/components/arm/` → `/reference/apis/components/arm/`) via existing Hugo alias stubs or (after this fix) the corrected splat redirect — the "fix" the checker wants is updating the *source* links in `viam-python-sdk`/`viam-typescript-sdk`/`viam-flutter-sdk`/`rdk`/`app`/`api` to use the canonical URL directly. This repo doesn't own those repos, so out of scope here.
- **17 broken-anchor findings**, both already-tracked, non-fixable-by-edit:
  - 8 are on `/reference/apis/fleet/` (`disablebillingservice`, `getbillingserviceconfig`, `listoauthapps`, `organizationgetlogo`, `organizationgetsupportemail`, `organizationsetlogo`, `organizationsetsupportemail`, `transferregistryitem`) — I confirmed these methods have no corresponding heading at all in the generated `static/include/app/apis/generated/app.md`, i.e. genuine SDK-coverage documentation gaps, the same `sdk_protos_map.csv`-backlog category already tracked and being chipped away at under #5142.
  - 9 are on `/reference/apis/services/navigation/` (`addwaypoint`, `getlocation`, `getmode`, `getobstacles`, `getpaths`, `getproperties`, `getwaypoints`, `removewaypoint`, `setmode`) — the Navigation service API page is now an intentional stub ("The navigation service API has been removed... see Motion service API") with no method-level content left to anchor to.

## Verification

- `npx prettier@3.2.5 --check docs/reference/apis/_index.md` — passes
- `npx markdownlint-cli --config .markdownlint.yaml docs/reference/apis/_index.md` — clean
- `vale docs/reference/apis/_index.md` — 0 errors/warnings/suggestions
- `make build-prod` — completes with only the expected old-page-date warnings, no errors
- Manually traced the redirect chains against `docs/reference/apis/*` and `docs/motion-planning/` page structure to confirm every new/changed redirect target is a real, existing page before pointing anything at it

Refs #5170 (the stale-redirect and broken-anchor categories above remain open items requiring other-repo edits or a coverage-gap decision, so this does not fully resolve what the job checks).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmizpnLCuiEdjBtxySS2dR)_