### PR TITLE
Update managed upgrade docs for reboot deferral during installs

### DIFF
--- a/docs/fleet/system-settings.md
+++ b/docs/fleet/system-settings.md
@@ -126,6 +126,7 @@ Managed modes work on apt-based distributions (Debian, Ubuntu, Raspberry Pi OS),
 When using a managed mode (`"managed-all"` or `"managed-security"`), you can also set `os_managed_upgrade_interval_hours` to control how often `viam-agent` checks for and installs updates. The default is `24` hours. The minimum value is `1` hour.
 
 If an upgrade in a managed mode requires a reboot, `viam-agent` waits until the configured [maintenance window](/fleet/manage-versions/#maintenance-windows) before rebooting the machine.
+It also defers reboots while any package manager transaction is in progress, whether started by `viam-agent` itself or by an external tool, to prevent interrupting an installation mid-transaction.
 
 The `"all"` and `"security"` modes require Debian (including Debian-based systems like Raspberry Pi OS) with the Bullseye, Bookworm, or Trixie release codename. On Ubuntu, an RPM-based distribution, or Windows, use a managed mode instead. When a selected mode is not supported on the running OS, the agent logs a warning and the setting has no effect.
 

--- a/docs/reference/viam-agent.md
+++ b/docs/reference/viam-agent.md
@@ -90,11 +90,12 @@ In the machine settings card, open **Settings** and expand **System**:
 The `"all"` and `"security"` modes delegate scheduling to the operating system's built-in upgrade timer (`unattended-upgrades` on Debian). The `"managed-all"` and `"managed-security"` modes let `viam-agent` control the upgrade schedule directly, which also enables upgrade support on Ubuntu and RPM-based distributions (Fedora, RHEL, Rocky Linux, AlmaLinux, CentOS).
 
 When using a managed mode, `viam-agent` disables the OS's built-in upgrade timer and runs upgrades itself at the configured interval. If an upgrade requires a reboot, `viam-agent` waits until the configured [maintenance window](/fleet/manage-versions/#maintenance-windows) before rebooting the machine.
+It also defers reboots while any package manager transaction is in progress, whether started by `viam-agent` itself or by an external tool, to prevent interrupting an installation mid-transaction.
 
-| Mode                                  | Supported distributions                                                                                                   | Schedule controlled by     | Reboot coordination          |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ---------------------------- |
-| `"all"`, `"security"`                 | Debian, Raspberry Pi OS (Bullseye, Bookworm, or Trixie)                                                                   | OS (`unattended-upgrades`) | None                         |
-| `"managed-all"`, `"managed-security"` | Debian, Ubuntu, Raspberry Pi OS, Fedora, RHEL 7+, Rocky, AlmaLinux, CentOS 7 (apt and RPM), and Windows (PSWindowsUpdate) | `viam-agent`               | Waits for maintenance window |
+| Mode                                  | Supported distributions                                                                                                   | Schedule controlled by     | Reboot coordination                                        |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ---------------------------------------------------------- |
+| `"all"`, `"security"`                 | Debian, Raspberry Pi OS (Bullseye, Bookworm, or Trixie)                                                                   | OS (`unattended-upgrades`) | None                                                       |
+| `"managed-all"`, `"managed-security"` | Debian, Ubuntu, Raspberry Pi OS, Fedora, RHEL 7+, Rocky, AlmaLinux, CentOS 7 (apt and RPM), and Windows (PSWindowsUpdate) | `viam-agent`               | Waits for maintenance window and active installs to finish |
 
 The `"all"` and `"security"` modes require Debian (including Debian-based systems like Raspberry Pi OS) with the Bullseye, Bookworm, or Trixie release codename. On Ubuntu, an RPM-based distribution, or Windows, use a managed mode instead. On Windows, managed modes use the `PSWindowsUpdate` PowerShell module. When a selected mode is not supported on the running OS, the agent logs a warning and the setting has no effect.
 


### PR DESCRIPTION
`viam-agent` now defers reboots while any package manager transaction is in progress (viamrobotics/agent#279). Previously, the only gate on reboots was the maintenance window. Now `viam-agent` also checks for active package installs — its own managed upgrades, concurrent `unattended-upgrades` runs, or an operator running `apt-get` manually — and holds off until they finish.

This prevents mid-transaction reboots that could corrupt the package database.

## Source changes

- viamrobotics/agent#279: Don't reboot while an OS package upgrade is installing

## Docs changes

- `docs/fleet/system-settings.md`: Added sentence noting that reboots are deferred during active package installs, alongside the existing maintenance window note.
- `docs/reference/viam-agent.md`: Same addition, plus updated the reboot coordination column in the mode comparison table from "Waits for maintenance window" to "Waits for maintenance window and active installs to finish".

## How I found these

- Diffed `viamrobotics/agent` from commit `d37016f` to `f3329a9` (1 commit, 11 files changed)
- Grepped docs for `managed.*upgrade.*reboot`, `os_auto_upgrade`, `managed-security`, `managed-all` — found 2 pages describing the reboot behavior

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_014CsZKWcLJaaK5gdfGnrTnd)_