### PR TITLE
Update module reload --home flag docs for dynamic VIAM_HOME

### DIFF
--- a/docs/build-modules/module-reference.md
+++ b/docs/build-modules/module-reference.md
@@ -561,7 +561,7 @@ with this model triple), `--name` (name the added resource),
 `--resource-name` (name the resource instance), `--id` (module ID,
 alternative to `--name`), `--cloud-config` (path to `viam.json`, alternative
 to `--part-id`), `--workdir` (subdirectory containing `meta.json`),
-`--home-dir` (remote user's home directory), `--no-progress` (hide transfer
+`--home` (override the remote machine's home directory), `--no-progress` (hide transfer
 progress).
 
 ## Environment variables

--- a/docs/build-modules/write-a-driver-module.md
+++ b/docs/build-modules/write-a-driver-module.md
@@ -1127,10 +1127,11 @@ If `reload-local` fails:
 - **"no build command"** -- Your `meta.json` is missing a `build.build` field.
   Add the path to your build script (for example, `"build": "./build.sh"`).
 - **"could not find module ID"** -- Run the command from the directory
-  containing `meta.json`, or use `--home <path>` to specify the module
-  directory.
-- **PermissionDenied errors** -- Try `--home $HOME` to ensure the CLI can
-  locate the module metadata.
+  containing `meta.json`, or pass `--module <path>` to point to your
+  `meta.json` file.
+- **Wrong destination directory** -- The CLI asks the target machine for
+  its Viam home directory automatically. If that query fails or returns a
+  wrong path, pass `--home <path>` to override it.
 
 {{< /expand >}}
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -1879,7 +1879,7 @@ viam module reload --part-id e1234f0c-912c-1234-a123-5ac1234612345
 
 ### `module reload-local`
 
-Build a module locally and run it on a target machine. Rebuild and restart if it is already running. The module is loaded to <FILE>~/.viam/packages-local/namespace_module-name_from_reload-module.tar.gz</FILE> on the target machine.
+Build a module locally and run it on a target machine. Rebuild and restart if it is already running. The module is loaded to <FILE><VIAM_HOME>/packages-local/namespace_module-name_from_reload-module.tar.gz</FILE> on the target machine, where `<VIAM_HOME>` is the machine's Viam home directory (typically `~/.viam` on Linux).
 
 ```sh {class="command-line" data-prompt="$"}
 # build and configure a module running on your local machine without shipping a tarball.
@@ -1899,7 +1899,7 @@ viam module reload-local --local
 | `--workdir` | Use this to indicate that your <file>meta.json</file> is in a subdirectory of your repo. `--module` flag should be relative to this. Default: `.`. | Optional |
 | `--no-build` | Skip build step. Default: `false`. | Optional |
 | `--no-progress` | Hide progress of the file transfer. Default: `false`. | Optional |
-| `--home` | Specify home directory for a remote machine where `$HOME` is not the default `/root`. | Optional |
+| `--home` | Remote machine home directory under which `<home>/.viam` is used as the module destination. By default the CLI queries the machine for its `VIAM_HOME`; pass `--home` only if the machine cannot be reached or reports a wrong value. | Optional |
 | `--name` | The name of the module. For example: `hello-world`. | Optional |
 
 ### `module restart`


### PR DESCRIPTION
## Source changes

- viamrobotics/rdk#6333: Fix Windows paths for local module reload. The `--home` flag on `viam module reload-local` changed behavior: it now queries the target machine for its VIAM_HOME directory via a shell service DoCommand, instead of defaulting to `~`. The flag is now an override for when the query fails or returns a wrong value. The usage text also changed.

## Docs changes

- `docs/cli/reference.md`: Updated `--home` flag description from "Specify home directory for a remote machine where `$HOME` is not the default `/root`" to accurately describe the new behavior (CLI queries the machine for its VIAM_HOME; `--home` is an override). Also updated the `reload-local` description to note that the destination path depends on the machine's Viam home directory rather than hardcoding `~/.viam`.
- `docs/build-modules/module-reference.md`: Fixed `--home-dir` typo to `--home` (the actual flag name) and updated the description from "remote user's home directory" to "override the remote machine's home directory".
- `docs/build-modules/write-a-driver-module.md`: Updated troubleshooting tips that incorrectly described `--home` as specifying the module directory. Now correctly describes `--home` as an override for the machine's Viam home directory, and points to `--module` for the meta.json path issue.

## How I found these

- Xref lookup: `cli-xref.md` pointed to `docs/cli/reference.md`
- Grep matches: Found 3 additional files referencing `--home` or `--home-dir` in the context of module reload

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeeUxjS46hfhDsAyxgky4J)_