### PR TITLE
Drop the Linux brew install method for the CLI

### DIFF
--- a/static/include/how-to/install-cli.md
+++ b/static/include/how-to/install-cli.md
@@ -29,14 +29,6 @@ sudo curl --compressed -o /usr/local/bin/viam https://storage.googleapis.com/pac
 sudo chmod a+rx /usr/local/bin/viam
 ```
 
-You can also install the Viam CLI using [brew](https://brew.sh/) on Linux `amd64` (Intel `x86_64`):
-
-```sh {class="command-line" data-prompt="$"}
-brew tap viamrobotics/brews
-brew trust viamrobotics/brews
-brew install viam
-```
-
 {{% /tab %}}
 {{% tab name="Windows" %}}
 


### PR DESCRIPTION
Follow-up to #5235: with the apt repository covering both Linux architectures, the Linux `amd64` brew snippet adds nothing — Homebrew on Linux supports x86_64 only and builds without bottles on aarch64. The Linux tabs now show apt first and the direct binary download for other distributions; macOS brew is untouched. The app's Connect → CLI tab makes the same change in viamrobotics/app#13024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)