### PR TITLE
Fix venv-based Python module packaging: include meta.json in archive

### DIFF
--- a/docs/build-modules/manage-modules.md
+++ b/docs/build-modules/manage-modules.md
@@ -177,7 +177,13 @@ if ! $PYTHON -m pip install pyinstaller -Uqq; then
 fi
 
 $PYTHON -m PyInstaller --onefile --collect-all viam --hidden-import="googleapiclient" src/main.py
-tar -czvf dist/archive.tar.gz ./dist/main
+
+TAR_FILES="meta.json ./dist/main"
+FIRST_RUN=$($PYTHON -c "import json; print(json.load(open('meta.json')).get('first_run', ''))" 2>/dev/null)
+if [ -n "$FIRST_RUN" ] && [ -f "$FIRST_RUN" ]; then
+    TAR_FILES="$TAR_FILES $FIRST_RUN"
+fi
+tar -czvf dist/archive.tar.gz $TAR_FILES
 ```
 
 {{< /expand >}}

--- a/docs/build-modules/manage-modules.md
+++ b/docs/build-modules/manage-modules.md
@@ -177,13 +177,7 @@ if ! $PYTHON -m pip install pyinstaller -Uqq; then
 fi
 
 $PYTHON -m PyInstaller --onefile --collect-all viam --hidden-import="googleapiclient" src/main.py
-
-TAR_FILES="meta.json ./dist/main"
-FIRST_RUN=$($PYTHON -c "import json; print(json.load(open('meta.json')).get('first_run', ''))" 2>/dev/null)
-if [ -n "$FIRST_RUN" ] && [ -f "$FIRST_RUN" ]; then
-    TAR_FILES="$TAR_FILES $FIRST_RUN"
-fi
-tar -czvf dist/archive.tar.gz $TAR_FILES
+tar -czvf dist/archive.tar.gz meta.json ./dist/main
 ```
 
 {{< /expand >}}

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -2161,7 +2161,7 @@ pip3 install -r requirements.txt
 #!/bin/bash
 pip3 install -r requirements.txt
 python3 -m PyInstaller --onefile --collect-all viam --hidden-import="googleapiclient" src/main.py
-tar -czvf dist/archive.tar.gz <PATH-TO-EXECUTABLE>
+tar -czvf dist/archive.tar.gz meta.json <PATH-TO-EXECUTABLE>
 ```
 
 {{% /expand %}}
@@ -2188,7 +2188,7 @@ python3 -m venv .venv
 . .venv/bin/activate
 pip3 install -r requirements.txt
 python3 -m PyInstaller --onefile --collect-all viam --hidden-import="googleapiclient" src/main.py
-tar -czvf dist/archive.tar.gz <PATH-TO-EXECUTABLE>
+tar -czvf dist/archive.tar.gz meta.json <PATH-TO-EXECUTABLE>
 ```
 
 {{% /expand%}}
@@ -2222,7 +2222,7 @@ python3 -m venv .venv
 . .venv/bin/activate
 pip3 install -r requirements.txt
 python3 -m PyInstaller --onefile --collect-all viam --hidden-import="googleapiclient" src/main.py
-tar -czvf dist/archive.tar.gz <PATH-TO-EXECUTABLE>
+tar -czvf dist/archive.tar.gz meta.json <PATH-TO-EXECUTABLE>
 ```
 
 { {% /expand%}}
@@ -2238,7 +2238,7 @@ python3 -m venv .venv
 . .venv/bin/activate
 pip3 install -r requirements.txt
 python3 -m PyInstaller --onefile --collect-all viam --hidden-import="googleapiclient" src/main.py
-tar -czvf dist/archive.tar.gz <PATH-TO-EXECUTABLE>
+tar -czvf dist/archive.tar.gz meta.json <PATH-TO-EXECUTABLE>
 ```
 
 { {% /expand%}}


### PR DESCRIPTION
## Summary
- DOCS-4924: the documented `build.sh` example for venv/PyInstaller-packaged Python modules produces a tarball missing `meta.json`. This breaks `viam module reload`/`reload-local` (hot-reload), which requires `meta.json` embedded in local tarballs — confirmed live: `local tarballs must contain a meta.json with the 'entrypoint' field`.
- The registry-install path (cloud build → `viam module upload`) works fine either way, since metadata comes from the registry entry. The current `viam module generate` CLI template already produces the correct tar command; these doc examples just predate that fix.
- Updated the `build.sh` example in `build-modules/manage-modules.md` to match the generator's actual command (`meta.json` + entrypoint + optional `first_run` file).
- Applied the same one-line fix to 4 duplicate copies of the same example in `cli/reference.md` (2 live, 2 in a commented-out block).

## Test plan
- [x] Reproduced the failure live: built the documented `build.sh` unmodified, deployed via `reload-local` to a real `viam-server` instance — failed with the meta.json error.
- [x] Confirmed the fix resolves it: same tarball + `meta.json` deployed successfully, sensor component constructed and responded correctly (tested against a live webcam reading — brightness dropped from ~212 to ~1 when the camera was covered).
- [x] Confirmed the registry path was never broken (control test): same meta.json-less tarball installed via the registry worked without issue.