### PR TITLE
Add --viam-home-dir flag to get-ftdc CLI reference

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -1309,6 +1309,7 @@ viam machines part get-ftdc --part=123 ~/some/existing/dir/
 | Argument | Description | Required? |
 | -------- | ----------- | --------- |
 | `--part` | Part ID for which the command is being issued. | **Required** |
+| `--viam-home-dir` | Path to the target machine's [VIAM_HOME](/reference/viam-server/#environment-variables) directory. Use when the machine uses a non-default VIAM_HOME location, for example when managed by `viam-agent`. Default: `~/.viam`. | Optional |
 
 ### `machines part create`
 


### PR DESCRIPTION
The `machines part get-ftdc` command now accepts the `--viam-home-dir` flag, matching the `traces` commands that already document it. Machines managed by `viam-agent` may use a non-default VIAM_HOME location (for example `/opt/viam`), and this flag lets the CLI resolve the correct FTDC data path on the remote machine.

## Source changes

- viamrobotics/rdk#6304: Use viam home prefix for FTDC when available — adds `commonPathFlags` (which includes `--viam-home-dir`) to the `get-ftdc` command

## Docs changes

- `docs/cli/reference.md`: Added `--viam-home-dir` row to the `machines part get-ftdc` argument table, matching the description already used by the `traces import-remote`, `traces print-remote`, and `traces get-remote` commands

## How I found these

- Xref lookup: `cli-xref.md` maps `rdk/cli/app.go` to CLI reference docs
- Grep matches: 4 pages reference `get-ftdc`; only the primary reference page (`cli/reference.md`) needed the flag table update — the other pages show usage examples where the optional flag is not needed

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01LwJaChxhA5E6jP5N9A31x3)_