### PR TITLE
Close out SDK coverage backlog for internal app methods

### DIFF
--- a/.github/workflows/sdk_protos_map.csv
+++ b/.github/workflows/sdk_protos_map.csv
@@ -453,8 +453,8 @@ app,RotateKey,,rotate_key,RotateKey,,rotateKey
 app,ListKeys,,list_keys,ListKeys,,listKeys
 app,RenameKey,,,RenameKey,,
 app,CreateKeyFromExistingKeyAuthorizations,,create_key_from_existing_key_authorizations,,,createKeyFromExistingKeyAuthorizations
-app,GetAppContent,,,,,getAppContent
-app,GetAppBranding,,,,,getAppBranding
+app,GetAppContent,,,GetAppContent,,getAppContent
+app,GetAppBranding,,,GetAppBranding,,getAppBranding
 
 ## Billing
 billing,GetCurrentMonthUsage,,get_current_month_usage,GetCurrentMonthUsage,,getCurrentMonthUsage

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -771,14 +771,15 @@ def check_for_unused_methods(methods, type):
                 if not "used" in methods[lang][type][resource][method].keys():
                     if resource in ["data_sync", "dataset", "data"]:
                         continue
-                    ## "create_oauth_app_user" / "createOAuthAppUser": part of the undocumented OAuth-apps
-                    ## family (CreateOAuthApp/ReadOAuthApp/UpdateOAuthApp/DeleteOAuthApp also have no docs
-                    ## coverage); push tokens and Firebase config are Viam mobile-app infrastructure, not
-                    ## customer-facing. See #5188.
-                    if lang == "python" and method not in ["from_robot", "close", "get_resource_name", "get_geometries", "do_command", "proto", "transform", "updated_fields", "ListUUIDs", "GetTransform", "StreamTransformChanges", "DoCommand", "GetStatus", "create_oauth_app_user", "upload_device_push_token", "get_device_push_tokens", "delete_device_push_token", "set_firebase_config", "get_firebase_config", "delete_firebase_config"] or \
+                    ## Push tokens and Firebase config are Viam mobile-app infrastructure, not
+                    ## customer-facing. See #5188. (create_oauth_app_user / createOAuthAppUser
+                    ## deliberately NOT ignored here -- the whole OAuth-apps family needs a
+                    ## domain-owner decision on document-vs-ignore before we suppress the
+                    ## warning; see the #5188/#5276 discussion.)
+                    if lang == "python" and method not in ["from_robot", "close", "get_resource_name", "get_geometries", "do_command", "proto", "transform", "updated_fields", "ListUUIDs", "GetTransform", "StreamTransformChanges", "DoCommand", "GetStatus", "upload_device_push_token", "get_device_push_tokens", "delete_device_push_token", "set_firebase_config", "get_firebase_config", "delete_firebase_config"] or \
                         lang == "go" and method not in ["Reconfigure", "ListTunnels", "Close", "DoCommand", "CurrentPosition", "AddTagsToBinaryDataByFilter", "RemoveTagsFromBinaryDataByFilter", "CurrentInputs", "GoToInputs"] or \
                         lang == "flutter" and method not in ["getResources", "getStream", "getStreamOptions", "resetStreamOptions", "setStreamOptions", "Discovery.fromProto", "addCallbacks", "getResource", "RobotClient.withClient"] or \
-                        lang == "typescript" and method not in ["connect", "disconnect", "dial", "isConnected", "discoverComponents", "createServiceClient", "getRoverRentalRobots", "doCommand", "createOAuthAppUser"]:
+                        lang == "typescript" and method not in ["connect", "disconnect", "dial", "isConnected", "discoverComponents", "createServiceClient", "getRoverRentalRobots", "doCommand"]:
                         print(f"WARNING: {lang} {type} {resource} {method} is unused")
                         warnings = True
 

--- a/.github/workflows/update_sdk_methods.py
+++ b/.github/workflows/update_sdk_methods.py
@@ -771,10 +771,14 @@ def check_for_unused_methods(methods, type):
                 if not "used" in methods[lang][type][resource][method].keys():
                     if resource in ["data_sync", "dataset", "data"]:
                         continue
-                    if lang == "python" and method not in ["from_robot", "close", "get_resource_name", "get_geometries", "do_command", "proto", "transform", "updated_fields", "ListUUIDs", "GetTransform", "StreamTransformChanges", "DoCommand", "GetStatus"] or \
+                    ## "create_oauth_app_user" / "createOAuthAppUser": part of the undocumented OAuth-apps
+                    ## family (CreateOAuthApp/ReadOAuthApp/UpdateOAuthApp/DeleteOAuthApp also have no docs
+                    ## coverage); push tokens and Firebase config are Viam mobile-app infrastructure, not
+                    ## customer-facing. See #5188.
+                    if lang == "python" and method not in ["from_robot", "close", "get_resource_name", "get_geometries", "do_command", "proto", "transform", "updated_fields", "ListUUIDs", "GetTransform", "StreamTransformChanges", "DoCommand", "GetStatus", "create_oauth_app_user", "upload_device_push_token", "get_device_push_tokens", "delete_device_push_token", "set_firebase_config", "get_firebase_config", "delete_firebase_config"] or \
                         lang == "go" and method not in ["Reconfigure", "ListTunnels", "Close", "DoCommand", "CurrentPosition", "AddTagsToBinaryDataByFilter", "RemoveTagsFromBinaryDataByFilter", "CurrentInputs", "GoToInputs"] or \
                         lang == "flutter" and method not in ["getResources", "getStream", "getStreamOptions", "resetStreamOptions", "setStreamOptions", "Discovery.fromProto", "addCallbacks", "getResource", "RobotClient.withClient"] or \
-                        lang == "typescript" and method not in ["connect", "disconnect", "dial", "isConnected", "discoverComponents", "createServiceClient", "getRoverRentalRobots", "doCommand"]:
+                        lang == "typescript" and method not in ["connect", "disconnect", "dial", "isConnected", "discoverComponents", "createServiceClient", "getRoverRentalRobots", "doCommand", "createOAuthAppUser"]:
                         print(f"WARNING: {lang} {type} {resource} {method} is unused")
                         warnings = True
 

--- a/static/include/app/apis/generated/app.md
+++ b/static/include/app/apis/generated/app.md
@@ -6403,6 +6403,28 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfac
 Retrieve the app content for an organization.
 
 {{< tabs >}}
+{{% tab name="Go" %}}
+
+**Parameters:**
+
+- `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
+- `orgPublicNamespace`
+- `appName` [(string)](https://pkg.go.dev/builtin#string)
+
+**Returns:**
+
+- [(*AppContent)](https://pkg.go.dev/go.viam.com/rdk/app#AppContent)
+- [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
+
+**Example:**
+
+```go {class="line-numbers linkable-line-numbers"}
+content, err := cloud.GetAppContent(context.Background(), "my-org", "my-app")
+```
+
+For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/app#AppClient.GetAppContent).
+
+{{% /tab %}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**
@@ -6433,6 +6455,28 @@ For more information, see the [TypeScript SDK Docs](https://ts.viam.dev/interfac
 Retrieves the app branding for an organization or app.
 
 {{< tabs >}}
+{{% tab name="Go" %}}
+
+**Parameters:**
+
+- `ctx` [(Context)](https://pkg.go.dev/context#Context): A Context carries a deadline, a cancellation signal, and other values across API boundaries.
+- `orgPublicNamespace`
+- `appName` [(string)](https://pkg.go.dev/builtin#string)
+
+**Returns:**
+
+- [(*AppBranding)](https://pkg.go.dev/go.viam.com/rdk/app#AppBranding)
+- [(error)](https://pkg.go.dev/builtin#error): An error, if one occurred.
+
+**Example:**
+
+```go {class="line-numbers linkable-line-numbers"}
+branding, err := cloud.GetAppBranding(context.Background(), "my-org", "my-app")
+```
+
+For more information, see the [Go SDK Docs](https://pkg.go.dev/go.viam.com/rdk/app#AppClient.GetAppBranding).
+
+{{% /tab %}}
 {{% tab name="TypeScript" %}}
 
 **Parameters:**


### PR DESCRIPTION
## Summary

Resolves most of #5188's 10 "unused method" warnings for internal-facing app methods. (One item — OAuth app user creation — has been pulled out; see below.)

- **6 methods ignored** — genuinely internal, no customer-facing doc link in their docstrings:
  - Python: `upload_device_push_token`, `get_device_push_tokens`, `delete_device_push_token`, `set_firebase_config`, `get_firebase_config`, `delete_firebase_config`
  - Added to the per-language ignore list in `check_for_unused_methods()`.
- **2 methods documented instead of ignored** — Go's `GetAppBranding`/`GetAppContent`. #5188 flagged these as needing a "domain-owner call," but the decision was already made and just never wired up: their Go doc comments (`rdk/app/app_client.go`) link to `docs.viam.com/reference/apis/fleet/#getappbranding`/`#getappcontent`, proto description override files already exist (`app.GetAppBranding.md`, `app.GetAppContent.md`, present since #4493, unused since), and TypeScript's versions are already fully rendered in `app.md`. The only bug was `sdk_protos_map.csv` having an empty Go column despite the Go SDK implementing both methods. Filled in the Go method names and regenerated `app.md` to add the missing Go tabs.
- **`create_oauth_app_user` / `createOAuthAppUser` deliberately left OUT of the ignore list** (not resolved by this PR — see discussion below). It'll keep showing as a warning until a domain-owner decision lands; that's intentional, not an oversight.

## Correction from review

An earlier revision of this PR (and its description) claimed none of the 8 originally-ignored methods carried a customer-facing doc link. That was wrong for one of them: **Python's `create_oauth_app_user`** does carry a `docs.viam.com/dev/reference/apis/fleet/#createoauthappuser` link in its docstring — I'd misread it, only checking the first ~25 lines and missing the trailing "For more information" line. Verified in full this time: the other 6 (push tokens ×3, Firebase config ×3) and TypeScript's own `createOAuthAppUser` genuinely have no link.

Dug into git history looking for the decision behind that link: it was added whole (docstring + link) in [viam-python-sdk#1206](https://github.com/viamrobotics/viam-python-sdk/pull/1206) ("Automated Protos Update," merged 2026-04-27), reviewed with a bare "APPROVED," no discussion. The underlying proto RPC comment is empty, so the link wasn't templated — someone wrote it by hand with no recorded rationale. The broader OAuth-apps family (`CreateOAuthApp`/`ReadOAuthApp`/`UpdateOAuthApp`/`DeleteOAuthApp`) has zero SDK coverage anywhere, and `ListOAuthApps` (Go-only) turns out to have the same dangling-link problem and isn't even caught by the coverage scraper today — worth a separate look.

Given there's no real paper trail settling "document vs. ignore" for OAuth app user creation, and end-to-end OAuth-app-user creation isn't even fully supported by any single SDK today (you need app listing to get the required app ID, which no SDK exposes), this needs an actual domain-owner decision rather than a default. Leaving `create_oauth_app_user`/`createOAuthAppUser` out of the ignore list for now, so the warning stays visible instead of being silently suppressed. #5188 will stay open for this piece.

## Incidental change avoided

Regenerating the `app` resource across all 4 SDKs (required to avoid erasing other SDKs' content) also picked up genuine unrelated upstream drift each time it was re-run (Python's `get_robot_part_logs` gaining `order`/`range` params). Reverted that hunk both times to keep this PR scoped to #5188 — real and worth picking up, but as a separate regen PR, not bundled here.

## Verification

- Ran `update_sdk_methods.py --coverage` before and after: confirmed `GetAppBranding`/`GetAppContent` and the 6 ignored methods no longer warn, `create_oauth_app_user`/`createOAuthAppUser` still warn (expected), and no other warnings changed.
- Diffed the regenerated `app.md` by hand — only the two new Go tab blocks were added, no other sections touched.
- `prettier`/`markdownlint` don't apply (generated files under `static/`, per `CLAUDE.md`). `vale sync && vale static/include/app/apis/generated/app.md` passes clean.
- `make build-prod` completes with no errors (only expected stale-date/missing-description warnings).

Refs #5188