### PR TITLE
Update reload-local docs for new --file flag

### DIFF
--- a/docs/build-modules/deploy-a-module.md
+++ b/docs/build-modules/deploy-a-module.md
@@ -72,7 +72,8 @@ The target machine must be online (visible in the Viam app). The CLI connects ov
 
 **Useful flags:**
 
-- `--no-build` skips the build step if you already built the archive manually with `bash build.sh`.
+- `--file <path>` uploads a pre-built tarball without running the build step or requiring `build.path` in `meta.json`. Use this when you build the archive outside the CLI (for example, in CI or with a custom script).
+- `--no-build` skips the build step if you already built the archive manually with `bash build.sh`. Unlike `--file`, this still requires `build.path` in `meta.json` to locate the archive.
 - `--local` runs the module from source files on your laptop instead of shipping a tarball. Use this only when the target machine is your laptop. In `--local` mode, `viam module restart` picks up Python source edits without a rebuild.
 
 For the full hot-reload walkthrough including how it fits into the development loop, see [Test locally](/build-modules/write-a-driver-module/#3-test-locally) on the driver-module page.

--- a/docs/build-modules/module-reference.md
+++ b/docs/build-modules/module-reference.md
@@ -554,15 +554,16 @@ resource instance), `--id` (module ID), `--cloud-config` (path to
 `viam.json`, alternative to `--part-id`), `--workdir` (subdirectory
 containing `meta.json`), `--local` (run entrypoint directly on localhost).
 
-`reload-local` flags: `--part-id` (target machine part), `--no-build` (skip
-build), `--local` (run entrypoint directly on localhost instead of bundling),
-`--module` (path to `meta.json`), `--model-name` (add a resource to config
-with this model triple), `--name` (name the added resource),
-`--resource-name` (name the resource instance), `--id` (module ID,
-alternative to `--name`), `--cloud-config` (path to `viam.json`, alternative
-to `--part-id`), `--workdir` (subdirectory containing `meta.json`),
-`--home-dir` (remote user's home directory), `--no-progress` (hide transfer
-progress).
+`reload-local` flags: `--part-id` (target machine part), `--file` (path to a
+pre-built tarball; implies `--no-build`, does not require `build.path` in
+`meta.json`), `--no-build` (skip build), `--local` (run entrypoint directly
+on localhost instead of bundling), `--module` (path to `meta.json`),
+`--model-name` (add a resource to config with this model triple), `--name`
+(name the added resource), `--resource-name` (name the resource instance),
+`--id` (module ID, alternative to `--name`), `--cloud-config` (path to
+`viam.json`, alternative to `--part-id`), `--workdir` (subdirectory
+containing `meta.json`), `--home-dir` (remote user's home directory),
+`--no-progress` (hide transfer progress).
 
 ## Environment variables
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -1897,6 +1897,7 @@ viam module reload-local --local
 | `--resource-name` | If passed, creates a new resource with the given resource name. Use with `--model-name`. Default: Creates no new resource. | Optional |
 | `--local` | Use if the target machine is localhost, to run the entrypoint directly rather than transferring a bundle. Default: `false`. | Optional |
 | `--workdir` | Use this to indicate that your <file>meta.json</file> is in a subdirectory of your repo. `--module` flag should be relative to this. Default: `.`. | Optional |
+| `--file` | Path to a pre-built module tarball to upload. Implies `--no-build` and does not require `build.path` in `meta.json`. Cannot be combined with `--local`. | Optional |
 | `--no-build` | Skip build step. Default: `false`. | Optional |
 | `--no-progress` | Hide progress of the file transfer. Default: `false`. | Optional |
 | `--home` | Specify home directory for a remote machine where `$HOME` is not the default `/root`. | Optional |


### PR DESCRIPTION
The `viam module reload-local` command gained a new `--file` flag that uploads a pre-built module tarball without running the build step or requiring `build.path` in `meta.json`. This is useful when the archive is built outside the CLI (for example, in CI or with a custom script).

## Source changes

- viamrobotics/rdk#6284: Add --file to module reload-local to upload a tarball without build.path in meta.json

## Docs changes

- `docs/cli/reference.md`: Added `--file` to the `module reload-local` flag table
- `docs/build-modules/module-reference.md`: Added `--file` to the `reload-local` flags summary paragraph
- `docs/build-modules/deploy-a-module.md`: Added `--file` to the "Useful flags" list under the `reload-local` section, with usage guidance

## How I found these

- Xref lookup: `cli-xref.md` maps `reload-local` to `docs/cli/reference.md`
- Grep matches: 3 additional pages found referencing `reload-local` flags (module-reference.md, deploy-a-module.md, and several tutorial pages that reference the command but not its full flag list)

---
Generated by daily docs change agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvPMDGVoWCjdZxER7749zP)_