### PR TITLE
Update os_auto_upgrade_type default to managed-security

### DIFF
--- a/docs/fleet/system-settings.md
+++ b/docs/fleet/system-settings.md
@@ -112,14 +112,14 @@ Control automatic operating system package updates on the machine.
 
 In the machine settings card, open **Settings** and expand **System**. Set `os_auto_upgrade_type`:
 
-| Value                                                       | Description                                                                                                                                  |
-| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `"all"`                                                     | Install all available OS package updates using the OS's built-in upgrade schedule. Debian only.                                              |
-| `"security"`                                                | Install security updates only using the OS's built-in upgrade schedule. Debian only.                                                         |
-| <code style="white-space: nowrap">"managed-all"</code>      | Install all available OS package updates on a schedule controlled by `viam-agent`. Works on apt-based, RPM-based, and Windows distributions. |
-| <code style="white-space: nowrap">"managed-security"</code> | Install security updates only on a schedule controlled by `viam-agent`. Works on apt-based, RPM-based, and Windows distributions.            |
-| `"disable"`                                                 | Disable automatic OS updates.                                                                                                                |
-| `""` (empty)                                                | Do not change the system's current update settings. This is the default.                                                                     |
+| Value                                                       | Description                                                                                                                                            |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `"all"`                                                     | Install all available OS package updates using the OS's built-in upgrade schedule. Debian only.                                                        |
+| `"security"`                                                | Install security updates only using the OS's built-in upgrade schedule. Debian only.                                                                   |
+| <code style="white-space: nowrap">"managed-all"</code>      | Install all available OS package updates on a schedule controlled by `viam-agent`. Works on apt-based, RPM-based, and Windows distributions.           |
+| <code style="white-space: nowrap">"managed-security"</code> | Install security updates only on a schedule controlled by `viam-agent`. Works on apt-based, RPM-based, and Windows distributions. This is the default. |
+| `"disable"`                                                 | Disable automatic OS updates.                                                                                                                          |
+| `""` (empty)                                                | Treated as `"managed-security"`. To disable automatic updates, set `"disable"` explicitly.                                                             |
 
 Managed modes work on apt-based distributions (Debian, Ubuntu, Raspberry Pi OS), RPM-based distributions (Fedora, RHEL 7+, Rocky Linux, AlmaLinux, CentOS 7), and Windows (using the PSWindowsUpdate PowerShell module).
 

--- a/docs/reference/viam-agent.md
+++ b/docs/reference/viam-agent.md
@@ -82,10 +82,10 @@ In the machine settings card, open **Settings** and expand **System**:
 
 ### OS package updates
 
-| Field                               | Type   | Default | Description                                                                                                                                                                           |
-| ----------------------------------- | ------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `os_auto_upgrade_type`              | string | `""`    | Controls automatic OS package updates. Accepts `"all"`, `"security"`, `"managed-all"`, `"managed-security"`, `"disable"`, or `""` (leave OS defaults). The modes are described below. |
-| `os_managed_upgrade_interval_hours` | float  | `24`    | How often `viam-agent` checks for and installs packages, in hours. Minimum value: `1`. Only applies when `os_auto_upgrade_type` is `"managed-all"` or `"managed-security"`.           |
+| Field                               | Type   | Default              | Description                                                                                                                                                                                                              |
+| ----------------------------------- | ------ | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `os_auto_upgrade_type`              | string | `"managed-security"` | Controls automatic OS package updates. Accepts `"all"`, `"security"`, `"managed-all"`, `"managed-security"`, `"disable"`, or `""`. If empty or missing, defaults to `"managed-security"`. The modes are described below. |
+| `os_managed_upgrade_interval_hours` | float  | `24`                 | How often `viam-agent` checks for and installs packages, in hours. Minimum value: `1`. Only applies when `os_auto_upgrade_type` is `"managed-all"` or `"managed-security"`.                                              |
 
 The `"all"` and `"security"` modes delegate scheduling to the operating system's built-in upgrade timer (`unattended-upgrades` on Debian). The `"managed-all"` and `"managed-security"` modes let `viam-agent` control the upgrade schedule directly, which also enables upgrade support on Ubuntu and RPM-based distributions (Fedora, RHEL, Rocky Linux, AlmaLinux, CentOS).
 


### PR DESCRIPTION
viam-agent now defaults to `"managed-security"` for `os_auto_upgrade_type` instead of `""` (no changes). Empty or missing values are treated as `"managed-security"`. Users who want no automatic updates must now set `"disable"` explicitly.

## Source changes

- viamrobotics/agent#267: Make managed-security the default for os_auto_upgrade_type

## Docs changes

- `docs/reference/viam-agent.md`: Updated default column from `""` to `"managed-security"` and clarified that empty/missing values default to `"managed-security"`
- `docs/fleet/system-settings.md`: Moved "This is the default" label from the `""` row to the `"managed-security"` row; updated `""` row to note it is treated as `"managed-security"` and that `"disable"` must be set explicitly to opt out

## How I found these

- Xref lookup: `maintenance.md` agent entry → `viam-agent.md`, `system-settings.md`
- Grep matches: 2 pages reference `os_auto_upgrade_type` with the old default

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWrq2oVBzgACupfTm5fgii)_