### PR TITLE
Fix the macOS viam-server install and background-service instructions

### DIFF
--- a/docs/reference/viam-server.md
+++ b/docs/reference/viam-server.md
@@ -342,11 +342,17 @@ The `viam-agent` and `viam-server` binaries are installed at <FILE>/opt/viam/bin
 brew tap viamrobotics/brews && brew trust viamrobotics/brews && brew install viam-server
 ```
 
-The `viam-server` binary is installed at <FILE>/opt/homebrew/bin/viam-server</FILE>.
+The `viam-server` binary is installed at <FILE>/opt/homebrew/bin/viam-server</FILE> on Apple silicon and at <FILE>/usr/local/bin/viam-server</FILE> on Intel Macs.
+The tap ships bottles for Apple silicon only, so on an Intel Mac brew builds `viam-server` from source, which takes considerably longer.
 
-The brew installation of `viam-server` CANNOT be run as a system service in the
-background. If you would like to run `viam-server` in the background, install
-[`viam-agent`](/reference/viam-agent/) instead.
+To run `viam-server` in the background, save your machine configuration to <FILE>$(brew --prefix)/etc/viam.json</FILE>, then start it as a launchd service:
+
+```sh {class="command-line" data-prompt="$"}
+brew services start viam-server
+```
+
+The service restarts `viam-server` if it exits and writes logs to <FILE>$(brew --prefix)/var/log/viam-server.log</FILE>.
+For automatic `viam-server` version updates from the cloud, install [`viam-agent`](/reference/viam-agent/) instead.
 
 {{% /tab %}}
 {{% tab name="Windows Subsystem for Linux (WSL)" %}}

--- a/docs/reference/viam-server.md
+++ b/docs/reference/viam-server.md
@@ -352,7 +352,9 @@ brew services start viam-server
 ```
 
 The service restarts `viam-server` if it exits and writes logs to <FILE>$(brew --prefix)/var/log/viam-server.log</FILE>.
-For automatic `viam-server` version updates from the cloud, install [`viam-agent`](/reference/viam-agent/) instead.
+
+[`viam-agent`](/reference/viam-agent/) does not support macOS, so brew is the only way to keep `viam-server` running in the background on a Mac.
+Upgrade it yourself with `brew upgrade viam-server`; nothing updates it from the cloud.
 
 {{% /tab %}}
 {{% tab name="Windows Subsystem for Linux (WSL)" %}}

--- a/docs/set-up-a-machine/viam-agent-and-server.md
+++ b/docs/set-up-a-machine/viam-agent-and-server.md
@@ -8,7 +8,8 @@ description: "The two programs that run on every Viam machine: what each does, h
 date: "2026-04-17"
 ---
 
-When you install Viam on a computer, two programs land on the machine: `viam-agent` and `viam-server`. They have distinct jobs.
+When you install Viam on a Linux or Windows computer, two programs land on the machine: `viam-agent` and `viam-server`. They have distinct jobs.
+On macOS you install `viam-server` on its own, as `viam-agent` does not support macOS.
 
 ## viam-server
 
@@ -21,7 +22,7 @@ Most of what people mean by "Viam running on my robot" is `viam-server`. When yo
 ## viam-agent
 
 `viam-agent` is a process manager that sits above `viam-server`.
-It runs as a system service (systemd on Linux, launchd on macOS) and manages three subsystems:
+It runs as a system service (systemd on Linux, a Windows service on Windows) and manages three subsystems:
 
 - **viam-server**: launches it, restarts it on unexpected exit, and applies version updates from the cloud.
 - **networking**: helps with connectivity when the machine boots, including Wi-Fi provisioning on supported platforms.
@@ -29,9 +30,11 @@ It runs as a system service (systemd on Linux, launchd on macOS) and manages thr
 
 `viam-agent` is the always-on layer. If the machine reboots, `viam-agent` comes up first and starts `viam-server`. If `viam-server` crashes, `viam-agent` restarts it.
 
+`viam-agent` supports Linux and Windows. On macOS, [install `viam-server` with brew](/reference/viam-server/) and run it as a brew service; nothing manages its version for you.
+
 ## How they work together
 
-At a typical startup, the OS starts the systemd or launchd service, which runs `viam-agent`. `viam-agent` starts `viam-server` as a subprocess, monitors it, and handles restarts. If a new `viam-server` version is released and your cloud config permits it, `viam-agent` downloads and installs the update, then restarts `viam-server` on the new version.
+At a typical startup, the OS starts the service that runs `viam-agent`. `viam-agent` starts `viam-server` as a subprocess, monitors it, and handles restarts. If a new `viam-server` version is released and your cloud config permits it, `viam-agent` downloads and installs the update, then restarts `viam-server` on the new version.
 
 You interact with `viam-server` through the Viam app, the CLI, and SDKs. You do not typically interact with `viam-agent` directly unless you are troubleshooting install or version-update issues.
 


### PR DESCRIPTION
## Problem

The macOS tab of [Install `viam-server` without the web UI](https://docs.viam.com/reference/viam-server/) says:

> The brew installation of `viam-server` CANNOT be run as a system service in the background. If you would like to run `viam-server` in the background, install `viam-agent` instead.

Both halves are wrong today, and the second one sends Mac users nowhere: **`viam-agent` is not a supported macOS install path.**

The formula ships a launchd `service` block and caveats telling users to run exactly what the docs call impossible:

```ruby
service do
  run [opt_bin/"viam-server", "-config", etc/"viam.json"]
  keep_alive true
  log_path var/"log/viam-server.log"
  error_log_path var/"log/viam-server.log"
end
```

`viam-server` shows up in `brew services list` accordingly.

### How the sentence got there

The service block was removed and then restored, and this page was written in the four-day window in between:

| Date | Change |
| --- | --- |
| 2025-11-05 | homebrew-brews#64 adds the `brew services` block |
| 2026-03-17 | homebrew-brews#69 removes it and points macOS users at `viam-agent` — "we want to push users toward the new agent support on MacOS" |
| 2026-04-14 | homebrew-brews#74 reverts #69; the service comes back |
| 2026-04-18 | docs#4971 creates this page with the "CANNOT" sentence |

So the guidance describes the state as of #69, which had already been rolled back four days earlier. The plan to move Mac users onto `viam-agent` did not land.

## Change

- Replace the incorrect claim with the `brew services start viam-server` instructions.
- Say plainly that `viam-agent` does not support macOS, and that brew is the only way to run `viam-server` in the background there.
- Note that nothing updates the brew install from the cloud — `brew upgrade viam-server` is the user's job.
- On [viam-agent and viam-server](https://docs.viam.com/set-up-a-machine/viam-agent-and-server/), drop the "launchd on macOS" claim and state the supported platforms so it does not come back.
- Note both install prefixes: `/opt/homebrew` on Apple silicon, `/usr/local` on Intel. The tap bottles `arm64_sequoia` and `arm64_sonoma` only, so an Intel Mac builds from source rather than pulling a bottle.

## Not changed

The `brew tap … && brew trust … && brew install` commands on this page and in `static/include/how-to/install-cli.md` are correct. I verified against a clean Homebrew trust store that the `brew trust` step is required on Homebrew 6 and that these commands then work. The Viam app was missing that step; viamrobotics/app#13124 fixes it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
