### PR TITLE
Update CLI log --count and --start flag defaults

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -1105,9 +1105,9 @@ viam machines logs --machine=123
 | `--errors` | Boolean, return only errors. Default: `false`. | Optional |
 | `--levels` | Filter logs by levels (debug, info, warn, error). Accepts multiple inputs in comma-separated list. | Optional |
 | `--keyword` | Filter logs by keyword. | Optional |
-| `--start` | Filter logs to include only those after the start time. Time format example: `2025-01-13T21:30:00Z` (ISO-8601 timestamp in RFC3339). | Optional |
+| `--start` | Filter logs to include only those after the start time. Time format example: `2025-01-13T21:30:00Z` (ISO-8601 timestamp in RFC3339). Default: 24 hours ago. | Optional |
 | `--end` | Filter logs to include only those before the end time. Time format example: `2025-01-13T21:35:00Z` (ISO-8601 timestamp in RFC3339). | Optional |
-| `--count` | The number of logs to fetch. | Optional |
+| `--count` | Maximum number of logs to fetch. Default: all logs in the time range. | Optional |
 | `--format` | The file format for the output file. Options: `text` or `json`. | Optional |
 | `--output` | The path to the output file to store logs in. | Optional |
 | `--location` | ID of the location that the machine belongs to. | Optional |
@@ -1199,9 +1199,9 @@ viam machines part logs --part=myrover-main --tail=true
 | `--errors` | Return only errors. Default: `false`. | Optional |
 | `--levels` | Filter logs by levels (debug, info, warn, error). Accepts multiple inputs in comma-separated list. | Optional |
 | `--keyword` | Filter logs by keyword. | Optional |
-| `--start` | Filter logs to include only those after the start time. | Optional |
+| `--start` | Filter logs to include only those after the start time. Default: 24 hours ago. | Optional |
 | `--end` | Filter logs to include only those before the end time. | Optional |
-| `--count` | The number of logs to fetch. | Optional |
+| `--count` | Maximum number of logs to fetch. Default: all logs in the time range. | Optional |
 | `--format` | The file format for the output file. Options: `text` or `json`. | Optional |
 | `--output` | The path to the output file to store logs in. | Optional |
 


### PR DESCRIPTION
viamrobotics/rdk#6288 removed the artificial log count limits from the CLI and changed the default start time. This PR updates the docs to reflect the new defaults.

## Source changes

- viamrobotics/rdk#6288: Remove artificial log count limits from the CLI (APP-17425)

## Docs changes

- `docs/cli/reference.md`: Update `--count` description from "The number of logs to fetch" to "Maximum number of logs to fetch. Default: all logs in the time range." for both `machines logs` and `machines part logs` commands.
- `docs/cli/reference.md`: Add "Default: 24 hours ago." to `--start` flag description for both log commands.

### What changed in the code

- The `maxNumLogs` constant (10,000) was removed. There is no longer a maximum on the `--count` flag.
- The `defaultNumLogs` constant (100) was removed. Without `--count`, all logs in the time range are returned.
- The `defaultLogStartTime` changed from 12 hours to 24 hours ago.

## How I found these

- Xref lookup: `cli-xref.md` maps CLI log commands to the CLI reference page
- Grep matches: 2 locations in `docs/cli/reference.md` (lines 1108-1110 and 1202-1204) reference the `--count` and `--start` flags

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_0183sfVTTGdPchhhNMh4WW95)_