### PR TITLE
Update logs filter label from Resource to Source

### DIFF
--- a/docs/monitor/overview.md
+++ b/docs/monitor/overview.md
@@ -53,7 +53,7 @@ See [Default control interface](/monitor/default-interface/) and [Teleop workspa
 
 When something goes wrong, Viam provides a set of debugging tools you can use without physical access to the machine:
 
-- **Logs**: the LOGS tab shows machine logs filterable by level, keyword, time range, and resource. You can enable debug logging for individual resources or log name patterns without restarting.
+- **Logs**: the LOGS tab shows machine logs filterable by level, keyword, time range, and source. You can enable debug logging for individual resources or log name patterns without restarting.
 - **Remote shell**: access a terminal on the machine through the CLI (`viam machines part shell`) without setting up SSH tunnels.
 - **Debug endpoints**: enable pprof profiling and resource graph visualization for performance issues.
 - **Configuration history**: view and revert to previous configurations if a config change caused the problem.

--- a/docs/monitor/troubleshoot.md
+++ b/docs/monitor/troubleshoot.md
@@ -124,7 +124,7 @@ You can filter logs by:
 - **Level**: Error, Warn, Info, Debug
 - **Keyword**: full text search (supports regular expressions)
 - **Time range**: set start and end times, or use live mode to stream logs in real time
-- **Resource**: filter by a specific component or service name
+- **Source**: filter by a specific component or service name
 
 The default log level is `Info`.
 If you are not seeing helpful logs, enable debug logging.


### PR DESCRIPTION
## Source changes

- viamrobotics/app#13023: Renamed the "Resource" facet filter to "Source" on the machine logs page

## Docs changes

- `docs/monitor/troubleshoot.md`: Changed "**Resource**" to "**Source**" in the logs filter options list
- `docs/monitor/overview.md`: Changed "filterable by level, keyword, time range, and resource" to "and source"

## How I found these

- Grep matches: searched for "Resource" in the context of logs filtering across the entire docs repo; found 2 pages referencing the old label

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVKN9o49ufddeQgYwoUvro)_