### PR TITLE
Remove link from connection error message

### DIFF
--- a/docs/monitor/common-errors.md
+++ b/docs/monitor/common-errors.md
@@ -238,7 +238,7 @@ resource build error: unknown resource type: API "rdk:component:camera" with mod
 
 ### Failed to connect to robot within time limit {#conn-time-out}
 
-**Full Error:** `failed to connect to machine within time limit. check network connection, whether the viam-server is running, and try again. see https://docs.viam.com/dev/tools/common-errors/#conn-time-out for troubleshooting steps`
+**Full Error:** `failed to connect to machine within time limit. check network connection, whether the viam-server is running, and try again.`
 
 **Description:** This error occurs when the host fails to connect to the robot within the time limit.
 


### PR DESCRIPTION
The link that was part of the error message is not quite right (should be https://docs.viam.com/monitor/common-errors/#conn-time-out), so it has to change. but if we get rid of the link we don't have to keep it updated at all