### PR TITLE
Pin @connectrpc/connect-node to v1 in Node.js setup docs

### DIFF
--- a/docs/build-apps/setup/node.md
+++ b/docs/build-apps/setup/node.md
@@ -31,10 +31,8 @@ npm init -y
 Node.js needs three runtime packages:
 
 - `@viamrobotics/sdk` — the Viam SDK
-- `@connectrpc/connect-node` — the Node-compatible gRPC transport
+- `@connectrpc/connect-node@^1.7.0` — the Node-compatible gRPC transport
 - `node-datachannel` — a WebRTC implementation for Node
-
-The SDK depends on the Connect-ES v1 API, so pin `@connectrpc/connect-node` to the matching major version. Installing it unpinned resolves to the incompatible v2 line and fails with a `TypeError` when the SDK tries to connect.
 
 Install everything at once:
 
@@ -152,6 +150,7 @@ If the script hangs or errors, the most common causes are:
 - **Polyfills registered too late.** The polyfill loop and transport factory must run before the first call into the SDK. If you split them into a separate module that is imported after the SDK, the SDK initializes without them.
 - **`.env` not loaded.** The `tsx --env-file=.env` flag loads the file. If you run the script a different way (`node`, `ts-node`, a bundler), use `dotenv` or your runtime's env loader instead.
 - **Wrong transport.** If you see `Unsupported HTTP version` or similar, confirm that `@connectrpc/connect-node` is installed and the transport factory is registered on `globalThis.VIAM`.
+- **Wrong `@connectrpc/connect-node` version.** The SDK depends on the Connect-ES v1 API. If `@connectrpc/connect-node` gets installed unpinned, it resolves to the incompatible v2 line and fails with a `TypeError` when the SDK tries to connect. Pin it to `^1.7.0`, as in the install command above.
 
 ## Next
 

--- a/docs/build-apps/setup/node.md
+++ b/docs/build-apps/setup/node.md
@@ -73,7 +73,6 @@ const wrtc = require("node-datachannel/polyfill");
 const connectNode = require("@connectrpc/connect-node");
 
 // Register a Node-compatible gRPC transport.
-// @ts-expect-error -- globalThis.VIAM is not in standard types
 globalThis.VIAM = {
   GRPC_TRANSPORT_FACTORY: (opts: any) =>
     connectNode.createGrpcTransport({ httpVersion: "2", ...opts }),

--- a/docs/build-apps/setup/node.md
+++ b/docs/build-apps/setup/node.md
@@ -34,10 +34,12 @@ Node.js needs three runtime packages:
 - `@connectrpc/connect-node` — the Node-compatible gRPC transport
 - `node-datachannel` — a WebRTC implementation for Node
 
+The SDK depends on the Connect-ES v1 API, so pin `@connectrpc/connect-node` to the matching major version. Installing it unpinned resolves to the incompatible v2 line and fails with a `TypeError` when the SDK tries to connect.
+
 Install everything at once:
 
 ```sh {class="command-line" data-prompt="$"}
-npm install @viamrobotics/sdk @connectrpc/connect-node node-datachannel
+npm install @viamrobotics/sdk @connectrpc/connect-node@^1.7.0 node-datachannel
 npm install --save-dev tsx typescript @types/node
 ```
 

--- a/docs/build-apps/setup/node.md
+++ b/docs/build-apps/setup/node.md
@@ -37,7 +37,7 @@ Node.js needs three runtime packages:
 Install everything at once:
 
 ```sh {class="command-line" data-prompt="$"}
-npm install @viamrobotics/sdk @connectrpc/connect-node@^1.7.0 node-datachannel
+npm install @viamrobotics/sdk "@connectrpc/connect-node@^1.7.0" node-datachannel
 npm install --save-dev tsx typescript @types/node
 ```
 
@@ -71,6 +71,7 @@ const wrtc = require("node-datachannel/polyfill");
 const connectNode = require("@connectrpc/connect-node");
 
 // Register a Node-compatible gRPC transport.
+// @ts-expect-error -- the require()-style snippet doesn't load the SDK's global VIAM declaration
 globalThis.VIAM = {
   GRPC_TRANSPORT_FACTORY: (opts: any) =>
     connectNode.createGrpcTransport({ httpVersion: "2", ...opts }),
@@ -150,7 +151,7 @@ If the script hangs or errors, the most common causes are:
 - **Polyfills registered too late.** The polyfill loop and transport factory must run before the first call into the SDK. If you split them into a separate module that is imported after the SDK, the SDK initializes without them.
 - **`.env` not loaded.** The `tsx --env-file=.env` flag loads the file. If you run the script a different way (`node`, `ts-node`, a bundler), use `dotenv` or your runtime's env loader instead.
 - **Wrong transport.** If you see `Unsupported HTTP version` or similar, confirm that `@connectrpc/connect-node` is installed and the transport factory is registered on `globalThis.VIAM`.
-- **Wrong `@connectrpc/connect-node` version.** The SDK depends on the Connect-ES v1 API. If `@connectrpc/connect-node` gets installed unpinned, it resolves to the incompatible v2 line and fails with a `TypeError` when the SDK tries to connect. Pin it to `^1.7.0`, as in the install command above.
+- **Wrong `@connectrpc/connect-node` version.** The SDK depends on the Connect-ES v1 API. An unpinned install resolves to the incompatible v2 line and fails with a `TypeError` when the SDK tries to connect. Pin it to `^1.7.0`, as in the install command above.
 
 ## Next
 


### PR DESCRIPTION
## Summary

Pins `@connectrpc/connect-node` to `^1.7.0` in the Node.js setup guide's install command.

## What was wrong

`@viamrobotics/sdk` depends on the Connect-ES **v1** API (`@connectrpc/connect@^1.7.0` even in the latest SDK release, 0.74.2). The guide's install command doesn't pin a version for `@connectrpc/connect-node`, so a fresh `npm install` resolves the latest release, which is **2.1.2** — Connect-ES v2. That version mismatch breaks the SDK's transport at runtime:

```
TypeError: Cannot read properties of undefined (reading 'typeName')
    at createMethodUrl (.../@connectrpc/connect/dist/esm/protocol/create-method-url.js:32:44)
    at Object.unary (.../@connectrpc/connect/dist/esm/protocol-grpc/transport.js:72:26)
    at Object.authenticate (.../@viamrobotics/sdk/dist/main.es.js:3773:23)
```

Found this by hitting the crash directly while validating #5250 — following this guide's own install command with an unpinned `@connectrpc/connect-node` reproduces it for anyone today.

## Fix

Pin the install command to `@connectrpc/connect-node@^1.7.0`, matching the SDK's own dependency range, with a short note explaining why the pin matters.

## Verification

`npx prettier --check`, `npx markdownlint-cli`, and `vale` all pass on the changed file; `make build-prod` completes with no new errors.

## Related

- Split out of #5250, which hit this while validating a separate fix
- The same unpinned-install issue exists in `viam-typescript-sdk`'s own `Node.md` (different repo, tracked separately)
