### PR TITLE
Add apt to viam update command description

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -3084,6 +3084,7 @@ viam traces get-remote --part=<part> [target] [--organization=<org>] [--location
 
 The `update` command updates the CLI to the latest version.
 If the CLI was installed with Homebrew, it updates through Homebrew.
+If the CLI was installed with apt, it updates through apt.
 Otherwise, it downloads and replaces the binary directly.
 
 ```sh {class="command-line" data-prompt="$"}


### PR DESCRIPTION
## Source changes

- viamrobotics/rdk#6293: Publish viam-cli as an apt package; `viam update` detects apt-installed binary and upgrades through `apt-get` instead of self-replacing

## Docs changes

- `docs/cli/reference.md`: Added "If the CLI was installed with apt, it updates through apt." to the `update` command description, alongside the existing Homebrew mention

## How I found these

- Diff review: rdk#6293 added `isRunningAptBinary()` and `tryAptUpgrade()` to cli/client.go, making `viam update` aware of apt-installed binaries
- Grep matches: confirmed the `update` command docs at cli/reference.md describe only Homebrew and direct binary replacement

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVKN9o49ufddeQgYwoUvro)_