### PR TITLE
Build the CLI from a clone instead of go install

### DIFF
--- a/static/include/how-to/install-cli.md
+++ b/static/include/how-to/install-cli.md
@@ -57,8 +57,7 @@ sudo chmod a+rx /usr/local/bin/viam
 {{% /tab %}}
 {{% tab name="Source" %}}
 
-If you have [Go installed](https://go.dev/doc/install), you can build the Viam CLI from source.
-The RDK module replaces one of its dependencies, and Go refuses `go install <package>@<version>` for a module carrying replace directives, so clone the repository and build it with `make`:
+If you have [Go installed](https://go.dev/doc/install), you can build the Viam CLI from source. Clone the repository and build it with `make`:
 
 ```sh {class="command-line" data-prompt="$"}
 git clone --depth 1 https://github.com/viamrobotics/rdk.git
@@ -68,6 +67,10 @@ sudo cp "bin/$(go env GOOS)-$(go env GOARCH)/viam-cli" /usr/local/bin/viam
 ```
 
 To confirm `viam` is installed and ready to use, run `viam version` from your terminal.
+
+{{< alert title="Why not `go install`?" color="caution" >}}
+The RDK module replaces one of its dependencies, and Go refuses `go install <package>@<version>` for a module carrying replace directives.
+{{< /alert >}}
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/static/include/how-to/install-cli.md
+++ b/static/include/how-to/install-cli.md
@@ -57,20 +57,17 @@ sudo chmod a+rx /usr/local/bin/viam
 {{% /tab %}}
 {{% tab name="Source" %}}
 
-If you have [Go installed](https://go.dev/doc/install), you can build the Viam CLI directly from source using the `go install` command:
+If you have [Go installed](https://go.dev/doc/install), you can build the Viam CLI from source.
+The RDK module replaces one of its dependencies, and Go refuses `go install <package>@<version>` for a module carrying replace directives, so clone the repository and build it with `make`:
 
 ```sh {class="command-line" data-prompt="$"}
-go install go.viam.com/rdk/cli/viam@latest
+git clone --depth 1 https://github.com/viamrobotics/rdk.git
+cd rdk
+make cli
+sudo cp "bin/$(go env GOOS)-$(go env GOARCH)/viam-cli" /usr/local/bin/viam
 ```
 
-To confirm `viam` is installed and ready to use, issue the _viam_ command from your terminal.
-If you see help instructions, everything is correctly installed.
-If you do not see help instructions, add your local <file>go/bin/\*</file> directory to your `PATH` variable.
-If you use `bash` as your shell, you can use the following command:
-
-```sh {class="command-line" data-prompt="$"}
-echo 'export PATH="$HOME/go/bin:$PATH"' >> ~/.bashrc
-```
+To confirm `viam` is installed and ready to use, run `viam version` from your terminal.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
## Problem

The Source tab of [install the Viam CLI](https://docs.viam.com/cli/) tells users to run:

```sh
go install go.viam.com/rdk/cli/viam@latest
```

That command cannot succeed, on any platform:

```
go: go.viam.com/rdk/cli/viam@latest (in go.viam.com/rdk@v1.2.0):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```

RDK's published `go.mod` at v1.2.0 carries a replace directive:

```
replace github.com/hashicorp/go-getter => github.com/viam-labs/go-getter v0.0.0-20251022162721-98d73b852c8a
```

Go refuses `install <package>@<version>` for any module whose `go.mod` has replace directives, so the documented path has been dead for as long as that directive has been there. I reproduced it on macOS as well as Linux.

## Change

Clone and build with `make cli`, then place the binary on `PATH` as the other platform tabs do:

```sh
git clone --depth 1 https://github.com/viamrobotics/rdk.git
cd rdk
make cli
sudo cp "bin/$(go env GOOS)-$(go env GOARCH)/viam-cli" /usr/local/bin/viam
```

Verified with a clean clone: `make cli` exits 0 and the resulting binary reports `Version (dev) Git=9b6b251f API=v0.1.574`. `make cli` is the same target the Homebrew formula builds with (`make cli-ci`).

The follow-up paragraph about adding `go/bin` to `PATH` no longer applies and is replaced with `viam version`.

## How this was found

viamrobotics/app#13125 adds a CI job that executes the install commands the app displays on real runners. This failure was its first finding, on its first run. The app carries the same broken command; that PR fixes it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
