### PR TITLE
Remove num_threads from motion service config docs

### DIFF
--- a/docs/motion-planning/reference/algorithms.md
+++ b/docs/motion-planning/reference/algorithms.md
@@ -50,10 +50,10 @@ The planner-relevant entries are:
 
 Callers override a default in one of two places: persistently in the motion service config, or per call through the `extra` map on a `Move` request. The table below shows which tunables live where.
 
-| Where                                | Scope                   | Example tunables                                                |
-| ------------------------------------ | ----------------------- | --------------------------------------------------------------- |
-| Motion service config (`attributes`) | Persistent, per-service | `num_threads`, `input_range_override`, planner-diagnostic flags |
-| `extra` map on a Move request        | Per-request             | `collision_buffer_mm`, `max_ik_solutions`, `timeout`            |
+| Where                                | Scope                   | Example tunables                                     |
+| ------------------------------------ | ----------------------- | ---------------------------------------------------- |
+| Motion service config (`attributes`) | Persistent, per-service | `input_range_override`, planner-diagnostic flags     |
+| `extra` map on a Move request        | Per-request             | `collision_buffer_mm`, `max_ik_solutions`, `timeout` |
 
 See [Motion service configuration](/motion-planning/reference/motion-service/)
 for the full list of configuration attributes.

--- a/docs/motion-planning/reference/motion-service.md
+++ b/docs/motion-planning/reference/motion-service.md
@@ -14,8 +14,7 @@ aliases:
 The motion service plans and executes component motion: arm end-effector moves, base moves across a SLAM map, and base moves to a GPS coordinate. The builtin service ships with every machine running `viam-server`, so you do not need to add it to your configuration.
 
 Most users never configure the motion service. Read this page if you need
-to log planning errors, cap planning threads, or narrow a joint's range
-below its kinematic limits.
+to log planning errors or narrow a joint's range below its kinematic limits.
 
 ## Access the motion service
 
@@ -50,15 +49,14 @@ if err != nil {
 The builtin motion service accepts the following optional configuration
 attributes:
 
-| Attribute                         | Type   | Default          | Description                                                                                                                                                                                                                                                                    |
-| --------------------------------- | ------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `log_file_path`                   | string | (none)           | Path to write planning debug logs.                                                                                                                                                                                                                                             |
-| `num_threads`                     | int    | (system default) | Number of threads for parallel planning.                                                                                                                                                                                                                                       |
-| `plan_file_path`                  | string | (none)           | Path to write plan output files.                                                                                                                                                                                                                                               |
-| `plan_directory_include_trace_id` | bool   | false            | Include trace ID in plan output directory names.                                                                                                                                                                                                                               |
-| `log_planner_errors`              | bool   | false            | Log planning errors to the log file.                                                                                                                                                                                                                                           |
-| `log_slow_plan_threshold_ms`      | int    | (none)           | Log plans that take longer than this threshold in milliseconds.                                                                                                                                                                                                                |
-| `input_range_override`            | object | (none)           | Narrow a joint's allowed range below its kinematic limits. The value is a map from frame name to a map from joint index (string) to `{"min": <value>, "max": <value>}`. For example, `{"my-arm": {"3": {"min": 0, "max": 2}}}` restricts joint 3 of `my-arm` to the range 0-2. |
+| Attribute                         | Type   | Default | Description                                                                                                                                                                                                                                                                    |
+| --------------------------------- | ------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `log_file_path`                   | string | (none)  | Path to write planning debug logs.                                                                                                                                                                                                                                             |
+| `plan_file_path`                  | string | (none)  | Path to write plan output files.                                                                                                                                                                                                                                               |
+| `plan_directory_include_trace_id` | bool   | false   | Include trace ID in plan output directory names.                                                                                                                                                                                                                               |
+| `log_planner_errors`              | bool   | false   | Log planning errors to the log file.                                                                                                                                                                                                                                           |
+| `log_slow_plan_threshold_ms`      | int    | (none)  | Log plans that take longer than this threshold in milliseconds.                                                                                                                                                                                                                |
+| `input_range_override`            | object | (none)  | Narrow a joint's allowed range below its kinematic limits. The value is a map from frame name to a map from joint index (string) to `{"min": <value>, "max": <value>}`. For example, `{"my-arm": {"3": {"min": 0, "max": 2}}}` restricts joint 3 of `my-arm` to the range 0-2. |
 
 Example configuration:
 


### PR DESCRIPTION
The `num_threads` config field was removed from the motion service in viamrobotics/rdk#6303. This PR removes references to the field from the docs.

## Source changes

- viamrobotics/rdk#6303: Remove motion service num threads config references (RSDK-14361)

## Docs changes

- `docs/motion-planning/reference/motion-service.md`: Remove `num_threads` row from the configuration attributes table and remove "cap planning threads" from the intro paragraph.
- `docs/motion-planning/reference/algorithms.md`: Remove `num_threads` from the tuning surfaces table example tunables.

## How I found these

- Xref lookup: `config-xref.md` maps motion service config to the motion-service.md page
- Grep matches: 2 pages reference `num_threads` (motion-service.md line 56, algorithms.md line 55)

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_0183sfVTTGdPchhhNMh4WW95)_