### PR TITLE
Regenerate SDK API reference docs after generator bugfixes

### DIFF
--- a/static/include/app/apis/generated/app.md
+++ b/static/include/app/apis/generated/app.md
@@ -57,9 +57,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 ```ts {class="line-numbers linkable-line-numbers"}
 // This method is used internally only. To obtain a user's ID, use the listOrganizationsByUser method.
-const members = await appClient.listOrganizationMembers(
-  '<YOUR-ORGANIZATION-ID>'
-);
+const members = await appClient.listOrganizationMembers('<YOUR-ORGANIZATION-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#getuseridbyemail).
@@ -120,7 +118,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Returns:**
 
-- (Promise<undefined | [Organization](https://ts.viam.dev/classes/appApi.Organization.html)>): The new organization.
+- (Promise<[Organization](https://ts.viam.dev/classes/appApi.Organization.html) | undefined>): The new organization.
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#createorganization).
 
@@ -140,7 +138,7 @@ List the {{< glossary_tooltip term_id="organization" text="organizations" >}} th
 
 **Returns:**
 
-- ([List[viam.proto.app.Organization]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Organization)): :   The list of organizations.
+- ([list[viam.proto.app.Organization]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Organization)): :   The list of organizations.
 
 **Example:**
 
@@ -205,7 +203,7 @@ Get all organizations that have access to a location.
 
 **Returns:**
 
-- ([List[viam.proto.app.OrganizationIdentity]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.OrganizationIdentity)): :   The list of organizations.
+- ([list[viam.proto.app.OrganizationIdentity]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.OrganizationIdentity)): :   The list of organizations.
 
 **Example:**
 
@@ -230,9 +228,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const organizations =
-  await appClient.getOrganizationsWithAccessToLocation(
-    '<YOUR-LOCATION-ID>'
-  );
+  await appClient.getOrganizationsWithAccessToLocation('<YOUR-LOCATION-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#getorganizationswithaccesstolocation).
@@ -253,7 +249,7 @@ List the organizations a user belongs to.
 
 **Returns:**
 
-- ([List[viam.proto.app.OrgDetails]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.OrgDetails)): :   The list of organizations.
+- ([list[viam.proto.app.OrgDetails]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.OrgDetails)): :   The list of organizations.
 
 **Example:**
 
@@ -357,14 +353,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Returns:**
 
-- (Promise<undefined | [Organization](https://ts.viam.dev/classes/appApi.Organization.html)>): Details about the organization, if it exists.
+- (Promise<[Organization](https://ts.viam.dev/classes/appApi.Organization.html) | undefined>): Details about the organization, if it exists.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const organization = await appClient.getOrganization(
-  '<YOUR-ORGANIZATION-ID>'
-);
+const organization = await appClient.getOrganization('<YOUR-ORGANIZATION-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#getorganization).
@@ -435,8 +429,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const isAvailable =
-  await appClient.getOrganizationNamespaceAvailability('name');
+const isAvailable = await appClient.getOrganizationNamespaceAvailability('name');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#getorganizationnamespaceavailability).
@@ -458,7 +451,7 @@ Updates organization details.
 - `public_namespace` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (optional): If provided, sets the org’s namespace if it hasn’t already been set.
 - `region` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (optional): If provided, updates the org’s region.
 - `cid` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (optional): If provided, update’s the org’s CRM ID.
-- `default_fragments` ([List[viam.proto.app.FragmentImport]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.FragmentImport)) (optional)
+- `default_fragments` ([list[viam.proto.app.FragmentImport]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.FragmentImport)) (optional)
 
 **Returns:**
 
@@ -518,19 +511,19 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 - `publicNamespace` (string) (optional): Optional namespace to update the organization with.
 - `region` (string) (optional): Optional region to update the organization with.
 - `cid` (string) (optional): Optional CRM ID to update the organization with.
-- `defaultFragments` ([FragmentImportList](https://ts.viam.dev/classes/appApi.FragmentImportList.html)) (optional): Optional default fragments to set for the
-  organization.
+- `defaultFragments` ([FragmentImportList](https://ts.viam.dev/classes/appApi.FragmentImportList.html)) (optional): Optional default fragments to set for the organization.
+- `allowedLoginMethods` ([AllowedLoginMethods](https://ts.viam.dev/classes/appApi.AllowedLoginMethods.html)) (optional): Optional allowed login methods to set for the organization.
 
 **Returns:**
 
-- (Promise<undefined | [Organization](https://ts.viam.dev/classes/appApi.Organization.html)>): The updated organization details.
+- (Promise<[Organization](https://ts.viam.dev/classes/appApi.Organization.html) | undefined>): The updated organization details.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const organization = await appClient.updateOrganization(
   '<YOUR-ORGANIZATION-ID>',
-  'newName'
+  'newName',
 );
 ```
 
@@ -616,7 +609,7 @@ List the members and invites of the {{< glossary_tooltip term_id="organization" 
 
 **Returns:**
 
-- (Tuple[List[[app.OrganizationMember](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.OrganizationMember)], List[[app.OrganizationInvite](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.OrganizationInvite)]]): :   A tuple containing two lists; the first
+- (tuple[list[[app.OrganizationMember](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.OrganizationMember)], list[[app.OrganizationInvite](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.OrganizationInvite)]]): :   A tuple containing two lists; the first
     [0] of organization members, and the second [1] of organization invites.
 
 **Example:**
@@ -658,15 +651,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Returns:**
 
-- (Promise<[ListOrganizationMembersResponse](https://ts.viam.dev/classes/appApi.ListOrganizationMembersResponse.html)>): An object containing organization members, pending invites, and
-org ID.
+- (Promise<[ListOrganizationMembersResponse](https://ts.viam.dev/classes/appApi.ListOrganizationMembersResponse.html)>): An object containing organization members, pending invites, and org ID.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const members = await appClient.listOrganizationMembers(
-  '<YOUR-ORGANIZATION-ID>'
-);
+const members = await appClient.listOrganizationMembers('<YOUR-ORGANIZATION-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#listorganizationmembers).
@@ -685,7 +675,7 @@ Create an {{< glossary_tooltip term_id="organization" text="organization" >}} in
 
 - `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to create an invite for. You can obtain your organization ID from the organization settings page.
 - `email` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The email address to send the invite to.
-- `authorizations` ([List[viam.proto.app.Authorization]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Authorization)) (optional): Specifications of the authorizations to include in the invite. If not provided, full owner permissions will be granted.
+- `authorizations` ([list[viam.proto.app.Authorization]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Authorization)) (optional): Specifications of the authorizations to include in the invite. If not provided, full owner permissions will be granted.
 - `send_email_invite` ([bool](https://docs.python.org/3/library/stdtypes.html#boolean-type-bool)) (required): Whether or not an email should be sent to the recipient of an invite. The user must accept the email to be added to the associated authorizations. When set to false, the user automatically receives the associated authorization on the next login of the user with the associated email address.
 
 **Returns:**
@@ -747,12 +737,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 - `organizationId` (string) (required): The id of the organization to create the invite for.
 - `email` (string) (required): The email address of the user to generate an invite for.
 - `authorizations` ([Authorization](https://ts.viam.dev/classes/appApi.Authorization.html)) (required): The authorizations to associate with the new invite.
-- `sendEmailInvite` (boolean) (optional): Bool of whether to send an email invite (true) or
-  automatically add a user. Defaults to true.
+- `sendEmailInvite` (boolean) (optional): Bool of whether to send an email invite (true) or automatically add a
+  user. Defaults to true.
 
 **Returns:**
 
-- (Promise<undefined | [OrganizationInvite](https://ts.viam.dev/classes/appApi.OrganizationInvite.html)>): The organization invite.
+- (Promise<[OrganizationInvite](https://ts.viam.dev/classes/appApi.OrganizationInvite.html) | undefined>): The organization invite.
 
 **Example:**
 
@@ -771,7 +761,7 @@ const auth = new VIAM.appApi.Authorization({
 const invite = await appClient.createOrganizationInvite(
   '<YOUR-ORGANIZATION-ID>',
   'youremail@email.com',
-  [auth]
+  [auth],
 );
 ```
 
@@ -792,8 +782,8 @@ If an invitation has only one authorization and you want to remove it, delete th
 
 - `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization that the invite is for. You can obtain your organization ID from the organization settings page.
 - `email` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): Email of the user the invite was sent to.
-- `add_authorizations` ([List[viam.proto.app.Authorization]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Authorization)) (optional): Optional list of authorizations to add to the invite.
-- `remove_authorizations` ([List[viam.proto.app.Authorization]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Authorization)) (optional): Optional list of authorizations to remove from the invite.
+- `add_authorizations` ([list[viam.proto.app.Authorization]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Authorization)) (optional): Optional list of authorizations to add to the invite.
+- `remove_authorizations` ([list[viam.proto.app.Authorization]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Authorization)) (optional): Optional list of authorizations to remove from the invite.
 
 **Returns:**
 
@@ -875,7 +865,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Returns:**
 
-- (Promise<undefined | [OrganizationInvite](https://ts.viam.dev/classes/appApi.OrganizationInvite.html)>): The organization invite.
+- (Promise<[OrganizationInvite](https://ts.viam.dev/classes/appApi.OrganizationInvite.html) | undefined>): The organization invite.
 
 **Example:**
 
@@ -894,7 +884,7 @@ const invite = await appClient.updateOrganizationInviteAuthorizations(
   '<YOUR-ORGANIZATION-ID>',
   'youremail@email.com',
   [auth],
-  []
+  [],
 );
 ```
 
@@ -969,10 +959,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.deleteOrganizationMember(
-  '<YOUR-ORGANIZATION-ID>',
-  '<YOUR-USER-ID>'
-);
+await appClient.deleteOrganizationMember('<YOUR-ORGANIZATION-ID>', '<YOUR-USER-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#deleteorganizationmember).
@@ -1047,10 +1034,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.deleteOrganizationInvite(
-  '<YOUR-ORGANIZATION-ID>',
-  'youremail@email.com'
-);
+await appClient.deleteOrganizationInvite('<YOUR-ORGANIZATION-ID>', 'youremail@email.com');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#deleteorganizationinvite).
@@ -1118,14 +1102,14 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Returns:**
 
-- (Promise<undefined | [OrganizationInvite](https://ts.viam.dev/classes/appApi.OrganizationInvite.html)>): The invite.
+- (Promise<[OrganizationInvite](https://ts.viam.dev/classes/appApi.OrganizationInvite.html) | undefined>): The invite.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const invite = await appClient.resendOrganizationInvite(
   '<YOUR-ORGANIZATION-ID>',
-  'youremail@email.com'
+  'youremail@email.com',
 );
 ```
 
@@ -1147,7 +1131,7 @@ Gets the user-defined metadata for an organization.
 
 **Returns:**
 
-- (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]): :   The user-defined metadata converted from JSON to a Python dictionary.
+- (collections.abc.Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]): :   The user-defined metadata converted from JSON to a Python dictionary.
 
 **Example:**
 
@@ -1194,9 +1178,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const metadata = await appClient.getOrganizationMetadata(
-  '<YOUR-ORGANIZATION-ID>'
-);
+const metadata = await appClient.getOrganizationMetadata('<YOUR-ORGANIZATION-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#getorganizationmetadata).
@@ -1215,7 +1197,7 @@ User-defined metadata is billed as data.
 **Parameters:**
 
 - `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required)
-- `metadata` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (required): The user-defined metadata to upload as a Python dictionary.
+- `metadata` (collections.abc.Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (required): The user-defined metadata to upload as a Python dictionary.
 
 **Returns:**
 
@@ -1348,23 +1330,18 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Parameters:**
 
-- `organizationId` (string) (required): The ID of the organization to create the location
-  under.
+- `organizationId` (string) (required): The ID of the organization to create the location under.
 - `name` (string) (required): The name of the location to create.
-- `parentLocationId` (string) (optional): Optional name of a parent location to create the
-  new location under.
+- `parentLocationId` (string) (optional): Optional name of a parent location to create the new location under.
 
 **Returns:**
 
-- (Promise<undefined | [Location](https://ts.viam.dev/classes/appApi.Location.html)>): The location object.
+- (Promise<[Location](https://ts.viam.dev/classes/appApi.Location.html) | undefined>): The location object.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const location = await appClient.createLocation(
-  '<YOUR-ORGANIZATION-ID>',
-  'name'
-);
+const location = await appClient.createLocation('<YOUR-ORGANIZATION-ID>', 'name');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#createlocation).
@@ -1429,7 +1406,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Returns:**
 
-- (Promise<undefined | [Location](https://ts.viam.dev/classes/appApi.Location.html)>): The location object.
+- (Promise<[Location](https://ts.viam.dev/classes/appApi.Location.html) | undefined>): The location object.
 
 **Example:**
 
@@ -1527,21 +1504,17 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 - `locId` (string) (required): The ID of the location to update.
 - `name` (string) (optional): Optional string to update the location's name to.
-- `parentLocId` (string) (optional): Optional string to update the location's parent location
-  to.
+- `parentLocId` (string) (optional): Optional string to update the location's parent location to.
 - `region` (string) (optional): Optional string to update the location's region to.
 
 **Returns:**
 
-- (Promise<undefined | [Location](https://ts.viam.dev/classes/appApi.Location.html)>): The location object.
+- (Promise<[Location](https://ts.viam.dev/classes/appApi.Location.html) | undefined>): The location object.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const location = await appClient.updateLocation(
-  '<YOUR-LOCATION-ID>',
-  'newName'
-);
+const location = await appClient.updateLocation('<YOUR-LOCATION-ID>', 'newName');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#updatelocation).
@@ -1631,7 +1604,7 @@ Get a list of all {{< glossary_tooltip term_id="location" text="locations" >}} u
 
 **Returns:**
 
-- ([List[viam.proto.app.Location]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Location)): :   The list of locations.
+- ([list[viam.proto.app.Location]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Location)): :   The list of locations.
 
 **Example:**
 
@@ -1676,9 +1649,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const locations = await appClient.listLocations(
-  '<YOUR-ORGANIZATION-ID>'
-);
+const locations = await appClient.listLocations('<YOUR-ORGANIZATION-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#listlocations).
@@ -1746,10 +1717,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.shareLocation(
-  '<OTHER-ORGANIZATION-ID>',
-  '<YOUR-LOCATION-ID>'
-);
+await appClient.shareLocation('<OTHER-ORGANIZATION-ID>', '<YOUR-LOCATION-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#sharelocation).
@@ -1817,10 +1785,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.unshareLocation(
-  '<OTHER-ORGANIZATION-ID>',
-  '<YOUR-LOCATION-ID>'
-);
+await appClient.unshareLocation('<OTHER-ORGANIZATION-ID>', '<YOUR-LOCATION-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#unsharelocation).
@@ -1885,14 +1850,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Returns:**
 
-- (Promise<undefined | [LocationAuth](https://ts.viam.dev/classes/appApi.LocationAuth.html)>): The `LocationAuth` for the requested location.
+- (Promise<[LocationAuth](https://ts.viam.dev/classes/appApi.LocationAuth.html) | undefined>): The `LocationAuth` for the requested location.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const locationAuth = await appClient.locationAuth(
-  '<YOUR-LOCATION-ID>'
-);
+const locationAuth = await appClient.locationAuth('<YOUR-LOCATION-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#locationauth).
@@ -1957,14 +1920,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Returns:**
 
-- (Promise<undefined | [LocationAuth](https://ts.viam.dev/classes/appApi.LocationAuth.html)>): The newly created `LocationAuth`.
+- (Promise<[LocationAuth](https://ts.viam.dev/classes/appApi.LocationAuth.html) | undefined>): The newly created `LocationAuth`.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const locationAuth = await appClient.createLocationSecret(
-  '<YOUR-LOCATION-ID>'
-);
+const locationAuth = await appClient.createLocationSecret('<YOUR-LOCATION-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#createlocationsecret).
@@ -2043,10 +2004,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.deleteLocationSecret(
-  '<YOUR-LOCATION-ID>',
-  '<YOUR-SECRET-ID>'
-);
+await appClient.deleteLocationSecret('<YOUR-LOCATION-ID>', '<YOUR-SECRET-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#deletelocationsecret).
@@ -2067,7 +2025,7 @@ Get the user-defined metadata for a location.
 
 **Returns:**
 
-- (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]): :   The user-defined metadata converted from JSON to a Python dictionary.
+- (collections.abc.Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]): :   The user-defined metadata converted from JSON to a Python dictionary.
 
 **Example:**
 
@@ -2112,9 +2070,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const metadata = await appClient.getLocationMetadata(
-  '<YOUR-LOCATION-ID>'
-);
+const metadata = await appClient.getLocationMetadata('<YOUR-LOCATION-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#getlocationmetadata).
@@ -2132,7 +2088,7 @@ Update the user-defined metadata for a location.
 **Parameters:**
 
 - `location_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the location with which to associate the user-defined metadata. You can obtain your location ID from the location’s page.
-- `metadata` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (required): The user-defined metadata converted from JSON to a Python dictionary.
+- `metadata` (collections.abc.Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (required): The user-defined metadata converted from JSON to a Python dictionary.
 
 **Returns:**
 
@@ -2257,7 +2213,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Returns:**
 
-- (Promise<undefined | [appApi](https://ts.viam.dev/modules/appApi.html).[Robot](https://ts.viam.dev/classes/appApi.Robot.html)>): The `Robot` object.
+- (Promise<[appApi](https://ts.viam.dev/modules/appApi.html).[Robot](https://ts.viam.dev/classes/appApi.Robot.html) | undefined>): The `Robot` object.
 
 **Example:**
 
@@ -2283,7 +2239,7 @@ Gets the [API keys](/organization/api-keys/) for the machine.
 
 **Returns:**
 
-- ([List[viam.proto.app.APIKeyWithAuthorizations]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.APIKeyWithAuthorizations)): :   The list of API keys.
+- ([list[viam.proto.app.APIKeyWithAuthorizations]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.APIKeyWithAuthorizations)): :   The list of API keys.
 
 **Example:**
 
@@ -2328,8 +2284,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const robotAPIKeys =
-  await appClient.getRobotAPIKeys('<YOUR-ROBOT-ID>');
+const robotAPIKeys = await appClient.getRobotAPIKeys('<YOUR-ROBOT-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#getrobotapikeys).
@@ -2350,7 +2305,7 @@ Get a list of all the {{< glossary_tooltip term_id="part" text="parts" >}} under
 
 **Returns:**
 
-- ([List[RobotPart]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.RobotPart)): :   The list of machine parts.
+- ([list[RobotPart]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.RobotPart)): :   The list of machine parts.
 
 **Raises:**
 
@@ -2490,10 +2445,7 @@ const robotPart = await appClient.getRobotPart('<YOUR-ROBOT-PART-ID>');
 // Get the part's address
 const address = robotPart.part.fqdn;
 // Check if machine is live (last access time less than 10 sec ago)
-if (
-  Date.now() - Number(robotPart.part.lastAccess.seconds) * 1000 <=
-  10000
-) {
+if (Date.now() - Number(robotPart.part.lastAccess.seconds) * 1000 <= 10000) {
   console.log('Machine is live');
 }
 ```
@@ -2515,14 +2467,14 @@ Get the logs associated with a specific machine {{< glossary_tooltip term_id="pa
 - `robot_part_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): ID of the machine part to get logs from.
 - `filter` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (optional): Only include logs with messages that contain the string filter. Defaults to empty string “” (that is, no filter).
 - `dest` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (optional): Optional filepath to write the log entries to.
-- `log_levels` (List[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]) (required): List of log levels for which entries should be returned. Defaults to empty list, which returns all logs.
+- `log_levels` (list[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]) (required): List of log levels for which entries should be returned. Defaults to empty list, which returns all logs.
 - `num_log_entries` ([int](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (required): Number of log entries to return. Passing 0 returns all logs. Defaults to 100. All logs or the first num_log_entries logs will be returned, whichever comes first.
 - `start` ([datetime.datetime](https://docs.python.org/3/library/datetime.html)) (optional): Optional start time for log retrieval. Only logs created after this time will be returned.
 - `end` ([datetime.datetime](https://docs.python.org/3/library/datetime.html)) (optional): Optional end time for log retrieval. Only logs created before this time will be returned.
 
 **Returns:**
 
-- ([List[LogEntry]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.LogEntry)): :   The list of log entries.
+- ([list[LogEntry]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.LogEntry)): :   The list of log entries.
 
 **Raises:**
 
@@ -2587,26 +2539,22 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 - `id` (string) (required): The ID of the requested robot part.
 - `filter` (string) (optional): Optional string to filter logs on.
-- `levels` (string) (optional): Optional array of log levels to return. Defaults to returning
-  all log levels.
-- `start` (Date) (optional): Optional start time for log retrieval. Only logs created after
-  this time will be returned.
-- `end` (Date) (optional): Optional end time for log retrieval. Only logs created before
-  this time will be returned.
-- `pageToken` (string) (optional): Optional string indicating which page of logs to query.
-  Defaults to the most recent.
+- `levels` (string) (optional): Optional array of log levels to return. Defaults to returning all log levels.
+- `start` (Date) (optional): Optional start time for log retrieval. Only logs created after this time will be
+  returned.
+- `end` (Date) (optional): Optional end time for log retrieval. Only logs created before this time will be
+  returned.
+- `pageToken` (string) (optional): Optional string indicating which page of logs to query. Defaults to the most
+  recent.
 
 **Returns:**
 
-- (Promise<[GetRobotPartLogsResponse](https://ts.viam.dev/classes/appApi.GetRobotPartLogsResponse.html)>): The robot requested logs and the page token for the next page of
-logs.
+- (Promise<[GetRobotPartLogsResponse](https://ts.viam.dev/classes/appApi.GetRobotPartLogsResponse.html)>): The robot requested logs and the page token for the next page of logs.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const robotPartLogs = await appClient.getRobotPartLogs(
-  '<YOUR-ROBOT-PART-ID>'
-);
+const robotPartLogs = await appClient.getRobotPartLogs('<YOUR-ROBOT-PART-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#getrobotpartlogs).
@@ -2635,7 +2583,7 @@ Query a specific robot part by name and location id.
 ```ts {class="line-numbers linkable-line-numbers"}
 const robotPart = await appClient.getRobotPartByNameAndLocation(
   '<YOUR-ROBOT-PART-NAME>',
-  '<YOUR-LOCATION-ID>'
+  '<YOUR-LOCATION-ID>',
 );
 ```
 
@@ -2659,7 +2607,7 @@ Get an asynchronous iterator that receives live machine part logs.
 
 **Returns:**
 
-- ([viam.app._logs._LogsStream[List[LogEntry]]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.LogEntry)): :   The asynchronous iterator receiving live machine part logs.
+- ([viam.app._logs._LogsStream[list[LogEntry]]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.LogEntry)): :   The asynchronous iterator receiving live machine part logs.
 
 **Example:**
 
@@ -2710,8 +2658,8 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 - `id` (string) (required): The ID of the requested robot part.
 - `queue` ([LogEntry](https://ts.viam.dev/classes/commonApi.LogEntry.html)) (required): A queue to put the log entries into.
 - `filter` (string) (optional): Optional string to filter logs on.
-- `errorsOnly` (boolean) (optional): Optional bool to indicate whether or not only error-level
-  logs should be returned. Defaults to true.
+- `errorsOnly` (boolean) (optional): Optional bool to indicate whether or not only error-level logs should be
+  returned. Defaults to true.
 
 **Returns:**
 
@@ -2720,9 +2668,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const robotPartLogs = await appClient.tailRobotPartLogs(
-  '<YOUR-ROBOT-PART-ID>'
-);
+const robotPartLogs = await appClient.tailRobotPartLogs('<YOUR-ROBOT-PART-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#tailrobotpartlogs).
@@ -2743,7 +2689,7 @@ Get a list containing the history of a machine {{< glossary_tooltip term_id="par
 
 **Returns:**
 
-- ([List[RobotPartHistoryEntry]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.RobotPartHistoryEntry)): :   The list of the machine part’s history.
+- ([list[RobotPartHistoryEntry]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.RobotPartHistoryEntry)): :   The list of the machine part’s history.
 
 **Raises:**
 
@@ -2796,9 +2742,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const robotPartHistory = await appClient.getRobotPartHistory(
-  '<YOUR-ROBOT-PART-ID>'
-);
+const robotPartHistory = await appClient.getRobotPartHistory('<YOUR-ROBOT-PART-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#getrobotparthistory).
@@ -2818,7 +2762,7 @@ You can only change the name and configuration of the machine part, not the loca
 
 - `robot_part_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): ID of the robot part to update.
 - `name` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): New name to be updated on the robot part.
-- `robot_config` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (optional): Optional new config represented as a dictionary to be updated on the machine part. The machine part’s config will remain as is (no change) if one isn’t passed.
+- `robot_config` ([collections.abc.Mapping[str, viam.utils.ValueTypes]](https://python.viam.dev/autoapi/viam/components/component_base/index.html#viam.components.component_base.ValueTypes)) (optional): Optional new config represented as a dictionary to be updated on the machine part. The machine part’s config will remain as is (no change) if one isn’t passed.
 - `last_known_update` ([datetime.datetime](https://docs.python.org/3/library/datetime.html)) (optional): Optional time of the last known update to this part’s config. If provided, this will result in a GRPCError if the upstream config has changed since this time, indicating that the local config is out of date. Omitting this parameter will result in an overwrite of the upstream config.
 - `robot_config_json` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (optional): Optional raw JSON string of the robot config, preserving user-defined key order. When set, this takes precedence over robot_config for storage purposes.
 
@@ -2892,15 +2836,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Returns:**
 
-- (Promise<undefined | [RobotPart](https://ts.viam.dev/classes/appApi.RobotPart.html)>): The updated robot part.
+- (Promise<[RobotPart](https://ts.viam.dev/classes/appApi.RobotPart.html) | undefined>): The updated robot part.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const robotPart = await appClient.updateRobotPart(
-  '<YOUR-ROBOT-PART-ID>',
-  'newName'
-);
+const robotPart = await appClient.updateRobotPart('<YOUR-ROBOT-PART-ID>', 'newName');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#updaterobotpart).
@@ -2978,10 +2919,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const robotPartId = await appClient.newRobotPart(
-  '<YOUR-ROBOT-ID>',
-  'newPart'
-);
+const robotPartId = await appClient.newRobotPart('<YOUR-ROBOT-ID>', 'newPart');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#newrobotpart).
@@ -3260,14 +3198,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Returns:**
 
-- (Promise<undefined | [RobotPart](https://ts.viam.dev/classes/appApi.RobotPart.html)>): The robot part object.
+- (Promise<[RobotPart](https://ts.viam.dev/classes/appApi.RobotPart.html) | undefined>): The robot part object.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const robotPart = await appClient.createRobotPartSecret(
-  '<YOUR-ROBOT-PART-ID>'
-);
+const robotPart = await appClient.createRobotPartSecret('<YOUR-ROBOT-PART-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#createrobotpartsecret).
@@ -3344,10 +3280,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.deleteRobotPartSecret(
-  '<YOUR-ROBOT-PART-ID>',
-  '<YOUR-SECRET-ID>'
-);
+await appClient.deleteRobotPartSecret('<YOUR-ROBOT-PART-ID>', '<YOUR-SECRET-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#deleterobotpartsecret).
@@ -3368,7 +3301,7 @@ Get a list of all machines in a specified location.
 
 **Returns:**
 
-- ([List[viam.proto.app.Robot]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Robot)): :   The list of robots.
+- ([list[viam.proto.app.Robot]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Robot)): :   The list of robots.
 
 **Raises:**
 
@@ -3490,10 +3423,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const robotId = await appClient.newRobot(
-  '<YOUR-LOCATION-ID>',
-  'newRobot'
-);
+const robotId = await appClient.newRobot('<YOUR-LOCATION-ID>', 'newRobot');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#newrobot).
@@ -3588,7 +3518,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Returns:**
 
-- (Promise<undefined | [appApi](https://ts.viam.dev/modules/appApi.html).[Robot](https://ts.viam.dev/classes/appApi.Robot.html)>): The newly-modified robot object.
+- (Promise<[appApi](https://ts.viam.dev/modules/appApi.html).[Robot](https://ts.viam.dev/classes/appApi.Robot.html) | undefined>): The newly-modified robot object.
 
 **Example:**
 
@@ -3596,7 +3526,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 const robot = await appClient.updateRobot(
   '<YOUR-ROBOT-ID>',
   '<YOUR-LOCATION-ID>',
-  'newName'
+  'newName',
 );
 ```
 
@@ -3687,7 +3617,7 @@ Gets the user-defined metadata for a machine.
 
 **Returns:**
 
-- (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]): :   The user-defined metadata converted from JSON to a Python dictionary.
+- (collections.abc.Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]): :   The user-defined metadata converted from JSON to a Python dictionary.
 
 **Example:**
 
@@ -3755,7 +3685,7 @@ Gets the user-defined metadata for a machine part.
 
 **Returns:**
 
-- (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]): :   The user-defined metadata converted from JSON to a Python dictionary.
+- (collections.abc.Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]): :   The user-defined metadata converted from JSON to a Python dictionary.
 
 **Example:**
 
@@ -3802,9 +3732,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const metadata = await appClient.getRobotPartMetadata(
-  '<YOUR-ROBOT-PART-ID>'
-);
+const metadata = await appClient.getRobotPartMetadata('<YOUR-ROBOT-PART-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#getrobotpartmetadata).
@@ -3823,7 +3751,7 @@ User-defined metadata is billed as data.
 **Parameters:**
 
 - `robot_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the robot with which to associate the user-defined metadata. You can obtain your robot ID from the machine page.
-- `metadata` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (required): The user-defined metadata converted from JSON to a Python dictionary.
+- `metadata` (collections.abc.Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (required): The user-defined metadata converted from JSON to a Python dictionary.
 
 **Returns:**
 
@@ -3902,7 +3830,7 @@ User-defined metadata is billed as data.
 **Parameters:**
 
 - `robot_part_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required)
-- `metadata` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (required): The user-defined metadata converted from JSON to a Python dictionary.
+- `metadata` (collections.abc.Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (required): The user-defined metadata converted from JSON to a Python dictionary.
 
 **Returns:**
 
@@ -3981,11 +3909,11 @@ Get a list of {{< glossary_tooltip term_id="fragment" text="fragments" >}} in th
 
 - `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to list fragments for. You can obtain your organization ID from the organization settings page.
 - `show_public` ([bool](https://docs.python.org/3/library/stdtypes.html#boolean-type-bool)) (required): Optional boolean specifying whether or not to only show public fragments. If True, only public fragments will return. If False, only private fragments will return. Defaults to True.  Deprecated since version 0.25.0: Use visibilities instead.
-- `visibilities` ([List[Fragment]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.Fragment.Visibility)) (optional): List of FragmentVisibilities specifying which types of fragments to include in the results. If empty, by default only public fragments will be returned.
+- `visibilities` ([list[Fragment]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.Fragment.Visibility)) (optional): List of FragmentVisibilities specifying which types of fragments to include in the results. If empty, by default only public fragments will be returned.
 
 **Returns:**
 
-- ([List[Fragment]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.Fragment)): :   The list of fragments.
+- ([list[Fragment]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.Fragment)): :   The list of fragments.
 
 **Example:**
 
@@ -4029,9 +3957,8 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Parameters:**
 
 - `organizationId` (string) (required): The ID of the organization to list fragments for.
-- `publicOnly` (boolean) (optional): Optional, deprecated boolean. Use fragmentVisibilities
-  instead. If true then only public fragments will be listed. Defaults to
-  true.
+- `publicOnly` (boolean) (optional): Optional, deprecated boolean. Use fragmentVisibilities instead. If true then
+  only public fragments will be listed. Defaults to true.
 - `fragmentVisibility` ([FragmentVisibility](https://ts.viam.dev/enums/appApi.FragmentVisibility.html)) (optional)
 
 **Returns:**
@@ -4041,9 +3968,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const fragments = await appClient.listFragments(
-  '<YOUR-ORGANIZATION-ID>'
-);
+const fragments = await appClient.listFragments('<YOUR-ORGANIZATION-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#listfragments).
@@ -4082,24 +4007,21 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Parameters:**
 
-- `machineId` (string) (required): The machine ID used to filter fragments defined in a
-  machine's parts. Also returns any fragments nested within the fragments
-  defined in parts.
-- `additionalFragmentIds` (string) (optional): Additional fragment IDs to append to the
-  response. Useful when needing to view fragments that will be
-  provisionally added to the machine alongside existing fragments.
+- `machineId` (string) (required): The machine ID used to filter fragments defined in a machine's parts. Also
+  returns any fragments nested within the fragments defined in parts.
+- `additionalFragmentIds` (string) (optional): Additional fragment IDs to append to the response. Useful when
+  needing to view fragments that will be provisionally added to the machine alongside existing
+  fragments.
 
 **Returns:**
 
-- (Promise<[Fragment](https://ts.viam.dev/classes/appApi.Fragment.html)[]>): The list of top level and nested fragments for a machine, as well
-as additionally specified fragment IDs.
+- (Promise<[Fragment](https://ts.viam.dev/classes/appApi.Fragment.html)[]>): The list of top level and nested fragments for a machine, as well as additionally
+specified fragment IDs.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const fragments = await appClient.listMachineFragments(
-  '<YOUR-MACHINE-ID>'
-);
+const fragments = await appClient.listMachineFragments('<YOUR-MACHINE-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#listmachinefragments).
@@ -4128,12 +4050,7 @@ Lists machine summaries for an organization, optionally filtered by fragment IDs
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const summaries = await appClient.listMachineSummaries(
-  'orgId',
-  ['frag1'],
-  ['loc1'],
-  10
-);
+const summaries = await appClient.listMachineSummaries('orgId', ['frag1'], ['loc1'], 10);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#listmachinesummaries).
@@ -4203,14 +4120,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Returns:**
 
-- (Promise<undefined | [Fragment](https://ts.viam.dev/classes/appApi.Fragment.html)>): The requested fragment.
+- (Promise<[Fragment](https://ts.viam.dev/classes/appApi.Fragment.html) | undefined>): The requested fragment.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const fragment = await appClient.getFragment(
-  '12a12ab1-1234-5678-abcd-abcd01234567'
-);
+const fragment = await appClient.getFragment('12a12ab1-1234-5678-abcd-abcd01234567');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#getfragment).
@@ -4229,7 +4144,7 @@ Create a new private {{< glossary_tooltip term_id="fragment" text="fragment" >}}
 
 - `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to create the fragment within. You can obtain your organization ID from the organization settings page.
 - `name` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): Name of the fragment.
-- `config` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (optional): Optional Dictionary representation of new config to assign to specified fragment. Can be assigned by updating the fragment.
+- `config` ([collections.abc.Mapping[str, viam.utils.ValueTypes]](https://python.viam.dev/autoapi/viam/components/component_base/index.html#viam.components.component_base.ValueTypes)) (optional): Optional Dictionary representation of new config to assign to specified fragment. Can be assigned by updating the fragment.
 
 **Returns:**
 
@@ -4293,22 +4208,18 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Parameters:**
 
-- `organizationId` (string) (required): The ID of the organization to create the fragment
-  under.
+- `organizationId` (string) (required): The ID of the organization to create the fragment under.
 - `name` (string) (required): The name of the new fragment.
 - `config` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The new fragment's config.
 
 **Returns:**
 
-- (Promise<undefined | [Fragment](https://ts.viam.dev/classes/appApi.Fragment.html)>): The newly created fragment.
+- (Promise<[Fragment](https://ts.viam.dev/classes/appApi.Fragment.html) | undefined>): The newly created fragment.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const fragment = await appClient.createFragment(
-  '<YOUR-ORGANIZATION-ID>',
-  'newFragment'
-);
+const fragment = await appClient.createFragment('<YOUR-ORGANIZATION-ID>', 'newFragment');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#createfragment).
@@ -4327,9 +4238,9 @@ Update a {{< glossary_tooltip term_id="fragment" text="fragment" >}} name and it
 
 - `fragment_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): ID of the fragment to update.
 - `name` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): New name to associate with the fragment.
-- `config` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (optional): Optional Dictionary representation of new config to assign to specified fragment. Not passing this parameter will leave the fragment’s config unchanged.
+- `config` ([collections.abc.Mapping[str, viam.utils.ValueTypes]](https://python.viam.dev/autoapi/viam/components/component_base/index.html#viam.components.component_base.ValueTypes)) (optional): Optional Dictionary representation of new config to assign to specified fragment. Not passing this parameter will leave the fragment’s config unchanged.
 - `public` ([bool](https://docs.python.org/3/library/stdtypes.html#boolean-type-bool)) (optional): Boolean specifying whether the fragment is public. Not passing this parameter will leave the fragment’s visibility unchanged. A fragment is private by default when created.  Deprecated since version 0.25.0: Use visibility instead.
-- `visibility` ([Fragment](https://python.viam.dev/autoapi/viam/gen/app/v1/app_pb2/index.html#viam.gen.app.v1.app_pb2.FragmentVisibility)) (optional): Optional FragmentVisibility list specifying who should be allowed to view the fragment. Not passing this parameter will leave the fragment’s visibility unchanged. A fragment is private by default when created.
+- `visibility` ([Fragment](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.Fragment.Visibility)) (optional): Optional FragmentVisibility list specifying who should be allowed to view the fragment. Not passing this parameter will leave the fragment’s visibility unchanged. A fragment is private by default when created.
 - `last_known_update` ([datetime.datetime](https://docs.python.org/3/library/datetime.html)) (optional): Optional time of the last known update to this fragment’s config. If provided, this will result in a GRPCError if the upstream config has changed since this time, indicating that the local config is out of date. Omitting this parameter will result in an overwrite of the upstream config.
 
 **Returns:**
@@ -4398,25 +4309,24 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 - `id` (string) (required): The ID of the fragment to update.
 - `name` (string) (required): The name to update the fragment to.
 - `config` ([Struct](https://ts.viam.dev/classes/Struct.html)) (required): The config to update the fragment to.
-- `makePublic` (boolean) (optional): Optional, deprecated boolean specifying whether the
-  fragment should be public or not. If not passed, the visibility will be
-  unchanged. Fragments are private by default when created.
-- `visibility` ([FragmentVisibility](https://ts.viam.dev/enums/appApi.FragmentVisibility.html)) (optional): Optional FragmentVisibility specifying the updated
-  fragment visibility. If not passed, the visibility will be unchanged. If
-  visibility is not set and makePublic is set, makePublic takes effect. If
-  makePublic and visibility are set, they must not be conflicting. If
-  neither is set, the fragment visibility will remain unchanged.
+- `makePublic` (boolean) (optional): Optional, deprecated boolean specifying whether the fragment should be public
+  or not. If not passed, the visibility will be unchanged. Fragments are private by default
+  when created.
+- `visibility` ([FragmentVisibility](https://ts.viam.dev/enums/appApi.FragmentVisibility.html)) (optional): Optional FragmentVisibility specifying the updated fragment visibility. If
+  not passed, the visibility will be unchanged. If visibility is not set and makePublic is set,
+  makePublic takes effect. If makePublic and visibility are set, they must not be conflicting.
+  If neither is set, the fragment visibility will remain unchanged.
 
 **Returns:**
 
-- (Promise<undefined | [Fragment](https://ts.viam.dev/classes/appApi.Fragment.html)>): The updated fragment.
+- (Promise<[Fragment](https://ts.viam.dev/classes/appApi.Fragment.html) | undefined>): The updated fragment.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const fragment = await appClient.updateFragment(
   '12a12ab1-1234-5678-abcd-abcd01234567',
-  'better_name'
+  'better_name',
 );
 ```
 
@@ -4509,7 +4419,7 @@ Get fragment history.
 
 **Returns:**
 
-- ([List[FragmentHistoryEntry]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.FragmentHistoryEntry)): :   A list of documents with the fragment history.
+- ([list[FragmentHistoryEntry]](https://python.viam.dev/autoapi/viam/app/app_client/index.html#viam.app.app_client.FragmentHistoryEntry)): :   A list of documents with the fragment history.
 
 **Raises:**
 
@@ -4568,8 +4478,8 @@ Add a role under the organization you are currently authenticated to.
 
 - `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to create the role in. You can obtain your organization ID from the organization settings page.
 - `identity_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): ID of the entity the role belongs to (for example, a user ID).
-- `role` (Literal['owner'] | Literal['operator']) (required): The role to add (either `"owner"` or `"operator"`).
-- `resource_type` (Literal['organization'] | Literal['location'] | Literal['robot']) (required): The type of the resource to add the role to (either `"organization"`, `"location"`, or `"robot"`). Must match the type of the `resource_id`'s resource.
+- `role` (_ROLE_TYPE) (required): The role to add (either `"owner"` or `"operator"`).
+- `resource_type` (_RESOURCE_TYPE_TYPE) (required): The type of the resource to add the role to (either `"organization"`, `"location"`, or `"robot"`). Must match the type of the `resource_id`'s resource.
 - `resource_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): ID of the resource the role applies to (the ID of either an {{< glossary_tooltip term_id="organization" text="organization" >}}, {{< glossary_tooltip term_id="location" text="location" >}}, or {{< glossary_tooltip term_id="machine" text="machine" >}}.).
 
 **Returns:**
@@ -4618,11 +4528,10 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Parameters:**
 
 - `organizationId` (string) (required): The ID of the organization to create the role under.
-- `entityId` (string) (required): The ID of the entity the role belongs to (for example a
-  user ID).
+- `entityId` (string) (required): The ID of the entity the role belongs to (for example a user ID).
 - `role` (string) (required): The role to add ("owner" or "operator").
-- `resourceType` (string) (required): The type of resource to create the role for ("robot",
-  "location", or "organization").
+- `resourceType` (string) (required): The type of resource to create the role for ("robot", "location", or
+  "organization").
 - `resourceId` (string) (required): The ID of the resource the role is being created for.
 
 **Returns:**
@@ -4637,7 +4546,7 @@ await appClient.addRole(
   '<YOUR-USER-ID>',
   'owner',
   'robot',
-  '<YOUR-ROBOT-ID>'
+  '<YOUR-ROBOT-ID>',
 );
 ```
 
@@ -4657,8 +4566,8 @@ Remove a role under the organization you are currently authenticated to.
 
 - `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization the role exists in. You can obtain your organization ID from the organization settings page.
 - `identity_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): ID of the entity the role belongs to (for example, a user ID).
-- `role` (Literal['owner'] | Literal['operator']) (required): The role to remove.
-- `resource_type` (Literal['organization'] | Literal['location'] | Literal['robot']) (required): Type of the resource the role is being removed from. Must match resource_id.
+- `role` (_ROLE_TYPE) (required): The role to remove.
+- `resource_type` (_RESOURCE_TYPE_TYPE) (required): Type of the resource the role is being removed from. Must match resource_id.
 - `resource_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): ID of the resource the role applies to (that is, either an organization, location, or robot ID).
 
 **Returns:**
@@ -4703,11 +4612,10 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Parameters:**
 
 - `organizationId` (string) (required): The ID of the organization to remove the role from.
-- `entityId` (string) (required): The ID of the entity the role belongs to (for example a
-  user ID).
+- `entityId` (string) (required): The ID of the entity the role belongs to (for example a user ID).
 - `role` (string) (required): The role to remove ("owner" or "operator").
-- `resourceType` (string) (required): The type of resource to remove the role from ("robot",
-  "location", or "organization").
+- `resourceType` (string) (required): The type of resource to remove the role from ("robot", "location", or
+  "organization").
 - `resourceId` (string) (required): The ID of the resource the role is being removes from.
 
 **Returns:**
@@ -4722,7 +4630,7 @@ await appClient.removeRole(
   '<YOUR-USER-ID>',
   'owner',
   'robot',
-  '<YOUR-ROBOT-ID>'
+  '<YOUR-ROBOT-ID>',
 );
 ```
 
@@ -4742,12 +4650,12 @@ Changes an existing role to a new role.
 
 - `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): ID of the organization.
 - `old_identity_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): ID of the entity the role belongs to (for example, a user ID).
-- `old_role` (Literal['owner'] | Literal['operator']) (required): The role to be changed.
-- `old_resource_type` (Literal['organization'] | Literal['location'] | Literal['robot']) (required): Type of the resource the role is added to. Must match old_resource_id.
+- `old_role` (_ROLE_TYPE) (required): The role to be changed.
+- `old_resource_type` (_RESOURCE_TYPE_TYPE) (required): Type of the resource the role is added to. Must match old_resource_id.
 - `old_resource_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): ID of the resource the role applies to (that is, either an organization, location, or robot ID).
 - `new_identity_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): New ID of the entity the role belongs to (for example, a user ID).
-- `new_role` (Literal['owner'] | Literal['operator']) (required): The new role.
-- `new_resource_type` (Literal['organization'] | Literal['location'] | Literal['robot']) (required): Type of the resource to add role to. Must match new_resource_id.
+- `new_role` (_ROLE_TYPE) (required): The new role.
+- `new_resource_type` (_RESOURCE_TYPE_TYPE) (required): Type of the resource to add role to. Must match new_resource_id.
 - `new_resource_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): New ID of the resource the role applies to (that is, either an organization, location, or robot ID).
 
 **Returns:**
@@ -4845,11 +4753,11 @@ If no resource IDs are provided, all resource authorizations within the organiza
 **Parameters:**
 
 - `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to list authorizations for.
-- `resource_ids` (List[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]) (optional): IDs of the resources to retrieve authorizations from. If None, defaults to all resources.
+- `resource_ids` (list[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]) (optional): IDs of the resources to retrieve authorizations from. If None, defaults to all resources.
 
 **Returns:**
 
-- ([List[viam.proto.app.Authorization]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Authorization)): :   The list of authorizations.
+- ([list[viam.proto.app.Authorization]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Authorization)): :   The list of authorizations.
 
 **Raises:**
 
@@ -4897,8 +4805,8 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Parameters:**
 
 - `organizationId` (string) (required): The ID of the organization to list authorizations for.
-- `resourceIds` (string) (optional): Optional list of IDs of resources to list authorizations
-  for. If not provided, all resources will be included.
+- `resourceIds` (string) (optional): Optional list of IDs of resources to list authorizations for. If not
+  provided, all resources will be included.
 
 **Returns:**
 
@@ -4918,11 +4826,11 @@ Check if the organization, location, or robot your `ViamClient` is authenticated
 
 **Parameters:**
 
-- `permissions` ([List[viam.proto.app.AuthorizedPermissions]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.AuthorizedPermissions)) (required): the permissions to validate (for example, “read_organization”, “control_robot”).
+- `permissions` ([list[viam.proto.app.AuthorizedPermissions]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.AuthorizedPermissions)) (required): the permissions to validate (for example, “read_organization”, “control_robot”).
 
 **Returns:**
 
-- ([List[viam.proto.app.AuthorizedPermissions]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.AuthorizedPermissions)): :   The permissions argument, with invalid permissions filtered out.
+- ([list[viam.proto.app.AuthorizedPermissions]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.AuthorizedPermissions)): :   The permissions argument, with invalid permissions filtered out.
 
 **Raises:**
 
@@ -5103,14 +5011,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Returns:**
 
-- (Promise<undefined | [RegistryItem](https://ts.viam.dev/classes/appApi.RegistryItem.html)>): The requested item.
+- (Promise<[RegistryItem](https://ts.viam.dev/classes/appApi.RegistryItem.html) | undefined>): The requested item.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const registryItem = await appClient.getRegistryItem(
-  '<YOUR-REGISTRY-ITEM-ID>'
-);
+const registryItem = await appClient.getRegistryItem('<YOUR-REGISTRY-ITEM-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#getregistryitem).
@@ -5176,8 +5082,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Parameters:**
 
-- `organizationId` (string) (required): The ID of the organization to create the registry
-  item under.
+- `organizationId` (string) (required): The ID of the organization to create the registry item under.
 - `name` (string) (required): The name of the registry item.
 - `type` (PackageType) (required): The type of the item in the registry.
 
@@ -5188,11 +5093,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await appClient.createRegistryItem(
-  '<YOUR-ORGANIZATION-ID>',
-  'newRegistryItemName',
-  5
-);
+await appClient.createRegistryItem('<YOUR-ORGANIZATION-ID>', 'newRegistryItemName', 5);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#createregistryitem).
@@ -5275,6 +5176,8 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 - `type` (PackageType) (required): The PackageType to update the item to.
 - `description` (string) (required): A description of the item.
 - `visibility` ([Visibility](https://ts.viam.dev/enums/appApi.Visibility.html)) (required): A visibility value to update to.
+- `billing` ([RegistryItemBilling](https://ts.viam.dev/classes/appApi.RegistryItemBilling.html)) (optional): Optional usage cost information to store on the item. When unset, the existing
+  billing configuration is left unchanged.
 
 **Returns:**
 
@@ -5287,7 +5190,7 @@ await appClient.updateRegistryItem(
   '<YOUR-REGISTRY-ITEM-ID>',
   5, // Package: ML Model
   'new description',
-  1 // Private
+  1, // Private
 );
 ```
 
@@ -5306,16 +5209,16 @@ List the registry items in an organization.
 **Parameters:**
 
 - `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to return registry items for.
-- `types` (List[viam.proto.app.packages.PackageType.ValueType]) (required): The types of registry items.
-- `visibilities` (List[viam.proto.app.Visibility.ValueType]) (required): The visibilities of registry items.
-- `platforms` (List[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]) (required): The platforms of registry items.
-- `statuses` (List[viam.proto.app.RegistryItemStatus.ValueType]) (required): The types of the items in the registry.
+- `types` (list[viam.proto.app.packages.PackageType.ValueType]) (required): The types of registry items.
+- `visibilities` (list[viam.proto.app.Visibility.ValueType]) (required): The visibilities of registry items.
+- `platforms` (list[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]) (required): The platforms of registry items.
+- `statuses` (list[viam.proto.app.RegistryItemStatus.ValueType]) (required): The types of the items in the registry.
 - `search_term` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (optional): The search term of the registry items.
 - `page_token` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (optional): The page token of the registry items.
 
 **Returns:**
 
-- ([List[viam.proto.app.RegistryItem]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.RegistryItem)): :   The list of registry items.
+- ([list[viam.proto.app.RegistryItem]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.RegistryItem)): :   The list of registry items.
 
 **Example:**
 
@@ -5391,18 +5294,14 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Parameters:**
 
-- `organizationId` (string) (required): The ID of the organization to query registry items
-  for.
+- `organizationId` (string) (required): The ID of the organization to query registry items for.
 - `types` (PackageType) (required): A list of types to query. If empty, will not filter on type.
-- `visibilities` ([Visibility](https://ts.viam.dev/enums/appApi.Visibility.html)) (required): A list of visibilities to query for. If empty, will not
-  filter on visibility.
-- `platforms` (string) (required): A list of platforms to query for. If empty, will not
-  filter on platform.
-- `statuses` ([RegistryItemStatus](https://ts.viam.dev/enums/appApi.RegistryItemStatus.html)) (required): A list of statuses to query for. If empty, will not filter
-  on status.
+- `visibilities` ([Visibility](https://ts.viam.dev/enums/appApi.Visibility.html)) (required): A list of visibilities to query for. If empty, will not filter on
+  visibility.
+- `platforms` (string) (required): A list of platforms to query for. If empty, will not filter on platform.
+- `statuses` ([RegistryItemStatus](https://ts.viam.dev/enums/appApi.RegistryItemStatus.html)) (required): A list of statuses to query for. If empty, will not filter on status.
 - `searchTerm` (string) (optional): Optional search term to filter on.
-- `pageToken` (string) (optional): Optional page token for results. If not provided, will
-  return all results.
+- `pageToken` (string) (optional): Optional page token for results. If not provided, will return all results.
 
 **Returns:**
 
@@ -5416,7 +5315,7 @@ const registryItems = await appClient.listRegistryItems(
   [], // All package types
   [1], // Private packages
   [],
-  [1] // Active packages
+  [1], // Active packages
 );
 ```
 
@@ -5504,7 +5403,7 @@ Create a {{< glossary_tooltip term_id="module" text="module" >}} under the organ
 
 **Returns:**
 
-- (Tuple[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), [str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]): :   A tuple containing the ID [0] of the new module and its URL [1].
+- (tuple[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), [str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]): :   A tuple containing the ID [0] of the new module and its URL [1].
 
 **Raises:**
 
@@ -5561,10 +5460,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const module = await appClient.createModule(
-  '<YOUR-ORGANIZATION-ID>',
-  'newModule'
-);
+const module = await appClient.createModule('<YOUR-ORGANIZATION-ID>', 'newModule');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#createmodule).
@@ -5584,7 +5480,7 @@ Update the documentation URL, description, models, entrypoint, and/or the visibi
 - `module_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): ID of the module being updated, containing either the namespace and module name (for example, my-org:my-module) or organization ID and module name (org-id:my-module).
 - `url` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The url to reference for documentation and code (NOT the url of the module itself).
 - `description` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): A short description of the module that explains its purpose.
-- `models` ([List[viam.proto.app.Model]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Model)) (optional): list of models that are available in the module.
+- `models` ([list[viam.proto.app.Model]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Model)) (optional): list of models that are available in the module.
 - `entrypoint` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The executable to run to start the module program.
 - `public` ([bool](https://docs.python.org/3/library/stdtypes.html#boolean-type-bool)) (required): The visibility that should be set for the module. Defaults to False (private).
 
@@ -5690,7 +5586,7 @@ const module = await appClient.updateModule(
   'https://example.com',
   'new description',
   [{ model: 'namespace:group:model1', api: 'rdk:component:generic' }],
-  'entrypoint'
+  'entrypoint',
 );
 ```
 
@@ -5821,7 +5717,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Returns:**
 
-- (Promise<undefined | [Module](https://ts.viam.dev/classes/appApi.Module.html)>): The requested module.
+- (Promise<[Module](https://ts.viam.dev/classes/appApi.Module.html) | undefined>): The requested module.
 
 **Example:**
 
@@ -5847,7 +5743,7 @@ List the {{< glossary_tooltip term_id="module" text="modules" >}} under the orga
 
 **Returns:**
 
-- ([List[viam.proto.app.Module]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Module)): :   The list of modules.
+- ([list[viam.proto.app.Module]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Module)): :   The list of modules.
 
 **Example:**
 
@@ -5911,12 +5807,12 @@ Create a new [API key](/organization/api-keys/).
 **Parameters:**
 
 - `org_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization to create the key for. You can obtain your organization ID from the organization settings page.
-- `authorizations` ([List[APIKeyAuthorization]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Authorization)) (required): A list of authorizations to associate with the key.
+- `authorizations` ([list[APIKeyAuthorization]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.Authorization)) (required): A list of authorizations to associate with the key.
 - `name` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (optional): A name for the key. If None, defaults to the current timestamp.
 
 **Returns:**
 
-- (Tuple[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), [str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]): :   The api key and api key ID.
+- (tuple[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), [str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]): :   The api key and api key ID.
 
 **Raises:**
 
@@ -5966,8 +5862,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Parameters:**
 
 - `authorizations` ([Authorization](https://ts.viam.dev/classes/appApi.Authorization.html)) (required): The list of authorizations to provide for the API key.
-- `name` (string) (optional): An optional name for the key. If none is passed, defaults to
-  present timestamp.
+- `name` (string) (optional): An optional name for the key. If none is passed, defaults to present timestamp.
 
 **Returns:**
 
@@ -6056,7 +5951,7 @@ Rotate an [API key](/organization/api-keys/#rotate-a-key).
 
 **Returns:**
 
-- (Tuple[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), [str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]): :   The API key and API key id.
+- (tuple[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), [str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]): :   The API key and API key id.
 
 **Example:**
 
@@ -6123,7 +6018,7 @@ List all keys for the {{< glossary_tooltip term_id="organization" text="organiza
 
 **Returns:**
 
-- ([List[viam.proto.app.APIKeyWithAuthorizations]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.APIKeyWithAuthorizations)): :   The existing API keys and authorizations.
+- ([list[viam.proto.app.APIKeyWithAuthorizations]](https://python.viam.dev/autoapi/viam/proto/app/index.html#viam.proto.app.APIKeyWithAuthorizations)): :   The existing API keys and authorizations.
 
 **Example:**
 
@@ -6219,7 +6114,7 @@ Create a new API key with an existing key’s authorizations.
 
 **Returns:**
 
-- (Tuple[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), [str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]): :   The API key and API key id.
+- (tuple[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), [str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]): :   The API key and API key id.
 
 **Example:**
 
@@ -6244,10 +6139,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const key =
-  await appClient.createKeyFromExistingKeyAuthorizations(
-    '<YOUR-KEY-ID>'
-  );
+const key = await appClient.createKeyFromExistingKeyAuthorizations('<YOUR-KEY-ID>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/AppClient.html#createkeyfromexistingkeyauthorizations).
@@ -6276,7 +6168,7 @@ Retrieve the app content for an organization.
 ```ts {class="line-numbers linkable-line-numbers"}
 const appContent = await appClient.getAppContent(
   '<YOUR-PUBLIC-NAMESPACE>',
-  '<YOUR-APP-NAME>'
+  '<YOUR-APP-NAME>',
 );
 ```
 
@@ -6306,7 +6198,7 @@ Retrieves the app branding for an organization or app.
 ```ts {class="line-numbers linkable-line-numbers"}
 const branding = await appClient.getAppBranding(
   '<YOUR-PUBLIC-NAMESPACE>',
-  '<YOUR-APP-NAME>'
+  '<YOUR-APP-NAME>',
 );
 ```
 

--- a/static/include/app/apis/generated/billing.md
+++ b/static/include/app/apis/generated/billing.md
@@ -115,9 +115,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const billingInfo = await billing.getOrgBillingInformation(
-  '<organization-id>'
-);
+const billingInfo = await billing.getOrgBillingInformation('<organization-id>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/BillingClient.html#getorgbillinginformation).
@@ -180,9 +178,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const invoicesSummary = await billing.getInvoicesSummary(
-  '<organization-id>'
-);
+const invoicesSummary = await billing.getInvoicesSummary('<organization-id>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/BillingClient.html#getinvoicessummary).
@@ -243,15 +239,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Returns:**
 
-- (Promise<Uint8Array>)
+- (Promise<Uint8Array<ArrayBuffer>>)
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const invoicePdf = await billing.getInvoicePdf(
-  '<invoice-id>',
-  '<organization-id>'
-);
+const invoicePdf = await billing.getInvoicePdf('<invoice-id>', '<organization-id>');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/BillingClient.html#getinvoicepdf).

--- a/static/include/app/apis/generated/data.md
+++ b/static/include/app/apis/generated/data.md
@@ -69,18 +69,16 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Parameters:**
 
 - `partId` (string) (required): The ID of the part that owns the data.
-- `resourceName` (string) (required): The name of the requested resource that captured the
-  data. Ex: "my-sensor".
-- `resourceSubtype` (string) (required): The subtype of the requested resource that captured
-  the data. Ex: "rdk:component:sensor".
+- `resourceName` (string) (required): The name of the requested resource that captured the data. Ex: "my-sensor".
+- `resourceSubtype` (string) (required): The subtype of the requested resource that captured the data. Ex:
+  "rdk:component:sensor".
 - `methodName` (string) (required): The data capture method name. Ex: "Readings".
 - `additionalParams` (Record) (optional)
 
 **Returns:**
 
-- (Promise<null | [Date, Date, Record<string, [JsonValue](https://ts.viam.dev/types/JsonValue.html)>]>): A tuple containing [timeCaptured, timeSynced, payload] or null if
-no data has been synced for the specified resource OR the most recently
-captured data was over a year ago.
+- (Promise<[Date, Date, Record<string, [JsonValue](https://ts.viam.dev/types/JsonValue.html)>] | null>): A tuple containing [timeCaptured, timeSynced, payload] or null if no data has been
+synced for the specified resource OR the most recently captured data was over a year ago.
 
 **Example:**
 
@@ -89,7 +87,7 @@ const data = await dataClient.getLatestTabularData(
   '123abc45-1234-5678-90ab-cdef12345678',
   'my-sensor',
   'rdk:component:sensor',
-  'Readings'
+  'Readings',
 );
 ```
 
@@ -203,15 +201,11 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Parameters:**
 
 - `partId` (string) (required): The ID of the part that owns the data.
-- `resourceName` (string) (required): The name of the requested resource that captured the
-  data.
-- `resourceSubtype` (string) (required): The subtype of the requested resource that captured
-  the data.
+- `resourceName` (string) (required): The name of the requested resource that captured the data.
+- `resourceSubtype` (string) (required): The subtype of the requested resource that captured the data.
 - `methodName` (string) (required): The data capture method name.
-- `startTime` (Date) (optional): Optional start time (`Date` object) for requesting a
-  specific range of data.
-- `endTime` (Date) (optional): Optional end time (`Date` object) for requesting a specific
-  range of data.
+- `startTime` (Date) (optional): Optional start time (`Date` object) for requesting a specific range of data.
+- `endTime` (Date) (optional): Optional end time (`Date` object) for requesting a specific range of data.
 - `additionalParams` (Record) (optional)
 
 **Returns:**
@@ -227,7 +221,7 @@ const data = await dataClient.exportTabularData(
   'rdk:component:sensor',
   'Readings',
   new Date('2025-03-25'),
-  new Date('2024-03-27')
+  new Date('2024-03-27'),
 );
 ```
 
@@ -354,23 +348,20 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Parameters:**
 
-- `filter` ([Filter](https://ts.viam.dev/classes/dataApi.Filter.html)) (optional): Optional `pb.Filter` specifying tabular data to retrieve. No
-  `filter` implies all tabular data.
-- `limit` (number) (optional): The maximum number of entries to include in a page. Defaults
-  to 50 if unspecfied.
+- `filter` ([Filter](https://ts.viam.dev/classes/dataApi.Filter.html)) (optional): Optional `pb.Filter` specifying tabular data to retrieve. No `filter` implies all
+  tabular data.
+- `limit` (number) (optional): The maximum number of entries to include in a page. Defaults to 50 if unspecfied.
 - `sortOrder` ([Order](https://ts.viam.dev/enums/dataApi.Order.html)) (optional): The desired sort order of the data.
-- `last` (string) (optional): Optional string indicating the ID of the last-returned data. If
-  provided, the server will return the next data entries after the `last`
-  ID.
+- `last` (string) (optional): Optional string indicating the ID of the last-returned data. If provided, the
+  server will return the next data entries after the `last` ID.
 - `countOnly` (boolean) (optional): Whether to return only the total count of entries.
-- `includeInternalData` (boolean) (optional): Whether to retun internal data. Internal data is
-  used for Viam-specific data ingestion, like cloud SLAM. Defaults to
-  `false`.
+- `includeInternalData` (boolean) (optional): Whether to retun internal data. Internal data is used for
+  Viam-specific data ingestion, like cloud SLAM. Defaults to `false`.
 
 **Returns:**
 
-- (Promise<{ count: bigint; data: TabularData[]; last: string }>): An array of data objects, the count (number of entries), and the
-last-returned page ID.
+- (Promise<{ count: bigint; data: TabularData[]; last: string }>): An array of data objects, the count (number of entries), and the last-returned page
+ID.
 
 **Example:**
 
@@ -380,7 +371,7 @@ const data = await dataClient.tabularDataByFilter(
     componentName: 'sensor-1',
     componentType: 'rdk:component:sensor',
   } as Filter,
-  5
+  5,
 );
 ```
 
@@ -478,7 +469,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Returns:**
 
-- [([]map[string]interface{})](https://pkg.go.dev/builtin#string)
+- [([]map[string]any)](https://pkg.go.dev/builtin#any)
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/app#DataClient.TabularDataBySQL).
@@ -500,7 +491,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 ```ts {class="line-numbers linkable-line-numbers"}
 const data = await dataClient.tabularDataBySQL(
   '123abc45-1234-5678-90ab-cdef12345678',
-  'SELECT * FROM readings LIMIT 5'
+  'SELECT * FROM readings LIMIT 5',
 );
 ```
 
@@ -585,12 +576,12 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 - `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
 - `organizationID` [(string)](https://pkg.go.dev/builtin#string)
-- `query` [([]map[string]interface{})](https://pkg.go.dev/builtin#string)
+- `query` [([]map[string]any)](https://pkg.go.dev/builtin#any)
 - `opts` [(*TabularDataByMQLOptions)](https://pkg.go.dev/go.viam.com/rdk/app#TabularDataByMQLOptions)
 
 **Returns:**
 
-- [([]map[string]interface{})](https://pkg.go.dev/builtin#string)
+- [([]map[string]any)](https://pkg.go.dev/builtin#any)
 - [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
 
 For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/app#DataClient.TabularDataByMQL).
@@ -602,8 +593,8 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 - `organizationId` (string) (required): The ID of the organization that owns the data.
 - `query` (Uint8Array) (required): The MQL query to run as a list of BSON documents.
-- `useRecentData` (boolean) (optional): Whether to query blob storage or your recent data
-  store. Defaults to false. Deprecated - use dataSource instead.
+- `useRecentData` (boolean) (optional): Whether to query blob storage or your recent data store. Defaults to
+  false. Deprecated - use dataSource instead.
 - `tabularDataSource` ([TabularDataSource](https://ts.viam.dev/classes/dataApi.TabularDataSource.html)) (optional)
 - `queryPrefixName` (string) (optional): Optional name of the query prefix.
 
@@ -628,7 +619,7 @@ const mqlQuery: Record<string, JsonValue>[] = [
 
 const data = await dataClient.tabularDataByMQL(
   '123abc45-1234-5678-90ab-cdef12345678',
-  mqlQuery
+  mqlQuery,
 );
 ```
 
@@ -772,25 +763,21 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Parameters:**
 
-- `filter` ([Filter](https://ts.viam.dev/classes/dataApi.Filter.html)) (optional): Optional `pb.Filter` specifying binary data to retrieve. No
-  `filter` implies all binary data.
-- `limit` (number) (optional): The maximum number of entries to include in a page. Defaults
-  to 50 if unspecfied.
+- `filter` ([Filter](https://ts.viam.dev/classes/dataApi.Filter.html)) (optional): Optional `pb.Filter` specifying binary data to retrieve. No `filter` implies all
+  binary data.
+- `limit` (number) (optional): The maximum number of entries to include in a page. Defaults to 50 if unspecfied.
 - `sortOrder` ([Order](https://ts.viam.dev/enums/dataApi.Order.html)) (optional): The desired sort order of the data.
-- `last` (string) (optional): Optional string indicating the ID of the last-returned data. If
-  provided, the server will return the next data entries after the `last`
-  ID.
-- `includeBinary` (boolean) (optional): Whether to include binary file data with each
-  retrieved file.
+- `last` (string) (optional): Optional string indicating the ID of the last-returned data. If provided, the
+  server will return the next data entries after the `last` ID.
+- `includeBinary` (boolean) (optional): Whether to include binary file data with each retrieved file.
 - `countOnly` (boolean) (optional): Whether to return only the total count of entries.
-- `includeInternalData` (boolean) (optional): Whether to retun internal data. Internal data is
-  used for Viam-specific data ingestion, like cloud SLAM. Defaults to
-  `false`.
+- `includeInternalData` (boolean) (optional): Whether to retun internal data. Internal data is used for
+  Viam-specific data ingestion, like cloud SLAM. Defaults to `false`.
 
 **Returns:**
 
-- (Promise<{ count: bigint; data: [BinaryData](https://ts.viam.dev/classes/dataApi.BinaryData.html)[]; last: string }>): An array of data objects, the count (number of entries), and the
-last-returned page ID.
+- (Promise<{ count: bigint; data: [BinaryData](https://ts.viam.dev/classes/dataApi.BinaryData.html)[]; last: string }>): An array of data objects, the count (number of entries), and the last-returned page
+ID.
 
 **Example:**
 
@@ -800,7 +787,7 @@ const data = await dataClient.binaryDataByFilter(
     componentName: 'camera-1',
     componentType: 'rdk:component:camera',
   } as Filter,
-  1
+  1,
 );
 ```
 
@@ -918,8 +905,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Parameters:**
 
 - `ids` (string) (required): The IDs of the requested binary data.
-- `includeBinary` (boolean) (optional): Whether to include binary file data with each
-  retrieved file.
+- `includeBinary` (boolean) (optional): Whether to include binary file data with each retrieved file.
 
 **Returns:**
 
@@ -1046,12 +1032,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Parameters:**
 
 - `organizationId` (string) (required): The ID of organization to delete data from.
-- `deleteOlderThanDays` (number) (required): Delete data that was captured more than this
-  many days ago. For example, a value of 10 deletes any data that was
-  captured more than 10 days ago. A value of 0 deletes all existing data.
-- `filter` (PartialMessage) (optional): Optional filter to further constrain which data is deleted.
-  If provided, only data matching the filter will be deleted. If omitted,
-  data is deleted based on organization\_id and delete\_older\_than\_days.
+- `deleteOlderThanDays` (number) (required): Delete data that was captured more than this many days ago. For
+  example, a value of 10 deletes any data that was captured more than 10 days ago. A value of 0
+  deletes all existing data.
+- `filter` (PartialMessage) (optional): Optional filter to further constrain which data is deleted. If provided, only
+  data matching the filter will be deleted. If omitted, data is deleted based on
+  organization\_id and delete\_older\_than\_days.
 
 **Returns:**
 
@@ -1062,7 +1048,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 ```ts {class="line-numbers linkable-line-numbers"}
 const data = await dataClient.deleteTabularData(
   '123abc45-1234-5678-90ab-cdef12345678',
-  10
+  10,
 );
 
 // Delete with additional filter constraints
@@ -1072,7 +1058,7 @@ const data = await dataClient.deleteTabularData(
   {
     locationIds: ['location-id'],
     componentName: 'camera',
-  }
+  },
 );
 ```
 
@@ -1166,10 +1152,9 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Parameters:**
 
-- `filter` ([Filter](https://ts.viam.dev/classes/dataApi.Filter.html)) (optional): Optional `pb.Filter` specifying binary data to delete. No
-  `filter` implies all binary data.
-- `includeInternalData` (boolean) (optional): Whether or not to delete internal data. Default
-  is true.
+- `filter` ([Filter](https://ts.viam.dev/classes/dataApi.Filter.html)) (optional): Optional `pb.Filter` specifying binary data to delete. No `filter` implies all
+  binary data.
+- `includeInternalData` (boolean) (optional): Whether or not to delete internal data. Default is true.
 
 **Returns:**
 
@@ -1416,8 +1401,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Parameters:**
 
-- `tags` (string) (required): The list of tags to add to specified binary data. Must be
-  non-empty.
+- `tags` (string) (required): The list of tags to add to specified binary data. Must be non-empty.
 - `ids` (string) (required): The IDs of the data to be tagged. Must be non-empty.
 
 **Returns:**
@@ -1431,7 +1415,7 @@ const data = await dataClient.addTagsToBinaryDataByIds(
   ['tag1', 'tag2'],
   [
     'ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh',
-  ]
+  ],
 );
 ```
 
@@ -1550,8 +1534,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Parameters:**
 
-- `tags` (string) (required): List of tags to remove from specified binary data. Must be
-  non-empty.
+- `tags` (string) (required): List of tags to remove from specified binary data. Must be non-empty.
 - `ids` (string) (required): The IDs of the data to be edited. Must be non-empty.
 
 **Returns:**
@@ -1565,7 +1548,7 @@ const data = await dataClient.removeTagsFromBinaryDataByIds(
   ['tag1', 'tag2'],
   [
     'ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh',
-  ]
+  ],
 );
 ```
 
@@ -1646,8 +1629,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Parameters:**
 
-- `filter` ([Filter](https://ts.viam.dev/classes/dataApi.Filter.html)) (optional): Optional `pb.Filter` specifying what data to get tags from.
-  No `filter` implies all data.
+- `filter` ([Filter](https://ts.viam.dev/classes/dataApi.Filter.html)) (optional): Optional `pb.Filter` specifying what data to get tags from. No `filter` implies
+  all data.
 
 **Returns:**
 
@@ -1771,19 +1754,14 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Parameters:**
 
-- `binaryId` (string) (required): The ID of the image to add the bounding
-  box to.
+- `binaryId` (string) (required): The ID of the image to add the bounding box to.
 - `label` (string) (required): A label for the bounding box.
-- `xMinNormalized` (number) (required): The min X value of the bounding box
-  normalized from 0 to 1.
-- `yMinNormalized` (number) (required): The min Y value of the bounding box
-  normalized from 0 to 1.
-- `xMaxNormalized` (number) (required): The max X value of the bounding box
-  normalized from 0 to 1.
-- `yMaxNormalized` (number) (required): The max Y value of the bounding box
-  normalized from 0 to 1.
-- `confidence` (number) (optional): Model's confidence in a predicted bounding box
-  expressed as a normalized value from 0 to 1.
+- `xMinNormalized` (number) (required): The min X value of the bounding box normalized from 0 to 1.
+- `yMinNormalized` (number) (required): The min Y value of the bounding box normalized from 0 to 1.
+- `xMaxNormalized` (number) (required): The max X value of the bounding box normalized from 0 to 1.
+- `yMaxNormalized` (number) (required): The max Y value of the bounding box normalized from 0 to 1.
+- `confidence` (number) (optional): Model's confidence in a predicted bounding box expressed as a
+  normalized value from 0 to 1.
 
 **Returns:**
 
@@ -1799,7 +1777,7 @@ const bboxId = await dataClient.addBoundingBoxToImageById(
   0.3,
   0.6,
   0.6,
-  0.4
+  0.4,
 );
 ```
 
@@ -1912,7 +1890,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 ```ts {class="line-numbers linkable-line-numbers"}
 await dataClient.removeBoundingBoxFromImageById(
   'ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh',
-  '5Z9ryhkW7ULaXROjJO6ghPYulNllnH20QImda1iZFroZpQbjahK6igQ1WbYigXED'
+  '5Z9ryhkW7ULaXROjJO6ghPYulNllnH20QImda1iZFroZpQbjahK6igQ1WbYigXED',
 );
 ```
 
@@ -2010,8 +1988,8 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Parameters:**
 
-- `filter` ([Filter](https://ts.viam.dev/classes/dataApi.Filter.html)) (optional): Optional `pb.Filter` specifying what data to get tags from.
-  No `filter` implies all labels.
+- `filter` ([Filter](https://ts.viam.dev/classes/dataApi.Filter.html)) (optional): Optional `pb.Filter` specifying what data to get tags from. No `filter` implies
+  all labels.
 
 **Returns:**
 
@@ -2120,7 +2098,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const hostname = await dataClient.getDatabaseConnection(
-  '123abc45-1234-5678-90ab-cdef12345678'
+  '123abc45-1234-5678-90ab-cdef12345678',
 );
 ```
 
@@ -2225,7 +2203,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 ```ts {class="line-numbers linkable-line-numbers"}
 await dataClient.configureDatabaseUser(
   '123abc45-1234-5678-90ab-cdef12345678',
-  'Password01!'
+  'Password01!',
 );
 ```
 
@@ -2342,7 +2320,7 @@ await dataClient.addBinaryDataToDatasetByIds(
   [
     'ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh',
   ],
-  '12ab3de4f56a7bcd89ef0ab1'
+  '12ab3de4f56a7bcd89ef0ab1',
 );
 ```
 
@@ -2468,7 +2446,7 @@ await dataClient.removeBinaryDataFromDatasetByIds(
   [
     'ccb74b53-1235-4328-a4b9-91dff1915a50/x5vur1fmps/YAEzj5I1kTwtYsDdf4a7ctaJpGgKRHmnM9bJNVyblk52UpqmrnMVTITaBKZctKEh',
   ],
-  '12ab3de4f56a7bcd89ef0ab1'
+  '12ab3de4f56a7bcd89ef0ab1',
 );
 ```
 
@@ -2567,14 +2545,12 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Returns:**
 
-- (Promise<null | DataPipeline>): The data pipeline configuration or null if it does not exist.
+- (Promise<DataPipeline | null>): The data pipeline configuration or null if it does not exist.
 
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const pipeline = await dataClient.getPipeline(
-  '123abc45-1234-5678-90ab-cdef12345678'
-);
+const pipeline = await dataClient.getPipeline('123abc45-1234-5678-90ab-cdef12345678');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/DataClient.html#getdatapipeline).
@@ -2635,7 +2611,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const pipelines = await dataClient.listDataPipelines(
-  '123abc45-1234-5678-90ab-cdef12345678'
+  '123abc45-1234-5678-90ab-cdef12345678',
 );
 ```
 
@@ -2686,7 +2662,7 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 - `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
 - `organizationID`
 - `name` [(string)](https://pkg.go.dev/builtin#string)
-- `query` [([]map[string]interface{})](https://pkg.go.dev/builtin#string)
+- `query` [([]map[string]any)](https://pkg.go.dev/builtin#any)
 - `schedule` [(string)](https://pkg.go.dev/builtin#string)
 - `enableBackfill` [(bool)](https://pkg.go.dev/builtin#bool)
 - `opts` [(*CreateDataPipelineOptions)](https://pkg.go.dev/go.viam.com/rdk/app#CreateDataPipelineOptions)
@@ -2794,9 +2770,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await dataClient.deleteDataPipeline(
-  '123abc45-1234-5678-90ab-cdef12345678'
-);
+await dataClient.deleteDataPipeline('123abc45-1234-5678-90ab-cdef12345678');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/DataClient.html#deletedatapipeline).
@@ -2860,9 +2834,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const page = await dataClient.listDataPipelineRuns(
-  '123abc45-1234-5678-90ab-cdef12345678'
-);
+const page = await dataClient.listDataPipelineRuns('123abc45-1234-5678-90ab-cdef12345678');
 page.runs.forEach((run) => {
   console.log(run);
 });
@@ -3026,7 +2998,7 @@ List all custom indexes for an organization.
 
 **Returns:**
 
-- ([Sequence[viam.proto.app.data.Index]](https://python.viam.dev/autoapi/viam/proto/app/data/index.html#viam.proto.app.data.Index)): :   A list of indexes.
+- ([Sequence[viam.proto.app.data.Index]](https://python.viam.dev/autoapi/viam/gen/app/data/v1/data_pb2/index.html#viam.gen.app.data.v1.data_pb2.Sequence)): :   A list of indexes.
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/app/data_client/index.html#viam.app.data_client.DataClient.list_indexes).
 
@@ -3096,15 +3068,15 @@ Update an existing bounding box on an image. You can change the label, position,
 **Example:**
 
 ```python {class="line-numbers linkable-line-numbers"}
-await data_client.update_bounding_box(
+bbox_id = await data_client.update_bounding_box_to_image_by_id(
     binary_id="<YOUR-BINARY-DATA-ID>",
-    bbox_id="2",
+    bbox_id="2"
     label="label",
     x_min_normalized=0,
-    y_min_normalized=0.1,
-    x_max_normalized=0.2,
-    y_max_normalized=0.3,
-    confidence_score=0.95
+    y_min_normalized=.1,
+    x_max_normalized=.2,
+    y_max_normalized=.3,
+    confidence_score=.95
 )
 ```
 

--- a/static/include/app/apis/generated/data_sync.md
+++ b/static/include/app/apis/generated/data_sync.md
@@ -21,7 +21,7 @@ Uploaded binary data can be found under the **Images**, **Point clouds**, or **F
 
 **Returns:**
 
-- ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)): : The binary data ID of the uploaded data.
+- ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)): :   The binary data ID of the uploaded data.
 
 **Raises:**
 
@@ -56,15 +56,14 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 - `binaryData` (Uint8Array) (required): The data to be uploaded, represented in bytes.
 - `partId` (string) (required): The part ID of the component used to capture the data.
-- `componentType` (string) (required): The type of the component used to capture the data
-  (for example, "movementSensor").
+- `componentType` (string) (required): The type of the component used to capture the data (for example,
+  "movementSensor").
 - `componentName` (string) (required): The name of the component used to capture the data.
 - `methodName` (string) (required): The name of the method used to capture the data.
-- `dataRequestTimes` (Date) (required): Tuple containing `Date` objects denoting the times
-  this data was requested[0] by the robot and received[1] from the
-  appropriate sensor.
-- `options` ([BinaryDataCaptureUploadOptions](https://ts.viam.dev/interfaces/BinaryDataCaptureUploadOptions.html)) (optional): Optional parameters including `mimeType`, `fileExtension`,
-  `tags`, and `datasetIds`.
+- `dataRequestTimes` (Date) (required): Tuple containing `Date` objects denoting the times this data was
+  requested[0] by the robot and received[1] from the appropriate sensor.
+- `options` ([BinaryDataCaptureUploadOptions](https://ts.viam.dev/interfaces/BinaryDataCaptureUploadOptions.html)) (optional): Optional parameters including `mimeType`, `fileExtension`, `tags`, and
+  `datasetIds`.
 
 **Returns:**
 
@@ -75,12 +74,12 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 ```ts {class="line-numbers linkable-line-numbers"}
 const binaryDataId = await dataClient.binaryDataCaptureUpload(
   binaryData,
-  "123abc45-1234-5678-90ab-cdef12345678",
-  "rdk:component:camera",
-  "my-camera",
-  "ReadImage",
-  [new Date("2025-03-19"), new Date("2025-03-19")],
-  { mimeType: "image/jpeg" },
+  '123abc45-1234-5678-90ab-cdef12345678',
+  'rdk:component:camera',
+  'my-camera',
+  'ReadImage',
+  [new Date('2025-03-19'), new Date('2025-03-19')],
+  { mimeType: 'image/jpeg' },
 );
 ```
 
@@ -167,7 +166,7 @@ Viam enforces a maximum size of 4MB for any single reading for tabular data.
 
 **Returns:**
 
-- ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)): : The file ID of the uploaded data.
+- ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)): :   The file ID of the uploaded data.
 
 **Raises:**
 
@@ -204,20 +203,17 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 **Parameters:**
 
-- `tabularData` (Record) (required): The list of data to be uploaded, represented tabularly
-  as an array.
+- `tabularData` (Record) (required): The list of data to be uploaded, represented tabularly as an array.
 - `partId` (string) (required): The part ID of the component used to capture the data.
-- `componentType` (string) (required): The type of the component used to capture the data
-  (for example, "movementSensor").
+- `componentType` (string) (required): The type of the component used to capture the data (for example,
+  "movementSensor").
 - `componentName` (string) (required): The name of the component used to capture the data.
 - `methodName` (string) (required): The name of the method used to capture the data.
-- `dataRequestTimes` (Date) (required): Array of Date tuples, each containing two `Date`
-  objects denoting the times this data was requested[0] by the robot and
-  received[1] from the appropriate sensor. Passing a list of tabular data
-  and Timestamps with length n > 1 will result in n datapoints being
-  uploaded, all tied to the same metadata.
-- `tags` (string) (optional): The list of tags to allow for tag-based filtering when
-  retrieving data.
+- `dataRequestTimes` (Date) (required): Array of Date tuples, each containing two `Date` objects denoting the
+  times this data was requested[0] by the robot and received[1] from the appropriate sensor.
+  Passing a list of tabular data and Timestamps with length n > 1 will result in n datapoints
+  being uploaded, all tied to the same metadata.
+- `tags` (string) (optional): The list of tags to allow for tag-based filtering when retrieving data.
 
 **Returns:**
 
@@ -230,16 +226,16 @@ const fileId = await dataClient.tabularDataCaptureUpload(
   [
     {
       readings: {
-        timestamp: "2025-03-26T10:00:00Z",
+        timestamp: '2025-03-26T10:00:00Z',
         value: 10,
       },
     },
   ],
-  "123abc45-1234-5678-90ab-cdef12345678",
-  "rdk:component:sensor",
-  "my-sensor",
-  "Readings",
-  [[new Date("2025-03-26T10:00:00Z"), new Date("2025-03-26T10:00:00Z")]],
+  '123abc45-1234-5678-90ab-cdef12345678',
+  'rdk:component:sensor',
+  'my-sensor',
+  'Readings',
+  [[new Date('2025-03-26T10:00:00Z'), new Date('2025-03-26T10:00:00Z')]],
 );
 ```
 
@@ -332,7 +328,7 @@ All other types of uploaded files can be found under the **Files** subtab of the
 
 **Returns:**
 
-- ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)): : Binary data ID of the new file.
+- ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)): :   Binary data ID of the new file.
 
 **Raises:**
 
@@ -443,11 +439,11 @@ Uploaded files can be found under the **Files** subtab of the [**Data** tab](htt
 - `tags` (List[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]) (optional): Optional list of tags to allow for tag-based filtering when retrieving data.
 - `dataset_ids` (List[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)]) (optional): Optional list of datasets to add the data to.
 - `mime_type` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (optional): Optional mime type of the data.
-- `file_name` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (optional): Optional name of the file. If not provided, the name is derived from the filepath.
+- `file_name` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (optional): Optional name of the file. If not provided, the name will be derived from the filepath.
 
 **Returns:**
 
-- ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)): : Binary data ID of the new file.
+- ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)): :   Binary data ID of the new file.
 
 **Raises:**
 
@@ -494,7 +490,7 @@ Uploaded streaming data can be found under the [**Data** tab](https://app.viam.c
 
 **Returns:**
 
-- ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)): : The binary data ID of the uploaded data.
+- ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)): :   The binary data ID of the uploaded data.
 
 **Raises:**
 

--- a/static/include/app/apis/generated/dataset.md
+++ b/static/include/app/apis/generated/dataset.md
@@ -9,6 +9,7 @@ Create a new dataset.
 
 - `name` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The name of the dataset being created.
 - `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization where the dataset is being created. To find your organization ID, visit the organization settings page.
+- `type` (viam.proto.app.dataset.DatasetType.ValueType) (optional): The membership kind for the new dataset. Defaults to DATASET_TYPE_BINARY_DATA when unset.
 
 **Returns:**
 
@@ -48,8 +49,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Parameters:**
 
 - `name` (string) (required): The name of the new dataset.
-- `organizationId` (string) (required): The ID of the organization the dataset is being
-  created in.
+- `organizationId` (string) (required): The ID of the organization the dataset is being created in.
 
 **Returns:**
 
@@ -60,7 +60,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 ```ts {class="line-numbers linkable-line-numbers"}
 const datasetId = await dataClient.createDataset(
   'my-new-dataset',
-  '123abc45-1234-5678-90ab-cdef12345678'
+  '123abc45-1234-5678-90ab-cdef12345678',
 );
 ```
 
@@ -256,10 +256,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-await dataClient.renameDataset(
-  '12ab3de4f56a7bcd89ef0ab1',
-  'my-new-dataset'
-);
+await dataClient.renameDataset('12ab3de4f56a7bcd89ef0ab1', 'my-new-dataset');
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/DataClient.html#renamedataset).
@@ -312,10 +309,11 @@ Get the datasets in an organization.
 **Parameters:**
 
 - `organization_id` ([str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str)) (required): The ID of the organization you’d like to retrieve datasets from. To find your organization ID, visit the organization settings page.
+- `dataset_type` (viam.proto.app.dataset.DatasetType.ValueType) (optional): Optional filter on dataset type. If not provided, all dataset types will be returned.
 
 **Returns:**
 
-- ([Sequence[viam.proto.app.dataset.Dataset]](https://python.viam.dev/autoapi/viam/proto/app/dataset/index.html#viam.proto.app.dataset.Dataset)): :   The list of datasets in the organization.
+- ([Sequence[viam.proto.app.dataset.Dataset]](https://python.viam.dev/autoapi/viam/gen/app/data/v1/data_pb2/index.html#viam.gen.app.data.v1.data_pb2.Sequence)): :   The list of datasets in the organization.
 
 **Example:**
 
@@ -349,6 +347,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Parameters:**
 
 - `organizationId` (string) (required): The ID of the organization.
+- `type` ([DatasetType](https://ts.viam.dev/enums/DatasetType.html)) (optional): Optional dataset type to filter on.
 
 **Returns:**
 
@@ -358,7 +357,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 ```ts {class="line-numbers linkable-line-numbers"}
 const datasets = await dataClient.listDatasetsByOrganizationID(
-  '123abc45-1234-5678-90ab-cdef12345678'
+  '123abc45-1234-5678-90ab-cdef12345678',
 );
 ```
 
@@ -414,7 +413,7 @@ Get a list of datasets using their IDs.
 
 **Returns:**
 
-- ([Sequence[viam.proto.app.dataset.Dataset]](https://python.viam.dev/autoapi/viam/proto/app/dataset/index.html#viam.proto.app.dataset.Dataset)): :   The list of datasets.
+- ([Sequence[viam.proto.app.dataset.Dataset]](https://python.viam.dev/autoapi/viam/gen/app/data/v1/data_pb2/index.html#viam.gen.app.data.v1.data_pb2.Sequence)): :   The list of datasets.
 
 **Example:**
 
@@ -456,9 +455,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 **Example:**
 
 ```ts {class="line-numbers linkable-line-numbers"}
-const datasets = await dataClient.listDatasetsByIds([
-  '12ab3de4f56a7bcd89ef0ab1',
-]);
+const datasets = await dataClient.listDatasetsByIds(['12ab3de4f56a7bcd89ef0ab1']);
 ```
 
 For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfaces/DataClient.html#listdatasetsbyids).

--- a/static/include/app/apis/generated/mltraining.md
+++ b/static/include/app/apis/generated/mltraining.md
@@ -77,7 +77,7 @@ await mlTrainingClient.submitTrainingJob(
   '<your-model-name>',
   '1.0.0',
   ModelType.SINGLE_LABEL_CLASSIFICATION,
-  ['tag1', 'tag2']
+  ['tag1', 'tag2'],
 );
 ```
 
@@ -165,7 +165,7 @@ await mlTrainingClient.submitCustomTrainingJob(
   'viam:classification-tflite',
   '1.0.0',
   '<your-model-name>',
-  '1.0.0'
+  '1.0.0',
 );
 ```
 
@@ -222,7 +222,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 
 **Returns:**
 
-- (Promise<undefined | [TrainingJobMetadata](https://ts.viam.dev/classes/mlTrainingApi.TrainingJobMetadata.html)>)
+- (Promise<[TrainingJobMetadata](https://ts.viam.dev/classes/mlTrainingApi.TrainingJobMetadata.html) | undefined>)
 
 **Example:**
 
@@ -295,7 +295,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/a
 ```ts {class="line-numbers linkable-line-numbers"}
 const jobs = await mlTrainingClient.listTrainingJobs(
   '<organization-id>',
-  TrainingStatus.RUNNING
+  TrainingStatus.RUNNING,
 );
 ```
 

--- a/static/include/components/apis/generated/arm.md
+++ b/static/include/components/apis/generated/arm.md
@@ -597,7 +597,7 @@ For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/r
 
 **Returns:**
 
-- (Promise<GetKinematicsResult>): The legacy kinematics data shape or the newer object containing kinematics data plus a
+- (Promise<[GetKinematicsResult](https://ts.viam.dev/types/GetKinematicsResult.html)>): The legacy kinematics data shape or the newer object containing kinematics data plus a
 map of URDF mesh file paths to mesh data.
 
 **Example:**

--- a/static/include/components/apis/generated/audio_out.md
+++ b/static/include/components/apis/generated/audio_out.md
@@ -99,8 +99,8 @@ Stream audio data in chunks for playback.
 
 **Parameters:**
 
-- `chunks` (AsyncIterator[[bytes](https://docs.python.org/3/library/stdtypes.html#bytes-objects)]) (required): async iterator of audio data chunks to play.
-- `info` (viam.components.audio_out.audio_out.AudioInfo) (optional): (optional) information about the audio data such as codec, sample rate, and channel count.
+- `info` (viam.components.audio_out.audio_out.AudioInfo) (required): information about the audio stream such as codec, sample rate, and channel count.
+- `chunks` (AsyncIterable[[bytes](https://docs.python.org/3/library/stdtypes.html#bytes-objects)]) (required): async iterable of audio bytes to play in order.
 - `extra` (Mapping[[str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str), Any]) (optional): Extra options to pass to the underlying RPC call.
 - `timeout` ([float](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex)) (optional): An option to set how long to wait (in seconds) before calling a time-out and closing the underlying RPC call.
 
@@ -111,14 +111,12 @@ Stream audio data in chunks for playback.
 **Example:**
 
 ```python {class="line-numbers linkable-line-numbers"}
-my_audio_out = AudioOut.from_robot(robot=machine, name="my_audio_out")
-
-async def audio_generator():
-    for chunk in audio_chunks:
+async def chunk_source():
+    for chunk in pcm_chunks:
         yield chunk
 
-audio_info = AudioInfo(codec=AudioCodec.PCM16, sample_rate_hz=44100, num_channels=2)
-await my_audio_out.play_stream(audio_generator(), audio_info)
+audio_info = AudioInfo(codec="pcm16", sample_rate_hz=22050, num_channels=1)
+await my_audio_out.play_stream(audio_info, chunk_source())
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/components/audio_out/client/index.html#viam.components.audio_out.client.AudioOutClient.play_stream).

--- a/static/include/components/apis/generated/sensor-table.md
+++ b/static/include/components/apis/generated/sensor-table.md
@@ -3,7 +3,7 @@
 | ----------- | ----------- | --------------------------- |
 | [`GetReadings`](/reference/apis/components/sensor/#getreadings) | Get the measurements or readings that this sensor provides. | <p class="center-text"><i class="fas fa-check" title="yes"></i></p> |
 | [`GetGeometries`](/reference/apis/components/sensor/#getgeometries) | Get all the geometries associated with the sensor in its current configuration, in the frame of the sensor. |
-| [`Reconfigure`](/reference/apis/components/sensor/#reconfigure) | Reconfigure this resource. |  |
+| [`Reconfigure`](/reference/apis/components/sensor/#reconfigure) | Reconstruct this resource. |  |
 | [`DoCommand`](/reference/apis/components/sensor/#docommand) | Execute model-specific commands that are not otherwise defined by the component API. |
 | [`GetStatus`](/reference/apis/components/sensor/#getstatus) | Get the current status of the sensor as a map of key-value pairs describing its state. |  |
 | [`GetResourceName`](/reference/apis/components/sensor/#getresourcename) | Get the `ResourceName` for this sensor. |  |

--- a/static/include/components/apis/generated/sensor.md
+++ b/static/include/components/apis/generated/sensor.md
@@ -128,8 +128,8 @@ For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/
 
 ### Reconfigure
 
-Reconfigure this resource.
-Reconfigure must reconfigure the resource atomically and in place.
+Reconstruct this resource.
+For modular resources, reconstruction destroys the existing resource instance and creates a new one using the constructor.
 
 {{< tabs >}}
 {{% tab name="Go" %}}

--- a/static/include/robot/apis/generated/robot.md
+++ b/static/include/robot/apis/generated/robot.md
@@ -56,7 +56,7 @@ Get status information about the machine including the status of the machine and
 
 **Returns:**
 
-- ([viam.proto.robot.GetMachineStatusResponse](https://python.viam.dev/autoapi/viam/proto/robot/index.html#viam.proto.robot.GetMachineStatusResponse)): :   current status of the machine (initializing or running), current status of the resources (List[ResourceStatus]), the revision of the config of the machine, and the status of modules (List[ModuleStatus]).
+- ([viam.proto.robot.GetMachineStatusResponse](https://python.viam.dev/autoapi/viam/proto/robot/index.html#viam.proto.robot.GetMachineStatusResponse)): :   current status of the machine (initializing or running), current status of the resources (List[ResourceStatus]), the revision of the config of the machine, the status of modules (List[ModuleStatus]), and the status of packages (List[PackageStatus]).
 
 **Example:**
 
@@ -67,6 +67,7 @@ resource_statuses = machine_status.resources
 cloud_metadata = machine_status.resources[0].cloud_metadata
 config_status = machine_status.config
 module_statuses = machine_status.modules
+package_statuses = machine_status.packages
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient.get_machine_status).
@@ -488,7 +489,7 @@ Do not move the robot between the generation of the initial pointcloud and the r
 my_camera = Camera.from_robot(robot=machine, name="my_camera")
 data, _ = await my_camera.get_point_cloud()
 
-transformed_pcd = await machine.transform_pcd(data, "my_camera", "world")
+transformed_pcd = await machine.transform_pcd(pcd, "my_camera", "world")
 ```
 
 For more information, see the [Python SDK Docs](https://python.viam.dev/autoapi/viam/robot/client/index.html#viam.robot.client.RobotClient.transform_pcd).


### PR DESCRIPTION
## What this adds

Content-only regeneration of the SDK API reference pages, now that #5241 fixed the two `BeautifulSoup` crashes and the shortcode-stripping regex bug in `update_sdk_methods.py`/`parse_typescript.py` that were blocking (or silently corrupting) regeneration. No new methods, no `sdk_protos_map.csv` or override-file changes — this just catches existing pages up to current upstream SDK state and to the fixed generator's output, wherever they'd drifted since their last regen.

This supersedes #5234, which hand-edited `audio_out.md`'s `play_stream` parameter order/type directly instead of regenerating it (introducing prettier-driven formatting noise inconsistent with every sibling file in the process). The `play_stream` fix itself was correct; this PR reproduces the same semantic fix via the generator, without the noise.

Files touched: `app.md`, `billing.md`, `data.md`, `data_sync.md`, `dataset.md`, `mltraining.md` (app APIs), `arm.md`, `audio_out.md` (components), `sensor.md`/`sensor-table.md` (components), `robot.md`.

## How

Ran `update_sdk_methods.py` (all four SDKs: Python, Go, TypeScript, Flutter; component/service/app/robot types) against current upstream SDK docs sites, on top of #5241's fixes. No CSV or override-file edits.

## Verification

- Diffed every changed file by hand rather than trusting the regen blind. Confirmed no `### <method>` sections were added or removed (`git diff | grep '^[-+]### '` is empty) — the diff is entirely within existing sections.
- No leaked raw HTML (`markdownify` misses) and no anomalous duplicated lines introduced.
- The prevalent `List[...]` → `list[...]` pattern across several files (33 occurrences) is real upstream drift, not a scraper artifact — spot-checked two cases directly against `python.viam.dev`: `viam.app.app_client` (all of `app.md`) has been migrated to PEP 585 lowercase generics; `viam.robot.client` (`robot.md`'s `GetOperations`) still uses `typing.List`. The mix in `data.md`/`robot.md`/etc. accurately reflects that the migration is partial upstream, module by module.
- `sensor.md`/`sensor-table.md`'s `Reconfigure` → `Reconstruct` description change reflects the already-merged `sensor.Reconfigure.md` override update from #5042 ("Resource.Reconfigure removal, shipped in RDK v1.0.0") — this page just hadn't been regenerated since.
- `data_sync-table.md` regenerated to a byte-identical match with its current committed content, confirming #5241's regex fix; it was the file that exposed the original truncation bug (`TabularDataCaptureUpload`'s description previously would have truncated to "...through a specific." mid-sentence with the pre-#5241 generator).
- Ran the CLAUDE.md pre-PR checks with the correct scope: `prettier`/`markdownlint` don't apply here — both required CI checks (`prettier-lint.yml`, `markdown-lint.yml`) are scoped to `docs/**`, and `static/` is explicitly excluded from markdownlint's `search_paths`, by design (these files are generator output, not hand-formatted prose — the generator's own style, e.g. single-quoted JS/TS strings, is the canonical committed style, and running prettier over it would just reintroduce the #5234 inconsistency-with-siblings problem). `vale` **does** run repo-wide and is a required, blocking check — ran it locally (`vale sync && vale <changed files>`): 0 errors, 0 warnings, 0 suggestions. `make build-prod` completes cleanly (only expected "old page date" warnings).

This doesn't touch `sdk_protos_map.csv`, so it doesn't move the #5142 method-coverage warning count — that's a separate, ongoing effort (#5184, #5185, and future companions). This is purely about keeping already-documented content in sync with upstream and validating #5241 end-to-end.

Refs #5142
Refs #5234

🤖 Generated with [Claude Code](https://claude.com/claude-code)