### PR TITLE
Fix three SDK-doc-generator scraper bugs (TypeScript whitespace nodes, shortcode-stripping regex)

### DIFF
--- a/.github/workflows/parse_typescript.py
+++ b/.github/workflows/parse_typescript.py
@@ -138,7 +138,7 @@ class TypeScriptParser:
                 param_object = {}
                 if method.find('div', class_="tsd-parameters"):
                     parameters = method.find('div', class_="tsd-parameters")
-                    parameter_list = parameters.find('ul', class_="tsd-parameter-list").children
+                    parameter_list = parameters.find('ul', class_="tsd-parameter-list").find_all('li', recursive=False)
 
                     for param in parameter_list:
                         param_name = param.find('span', class_="tsd-kind-parameter").text
@@ -166,9 +166,9 @@ class TypeScriptParser:
                 returns = md(str(method.find('h4', class_="tsd-returns-title"))).replace("#### Returns ", "").strip().replace('\\', '')
                 returns = " ".join(returns.split())
                 return_description = ""
-                if method.find('h4', class_="tsd-returns-title").next_sibling:
-                    if not method.find('h4', class_="tsd-returns-title").next_sibling.get('class'):
-                        return_description = md(str(method.find('h4', class_="tsd-returns-title").next_sibling)).strip()
+                if method.find('h4', class_="tsd-returns-title").find_next_sibling():
+                    if not method.find('h4', class_="tsd-returns-title").find_next_sibling().get('class'):
+                        return_description = md(str(method.find('h4', class_="tsd-returns-title").find_next_sibling())).strip()
                     else:
                         return_description = None
                 else:

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -957,17 +957,19 @@ def write_markdown(type, names, methods):
                             proto_anchor_link = '/reference/apis/' + resource + '/#' + proto_link
 
                         ## Fetch just the first sentence from the proto_override_file (first text string terminated by '.\n'), ignoring hugo
-                        ## shortcodes like alerts ('{{%.*%}}.*{{% \[a-b].* %}}'), which precede some override files' (proto descriptions')
-                        ## first sentence:
+                        ## shortcodes like alerts ('{{% alert %}}...{{% /alert %}}'), which precede some override files' (proto descriptions')
+                        ## first sentence. The closing tag must match the same shortcode name as the opener (via backreference), so a
+                        ## self-closing shortcode earlier in the file (e.g. {{< glossary_tooltip ... >}}, no closing tag of its own) can't
+                        ## get matched up with an unrelated block shortcode's closer later in the file:
 
 
                         if os.path.isfile(proto_override_file):
                             with open(proto_override_file, 'r') as f:
                                 file_contents = f.read().strip()
-                                file_contents = regex.sub(r'\{\{\%.*\%\}\}.*\{\{\% \/[a-b].* \%\}\}', '', file_contents, flags=regex.DOTALL)
+                                file_contents = regex.sub(r'\{\{\%\s*(\w+)[^%]*\%\}\}.*?\{\{\%\s*\/\1\s*\%\}\}', '', file_contents, flags=regex.DOTALL)
                                 ## Same, for angle-bracket shortcodes ({{< alert >}}...{{< /alert >}}), which
                                 ## otherwise leak an unclosed shortcode opener into the table description:
-                                file_contents = regex.sub(r'\{\{<.*?>\}\}.*?\{\{< \/[a-b].*? >\}\}', '', file_contents, flags=regex.DOTALL)
+                                file_contents = regex.sub(r'\{\{<\s*(\w+)[^>]*>\}\}.*?\{\{<\s*\/\1\s*>\}\}', '', file_contents, flags=regex.DOTALL)
                                 search_result = file_contents.split('.\n', 1)[0].strip().replace("\n", " ")
 
                                 ## If the proto description contains any MD links, strip them out:


### PR DESCRIPTION
## Summary

While regenerating `static/include/*/apis/generated/` locally to validate #5234, `update_sdk_methods.py` crashed twice, and a successful run after those crashes surfaced a silent content-truncation bug. All three are fixed here; none are new regressions from this branch — all three bugs are already live on `main`.

1. **`parse_typescript.py:141`** — `TypeError: str.find() takes no keyword arguments`
   `parameters.find('ul', class_="tsd-parameter-list").children` iterates *every* child node of the `<ul>`, including whitespace-only text nodes between `<li>` elements. BeautifulSoup's `.children` yields both `Tag` and `NavigableString` (a `str` subclass); calling `.find(class_=...)` on a whitespace text node hits `str.find()` instead of `Tag.find()`. Fixed by switching to `find_all('li', recursive=False)`, which only iterates actual elements. (Same fix as already-open #5222, found independently before discovering that PR — recommend closing #5222 as superseded by this one.)

2. **`parse_typescript.py:169-171`** — `AttributeError: 'NavigableString' object has no attribute 'get'`
   Same root cause, different call site: `.next_sibling` returns the literal next node (which can be a whitespace `NavigableString`), not the next actual tag. Fixed with `.find_next_sibling()`, which skips text nodes.

3. **`update_sdk_methods.py:967,970`** — silent content truncation, no crash
   The shortcode-stripping regexes used for proto-override table descriptions matched from *any* opening shortcode to the *nearest* closing tag whose name started with `a` or `b`, with no requirement that it be the matching closer. This is fine for a file with a single paired shortcode (e.g. `board.SetPWMFrequency.md`'s `{{< alert >}}...{{< /alert >}}`, which is what 93487ff43/#5184 added this angle-bracket regex to handle, and does handle correctly). It breaks when a file has an earlier, unrelated self-closing shortcode ahead of a later paired block shortcode: `data_sync.TabularDataCaptureUpload.md` opens with a self-closing `{{< glossary_tooltip ... >}}` (no closing tag of its own) and later has an `{{< alert >}}...{{< /alert >}}` block. The old regex matched from the glossary tooltip all the way to the alert's closer, silently deleting everything in between — including "component to Viam" — leaving `data_sync-table.md`'s `TabularDataCaptureUpload` row truncated mid-sentence. Fixed by requiring the closing tag to match the opening tag's name via backreference (applied to both the `{{%...%}}` and `{{<...>}}` variants). Verified against every override file currently using either shortcode style: the previously-broken case now reproduces the original committed text exactly, and the previously-working case (`board.SetPWMFrequency.md`) is unaffected.

## How this was found

Evaluating #5234 (a hand-edit to a generated file) led to actually running the generator locally to produce the correct output instead. That surfaced bugs 1 and 2 as crashes; after fixing those, a successful regen run's diff included the truncated `data_sync-table.md` row, which traced back to bug 3.

## What this doesn't fix

Left out of scope for this PR, since they're different bugs in the same files that weren't touched here:
- #5194 (Go-tab loss for methods inherited via `framesystem.InputEnabled`) and its root-cause issue #5192
- #5198 (`parse_go.py` hardcoded skip for `world_state_store`)
- #5189, #5190, #5188 (scraper-artifact / coverage-policy issues in `check_for_unused_methods`)

## Expected follow-up

Once merged, plan to regenerate `static/include/*/apis/generated/` against current upstream SDK docs in a separate PR (content-only, no script changes), which should supersede #5234 and likely resolve #5142 ("CI failure: SDK method coverage" — same `parse()` code path, so worth confirming this was the actual cause of that failure before closing it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)