### PR TITLE
[DOCS-4930] Add --order and --range flags to machines logs CLI reference

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -1105,8 +1105,10 @@ viam machines logs --machine=123
 | `--errors` | Boolean, return only errors. Default: `false`. | Optional |
 | `--levels` | Filter logs by levels (debug, info, warn, error). Accepts multiple inputs in comma-separated list. | Optional |
 | `--keyword` | Filter logs by keyword. | Optional |
-| `--start` | Filter logs to include only those after the start time. Time format example: `2025-01-13T21:30:00Z` (ISO-8601 timestamp in RFC3339). Default: 24 hours ago. | Optional |
+| `--start` | Filter logs to include only those after the start time. Time format example: `2025-01-13T21:30:00Z` (ISO-8601 timestamp in RFC3339). Default: 24 hours ago, unless `--range` is set. | Optional |
 | `--end` | Filter logs to include only those before the end time. Time format example: `2025-01-13T21:35:00Z` (ISO-8601 timestamp in RFC3339). | Optional |
+| `--range` | Duration string in minutes, hours, or days (for example, `10m`, `10h`, `10d`) that sets a relative time window. Resolved against whichever of `--start` and `--end` is present: with only `--end`, the window is `[end - range, end]`; with only `--start`, the window is `[start, start + range]`; with neither, the window is `[now - range, now]`. Cannot be used together with both `--start` and `--end`. | Optional |
+| `--order` | Order in which logs are returned by time. Accepted values: `asc` (oldest first), `desc` (newest first). Default: `desc`. | Optional |
 | `--count` | Maximum number of logs to fetch. Default: all logs in the time range. | Optional |
 | `--format` | The file format for the output file. Options: `text` or `json`. | Optional |
 | `--output` | The path to the output file to store logs in. | Optional |

--- a/docs/monitor/troubleshoot.md
+++ b/docs/monitor/troubleshoot.md
@@ -180,6 +180,18 @@ Filter by keyword and time range:
 viam machines logs --machine <machine-name-or-id> --keyword "motor" --start 2026-04-07T10:00:00Z --end 2026-04-07T11:00:00Z
 ```
 
+Filter by a relative time window:
+
+```sh {class="command-line" data-prompt="$"}
+viam machines logs --machine <machine-name-or-id> --range 2h --levels error
+```
+
+View oldest logs first:
+
+```sh {class="command-line" data-prompt="$"}
+viam machines logs --machine <machine-name-or-id> --range 1d --order asc
+```
+
 ## Remote shell access
 
 Access a terminal on the machine without setting up SSH tunnels:


### PR DESCRIPTION
The RDK CLI gained `--order` and `--range` flags on the `viam machines logs` command (viamrobotics/rdk#6337), backed by the proto-level `order` and `range` fields added to `GetRobotPartLogsRequest` (viamrobotics/api#888) and the app backend implementation (viamrobotics/app#13101, viamrobotics/app#13122).

## Summary

- Add `--range` and `--order` to the `machines logs` flag table in CLI reference
- Update `--start` default text to note it is overridden when `--range` is set
- Add two usage examples to the troubleshooting guide showing `--range` and `--order`

## Source changes

- viamrobotics/rdk#6337: Add `--order` and `--range` flags for `machines logs`
- viamrobotics/api#888: Add `LogOrder` enum, `order` and `range` fields to `GetRobotPartLogsRequest`
- viamrobotics/app#13122: Emit `--range` and `--order` from CLI logs export command in app UI

## Docs changes

- `docs/cli/reference.md`: Added `--range` and `--order` rows to the `machines logs` flag table; updated `--start` default text
- `docs/monitor/troubleshoot.md`: Added two examples showing relative time window (`--range 2h`) and oldest-first ordering (`--order asc`)

## How I found these

- Backlog item `api-af2e9b6-log-order-range` was deferred "until CLI flags or SDK wrappers ship" — CLI flags shipped in rdk#6337
- Grep confirmed `--order` and `--range` were not documented anywhere in the docs repo

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_015iCdDmnptAMYXX6DeXrEEP)_