### PR TITLE
Fix dead tutorial links flagged by link-rot audit

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -28,7 +28,12 @@ IgnoreURLs:
   - "example.com"
   - "^/misc/js/script.js$"
   - "linkedin.com"
+  # app.viam.com and elevenlabs.io/app are authenticated client-rendered SPAs:
+  # the server always returns 200 with the app shell and the login gate only
+  # appears after JS runs, so an HTTP status check can't verify these either
+  # way.
   - "app.viam.com"
+  - "elevenlabs.io/app"
   - "beaglebone.local"
   - "instagram.com"
   - "twitter.com"

--- a/docs/tutorials/projects/claw-game.md
+++ b/docs/tutorials/projects/claw-game.md
@@ -38,9 +38,9 @@ To build your own claw game machine, you need the following hardware:
 
 - A [Raspberry Pi](https://a.co/d/bxEdcAT) with a microSD card, set up following the [Raspberry Pi Setup Guide](/reference/device-setup/rpi-setup/).
 - An [xarm6](https://www.ufactory.us/product/ufactory-xarm-6) robotic arm
-- An [Arcade claw](https://www.ebay.com/itm/393988987705)
+- An [Arcade claw](https://www.ebay.com/itm/389205760045)
 - A [Relay](https://www.amazon.com/gp/product/B095YFJ69T)
-- A [24V power supply](https://www.amazon.com/gp/product/B08F7DVY8G) for the claw
+- A [24V power supply](https://a.co/d/0iAPD3A4) for the claw
 - An iPad or other tablet
 - 1 x 4’x4’ fiberboard
 - 10 x 2”x4”x8’ lumber

--- a/docs/tutorials/projects/integrating-viam-with-openai.md
+++ b/docs/tutorials/projects/integrating-viam-with-openai.md
@@ -51,7 +51,7 @@ When we think of robots, most of us tend to group them into categories:
 
 One type of “good” robot is a companion robot - a robot created for the purposes of providing real or apparent companionship for human beings.
 While some [examples](https://www.google.com/search?q=companion+robot) have recently been brought to market, primarily marketed towards children and the elderly, we are all familiar with robots from popular movies that ultimately have proven to be endearing companions and became embedded in our culture.
-Think [C-3P0](https://en.wikipedia.org/wiki/C-3PO), [Baymax](https://en.wikipedia.org/wiki/Baymax!), and [Rosey](https://thejetsons.fandom.com/wiki/Rosey) from the Jetsons.
+Think [C-3P0](https://en.wikipedia.org/wiki/C-3PO), [Baymax](https://en.wikipedia.org/wiki/Baymax!), and [Rosie](https://en.wikipedia.org/wiki/List_of_The_Jetsons_characters#Rosie) from the Jetsons.
 
 AI language models like OpenAI's [ChatGPT](https://openai.com/blog/chatgpt/) are making companion robots with realistic, human-like speech a potential reality.
 By combining ChatGPT with the Viam platform’s built-in [computer vision service](/reference/services/vision/), ML model support, and [locomotion](/reference/components/base/), you can within a few hours create a basic companion robot that:
@@ -407,7 +407,7 @@ Use the above configuration to set up listening mode, use an ElevenLabs voice `"
 Edit the attributes as applicable:
 
 - Edit `"completion_provider_org"` and `"completion_provider_key"` to match your AI API organization and API credentials, for example your [OpenAI organization header and API key credentials](https://platform.openai.com/account/api-keys).
-- Edit `"speech_provider_key"` to match [your API key from elevenlabs](https://docs.elevenlabs.io/api-quick-start/authentication) or another speech provider.
+- Edit `"speech_provider_key"` to match [your API key from elevenlabs](https://elevenlabs.io/app/settings/api-keys) or another speech provider.
 - Edit `"mic_device_name"` to match the name your microphone is assigned on your robot's computer.
   Available microphone device names will logged on module startup.
   If left blank, the module will attempt to auto-detect the microphone.


### PR DESCRIPTION
## Summary

Fixes #5196 (recurring `run-htmltest-external` CI failure on the Amazon 24V
power supply link in `claw-game.md`), plus three more dead links found while
looking into that same tutorial and running a one-off link audit:

- `docs/tutorials/projects/claw-game.md`: replaced the dead Amazon 24V power
  supply link and the dead eBay arcade-claw link (auction had ended; not
  caught by CI because `ebay.com` is in `.htmltest.yml`'s `IgnoreURLs`).
- `docs/tutorials/projects/integrating-viam-with-openai.md`: replaced a dead
  ElevenLabs auth-docs link with the ElevenLabs dashboard API-keys page
  (added `elevenlabs.io/app` to `.htmltest.yml`'s ignore list, since it's an
  authenticated client-rendered SPA that a plain HTTP check can't verify
  either way — same reasoning as the existing `app.viam.com` entry). Also
  swapped a dead Fandom wiki link for a Wikipedia one in the same file.

All four pre-PR checks (prettier, markdownlint, vale, `make build-prod`)
pass clean.

## Context

While fixing the CI-flagged Amazon link, noticed the eBay link on the same
page was also dead but invisible to CI (ignore-listed domain), which raised
a bigger question about the amount of unmaintained tutorial content in this
repo. Wrote a quick audit script to check every external link under
`docs/tutorials/` (not just what htmltest is willing to check) against
`.htmltest.yml`'s ignore list — it's on a separate branch,
[`add-tutorial-link-audit-script`](https://github.com/jeremyrose-viam/docs/tree/add-tutorial-link-audit-script),
not included in this PR since we're not adding it to the repo at this time.
Running it against all tutorials turned up the 3 additional dead links fixed
here; everything else checked out clean.