### PR TITLE
Document part-level data retention policies

### DIFF
--- a/docs/data/delete-data.md
+++ b/docs/data/delete-data.md
@@ -10,7 +10,7 @@ description: "Delete captured tabular and binary data through the Viam app, the 
 You can delete captured data through the Viam app, the CLI, or the SDK.
 The SQL and MQL query editor is read-only: you cannot run `DELETE`, `DROP TABLE`, or any write operation through it.
 
-[Retention policies](/data/reference/#platform-managed-capture-settings) can also auto-delete data in the cloud after a configured number of days, without anyone running a delete operation.
+[Retention policies](/data/reference/#platform-managed-capture-settings) can also auto-delete data in the cloud after a configured number of days, without anyone running a delete operation. Set them per resource or for [a whole machine part](/data/reference/#part-level-retention-policy).
 
 ## Delete captured data
 
@@ -120,4 +120,4 @@ See the [data client API](/reference/apis/data-client/) for the full set of meth
 - [Manage data with the CLI](/cli/manage-data/) for the full CLI reference, including all `viam data delete` filters
 - [Data client API](/reference/apis/data-client/) for SDK methods
 - [Hot data store](/data/hot-data-store/) for how the hot store interacts with tabular deletes
-- [Data management reference](/data/reference/#platform-managed-capture-settings) for `retention_policy` configuration
+- [Data management reference](/data/reference/#platform-managed-capture-settings) for resource-level and [part-level](/data/reference/#part-level-retention-policy) retention policy configuration

--- a/docs/data/reference.md
+++ b/docs/data/reference.md
@@ -291,7 +291,36 @@ The following settings are processed by the Viam cloud platform, not by `viam-se
 | `retention_policy` | object | `attributes` (sibling to `capture_methods`) | How long captured data is retained in the default data store. Options: `"days": <int>`, `"binary_limit_gb": <int>`, `"tabular_limit_gb": <int>`. Days are in UTC. |
 | `recent_data_store` | object | Inside a `capture_methods[]` entry | Store a rolling window of recent data in a [hot data store](/data/hot-data-store/) for faster queries. Example: `{ "stored_hours": 24 }` |
 
+A resource-level `retention_policy` covers one component or service. To apply one retention period to everything the part captures, set a [part-level retention policy](#part-level-retention-policy) instead.
+
 For remote parts capture, see [Capture from multi-part machines](/data/capture-sync/remote-parts-capture/).
+
+### Part-level retention policy
+
+A part-level retention policy applies one retention period to all data a machine {{< glossary_tooltip term_id="part" text="part" >}} captures, across every component and service. Once per day, the Viam cloud platform deletes captured data (binary and tabular) older than the configured number of days.
+
+Set the policy in **JSON** mode on the **CONFIGURE** tab. `data_retention_policy` is a top-level field in the part's configuration, alongside `components` and `services`:
+
+```json
+{
+  "components": [],
+  "services": [],
+  "data_retention_policy": {
+    "days": 30
+  }
+}
+```
+
+<!-- prettier-ignore -->
+| Name | Type | Description |
+| --- | --- | --- |
+| `days` | int | Number of days to keep the part's captured data in the default data store. Must be a positive whole number. The platform ignores other values. Days are in UTC. |
+
+The part-level policy supports one option: `days`. Set size-based limits (`binary_limit_gb` and `tabular_limit_gb`) per resource in a [resource-level `retention_policy`](#platform-managed-capture-settings).
+
+When a resource also has its own `retention_policy`, the shorter of the two retention periods applies to that resource's data. For example, set a long period for the whole part and a shorter period for a high-volume resource, such as a camera.
+
+A {{< glossary_tooltip term_id="fragment" text="fragment" >}} can include `data_retention_policy`. The policy then applies to every part that uses the fragment.
 
 ## Local storage
 

--- a/docs/data/reference.md
+++ b/docs/data/reference.md
@@ -297,14 +297,19 @@ For remote parts capture, see [Capture from multi-part machines](/data/capture-s
 
 ### Part-level retention policy
 
-A part-level retention policy applies one retention period to all data a machine {{< glossary_tooltip term_id="part" text="part" >}} captures, across every component and service. Once per day, the Viam cloud platform deletes captured data (binary and tabular) older than the configured number of days.
+A part-level retention policy applies one retention period to all data a machine {{< glossary_tooltip term_id="part" text="part" >}} captures, across every component and service. The Viam cloud platform deletes the part's captured data (binary and tabular) from the default data store when the retention period passes. The policy covers the default data store only: a [hot data store](/data/hot-data-store/) keeps its own rolling window of recent data, set by `stored_hours`.
 
 Set the policy in **JSON** mode on the **CONFIGURE** tab. `data_retention_policy` is a top-level field in the part's configuration, alongside `components` and `services`:
 
 ```json
 {
-  "components": [],
-  "services": [],
+  "components": [
+    {
+      "name": "my-sensor",
+      "api": "rdk:component:sensor",
+      "model": "rdk:builtin:fake"
+    }
+  ],
   "data_retention_policy": {
     "days": 30
   }
@@ -314,13 +319,13 @@ Set the policy in **JSON** mode on the **CONFIGURE** tab. `data_retention_policy
 <!-- prettier-ignore -->
 | Name | Type | Description |
 | --- | --- | --- |
-| `days` | int | Number of days to keep the part's captured data in the default data store. Must be a positive whole number. The platform ignores other values. Days are in UTC. |
+| `days` | int | Number of days to keep the part's captured data in the default data store. Days are UTC calendar days: the platform deletes data once its capture day is `days` or more days in the past. Must be a positive whole number. The platform ignores other values. |
 
 The part-level policy supports one option: `days`. Set size-based limits (`binary_limit_gb` and `tabular_limit_gb`) per resource in a [resource-level `retention_policy`](#platform-managed-capture-settings).
 
 When a resource also has its own `retention_policy`, the shorter of the two retention periods applies to that resource's data. For example, set a long period for the whole part and a shorter period for a high-volume resource, such as a camera.
 
-A {{< glossary_tooltip term_id="fragment" text="fragment" >}} can include `data_retention_policy`. The policy then applies to every part that uses the fragment.
+A {{< glossary_tooltip term_id="fragment" text="fragment" >}} can include `data_retention_policy` to set the policy for every part that uses the fragment. A `data_retention_policy` set directly on a part takes precedence over one from a fragment.
 
 ## Local storage
 


### PR DESCRIPTION
## Summary

Documents setting a data retention policy for a whole machine part instead of a single component.

- Adds a **Part-level retention policy** section to the data management reference (`docs/data/reference.md`), documenting the top-level `data_retention_policy` config key: where it goes in the part's JSON config, the `days` option and its constraints (positive whole number; other values ignored; UTC calendar days), that it covers binary and tabular data across every resource on the part, and that fragments can set it (with the part's own value taking precedence).
- Scopes the policy explicitly to the **default data store**: a hot data store keeps its own rolling window, set by `stored_hours`.
- Documents the interaction with resource-level `retention_policy`: the shorter of the two periods applies to that resource's data. Size limits (`binary_limit_gb`, `tabular_limit_gb`) remain resource-level only.
- Cross-links from the existing platform-managed capture settings table and from `docs/data/delete-data.md`.

## Source verification

Verified against `viamrobotics/app` main:

- Top-level key extraction: `domains/robotservice/config_retriever.go:724` and `domains/datamanagement/retention/retention.go` (`PartDataRetentionPolicyKey = "data_retention_policy"`, struct supports `days` only).
- Part-scope enforcement (binary + tabular, filtered by part ID only): `domains/datamanagement/part_level_data_retention_job.go`; deletion boundary is a UTC calendar-day cutoff (`retention.RetentionCutoff`); non-integer or non-positive `days` ignored.
- Shorter-period-wins: `retention.EffectiveRetentionDays` takes the stricter of part-level and resource-level policies; the part-level and resource-level deletion jobs run independently, so the earlier cutoff wins.
- Fragment support and precedence: fragment configs merge under the part's own config (`data/fragments.go`, `mergeFragmentMaps`), so a part-set policy overrides a fragment-set one.
- Size-based limits are read from resource-level configs only: `domains/datamanagement/data_retention_by_size_job.go`.

## Review

An adversarial source-verification pass tightened three points, and reviewer feedback was applied:

- Stated the UTC calendar-day deletion boundary precisely (the prior wording overstated retention by up to a day).
- Replaced the empty-arrays config example with one containing a component (policy extraction iterates a part's components and services, so the empty example modeled a config the platform never enforces).
- Documented fragment-vs-part precedence.
- Made the default-data-store scope explicit and dropped the deletion-frequency detail.

## Checks

- prettier, markdownlint, vale (0 errors/warnings/suggestions on changed files), `make build-prod` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5fWiUAkE24QEDiJL7wQfN