### PR TITLE
Remove purchase framing from Viam Rover docs

### DIFF
--- a/docs/try/viam-rover/jetson-setup.md
+++ b/docs/try/viam-rover/jetson-setup.md
@@ -14,7 +14,7 @@ aliases:
 date: "2026-05-23"
 ---
 
-The [Viam Rover 2](https://www.viam.com/resources/rover) arrives preassembled with two encoded motors with suspension, a webcam with a microphone unit, a 6 axis IMU, power management and more.
+The [Viam Rover 2](https://www.viam.com/resources/rover) comes preassembled with two encoded motors with suspension, a webcam with a microphone unit, a 6 axis IMU, power management and more.
 It is primarily designed for use with a Raspberry Pi 4, but you can use it with a larger Jetson board with some additional setup.
 
 This guide provides supplemental instructions for setting up your rover with a Jetson Orin Nano.

--- a/docs/try/viam-rover/overview.md
+++ b/docs/try/viam-rover/overview.md
@@ -8,7 +8,7 @@ simple_list: true
 tags: ["rover", "viam rover"]
 images: ["/appendix/try-viam/rover-resources/viam-rover/box-contents.jpg"]
 imageAlt: "A Viam Rover in a box"
-description: "Rent a Viam Rover in our robotics lab or order one of your own, and use it to learn Viam."
+description: "Rent a Viam Rover in our robotics lab or set up your own, and use it to learn Viam."
 date: "2026-05-23"
 aliases:
   - /viam-rover-resources/
@@ -23,18 +23,24 @@ There are two ways to get hands on a Viam Rover:
 
 - **[Rent one](/try/viam-rover/rent-a-rover/)** in our robotics lab.
   Reserve a rover, drive it remotely for 10 minutes, and try the Viam platform with no hardware setup.
-- **[Order your own](https://www.viam.com/resources/rover)** for use in your own projects.
-  The [Viam Rover 2](https://www.viam.com/resources/rover) arrives preassembled and is ready to configure with Viam.
+- **[Set up your own](/try/viam-rover/setup/)** for use in your own projects.
+  The [Viam Rover 2](https://www.viam.com/resources/rover) comes preassembled and is ready to configure with Viam.
+
+{{< alert title="Note" color="note" >}}
+Viam no longer sells the Viam Rover 2.
+These guides remain available for everyone who already has a rover.
+{{< /alert >}}
 
 <div class="td-max-width-on-larger-screens">
 <div class="row">
     <div class="col">
         <a href="https://www.viam.com/resources/rover" target="_blank">
             {{<imgproc src="appendix/try-viam/rover-resources/viam-rover/rover-front.jpg" resize="400x" alt="The front of the assembled Viam Rover" style="width:400px; min-width:300px; float: left" >}}
+        </a>
     </div>
     <div class="col" style= "min-width:300px;">
         <p>
-            The <a href="https://www.viam.com/resources/rover" target="_blank">Viam Rover 2</a> arrives preassembled with two encoded motors with suspension, a webcam with a microphone unit, a 6 axis IMU, power management and more.
+            The <a href="https://www.viam.com/resources/rover" target="_blank">Viam Rover 2</a> comes preassembled with two encoded motors with suspension, a webcam with a microphone unit, a 6 axis IMU, power management and more.
             It is primarily designed for use with a Raspberry Pi 4.
             Featuring an anodized aluminum chassis with expandable mounting features, the rover can comfortably navigate indoor environments with a 20 lb payload.
             You can customize your rover by mounting <a href="/reference/components/sensor/">sensors</a>, <a href="/hardware/common-components/add-a-camera/">depth cameras and LiDAR</a>, and <a href="/reference/components/arm/">arms</a>.
@@ -44,7 +50,7 @@ There are two ways to get hands on a Viam Rover:
 </div>
 
 {{< alert title="Important" color="note" >}}
-If you order your own Viam Rover, you must purchase the following hardware separately:
+If you have your own Viam Rover, you must purchase the following hardware separately:
 
 - A Raspberry Pi 4
 - Four 18650 batteries or RC-type battery (with charger)

--- a/docs/try/viam-rover/rent-a-rover.md
+++ b/docs/try/viam-rover/rent-a-rover.md
@@ -161,11 +161,12 @@ You can also follow this tutorial:
 
 - [Drive a rover in a square with the Viam SDK](/try/viam-rover/drive-rover/)
 
-If you want to get your own Viam Rover, [you can](https://www.viam.com/resources/rover).
+Viam no longer sells the [Viam Rover 2](https://www.viam.com/resources/rover).
+If you already have a rover, follow the [setup instructions](/try/viam-rover/setup/) to get started with it.
 
 ### Why can't I use the rover's microphone?
 
 For security reasons, Viam has disabled the microphone on rover rentals.
-The microphone on [Viam Rovers shipped to you](/try/viam-rover/) functions normally.
+The microphone on [your own Viam Rover](/try/viam-rover/) functions normally.
 
 {{< snippet "social.md" >}}

--- a/docs/try/viam-rover/rover-1-setup.md
+++ b/docs/try/viam-rover/rover-1-setup.md
@@ -16,11 +16,11 @@ date: "2026-05-23"
 ---
 
 {{% alert title="Tip" color="tip" %}}
-A new version of the Viam Rover is available, the [Viam Rover 2](https://www.viam.com/resources/rover).
-If you have purchased a Viam Rover 2, follow [these instructions](/try/viam-rover/setup/) instead.
+A newer version of the Viam Rover, the [Viam Rover 2](https://www.viam.com/resources/rover), replaced the Viam Rover 1.
+If you have a Viam Rover 2, follow [these instructions](/try/viam-rover/setup/) instead.
 {{% /alert %}}
 
-The [Viam Rover 1](https://www.viam.com/resources/rover) arrives preassembled with two encoded motors with suspension, a webcam with a microphone unit, and a 3D accelerometer module.
+The Viam Rover 1 shipped preassembled with two encoded motors with suspension, a webcam with a microphone unit, and a 3D accelerometer module.
 
 {{< alert title="Important" color="note" >}}
 You must purchase the following hardware separately:

--- a/docs/try/viam-rover/setup.md
+++ b/docs/try/viam-rover/setup.md
@@ -17,11 +17,14 @@ date: "2026-05-23"
 ---
 
 {{% alert title="Tip" color="tip" %}}
+Viam no longer sells the Viam Rover 2.
+This guide remains available for everyone who already has a rover.
+
 Another version of the Viam Rover was sold until January 2024.
-If you have purchased a Viam Rover 1, follow [these instructions](/try/viam-rover/rover-1-setup/) instead.
+If you have a Viam Rover 1, follow [these instructions](/try/viam-rover/rover-1-setup/) instead.
 {{% /alert %}}
 
-The [Viam Rover 2](https://www.viam.com/resources/rover) arrives preassembled with two encoded motors with suspension, a webcam with a microphone unit, a 6 axis IMU, power management and more.
+The [Viam Rover 2](https://www.viam.com/resources/rover) comes preassembled with two encoded motors with suspension, a webcam with a microphone unit, a 6 axis IMU, power management and more.
 It is primarily designed for use with a Raspberry Pi 4.
 You can use it with [other types of boards](#motherboard) with some additional setup.
 

--- a/docs/tutorials/projects/integrating-viam-with-openai.md
+++ b/docs/tutorials/projects/integrating-viam-with-openai.md
@@ -68,7 +68,7 @@ This tutorial will show you how to use the Viam platform to create an AI-integra
 ## Hardware list
 
 - [Raspberry Pi with microSD card](https://a.co/d/bxEdcAT), with [`viam-server` installed](/reference/device-setup/rpi-setup/).
-- [Viam rover](https://www.viam.com/resources/rover) (note: this tutorial can also be adapted to work with any other configured rover that has a webcam and a microphone)
+- A configured rover with a webcam and a microphone, such as the [Viam Rover](https://www.viam.com/resources/rover)
 - [270 degree servo](https://www.amazon.com/ANNIMOS-Digital-Waterproof-DS3218MG-Control/dp/B076CNKQX4/)
 - [USB powered speaker](https://www.amazon.com/Bluetooth-Portable-Wireless-Speakers-Playtime/dp/B07PLFCP3W/) (with included 3.5mm audio cable and USB power cable)
 - A servo mounting bracket - [3D printed](https://www.thingiverse.com/thing:3995995) or [purchased](https://www.amazon.com/Bolsen-Servos-Bracket-Sensor-Compatible/dp/B07HQB95VY/)


### PR DESCRIPTION
## Why

Viam no longer sells the Viam Rover 2, but the docs still prompt readers to order one. This removes the purchase-oriented calls to action while keeping every page fully useful for readers who already have a rover.

The `viam.com/resources/rover` link is **retained** everywhere it appears, on the assumption that the page stays live or redirects. Only the surrounding verbs and CTAs changed. If that page ends up 404ing, the fallback target for the informational links is the open source hardware repo at `github.com/viamrobotics/Viam-Rover-2`, already linked from the setup guide.

## Changes

| Page | What changed |
|---|---|
| `try/viam-rover/overview.md` | "Order your own" CTA → "Set up your own", now pointing at the setup guide. Added a note that the Rover 2 is no longer sold. Frontmatter description no longer says "order one of your own". "If you order your own" → "If you have your own". Closed the unclosed `</a>` around the hero image. |
| `try/viam-rover/setup.md` | Added the no-longer-sold note to the existing tip. "purchased a Viam Rover 1" → "have a Viam Rover 1". |
| `try/viam-rover/rover-1-setup.md` | Rover 2 no longer described as "available", which implied purchasable. Removed the Rover 1 link that pointed at a Rover 2 page. "arrives preassembled" → "shipped preassembled". |
| `try/viam-rover/jetson-setup.md` | "arrives preassembled" → "comes preassembled". |
| `try/viam-rover/rent-a-rover.md` | Replaced the buy prompt in the FAQ with the sales status plus a link to setup. "Viam Rovers shipped to you" → "your own Viam Rover". |
| `tutorials/projects/integrating-viam-with-openai.md` | Hardware list now leads with the generic requirement ("A configured rover with a webcam and a microphone, such as the Viam Rover"), absorbing the trailing parenthetical that said the same thing. |

`fragments.md` and `drive-rover.md` also link the rover page, but purely descriptively with no purchase framing, so they are unchanged.

No pages were deleted. Setup, wiring, and fragment docs remain valuable for existing owners.

## Checks

All four pre-PR checks pass:

- `npx prettier --check` — all matched files use Prettier code style
- `npx markdownlint-cli --config .markdownlint.yaml` — no output
- `vale` — 0 errors, 0 warnings, 0 suggestions
- `make build-prod` — completes with no errors (only pre-existing stale-date and missing-description warnings on unrelated pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)