### PR TITLE
Revert os_auto_upgrade_type default to empty string

### DIFF
--- a/docs/fleet/system-settings.md
+++ b/docs/fleet/system-settings.md
@@ -112,14 +112,14 @@ Control automatic operating system package updates on the machine.
 
 In the machine settings card, open **Settings** and expand **System**. Set `os_auto_upgrade_type`:
 
-| Value                                                       | Description                                                                                                                                            |
-| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `"all"`                                                     | Install all available OS package updates using the OS's built-in upgrade schedule. Debian only.                                                        |
-| `"security"`                                                | Install security updates only using the OS's built-in upgrade schedule. Debian only.                                                                   |
-| <code style="white-space: nowrap">"managed-all"</code>      | Install all available OS package updates on a schedule controlled by `viam-agent`. Works on apt-based, RPM-based, and Windows distributions.           |
-| <code style="white-space: nowrap">"managed-security"</code> | Install security updates only on a schedule controlled by `viam-agent`. Works on apt-based, RPM-based, and Windows distributions. This is the default. |
-| `"disable"`                                                 | Disable automatic OS updates.                                                                                                                          |
-| `""` (empty)                                                | Treated as `"managed-security"`. To disable automatic updates, set `"disable"` explicitly.                                                             |
+| Value                                                       | Description                                                                                                                                  |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"all"`                                                     | Install all available OS package updates using the OS's built-in upgrade schedule. Debian only.                                              |
+| `"security"`                                                | Install security updates only using the OS's built-in upgrade schedule. Debian only.                                                         |
+| <code style="white-space: nowrap">"managed-all"</code>      | Install all available OS package updates on a schedule controlled by `viam-agent`. Works on apt-based, RPM-based, and Windows distributions. |
+| <code style="white-space: nowrap">"managed-security"</code> | Install security updates only on a schedule controlled by `viam-agent`. Works on apt-based, RPM-based, and Windows distributions.            |
+| `"disable"`                                                 | Disable automatic OS updates.                                                                                                                |
+| `""` (empty)                                                | Do not change the system's current update settings. This is the default.                                                                     |
 
 Managed modes work on apt-based distributions (Debian, Ubuntu, Raspberry Pi OS), RPM-based distributions (Fedora, RHEL 7+, Rocky Linux, AlmaLinux, CentOS 7), and Windows (using the PSWindowsUpdate PowerShell module).
 

--- a/docs/reference/viam-agent.md
+++ b/docs/reference/viam-agent.md
@@ -82,10 +82,10 @@ In the machine settings card, open **Settings** and expand **System**:
 
 ### OS package updates
 
-| Field                               | Type   | Default              | Description                                                                                                                                                                                                              |
-| ----------------------------------- | ------ | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `os_auto_upgrade_type`              | string | `"managed-security"` | Controls automatic OS package updates. Accepts `"all"`, `"security"`, `"managed-all"`, `"managed-security"`, `"disable"`, or `""`. If empty or missing, defaults to `"managed-security"`. The modes are described below. |
-| `os_managed_upgrade_interval_hours` | float  | `24`                 | How often `viam-agent` checks for and installs packages, in hours. Minimum value: `1`. Only applies when `os_auto_upgrade_type` is `"managed-all"` or `"managed-security"`.                                              |
+| Field                               | Type   | Default | Description                                                                                                                                                                           |
+| ----------------------------------- | ------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `os_auto_upgrade_type`              | string | `""`    | Controls automatic OS package updates. Accepts `"all"`, `"security"`, `"managed-all"`, `"managed-security"`, `"disable"`, or `""` (leave OS defaults). The modes are described below. |
+| `os_managed_upgrade_interval_hours` | float  | `24`    | How often `viam-agent` checks for and installs packages, in hours. Minimum value: `1`. Only applies when `os_auto_upgrade_type` is `"managed-all"` or `"managed-security"`.           |
 
 The `"all"` and `"security"` modes delegate scheduling to the operating system's built-in upgrade timer (`unattended-upgrades` on Debian). The `"managed-all"` and `"managed-security"` modes let `viam-agent` control the upgrade schedule directly, which also enables upgrade support on Ubuntu and RPM-based distributions (Fedora, RHEL, Rocky Linux, AlmaLinux, CentOS).
 


### PR DESCRIPTION
Agent PR viamrobotics/agent#277 reverted the `os_auto_upgrade_type` default from `"managed-security"` back to `""` (make no changes to OS update settings). This was merged on 2026-07-29, the same day docs PR #5228 landed stating the default was `"managed-security"`. The docs are now incorrect.

## Source changes

- viamrobotics/agent#277: Revert managed-security default for os_auto_upgrade_type

## Docs changes

- `docs/fleet/system-settings.md`: Reverted the default description for `""` (empty) back to "Do not change the system's current update settings. This is the default." Removed "This is the default" from the `managed-security` row.
- `docs/reference/viam-agent.md`: Reverted the Default column for `os_auto_upgrade_type` from `"managed-security"` back to `""`, and restored the original description text.

## How I found these

- Xref lookup: `maintenance.md` agent entry, `flows.md` agent behavior paths
- Grep matches: 2 files matched `managed-security` in docs repo

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsyZVh7S6xZVfNe8fBpWov)_